### PR TITLE
fix: :bug: anthropic think encryption

### DIFF
--- a/internal/llm/pipeline/integration_test.go
+++ b/internal/llm/pipeline/integration_test.go
@@ -162,7 +162,7 @@ func TestPipeline_OpenAI_to_Anthropic(t *testing.T) {
 		Content: []anthropic.MessageContentBlock{
 			{
 				Type: "text",
-				Text: "Hello! I'm Claude, how can I assist you today?",
+				Text: lo.ToPtr("Hello! I'm Claude, how can I assist you today?"),
 			},
 		},
 		Model:      "claude-3-sonnet-20240229",
@@ -373,7 +373,7 @@ func TestPipeline_Anthropic_to_Anthropic(t *testing.T) {
 		Content: []anthropic.MessageContentBlock{
 			{
 				Type: "text",
-				Text: "Hello! I'm Claude, nice to meet you!",
+				Text: lo.ToPtr("Hello! I'm Claude, nice to meet you!"),
 			},
 		},
 		Model:      "claude-3-sonnet-20240229",

--- a/internal/llm/transformer/anthropic/aggregator.go
+++ b/internal/llm/transformer/anthropic/aggregator.go
@@ -54,27 +54,38 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		case "content_block_delta":
 			if event.Index != nil {
 				index := int(*event.Index)
-				// Ensure we have enough content blocks
-				for len(contentBlocks) <= index {
-					contentBlocks = append(contentBlocks, MessageContentBlock{Type: "text", Text: ""})
+			// Ensure we have enough content blocks
+			for len(contentBlocks) <= index {
+				emptyText := ""
+				contentBlocks = append(contentBlocks, MessageContentBlock{Type: "text", Text: &emptyText})
+			}
+
+			if event.Delta != nil {
+				if event.Delta.Text != nil {
+					if contentBlocks[index].Type == "text" {
+						if contentBlocks[index].Text == nil {
+							contentBlocks[index].Text = event.Delta.Text
+						} else {
+							newText := *contentBlocks[index].Text + *event.Delta.Text
+							contentBlocks[index].Text = &newText
+						}
+					}
 				}
 
-				if event.Delta != nil {
-					if event.Delta.Text != nil {
-						if contentBlocks[index].Type == "text" {
-							contentBlocks[index].Text += *event.Delta.Text
-						}
-					}
-
-					if event.Delta.Thinking != nil {
-						if contentBlocks[index].Type == "thinking" {
-							contentBlocks[index].Thinking += *event.Delta.Thinking
+				if event.Delta.Thinking != nil {
+					if contentBlocks[index].Type == "thinking" {
+						if contentBlocks[index].Thinking == nil {
+							contentBlocks[index].Thinking = event.Delta.Thinking
 						} else {
-							// Convert to thinking block if it's not already
-							contentBlocks[index].Type = "thinking"
-							contentBlocks[index].Thinking = *event.Delta.Thinking
+							newThinking := *contentBlocks[index].Thinking + *event.Delta.Thinking
+							contentBlocks[index].Thinking = &newThinking
 						}
+					} else {
+						// Convert to thinking block if it's not already
+						contentBlocks[index].Type = "thinking"
+						contentBlocks[index].Thinking = event.Delta.Thinking
 					}
+				}
 
 					if event.Delta.Signature != nil {
 						// Handle signature delta - append to thinking block signature
@@ -96,7 +107,12 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 								contentBlocks[index].Input = append(contentBlocks[index].Input, []byte(*event.Delta.PartialJSON)...)
 							}
 						case "text":
-							contentBlocks[index].Text += *event.Delta.PartialJSON
+							if contentBlocks[index].Text == nil {
+								contentBlocks[index].Text = event.Delta.PartialJSON
+							} else {
+								newText := *contentBlocks[index].Text + *event.Delta.PartialJSON
+								contentBlocks[index].Text = &newText
+							}
 						}
 					}
 				}
@@ -160,8 +176,9 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 	if messageStart != nil {
 		// Ensure we have at least one content block
 		if len(contentBlocks) == 0 {
+			emptyText := ""
 			contentBlocks = []MessageContentBlock{
-				{Type: "text", Text: ""},
+				{Type: "text", Text: &emptyText},
 			}
 		}
 
@@ -177,8 +194,9 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 	} else {
 		// Ensure we have at least one content block
 		if len(contentBlocks) == 0 {
+			emptyText := ""
 			contentBlocks = []MessageContentBlock{
-				{Type: "text", Text: ""},
+				{Type: "text", Text: &emptyText},
 			}
 		}
 

--- a/internal/llm/transformer/anthropic/inbound_convert.go
+++ b/internal/llm/transformer/anthropic/inbound_convert.go
@@ -91,8 +91,8 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 				switch block.Type {
 				case "thinking":
 					// Keep thinking content in MultipleContent to preserve order
-					if block.Thinking != "" {
-						reasoningContent = block.Thinking
+					if block.Thinking != nil && *block.Thinking != "" {
+						reasoningContent = *block.Thinking
 						hasReasoningInContent = true
 					}
 
@@ -102,7 +102,7 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 				case "text":
 					contentParts = append(contentParts, llm.MessageContentPart{
 						Type:         "text",
-						Text:         &block.Text,
+						Text:         block.Text,
 						CacheControl: convertToLLMCacheControl(block.CacheControl),
 					})
 					hasContent = true
@@ -151,7 +151,7 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 								if contentBlock.Type == "text" {
 									toolContentParts = append(toolContentParts, llm.MessageContentPart{
 										Type: "text",
-										Text: &contentBlock.Text,
+										Text: contentBlock.Text,
 									})
 								}
 							}
@@ -288,7 +288,7 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 			if message.ReasoningContent != nil && *message.ReasoningContent != "" {
 				thinkingBlock := MessageContentBlock{
 					Type:     "thinking",
-					Thinking: *message.ReasoningContent,
+					Thinking: message.ReasoningContent,
 				}
 				if message.ReasoningSignature != nil && *message.ReasoningSignature != "" {
 					thinkingBlock.Signature = *message.ReasoningSignature
@@ -303,7 +303,7 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 			if message.Content.Content != nil && *message.Content.Content != "" {
 				contentBlocks = append(contentBlocks, MessageContentBlock{
 					Type: "text",
-					Text: *message.Content.Content,
+					Text: message.Content.Content,
 				})
 			} else if len(message.Content.MultipleContent) > 0 {
 				for _, part := range message.Content.MultipleContent {
@@ -312,7 +312,7 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 						if part.Text != nil {
 							contentBlocks = append(contentBlocks, MessageContentBlock{
 								Type: "text",
-								Text: *part.Text,
+								Text: part.Text,
 							})
 						}
 					case "image_url":

--- a/internal/llm/transformer/anthropic/inbound_convert.go
+++ b/internal/llm/transformer/anthropic/inbound_convert.go
@@ -293,7 +293,9 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 				if message.ReasoningSignature != nil && *message.ReasoningSignature != "" {
 					thinkingBlock.Signature = *message.ReasoningSignature
 				}
-
+				if thinkingBlock.Signature == "" {
+					thinkingBlock.Signature = "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB"
+				}
 				contentBlocks = append(contentBlocks, thinkingBlock)
 			}
 

--- a/internal/llm/transformer/anthropic/inbound_stream.go
+++ b/internal/llm/transformer/anthropic/inbound_stream.go
@@ -162,15 +162,15 @@ func (s *anthropicInboundStream) Next() bool {
 			if !s.hasThinkingContentStarted {
 				s.hasThinkingContentStarted = true
 
-				streamEvent := StreamEvent{
-					Type:  "content_block_start",
-					Index: &s.contentIndex,
-					ContentBlock: &MessageContentBlock{
-						Type:      "thinking",
-						Thinking:  "",
-						Signature: "",
-					},
-				}
+			streamEvent := StreamEvent{
+				Type:  "content_block_start",
+				Index: &s.contentIndex,
+				ContentBlock: &MessageContentBlock{
+					Type:      "thinking",
+					Thinking:  lo.ToPtr(""),
+					Signature: "",
+				},
+			}
 
 				err := s.enqueEvent(&streamEvent)
 				if err != nil {
@@ -254,14 +254,14 @@ func (s *anthropicInboundStream) Next() bool {
 			if !s.hasTextContentStarted {
 				s.hasTextContentStarted = true
 
-				streamEvent := StreamEvent{
-					Type:  "content_block_start",
-					Index: &s.contentIndex,
-					ContentBlock: &MessageContentBlock{
-						Type: "text",
-						Text: "",
-					},
-				}
+			streamEvent := StreamEvent{
+				Type:  "content_block_start",
+				Index: &s.contentIndex,
+				ContentBlock: &MessageContentBlock{
+					Type: "text",
+					Text: lo.ToPtr(""),
+				},
+			}
 
 				err := s.enqueEvent(&streamEvent)
 				if err != nil {

--- a/internal/llm/transformer/anthropic/inbound_test.go
+++ b/internal/llm/transformer/anthropic/inbound_test.go
@@ -1241,15 +1241,15 @@ func TestAnthropicMessageContent_MarshalUnmarshal(t *testing.T) {
 			jsonStr: `"Hello, world!"`,
 		},
 		{
-			name: "array content",
-			content: MessageContent{
-				MultipleContent: []MessageContentBlock{
-					{
-						Type: "text",
-						Text: "Hello",
-					},
+		name: "array content",
+		content: MessageContent{
+			MultipleContent: []MessageContentBlock{
+				{
+					Type: "text",
+					Text: lo.ToPtr("Hello"),
 				},
 			},
+		},
 			jsonStr: `[{"type":"text","text":"Hello"}]`,
 		},
 	}

--- a/internal/llm/transformer/anthropic/integration_test.go
+++ b/internal/llm/transformer/anthropic/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/pkg/httpclient"
@@ -128,12 +129,12 @@ func TestAnthropicTransformers_Integration(t *testing.T) {
 				ID:   "msg_test_123",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{
-						Type: "text",
-						Text: "This is a test response from Claude.",
-					},
+			Content: []MessageContentBlock{
+				{
+					Type: "text",
+					Text: lo.ToPtr("This is a test response from Claude."),
 				},
+			},
 				Model:      tt.expectedModel,
 				StopReason: func() *string { s := "end_turn"; return &s }(),
 				Usage: &Usage{

--- a/internal/llm/transformer/anthropic/model.go
+++ b/internal/llm/transformer/anthropic/model.go
@@ -195,12 +195,12 @@ func (m MessageContent) ExtractTrivalBlocks(cacheControl *CacheControl) []Messag
 	if m.Content != nil && *m.Content != "" {
 		contentBlocks = append(contentBlocks, MessageContentBlock{
 			Type:         "text",
-			Text:         *m.Content,
+			Text:         m.Content,
 			CacheControl: cacheControl,
 		})
 	} else if len(m.MultipleContent) > 0 {
 		for _, part := range m.MultipleContent {
-			if part.Type == "text" && part.Text != "" {
+			if part.Type == "text" && part.Text != nil && *part.Text != "" {
 				contentBlocks = append(contentBlocks, part)
 			}
 
@@ -251,10 +251,10 @@ type MessageContentBlock struct {
 	Type string `json:"type"`
 
 	// Text will be present if type is "text".
-	Text string `json:"text,omitempty"`
+	Text *string `json:"text,omitempty"`
 
 	// Thinking will be present if type is "thinking".
-	Thinking string `json:"thinking,omitempty"`
+	Thinking *string `json:"thinking,omitempty"`
 
 	// Signature will be present if type is "thinking".
 	Signature string `json:"signature,omitempty"`

--- a/internal/llm/transformer/anthropic/outbound_convert.go
+++ b/internal/llm/transformer/anthropic/outbound_convert.go
@@ -253,7 +253,7 @@ func buildPreBlocks(msg llm.Message) []MessageContentBlock {
 	if msg.Content.Content != nil && *msg.Content.Content != "" {
 		blocks = append(blocks, MessageContentBlock{
 			Type:         "text",
-			Text:         *msg.Content.Content,
+			Text:         msg.Content.Content,
 			CacheControl: convertToAnthropicCacheControl(msg.CacheControl),
 		})
 	}
@@ -264,7 +264,7 @@ func buildPreBlocks(msg llm.Message) []MessageContentBlock {
 // buildContentFromBlocks converts blocks to MessageContent.
 func buildContentFromBlocks(blocks []MessageContentBlock) MessageContent {
 	if len(blocks) == 1 && blocks[0].Type == "text" {
-		return MessageContent{Content: &blocks[0].Text}
+		return MessageContent{Content: blocks[0].Text}
 	}
 
 	return MessageContent{MultipleContent: blocks}
@@ -304,7 +304,7 @@ func buildMultipleContentWithThinking(msg llm.Message) MessageContent {
 
 	blocks = append(blocks, MessageContentBlock{
 		Type:         "text",
-		Text:         *msg.Content.Content,
+		Text:         msg.Content.Content,
 		CacheControl: convertToAnthropicCacheControl(msg.CacheControl),
 	})
 
@@ -319,7 +319,7 @@ func buildThinkingBlock(reasoningContent, reasoningSignature *string) *MessageCo
 
 	block := &MessageContentBlock{
 		Type:     "thinking",
-		Thinking: *reasoningContent,
+		Thinking: reasoningContent,
 	}
 
 	if reasoningSignature != nil && *reasoningSignature != "" {
@@ -378,22 +378,22 @@ func convertToAnthropicTrivialContent(content llm.MessageContent) *MessageConten
 	} else if len(content.MultipleContent) > 0 {
 		blocks := make([]MessageContentBlock, 0, len(content.MultipleContent))
 
-		for _, part := range content.MultipleContent {
-			switch part.Type {
-			case "text":
-				if part.Text != nil {
-					blocks = append(blocks, MessageContentBlock{
-						Type:         "text",
-						Text:         *part.Text,
-						CacheControl: convertToAnthropicCacheControl(part.CacheControl),
-					})
-				}
-			case "image_url":
-				if block, ok := convertImageURLToAnthropicBlock(part); ok {
-					blocks = append(blocks, block)
-				}
+	for _, part := range content.MultipleContent {
+		switch part.Type {
+		case "text":
+			if part.Text != nil {
+				blocks = append(blocks, MessageContentBlock{
+					Type:         "text",
+					Text:         part.Text,
+					CacheControl: convertToAnthropicCacheControl(part.CacheControl),
+				})
+			}
+		case "image_url":
+			if block, ok := convertImageURLToAnthropicBlock(part); ok {
+				blocks = append(blocks, block)
 			}
 		}
+	}
 
 		return &MessageContent{
 			MultipleContent: blocks,
@@ -455,7 +455,7 @@ func convertMultiplePartContent(msg llm.Message) (MessageContent, bool) {
 			if part.Text != nil {
 				blocks = append(blocks, MessageContentBlock{
 					Type:         "text",
-					Text:         *part.Text,
+					Text:         part.Text,
 					CacheControl: convertToAnthropicCacheControl(part.CacheControl),
 				})
 			}
@@ -541,11 +541,11 @@ func convertToLlmResponse(anthropicResp *Message, platformType PlatformType) *ll
 	for _, block := range anthropicResp.Content {
 		switch block.Type {
 		case "text":
-			if block.Text != "" {
-				textParts = append(textParts, block.Text)
+			if block.Text != nil && *block.Text != "" {
+				textParts = append(textParts, *block.Text)
 				content.MultipleContent = append(content.MultipleContent, llm.MessageContentPart{
 					Type:     "text",
-					Text:     &block.Text,
+					Text:     block.Text,
 					ImageURL: &llm.ImageURL{},
 				})
 			}
@@ -573,7 +573,9 @@ func convertToLlmResponse(anthropicResp *Message, platformType PlatformType) *ll
 				toolCalls = append(toolCalls, toolCall)
 			}
 		case "thinking":
-			thinkingText = block.Thinking
+			if block.Thinking != nil {
+				thinkingText = *block.Thinking
+			}
 			thinkingSignature = block.Signature
 		}
 	}

--- a/internal/llm/transformer/anthropic/outbound_convert_test.go
+++ b/internal/llm/transformer/anthropic/outbound_convert_test.go
@@ -15,12 +15,12 @@ func TestConvertToChatCompletionResponse(t *testing.T) {
 		ID:   "msg_123",
 		Type: "message",
 		Role: "assistant",
-		Content: []MessageContentBlock{
-			{
-				Type: "text",
-				Text: "Hello! How can I help you?",
-			},
+	Content: []MessageContentBlock{
+		{
+			Type: "text",
+			Text: lo.ToPtr("Hello! How can I help you?"),
 		},
+	},
 		Model:      "claude-3-sonnet-20240229",
 		StopReason: func() *string { s := "end_turn"; return &s }(),
 		Usage: &Usage{
@@ -193,11 +193,11 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_multi",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{Type: "text", Text: "Hello"},
-					{Type: "text", Text: " world!"},
-					{Type: "text", Text: " How are you?"},
-				},
+			Content: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("Hello")},
+				{Type: "text", Text: lo.ToPtr(" world!")},
+				{Type: "text", Text: lo.ToPtr(" How are you?")},
+			},
 				Model: "claude-3-sonnet-20240229",
 			},
 			validate: func(t *testing.T, result *llm.Response) {
@@ -217,15 +217,15 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_mixed",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{Type: "text", Text: "Check this image: "},
-					{Type: "image", Source: &ImageSource{
-						Type:      "base64",
-						MediaType: "image/jpeg",
-						Data:      "/9j/4AAQSkZJRg==",
-					}},
-					{Type: "text", Text: " and this text"},
-				},
+			Content: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("Check this image: ")},
+				{Type: "image", Source: &ImageSource{
+					Type:      "base64",
+					MediaType: "image/jpeg",
+					Data:      "/9j/4AAQSkZJRg==",
+				}},
+				{Type: "text", Text: lo.ToPtr(" and this text")},
+			},
 				Model: "claude-3-sonnet-20240229",
 			},
 			validate: func(t *testing.T, result *llm.Response) {
@@ -244,18 +244,18 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_tool",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{
-						Type: "text",
-						Text: "I'll help you with that calculation.",
-					},
-					{
-						Type:  "tool_use",
-						ID:    "tool_123",
-						Name:  lo.ToPtr("calculator"),
-						Input: json.RawMessage(`{"expression": "2+2"}`),
-					},
+			Content: []MessageContentBlock{
+				{
+					Type: "text",
+					Text: lo.ToPtr("I'll help you with that calculation."),
 				},
+				{
+					Type:  "tool_use",
+					ID:    "tool_123",
+					Name:  lo.ToPtr("calculator"),
+					Input: json.RawMessage(`{"expression": "2+2"}`),
+				},
+			},
 				Model: "claude-3-sonnet-20240229",
 			},
 			validate: func(t *testing.T, result *llm.Response) {
@@ -279,7 +279,7 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 					ID:      "msg_stop",
 					Type:    "message",
 					Role:    "assistant",
-					Content: []MessageContentBlock{{Type: "text", Text: "Test"}},
+					Content: []MessageContentBlock{{Type: "text", Text: lo.ToPtr("Test")}},
 					Model:   "claude-3-sonnet-20240229",
 				}
 			}(),
@@ -296,14 +296,14 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				}
 
 				for anthropicReason, expectedReason := range stopReasons {
-					msg := &Message{
-						ID:         "msg_stop",
-						Type:       "message",
-						Role:       "assistant",
-						Content:    []MessageContentBlock{{Type: "text", Text: "Test"}},
-						Model:      "claude-3-sonnet-20240229",
-						StopReason: lo.ToPtr(anthropicReason),
-					}
+				msg := &Message{
+					ID:         "msg_stop",
+					Type:       "message",
+					Role:       "assistant",
+					Content:    []MessageContentBlock{{Type: "text", Text: lo.ToPtr("Test")}},
+					Model:      "claude-3-sonnet-20240229",
+					StopReason: lo.ToPtr(anthropicReason),
+				}
 
 					result := convertToLlmResponse(msg, PlatformDirect)
 					if expectedReason == "stop" {
@@ -320,9 +320,9 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_cache",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{Type: "text", Text: "Cached response"},
-				},
+			Content: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("Cached response")},
+			},
 				Model: "claude-3-sonnet-20240229",
 				Usage: &Usage{
 					InputTokens:              100,
@@ -347,9 +347,9 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_detailed",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{Type: "text", Text: "Detailed response"},
-				},
+			Content: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("Detailed response")},
+			},
 				Model: "claude-3-sonnet-20240229",
 				Usage: &Usage{
 					InputTokens:              200,
@@ -376,9 +376,9 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:   "msg_no_cache",
 				Type: "message",
 				Role: "assistant",
-				Content: []MessageContentBlock{
-					{Type: "text", Text: "No cache response"},
-				},
+			Content: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("No cache response")},
+			},
 				Model: "claude-3-sonnet-20240229",
 				Usage: &Usage{
 					InputTokens:              80,
@@ -402,7 +402,7 @@ func TestConvertToChatCompletionResponse_EdgeCases(t *testing.T) {
 				ID:      "msg_nusage",
 				Type:    "message",
 				Role:    "assistant",
-				Content: []MessageContentBlock{{Type: "text", Text: "No usage"}},
+				Content: []MessageContentBlock{{Type: "text", Text: lo.ToPtr("No usage")}},
 				Model:   "claude-3-sonnet-20240229",
 				Usage:   nil,
 			},
@@ -524,10 +524,10 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 						Role: "user",
 						Content: MessageContent{
 							MultipleContent: []MessageContentBlock{
-								{
-									Type: "text",
-									Text: "What's in this image?",
-								},
+							{
+								Type: "text",
+								Text: lo.ToPtr("What's in this image?"),
+							},
 								{
 									Type: "image",
 									Source: &ImageSource{
@@ -589,10 +589,10 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 						Role: "user",
 						Content: MessageContent{
 							MultipleContent: []MessageContentBlock{
-								{
-									Type: "text",
-									Text: "Compare these two images:",
-								},
+							{
+								Type: "text",
+								Text: lo.ToPtr("Compare these two images:"),
+							},
 								{
 									Type: "image",
 									Source: &ImageSource{
@@ -601,10 +601,10 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 										Data:      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
 									},
 								},
-								{
-									Type: "text",
-									Text: "and",
-								},
+							{
+								Type: "text",
+								Text: lo.ToPtr("and"),
+							},
 								{
 									Type: "image",
 									Source: &ImageSource{
@@ -613,10 +613,10 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 										Data:      "UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA",
 									},
 								},
-								{
-									Type: "text",
-									Text: "What are the differences?",
-								},
+							{
+								Type: "text",
+								Text: lo.ToPtr("What are the differences?"),
+							},
 							},
 						},
 					},
@@ -658,14 +658,14 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 						Role: "assistant",
 						Content: MessageContent{
 							MultipleContent: []MessageContentBlock{
-								{
-									Type:     "thinking",
-									Thinking: "Let me calculate: 2 + 2 = 4",
-								},
-								{
-									Type: "text",
-									Text: "The answer is 4.",
-								},
+							{
+								Type:     "thinking",
+								Thinking: lo.ToPtr("Let me calculate: 2 + 2 = 4"),
+							},
+							{
+								Type: "text",
+								Text: lo.ToPtr("The answer is 4."),
+							},
 							},
 						},
 					},
@@ -712,14 +712,14 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 						Role: "assistant",
 						Content: MessageContent{
 							MultipleContent: []MessageContentBlock{
-								{
-									Type:     "thinking",
-									Thinking: "First, I need to analyze the problem...",
-								},
-								{
-									Type: "text",
-									Text: "Here is the solution.",
-								},
+							{
+								Type:     "thinking",
+								Thinking: lo.ToPtr("First, I need to analyze the problem..."),
+							},
+							{
+								Type: "text",
+								Text: lo.ToPtr("Here is the solution."),
+							},
 							},
 						},
 					},
@@ -771,14 +771,14 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 						Role: "assistant",
 						Content: MessageContent{
 							MultipleContent: []MessageContentBlock{
-								{
-									Type: "text",
-									Text: "I'll use the calculator.",
-								},
-								{
-									Type:     "thinking",
-									Thinking: "I need to use the calculator tool for this.",
-								},
+							{
+								Type: "text",
+								Text: lo.ToPtr("I'll use the calculator."),
+							},
+							{
+								Type:     "thinking",
+								Thinking: lo.ToPtr("I need to use the calculator tool for this."),
+							},
 								{
 									Type: "tool_use",
 									ID:   "call_123",

--- a/internal/llm/transformer/anthropic/thinking_test.go
+++ b/internal/llm/transformer/anthropic/thinking_test.go
@@ -24,10 +24,10 @@ func TestConvertToChatCompletionResponse_WithThinking(t *testing.T) {
 		ID:   "msg_thinking",
 		Type: "message",
 		Role: "assistant",
-		Content: []MessageContentBlock{
-			{Type: "thinking", Thinking: thinking, Signature: signature},
-			{Type: "text", Text: answer},
-		},
+	Content: []MessageContentBlock{
+		{Type: "thinking", Thinking: lo.ToPtr(thinking), Signature: signature},
+		{Type: "text", Text: lo.ToPtr(answer)},
+	},
 		Model: "claude-3-sonnet-20240229",
 	}
 


### PR DESCRIPTION
供应商为openai格式的
当使用 anthropic  的 messages 的 api 向 axonhub 发起非流式请求时,思考内容没有没有 signature 
缺少此字段会导致很多客户端请求失败,我测试了  Cherry Studio 和 AI as Workspace

下图为 Cherry Studio 报错截图,增加 ` "signature": "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB"` 后报错消失可以正常使用

<img width="760" height="211" alt="image" src="https://github.com/user-attachments/assets/10d58109-7d78-45c0-bbe2-907423733a1b" />

https://platform.claude.com/docs/en/build-with-claude/extended-thinking#thinking-encryption

https://github.com/BerriAI/litellm/issues/8964#issuecomment-2702637190