### PR TITLE
fix: 修复 Volcengine 和 LongCat Anthropic 渠道的认证问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ test-results
 .qoder
 dumps
 .builds
+.pnpm-store
+.serena
+.claude
 
 config.yml
 internal/server/static/dist

--- a/internal/llm/transformer/anthropic/outbound.go
+++ b/internal/llm/transformer/anthropic/outbound.go
@@ -188,12 +188,12 @@ func (t *OutboundTransformer) TransformRequest(
 		// LongCat uses Bearer token authentication instead of X-API-Key
 		if t.config.Type == PlatformLongCat {
 			auth = &httpclient.AuthConfig{
-				Type:   "bearer",
+				Type:   httpclient.AuthTypeBearer,
 				APIKey: t.config.APIKey,
 			}
 		} else {
 			auth = &httpclient.AuthConfig{
-				Type:      "api_key",
+				Type:      httpclient.AuthTypeAPIKey,
 				APIKey:    t.config.APIKey,
 				HeaderKey: "X-API-Key",
 			}

--- a/internal/llm/transformer/anthropic/outbound.go
+++ b/internal/llm/transformer/anthropic/outbound.go
@@ -27,6 +27,7 @@ const (
 	PlatformMoonshot PlatformType = "moonshot" // Moonshot with Anthropic format
 	PlatformZhipu    PlatformType = "zhipu"    // Zhipu with Anthropic format
 	PlatformZai      PlatformType = "zai"      // Zai with Anthropic format
+	PlatformLongCat  PlatformType = "longcat"  // LongCat with Anthropic format (Bearer auth)
 )
 
 // Config holds all configuration for the Anthropic outbound transformer.
@@ -184,10 +185,18 @@ func (t *OutboundTransformer) TransformRequest(
 	// Prepare authentication
 	var auth *httpclient.AuthConfig
 	if t.config.APIKey != "" && (t.config.Type != PlatformBedrock && t.config.Type != PlatformVertex) {
-		auth = &httpclient.AuthConfig{
-			Type:      "api_key",
-			APIKey:    t.config.APIKey,
-			HeaderKey: "X-API-Key",
+		// LongCat uses Bearer token authentication instead of X-API-Key
+		if t.config.Type == PlatformLongCat {
+			auth = &httpclient.AuthConfig{
+				Type:   "bearer",
+				APIKey: t.config.APIKey,
+			}
+		} else {
+			auth = &httpclient.AuthConfig{
+				Type:      "api_key",
+				APIKey:    t.config.APIKey,
+				HeaderKey: "X-API-Key",
+			}
 		}
 	}
 

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/llm"
 	"github.com/looplj/axonhub/internal/llm/pipeline"
+	"github.com/looplj/axonhub/internal/llm/transformer"
 	"github.com/looplj/axonhub/internal/llm/transformer/anthropic"
 	"github.com/looplj/axonhub/internal/llm/transformer/doubao"
 	"github.com/looplj/axonhub/internal/llm/transformer/gemini"

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -158,6 +158,19 @@ func getProxyConfig(channelSettings *objects.ChannelSettings) *objects.ProxyConf
 	return channelSettings.Proxy
 }
 
+// buildChannelWithTransformer is a helper function to build a Channel with the given transformer.
+func buildChannelWithTransformer(
+	c *ent.Channel,
+	transformer transformer.Outbound,
+	httpClient *httpclient.HttpClient,
+) *Channel {
+	return &Channel{
+		Channel:    c,
+		Outbound:   transformer,
+		HTTPClient: httpClient,
+	}
+}
+
 //nolint:maintidx // Simple switch statement.
 func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 	httpClient := httpclient.NewHttpClientWithProxy(getProxyConfig(c.Settings))
@@ -173,44 +186,28 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeOpenrouter:
 		transformer, err := openrouter.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZai, channel.TypeZhipu:
 		transformer, err := zai.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeXai:
 		transformer, err := xai.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeLongcatAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformLongCat,
@@ -221,11 +218,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeAnthropic, channel.TypeMinimaxAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformDirect,
@@ -236,11 +229,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeDeepseekAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformDeepSeek,
@@ -251,11 +240,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeDoubaoAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformDoubao,
@@ -266,11 +251,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeMoonshotAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformMoonshot,
@@ -281,11 +262,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZhipuAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformZhipu,
@@ -296,11 +273,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZaiAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformZai,
@@ -311,11 +284,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 
 	case channel.TypeAnthropicAWS:
 		// For anthropic_aws, we need to create a transformer with AWS credentials
@@ -330,11 +299,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeAnthropicGcp:
 		// For anthropic_vertex, we need to create a VertexTransformer with GCP credentials
 		// The transformer will handle Google Vertex AI integration
@@ -352,11 +317,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeAnthropicFake:
 		// For anthropic_fake, we use the fake transformer for testing
 		fakeTransformer := anthropic.NewFakeTransformer()
@@ -381,11 +342,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeGeminiOpenai:
 		transformer, err := geminioai.NewOutboundTransformerWithConfig(&geminioai.Config{
 			BaseURL: c.BaseURL,
@@ -395,11 +352,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeOpenai,
 		channel.TypeDeepseek, channel.TypeMoonshot, channel.TypeLongcat, channel.TypeMinimax,
 		channel.TypePpio, channel.TypeSiliconflow,
@@ -413,11 +366,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeGemini:
 		transformer, err := gemini.NewOutboundTransformerWithConfig(gemini.Config{
 			BaseURL: c.BaseURL,
@@ -427,11 +376,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		return &Channel{
-			Channel:    c,
-			Outbound:   transformer,
-			HTTPClient: httpClient,
-		}, nil
+		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	default:
 		return nil, errors.New("unknown channel type")
 	}

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -164,7 +164,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 
 	//nolint:exhaustive // TODO SUPPORT more providers.
 	switch c.Type {
-	case channel.TypeDoubao:
+	case channel.TypeDoubao, channel.TypeVolcengine:
 		transformer, err := doubao.NewOutboundTransformerWithConfig(&doubao.Config{
 			BaseURL: c.BaseURL,
 			APIKey:  c.Credentials.APIKey,
@@ -211,7 +211,22 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 			Outbound:   transformer,
 			HTTPClient: httpClient,
 		}, nil
-	case channel.TypeAnthropic, channel.TypeLongcatAnthropic, channel.TypeMinimaxAnthropic:
+	case channel.TypeLongcatAnthropic:
+		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
+			Type:    anthropic.PlatformLongCat,
+			BaseURL: c.BaseURL,
+			APIKey:  c.Credentials.APIKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
+		}
+
+		return &Channel{
+			Channel:    c,
+			Outbound:   transformer,
+			HTTPClient: httpClient,
+		}, nil
+	case channel.TypeAnthropic, channel.TypeMinimaxAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:    anthropic.PlatformDirect,
 			BaseURL: c.BaseURL,
@@ -387,7 +402,7 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		}, nil
 	case channel.TypeOpenai,
 		channel.TypeDeepseek, channel.TypeMoonshot, channel.TypeLongcat, channel.TypeMinimax,
-		channel.TypePpio, channel.TypeSiliconflow, channel.TypeVolcengine,
+		channel.TypePpio, channel.TypeSiliconflow,
 		channel.TypeVercel, channel.TypeAihubmix, channel.TypeBurncloud, channel.TypeBailian:
 		transformer, err := openai.NewOutboundTransformerWithConfig(&openai.Config{
 			Type:    openai.PlatformOpenAI,


### PR DESCRIPTION
## Summary

本 PR 修复了两个渠道的认证和 transformer 配置问题：

- **Volcengine（火山引擎）渠道**：修复了被错误归类到 OpenAI 兼容组的问题，导致 URL 构建错误（404 Not Found）
- **LongCat Anthropic 渠道**：修复了认证方式不匹配的问题，LongCat 使用 Bearer Token 而不是标准的 X-API-Key

### 主要改动

1. **Volcengine 渠道修复**
   - 将 `channel.TypeVolcengine` 从 OpenAI 兼容组移到 Doubao transformer 组
   - 确保使用正确的 API 路径：`/api/v3/chat/completions` 而不是 `/api/v3/v1/chat/completions`

2. **LongCat Anthropic 渠道修复**
   - 新增 `PlatformLongCat` 平台类型
   - 为 LongCat 使用 Bearer Token 认证（`Authorization: Bearer <token>`）
   - 将 LongCat Anthropic 从通用 Anthropic 处理逻辑中分离，单独处理

### 技术细节

**文件变更：**
- `internal/llm/transformer/anthropic/outbound.go`：添加 PlatformLongCat 类型和对应的认证逻辑
- `internal/server/biz/channel_llm.go`：调整渠道类型映射关系

**认证方式对比：**
- 标准 Anthropic API：`X-API-Key: <token>`
- LongCat Anthropic API：`Authorization: Bearer <token>`
- Volcengine/Doubao API：`Authorization: Bearer <token>`

## Test plan

- [x] 测试 Volcengine 渠道使用正确的 Doubao transformer
- [x] 验证 Volcengine 渠道的 URL 构建正确（`/api/v3/chat/completions`）
- [x] 测试 LongCat Anthropic 渠道使用 Bearer Token 认证
- [x] 验证 LongCat Anthropic 渠道不再返回 `missing_api_key` 错误
- [x] 确保其他 Anthropic 兼容渠道（Anthropic、Minimax）仍使用 X-API-Key 认证
- [x] 代码编译通过，无语法错误

<img width="864" height="373" alt="image" src="https://github.com/user-attachments/assets/085cd4ce-1dfa-43c8-8a04-550a1bac265c" />