### PR TITLE
fix: ensure channel override headers are applied

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -160,7 +160,7 @@ func (c *Channel) chooseModelInternal(model string) (string, error) {
 // GetOverrideParameters returns the cached override parameters for the channel.
 // If the parameters haven't been parsed yet, it parses and caches them.
 func (c *Channel) GetOverrideParameters() map[string]any {
-	if c.CachedOverrideParams != nil && len(c.CachedOverrideParams) > 0 {
+	if c.CachedOverrideParams != nil {
 		return c.CachedOverrideParams
 	}
 
@@ -189,7 +189,7 @@ func (c *Channel) GetOverrideParameters() map[string]any {
 // GetOverrideHeaders returns the cached override headers for the channel.
 // If the headers haven't been loaded yet, it loads and caches them.
 func (c *Channel) GetOverrideHeaders() []objects.HeaderEntry {
-	if c.CachedOverrideHeaders != nil && len(c.CachedOverrideHeaders) > 0 {
+	if c.CachedOverrideHeaders != nil {
 		return c.CachedOverrideHeaders
 	}
 

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -160,7 +160,7 @@ func (c *Channel) chooseModelInternal(model string) (string, error) {
 // GetOverrideParameters returns the cached override parameters for the channel.
 // If the parameters haven't been parsed yet, it parses and caches them.
 func (c *Channel) GetOverrideParameters() map[string]any {
-	if c.CachedOverrideParams != nil {
+	if c.CachedOverrideParams != nil && len(c.CachedOverrideParams) > 0 {
 		return c.CachedOverrideParams
 	}
 
@@ -189,7 +189,7 @@ func (c *Channel) GetOverrideParameters() map[string]any {
 // GetOverrideHeaders returns the cached override headers for the channel.
 // If the headers haven't been loaded yet, it loads and caches them.
 func (c *Channel) GetOverrideHeaders() []objects.HeaderEntry {
-	if c.CachedOverrideHeaders != nil {
+	if c.CachedOverrideHeaders != nil && len(c.CachedOverrideHeaders) > 0 {
 		return c.CachedOverrideHeaders
 	}
 
@@ -223,13 +223,11 @@ func buildChannelWithTransformer(
 	httpClient *httpclient.HttpClient,
 ) *Channel {
 	return &Channel{
-		Channel:               c,
-		Outbound:              transformer,
-		HTTPClient:            httpClient,
-		CachedOverrideParams:  make(map[string]any),
-		CachedOverrideHeaders: make([]objects.HeaderEntry, 0),
-		modelSupportCache:     xmap.New[string, bool](),
-		chooseModelCache:      xmap.New[string, chooseModelResult](),
+		Channel:           c,
+		Outbound:          transformer,
+		HTTPClient:        httpClient,
+		modelSupportCache: xmap.New[string, bool](),
+		chooseModelCache:  xmap.New[string, chooseModelResult](),
 	}
 }
 

--- a/internal/server/chat/outbound_test.go
+++ b/internal/server/chat/outbound_test.go
@@ -976,7 +976,7 @@ func TestOverrideHeadersMiddleware_EmptyOverrideHeaders(t *testing.T) {
 	assert.Equal(t, httpRequest.Headers, modifiedRequest.Headers)
 }
 
-func TestOverrideHeadersMiddleware_PreserveExistingAuth(t *testing.T) {
+func TestOverrideHeadersMiddleware_OverrideExistingAuth(t *testing.T) {
 	ctx := context.Background()
 
 	channel := &biz.Channel{


### PR DESCRIPTION
  - 根因：12-07 提交 776ad817 在 Channel 构造时把覆盖头/参数缓存预置为空，GetOverrideHeaders/Parameters 看到缓存非 nil就直接返回，导致配置的自定义认证头（如 cf-aig-authorization）未发送，Cloudflare/OpenRouter 401。
```
Request failed: Unauthorized, error: Unauthorized, type: api_error
```
  - 修复：仅在缓存非空时复用，否则从配置加载并缓存；逻辑保持不变。
  - 影响：所有使用 OverrideHeaders/OverrideParameters 的渠道，尤其自定义鉴权头场景。
  - 测试：go test ./internal/server/chat -run OverrideHeaders ✅