### PR TITLE
fix: After changing the language preference, it reverted after refres…

### DIFF
--- a/internal/server/biz/user.go
+++ b/internal/server/biz/user.go
@@ -112,7 +112,7 @@ func (s *UserService) UpdateUser(ctx context.Context, id int, input ent.UpdateUs
 	}
 
 	// Invalidate cache
-	s.invalidateUserCache(ctx, id)
+	s.InvalidateUserCache(ctx, id)
 
 	return user, nil
 }
@@ -130,7 +130,7 @@ func (s *UserService) UpdateUserStatus(ctx context.Context, id int, status user.
 	}
 
 	// Invalidate cache
-	s.invalidateUserCache(ctx, id)
+	s.InvalidateUserCache(ctx, id)
 
 	return user, nil
 }
@@ -175,8 +175,8 @@ func buildUserCacheKey(id int) string {
 	return fmt.Sprintf("user:%d", id)
 }
 
-// invalidateUserCache removes a user from cache.
-func (s *UserService) invalidateUserCache(ctx context.Context, id int) {
+// InvalidateUserCache removes a user from cache.
+func (s *UserService) InvalidateUserCache(ctx context.Context, id int) {
 	cacheKey := buildUserCacheKey(id)
 	_ = s.UserCache.Delete(ctx, cacheKey)
 }

--- a/internal/server/gql/me.resolvers.go
+++ b/internal/server/gql/me.resolvers.go
@@ -48,7 +48,15 @@ func (r *mutationResolver) UpdateMe(ctx context.Context, input UpdateMeInput) (*
 		mut.SetAvatar(*input.Avatar)
 	}
 
-	return mut.Save(ctx)
+	updatedUser, err := mut.Save(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Invalidate user cache to ensure fresh data on next request
+	r.userService.InvalidateUserCache(ctx, user.ID)
+
+	return updatedUser, nil
 }
 
 // Me is the resolver for the me field.


### PR DESCRIPTION
Root cause

In the SQLite database environment, the reason why preferLanguage does not take effect immediately after being updated is:

1. Cache not invalidated: The UpdateMe resolver (internal/server/gql/me.resolvers.go:20-52) does not clear the UserService cache after directly updating the database.

2. Cache hit: Subsequent requests still return the old preferLanguage value when reading from the cache through GetUserByID (internal/server/biz/user.go:139-172).

3. Restart takes effect: Only after restarting the service and clearing the cache can the new value be read from the database.