### PR TITLE
fix 在更新头像后右上角不显示更新后的头像

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ dumps
 .pnpm-store
 .serena
 .claude
+.gomodcache
+.gocache
 
 config.yml
 internal/server/static/dist

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ test-results
 .qoder
 dumps
 .builds
+.pnpm-store
+.serena
+.claude
 
 config.yml
 internal/server/static/dist

--- a/internal/server/biz/user.go
+++ b/internal/server/biz/user.go
@@ -104,6 +104,12 @@ func (s *UserService) UpdateUser(ctx context.Context, id int, input ent.UpdateUs
 		SetNillableIsOwner(input.IsOwner).
 		SetNillablePreferLanguage(input.PreferLanguage)
 
+    if input.ClearAvatar {
+    		mut.ClearAvatar()
+    } else {
+    		mut.SetNillableAvatar(input.Avatar)
+    }
+	
 	if input.Password != nil {
 		hashedPassword, err := HashPassword(*input.Password)
 		if err != nil {


### PR DESCRIPTION
- 在更新用户信息时，新增对 ClearAvatar 标志的判断 
- 当 ClearAvatar 为 true 时，清除用户的头像字段
- 当 ClearAvatar 为 false 时，正常设置可选的 Avatar 字段
- 确保头像更新逻辑与密码更新逻辑保持独立