### PR TITLE
feat: Add Redis TLS support with flexible URL configuration

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -176,6 +176,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cache.redis.username", "")
 	v.SetDefault("cache.redis.password", "")
 	v.SetDefault("cache.redis.db", 0)
+	v.SetDefault("cache.redis.tls", false)
+	v.SetDefault("cache.redis.tls_insecure_skip_verify", false)
 }
 
 // parseLogLevel converts a string log level to zapcore.Level.

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -173,6 +173,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cache.default_expiration", "5m")
 	v.SetDefault("cache.cleanup_interval", "10m")
 	v.SetDefault("cache.redis.addr", "")
+	v.SetDefault("cache.redis.url", "")
 	v.SetDefault("cache.redis.username", "")
 	v.SetDefault("cache.redis.password", "")
 	v.SetDefault("cache.redis.db", 0)

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -176,7 +176,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cache.redis.url", "")
 	v.SetDefault("cache.redis.username", "")
 	v.SetDefault("cache.redis.password", "")
-	v.SetDefault("cache.redis.db", 0)
+	// Note: cache.redis.db has no default value to allow explicit override to 0
 	v.SetDefault("cache.redis.tls", false)
 	v.SetDefault("cache.redis.tls_insecure_skip_verify", false)
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -33,17 +33,22 @@ cache:
   
   # Redis cache configuration
   redis:
-    # Supported address formats:
-    #   - "127.0.0.1:6379"
+    # Simple mode: Use addr for plain host:port
+    addr: ""                    # Redis address (host:port) (env: AXONHUB_CACHE_REDIS_ADDR)
+
+    # URL mode: Use url for full redis:// or rediss:// URLs (takes priority over addr)
+    # Supported formats:
     #   - "redis://127.0.0.1:6379"
     #   - "rediss://127.0.0.1:6380" (auto-enables TLS)
     #   - "redis://user:pass@127.0.0.1:6379/0"
-    addr: ""                    # Redis address (env: AXONHUB_CACHE_REDIS_ADDR)
-    username: ""                # Optional, overrides URL username (env: AXONHUB_CACHE_REDIS_USERNAME)
-    password: ""                # Optional, overrides URL password (env: AXONHUB_CACHE_REDIS_PASSWORD)
-    db: 0                       # Redis DB index, overrides URL /db (env: AXONHUB_CACHE_REDIS_DB)
-    tls: false                  # Enable TLS (env: AXONHUB_CACHE_REDIS_TLS)
-    tls_insecure_skip_verify: false # Skip TLS cert verification for self-signed certs (env: AXONHUB_CACHE_REDIS_TLS_INSECURE_SKIP_VERIFY)
+    url: ""                     # Redis URL (env: AXONHUB_CACHE_REDIS_URL)
+
+    # Optional overrides (apply to both addr and url modes)
+    username: ""                # Overrides URL username (env: AXONHUB_CACHE_REDIS_USERNAME)
+    password: ""                # Overrides URL password (env: AXONHUB_CACHE_REDIS_PASSWORD)
+    db: 0                       # Overrides URL /db (env: AXONHUB_CACHE_REDIS_DB)
+    tls: false                  # Enable TLS for addr mode (env: AXONHUB_CACHE_REDIS_TLS)
+    tls_insecure_skip_verify: false # Skip TLS cert verification (env: AXONHUB_CACHE_REDIS_TLS_INSECURE_SKIP_VERIFY)
     expiration: "30m"           # Redis cache TTL (env: AXONHUB_CACHE_REDIS_EXPIRATION)
 
 # Logging configuration

--- a/config.example.yml
+++ b/config.example.yml
@@ -33,10 +33,17 @@ cache:
   
   # Redis cache configuration
   redis:
-    addr: ""                    # e.g. 127.0.0.1:6379 (env: AXONHUB_CACHE_REDIS_ADDR)
-    username: ""                # Optional (env: AXONHUB_CACHE_REDIS_USERNAME)
-    password: ""                # Optional (env: AXONHUB_CACHE_REDIS_PASSWORD)
-    db: 0                       # Redis DB index (env: AXONHUB_CACHE_REDIS_DB)
+    # Supported address formats:
+    #   - "127.0.0.1:6379"
+    #   - "redis://127.0.0.1:6379"
+    #   - "rediss://127.0.0.1:6380" (auto-enables TLS)
+    #   - "redis://user:pass@127.0.0.1:6379/0"
+    addr: ""                    # Redis address (env: AXONHUB_CACHE_REDIS_ADDR)
+    username: ""                # Optional, overrides URL username (env: AXONHUB_CACHE_REDIS_USERNAME)
+    password: ""                # Optional, overrides URL password (env: AXONHUB_CACHE_REDIS_PASSWORD)
+    db: 0                       # Redis DB index, overrides URL /db (env: AXONHUB_CACHE_REDIS_DB)
+    tls: false                  # Enable TLS (env: AXONHUB_CACHE_REDIS_TLS)
+    tls_insecure_skip_verify: false # Skip TLS cert verification for self-signed certs (env: AXONHUB_CACHE_REDIS_TLS_INSECURE_SKIP_VERIFY)
     expiration: "30m"           # Redis cache TTL (env: AXONHUB_CACHE_REDIS_EXPIRATION)
 
 # Logging configuration

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -114,10 +114,12 @@ cache:
 
   # Redis cache configuration
   redis:
-    addr: ""                    # Redis server address
-    username: ""                # Redis username
-    password: ""                # Redis password
-    db: 0                       # Redis DB index
+    addr: ""                    # Redis address: 127.0.0.1:6379 | redis://... | rediss://...
+    username: ""                # Overrides username in URL if set
+    password: ""                # Overrides password in URL if set
+    db: 0                       # Overrides DB in URL path (/0)
+    tls: false                  # Enable TLS (also auto-enabled for rediss://)
+    tls_insecure_skip_verify: false # Skip TLS cert verification (self-signed)
     expiration: "30m"           # Redis cache TTL
 ```
 
@@ -129,6 +131,8 @@ cache:
 - `AXONHUB_CACHE_REDIS_USERNAME`
 - `AXONHUB_CACHE_REDIS_PASSWORD`
 - `AXONHUB_CACHE_REDIS_DB`
+- `AXONHUB_CACHE_REDIS_TLS`
+- `AXONHUB_CACHE_REDIS_TLS_INSECURE_SKIP_VERIFY`
 - `AXONHUB_CACHE_REDIS_EXPIRATION`
 
 ### Logging Configuration

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -114,7 +114,8 @@ cache:
 
   # Redis cache configuration
   redis:
-    addr: ""                    # Redis address: 127.0.0.1:6379 | redis://... | rediss://...
+    url: ""                     # Redis connection URL(redis:// or rediss://)
+    addr: ""                    # Redis address: 127.0.0.1:6379
     username: ""                # Overrides username in URL if set
     password: ""                # Overrides password in URL if set
     db: 0                       # Overrides DB in URL path (/0)
@@ -127,6 +128,7 @@ cache:
 - `AXONHUB_CACHE_MODE`
 - `AXONHUB_CACHE_MEMORY_EXPIRATION`
 - `AXONHUB_CACHE_MEMORY_CLEANUP_INTERVAL`
+- `AXONHUB_CACHE_REDIS_URL`
 - `AXONHUB_CACHE_REDIS_ADDR`
 - `AXONHUB_CACHE_REDIS_USERNAME`
 - `AXONHUB_CACHE_REDIS_PASSWORD`

--- a/internal/pkg/xcache/cache.go
+++ b/internal/pkg/xcache/cache.go
@@ -232,8 +232,8 @@ func newRedisOptions(cfg RedisConfig) (*redis.Options, error) {
 	if cfg.Password != "" {
 		opts.Password = cfg.Password
 	}
-	if cfg.DB != 0 {
-		opts.DB = cfg.DB
+	if cfg.DB != nil {
+		opts.DB = *cfg.DB
 	}
 
 	// Explicit TLS flag

--- a/internal/pkg/xcache/cache.go
+++ b/internal/pkg/xcache/cache.go
@@ -211,8 +211,8 @@ func newRedisOptions(cfg RedisConfig) (*redis.Options, error) {
 
 		if u.Scheme == "rediss" {
 			opts.TLSConfig = &tls.Config{
-				MinVersion:         tls.VersionTLS12, // #nosec G402 -- User can explicitly enable InsecureSkipVerify via config
-				InsecureSkipVerify: cfg.TLSInsecureSkipVerify,
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: cfg.TLSInsecureSkipVerify, // #nosec G402 -- User explicitly controls this via config
 			}
 		}
 	} else if cfg.Addr != "" {

--- a/internal/pkg/xcache/cache.go
+++ b/internal/pkg/xcache/cache.go
@@ -85,7 +85,7 @@ func NewFromConfig[T any](cfg Config) Cache[T] {
 	// Build redis setter cache if configured
 	var rds SetterCache[T]
 
-	if cfg.Redis.Addr != "" && cfg.Mode != ModeMemory {
+	if (cfg.Redis.Addr != "" || cfg.Redis.URL != "") && cfg.Mode != ModeMemory {
 		opts, err := newRedisOptions(cfg.Redis)
 		if err != nil {
 			panic(fmt.Errorf("invalid redis config: %w", err))

--- a/internal/pkg/xcache/cache.go
+++ b/internal/pkg/xcache/cache.go
@@ -211,6 +211,7 @@ func newRedisOptions(cfg RedisConfig) (*redis.Options, error) {
 
 		if u.Scheme == "rediss" {
 			opts.TLSConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12, // #nosec G402 -- User can explicitly enable InsecureSkipVerify via config
 				InsecureSkipVerify: cfg.TLSInsecureSkipVerify,
 			}
 		}
@@ -238,9 +239,11 @@ func newRedisOptions(cfg RedisConfig) (*redis.Options, error) {
 	// Explicit TLS flag
 	if cfg.TLS {
 		if opts.TLSConfig == nil {
-			opts.TLSConfig = &tls.Config{}
+			opts.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12, // #nosec G402 -- User can explicitly enable InsecureSkipVerify via config
+			}
 		}
-		opts.TLSConfig.InsecureSkipVerify = cfg.TLSInsecureSkipVerify
+		opts.TLSConfig.InsecureSkipVerify = cfg.TLSInsecureSkipVerify // #nosec G402 -- User explicitly controls this via config
 	}
 
 	// Ensure TLSInsecureSkipVerify is not silently set without TLS

--- a/internal/pkg/xcache/cache_test.go
+++ b/internal/pkg/xcache/cache_test.go
@@ -499,7 +499,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("rediss url auto tls and db", func(t *testing.T) {
 		opts, err := newRedisOptions(RedisConfig{
-			Addr:                  "rediss://user:pass@localhost:6380/2",
+			URL:                   "rediss://user:pass@localhost:6380/2",
 			TLSInsecureSkipVerify: true,
 		})
 		require.NoError(t, err)
@@ -513,7 +513,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("config overrides url credentials and db", func(t *testing.T) {
 		opts, err := newRedisOptions(RedisConfig{
-			Addr:     "redis://u1:p1@127.0.0.1:6379/1",
+			URL:      "redis://u1:p1@127.0.0.1:6379/1",
 			Username: "u2",
 			Password: "p2",
 			DB:       3,
@@ -527,7 +527,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("redis url without credentials", func(t *testing.T) {
 		opts, err := newRedisOptions(RedisConfig{
-			Addr: "redis://127.0.0.1:6379",
+			URL: "redis://127.0.0.1:6379",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
@@ -554,12 +554,10 @@ func TestNewRedisOptions(t *testing.T) {
 		assert.Contains(t, err.Error(), "tls_insecure_skip_verify requires TLS to be enabled")
 	})
 
-	t.Run("empty addr", func(t *testing.T) {
-		_, err := newRedisOptions(RedisConfig{
-			Addr: "",
-		})
+	t.Run("empty addr and url", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "redis addr is empty")
+		assert.Contains(t, err.Error(), "redis addr or url is required")
 	})
 
 	t.Run("whitespace only addr", func(t *testing.T) {
@@ -567,18 +565,18 @@ func TestNewRedisOptions(t *testing.T) {
 			Addr: "   ",
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "redis addr is empty")
+		assert.Contains(t, err.Error(), "redis addr or url is required")
 	})
 
 	t.Run("invalid scheme", func(t *testing.T) {
-		_, err := newRedisOptions(RedisConfig{Addr: "http://example.com"})
+		_, err := newRedisOptions(RedisConfig{URL: "http://example.com"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported redis scheme")
 	})
 
 	t.Run("redis url with invalid db", func(t *testing.T) {
 		_, err := newRedisOptions(RedisConfig{
-			Addr: "redis://127.0.0.1:6379/invalid",
+			URL: "redis://127.0.0.1:6379/invalid",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid redis db in url")
@@ -586,7 +584,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("redis url missing host", func(t *testing.T) {
 		_, err := newRedisOptions(RedisConfig{
-			Addr: "redis://",
+			URL: "redis://",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "redis url missing host")
@@ -594,7 +592,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("invalid url format", func(t *testing.T) {
 		_, err := newRedisOptions(RedisConfig{
-			Addr: "redis://:invalid",
+			URL: "redis://:invalid",
 		})
 		require.Error(t, err)
 	})
@@ -613,7 +611,7 @@ func TestNewRedisOptions(t *testing.T) {
 
 	t.Run("redis url with explicit tls flag", func(t *testing.T) {
 		opts, err := newRedisOptions(RedisConfig{
-			Addr:     "redis://127.0.0.1:6379",
+			URL:      "redis://127.0.0.1:6379",
 			TLS:      true,
 			Username: "user",
 			Password: "pass",

--- a/internal/pkg/xcache/cache_test.go
+++ b/internal/pkg/xcache/cache_test.go
@@ -14,6 +14,10 @@ import (
 	gocache "github.com/patrickmn/go-cache"
 )
 
+func intPtr(i int) *int {
+	return &i
+}
+
 func TestNewMemory(t *testing.T) {
 	client := gocache.New(5*time.Minute, 10*time.Minute)
 	cache := NewMemory[string](client)
@@ -516,13 +520,23 @@ func TestNewRedisOptions(t *testing.T) {
 			URL:      "redis://u1:p1@127.0.0.1:6379/1",
 			Username: "u2",
 			Password: "p2",
-			DB:       3,
+			DB:       intPtr(3),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
 		assert.Equal(t, "u2", opts.Username)
 		assert.Equal(t, "p2", opts.Password)
 		assert.Equal(t, 3, opts.DB)
+	})
+
+	t.Run("config overrides url db to 0", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			URL: "redis://127.0.0.1:6379/1",
+			DB:  intPtr(0),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		assert.Equal(t, 0, opts.DB)
 	})
 
 	t.Run("redis url without credentials", func(t *testing.T) {
@@ -615,7 +629,7 @@ func TestNewRedisOptions(t *testing.T) {
 			TLS:      true,
 			Username: "user",
 			Password: "pass",
-			DB:       5,
+			DB:       intPtr(5),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "127.0.0.1:6379", opts.Addr)

--- a/internal/pkg/xcache/cache_test.go
+++ b/internal/pkg/xcache/cache_test.go
@@ -484,3 +484,147 @@ func TestSeparateExpirationConfig(t *testing.T) {
 	// since the two-level cache behavior is complex, but we can verify the
 	// configuration is accepted and the cache works
 }
+
+func TestNewRedisOptions(t *testing.T) {
+	t.Run("plain addr with tls flag", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr: "127.0.0.1:6379",
+			TLS:  true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		require.NotNil(t, opts.TLSConfig)
+		assert.False(t, opts.TLSConfig.InsecureSkipVerify)
+	})
+
+	t.Run("rediss url auto tls and db", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr:                  "rediss://user:pass@localhost:6380/2",
+			TLSInsecureSkipVerify: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "localhost:6380", opts.Addr)
+		assert.Equal(t, "user", opts.Username)
+		assert.Equal(t, "pass", opts.Password)
+		assert.Equal(t, 2, opts.DB)
+		require.NotNil(t, opts.TLSConfig)
+		assert.True(t, opts.TLSConfig.InsecureSkipVerify)
+	})
+
+	t.Run("config overrides url credentials and db", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr:     "redis://u1:p1@127.0.0.1:6379/1",
+			Username: "u2",
+			Password: "p2",
+			DB:       3,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		assert.Equal(t, "u2", opts.Username)
+		assert.Equal(t, "p2", opts.Password)
+		assert.Equal(t, 3, opts.DB)
+	})
+
+	t.Run("redis url without credentials", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr: "redis://127.0.0.1:6379",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		assert.Empty(t, opts.Username)
+		assert.Empty(t, opts.Password)
+		assert.Equal(t, 0, opts.DB)
+	})
+
+	t.Run("plain addr without tls", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr: "127.0.0.1:6379",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		assert.Nil(t, opts.TLSConfig)
+	})
+
+	t.Run("plain addr with insecure skip verify only", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr:                  "127.0.0.1:6379",
+			TLSInsecureSkipVerify: true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tls_insecure_skip_verify requires TLS to be enabled")
+	})
+
+	t.Run("empty addr", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr: "",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "redis addr is empty")
+	})
+
+	t.Run("whitespace only addr", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr: "   ",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "redis addr is empty")
+	})
+
+	t.Run("invalid scheme", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{Addr: "http://example.com"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported redis scheme")
+	})
+
+	t.Run("redis url with invalid db", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr: "redis://127.0.0.1:6379/invalid",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid redis db in url")
+	})
+
+	t.Run("redis url missing host", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr: "redis://",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "redis url missing host")
+	})
+
+	t.Run("invalid url format", func(t *testing.T) {
+		_, err := newRedisOptions(RedisConfig{
+			Addr: "redis://:invalid",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("plain addr with tls config", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr:                  "127.0.0.1:6379",
+			TLS:                   true,
+			TLSInsecureSkipVerify: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		require.NotNil(t, opts.TLSConfig)
+		assert.True(t, opts.TLSConfig.InsecureSkipVerify)
+	})
+
+	t.Run("redis url with explicit tls flag", func(t *testing.T) {
+		opts, err := newRedisOptions(RedisConfig{
+			Addr:     "redis://127.0.0.1:6379",
+			TLS:      true,
+			Username: "user",
+			Password: "pass",
+			DB:       5,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:6379", opts.Addr)
+		assert.Equal(t, "user", opts.Username)
+		assert.Equal(t, "pass", opts.Password)
+		assert.Equal(t, 5, opts.DB)
+		require.NotNil(t, opts.TLSConfig)
+		assert.False(t, opts.TLSConfig.InsecureSkipVerify)
+	})
+}

--- a/internal/pkg/xcache/config.go
+++ b/internal/pkg/xcache/config.go
@@ -24,9 +24,11 @@ type MemoryConfig struct {
 }
 
 type RedisConfig struct {
-	Addr       string        `conf:"addr" yaml:"addr" json:"addr"`
-	Username   string        `conf:"username" yaml:"username" json:"username"`
-	Password   string        `conf:"password" yaml:"password" json:"password"`
-	DB         int           `conf:"db" yaml:"db" json:"db"`
-	Expiration time.Duration `conf:"expiration" yaml:"expiration" json:"expiration"`
+	Addr                  string        `conf:"addr" yaml:"addr" json:"addr"`
+	Username              string        `conf:"username" yaml:"username" json:"username"`
+	Password              string        `conf:"password" yaml:"password" json:"password"`
+	DB                    int           `conf:"db" yaml:"db" json:"db"`
+	TLS                   bool          `conf:"tls" yaml:"tls" json:"tls"`
+	TLSInsecureSkipVerify bool          `conf:"tls_insecure_skip_verify" yaml:"tls_insecure_skip_verify" json:"tls_insecure_skip_verify"`
+	Expiration            time.Duration `conf:"expiration" yaml:"expiration" json:"expiration"`
 }

--- a/internal/pkg/xcache/config.go
+++ b/internal/pkg/xcache/config.go
@@ -25,6 +25,7 @@ type MemoryConfig struct {
 
 type RedisConfig struct {
 	Addr                  string        `conf:"addr" yaml:"addr" json:"addr"`
+	URL                   string        `conf:"url" yaml:"url" json:"url"`
 	Username              string        `conf:"username" yaml:"username" json:"username"`
 	Password              string        `conf:"password" yaml:"password" json:"password"`
 	DB                    int           `conf:"db" yaml:"db" json:"db"`

--- a/internal/pkg/xcache/config.go
+++ b/internal/pkg/xcache/config.go
@@ -28,7 +28,7 @@ type RedisConfig struct {
 	URL                   string        `conf:"url" yaml:"url" json:"url"`
 	Username              string        `conf:"username" yaml:"username" json:"username"`
 	Password              string        `conf:"password" yaml:"password" json:"password"`
-	DB                    int           `conf:"db" yaml:"db" json:"db"`
+	DB                    *int          `conf:"db" yaml:"db" json:"db"`
 	TLS                   bool          `conf:"tls" yaml:"tls" json:"tls"`
 	TLSInsecureSkipVerify bool          `conf:"tls_insecure_skip_verify" yaml:"tls_insecure_skip_verify" json:"tls_insecure_skip_verify"`
 	Expiration            time.Duration `conf:"expiration" yaml:"expiration" json:"expiration"`


### PR DESCRIPTION
## Summary

This PR adds comprehensive Redis TLS support and flexible URL-based configuration for the cache system.

### Key Features

**1. Flexible Redis Connection Configuration**
- Support for traditional `addr` mode (host:port)
- Support for new `url` mode (redis:// or rediss://)
- URL mode takes priority and can include complete authentication information

**2. TLS Support**
- `rediss://` URLs automatically enable TLS
- Manual TLS enablement via `tls` flag
- Support for `tls_insecure_skip_verify` to skip certificate verification

**3. Configuration Override Mechanism**
- Authentication information in URLs can be overridden by configuration fields
- Flexible configuration priority: explicit config > URL parameters > defaults

**4. Robust Error Handling**
- Empty address and URL detection
- Whitespace handling (trim and validate)
- Invalid URL format detection
- TLS configuration conflict detection

### Changes

- **internal/pkg/xcache/config.go**: Added `URL` field to `RedisConfig` structure
- **internal/pkg/xcache/cache.go**: Updated `newRedisOptions` function with URL priority logic and whitespace handling
- **internal/pkg/xcache/cache_test.go**: Comprehensive test coverage for all URL and TLS scenarios
- **conf/conf.go**: Added default value for `cache.redis.url`
- **config.example.yml**: Complete documentation and examples for URL configuration

### Testing

All 23 test cases pass, including:
- Basic memory cache tests
- Redis connection tests
- Two-level cache tests
- URL mode tests (redis:// and rediss://)
- TLS configuration tests
- Error handling tests
- Configuration override tests

### Configuration Example

```yaml
cache:
  mode: redis
  redis:
    # Option 1: Traditional address mode
    addr: "127.0.0.1:6379"
    tls: true
    
    # Option 2: URL mode (takes priority)
    url: "rediss://user:pass@localhost:6380/2"
    
    # Optional overrides
    username: "override_user"
    password: "override_pass"
    db: 3
```

### Backward Compatibility

This change is fully backward compatible. Existing configurations using `addr` will continue to work without any modifications.

<img width="318" height="180" alt="image" src="https://github.com/user-attachments/assets/7d917d70-e5e8-44c9-bdd6-8a6c822bfeaf" />
<img width="1188" height="320" alt="image" src="https://github.com/user-attachments/assets/c92a18aa-6632-4685-a3e2-9969ab2e7cb4" />
