### PR TITLE
新增：支持 API 密钥限定渠道使用功能

### DIFF
--- a/frontend/src/features/apikeys/components/apikeys-view-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-view-dialog.tsx
@@ -1,4 +1,4 @@
-import { Copy, Eye, EyeOff, AlertTriangle } from 'lucide-react'
+import { Copy, Eye, EyeOff, AlertTriangle, Info, Target, MapPin, Lightbulb } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -46,7 +46,7 @@ export function ApiKeysViewDialog() {
           </AlertDescription>
         </Alert>
 
-        <div className="space-y-4">
+        <div className="space-y-4 overflow-auto flex-1">
           <div>
             <label className="text-sm font-medium">{t('apikeys.columns.name')}</label>
             <div className="mt-1 p-3 bg-muted rounded-md">
@@ -82,6 +82,48 @@ export function ApiKeysViewDialog() {
               </Button>
             </div>
           </div>
+
+          <Alert className="border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950">
+            <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            <AlertDescription className="text-blue-800 dark:text-blue-200">
+              <div className="space-y-4">
+                {/* Title and Description */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Target className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <p className="font-semibold">{t('apikeys.dialogs.view.channelUsage.title')}</p>
+                  </div>
+                  <p className="text-sm">{t('apikeys.dialogs.view.channelUsage.description')}</p>
+                </div>
+
+                {/* How to Find ID Section */}
+                <div className="space-y-2 pt-2 border-t border-blue-200 dark:border-blue-800">
+                  <div className="flex items-center gap-2">
+                    <MapPin className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <p className="font-semibold text-sm">{t('apikeys.dialogs.view.channelUsage.howToFindId')}</p>
+                  </div>
+                  <ol className="text-sm space-y-1.5 ml-6 list-decimal">
+                    <li>{t('apikeys.dialogs.view.channelUsage.step1')}</li>
+                    <li>{t('apikeys.dialogs.view.channelUsage.step2')}</li>
+                    <li>{t('apikeys.dialogs.view.channelUsage.step3')}</li>
+                  </ol>
+                </div>
+
+                {/* Example Section */}
+                <div className="space-y-2 pt-2 border-t border-blue-200 dark:border-blue-800">
+                  <div className="flex items-center gap-2">
+                    <Lightbulb className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <p className="font-semibold text-sm">{t('apikeys.dialogs.view.channelUsage.exampleTitle')}</p>
+                  </div>
+                  <div className="p-3 bg-blue-100/50 dark:bg-blue-900/30 rounded-md">
+                    <code className="text-sm break-all font-sans">
+                      {t('apikeys.dialogs.view.channelUsage.example', { key: selectedApiKey?.key || 'your-api-key' })}
+                    </code>
+                  </div>
+                </div>
+              </div>
+            </AlertDescription>
+          </Alert>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -22,6 +22,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Badge } from '@/components/ui/badge'
 import { ServerSidePagination } from '@/components/server-side-pagination'
 import { formatDuration } from '@/utils/format-duration'
+import { extractNumberID } from '@/lib/utils'
 import { useChannels } from '../context/channels-context'
 import { Channel, ChannelConnection } from '../data/schema'
 import { CHANNEL_CONFIGS } from '../data/config_channels'
@@ -288,6 +289,10 @@ export function ChannelsTable({
                               <div className='space-y-3'>
                                 <h4 className='text-sm font-semibold'>{t('channels.expandedRow.basicInfo')}</h4>
                                 <div className='space-y-2 text-sm'>
+                                  <div className='flex justify-between items-center'>
+                                    <span className='text-muted-foreground'>{t('channels.expandedRow.channelId')}:</span>
+                                    <span className='font-mono text-xs'>#{extractNumberID(channel.id)}</span>
+                                  </div>
                                   <div className='flex justify-between gap-4'>
                                     <span className='text-muted-foreground shrink-0'>{t('channels.columns.baseURL')}:</span>
                                     <span className='font-mono text-xs break-all text-right'>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -316,7 +316,17 @@
       "view": {
         "title": "View API Key",
         "description": "View the complete API key details.",
-        "warning": "⚠️ Keep your API key secure and do not share it with unauthorized parties. Anyone with access to this key can make requests on your behalf."
+        "warning": "⚠️ Keep your API key secure and do not share it with unauthorized parties. Anyone with access to this key can make requests on your behalf.",
+        "channelUsage": {
+          "title": "Specify Channel by ID",
+          "description": "You can specify a particular channel to use by appending #channelID to your API key. This will restrict requests to use only that specific channel.",
+          "howToFindId": "How to Find Channel ID?",
+          "step1": "Go to the Channels management page",
+          "step2": "Click the expand button on the left side of the channel you want to use",
+          "step3": "View the Channel ID in the expanded Basic Info section (displayed as: #123)",
+          "exampleTitle": "Usage Example",
+          "example": "{{key}}#10"
+        }
       },
       "bulkDisable": {
         "title": "Bulk Disable API Keys",
@@ -1045,6 +1055,7 @@
     },
     "expandedRow": {
       "basicInfo": "Basic Information",
+      "channelId": "Channel ID",
       "performance": "Performance",
       "modelsAndRemark": "Models & Remark",
       "modelInfo": "Model Information",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -339,7 +339,17 @@
       "view": {
         "title": "查看 API 密钥",
         "description": "查看完整的 API 密钥详情。",
-        "warning": "  请妥善保管您的 API 密钥，不要与未授权的人员分享。任何拥有此密钥的人都可以代表您发出请求。"
+        "warning": "  请妥善保管您的 API 密钥，不要与未授权的人员分享。任何拥有此密钥的人都可以代表您发出请求。",
+        "channelUsage": {
+          "title": "指定渠道ID使用",
+          "description": "您可以通过在 API 密钥后面添加 #渠道ID 的方式指定使用特定渠道。这将限制请求仅使用该指定的渠道。",
+          "howToFindId": "如何查找渠道ID？",
+          "step1": "前往渠道管理页面",
+          "step2": "点击要使用的渠道左侧的展开按钮",
+          "step3": "在展开的基本信息中查看渠道ID（显示格式如：#123）",
+          "exampleTitle": "使用示例",
+          "example": "{{key}}#10"
+        }
       },
       "bulkDisable": {
         "title": "批量禁用 API Keys",
@@ -1074,6 +1084,7 @@
     },
     "expandedRow": {
       "basicInfo": "基本信息",
+      "channelId": "渠道ID",
       "performance": "性能",
       "modelsAndRemark": "模型与备注",
       "modelInfo": "模型信息",

--- a/internal/contexts/container.go
+++ b/internal/contexts/container.go
@@ -9,15 +9,16 @@ import (
 
 // contextContainer contains all values in the context.
 type contextContainer struct {
-	ProjectID     *int
-	TraceID       *string
-	RequestID     *string
-	OperationName *string
-	APIKey        *ent.APIKey
-	User          *ent.User
-	Source        *request.Source
-	Thread        *ent.Thread
-	Trace         *ent.Trace
+	ProjectID          *int
+	TraceID            *string
+	RequestID          *string
+	OperationName      *string
+	SpecifiedChannelID *int // API密钥中指定的渠道ID（如：ah-xxx#10）
+	APIKey             *ent.APIKey
+	User               *ent.User
+	Source             *request.Source
+	Thread             *ent.Thread
+	Trace              *ent.Trace
 }
 
 // getContainer retrieves the existing container from context, or creates a new one and stores it in the context if it doesn't exist.

--- a/internal/contexts/context.go
+++ b/internal/contexts/context.go
@@ -123,3 +123,23 @@ func GetProjectID(ctx context.Context) (int, bool) {
 
 	return 0, false
 }
+
+// WithSpecifiedChannelID stores the specified channel ID in the context.
+// 此渠道ID来自API密钥后缀（如：ah-xxx#10），用于限制请求仅使用特定渠道。
+func WithSpecifiedChannelID(ctx context.Context, channelID int) context.Context {
+	container := getContainer(ctx)
+	container.SpecifiedChannelID = &channelID
+
+	return withContainer(ctx, container)
+}
+
+// GetSpecifiedChannelID retrieves the specified channel ID from the context.
+// 返回值：(channelID, found)
+func GetSpecifiedChannelID(ctx context.Context) (int, bool) {
+	container := getContainer(ctx)
+	if container.SpecifiedChannelID != nil {
+		return *container.SpecifiedChannelID, true
+	}
+
+	return 0, false
+}

--- a/internal/server/biz/errors.go
+++ b/internal/server/biz/errors.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	ErrInvalidJWT      = errors.New("invalid jwt token")
-	ErrInvalidAPIKey   = errors.New("invalid api key")
-	ErrInvalidPassword = errors.New("invalid password")
-	ErrInvalidModel    = transformer.ErrInvalidModel
-	ErrInternal        = errors.New("server internal error, please try again later")
+	ErrInvalidJWT           = errors.New("invalid jwt token")
+	ErrInvalidAPIKey        = errors.New("invalid api key")
+	ErrInvalidPassword      = errors.New("invalid password")
+	ErrInvalidModel         = transformer.ErrInvalidModel
+	ErrChannelNotAvailable  = errors.New("specified channel is not available")
+	ErrInternal             = errors.New("server internal error, please try again later")
 )

--- a/internal/server/chat/channels.go
+++ b/internal/server/chat/channels.go
@@ -79,9 +79,9 @@ func (s *SelectedChannelsSelector) Select(ctx context.Context, req *llm.Request)
 
 		// 否则是指定的渠道ID不存在或不支持该模型
 		if len(s.allowedChannelIDs) == 1 {
-			return nil, fmt.Errorf("指定的渠道 ID %d 不可用或不支持模型 %s", s.allowedChannelIDs[0], req.Model)
+			return nil, fmt.Errorf("%w: specified channel ID %d is not available or does not support model %s", biz.ErrChannelNotAvailable, s.allowedChannelIDs[0], req.Model)
 		}
-		return nil, fmt.Errorf("指定的渠道 IDs %v 中没有可用的渠道支持模型 %s", s.allowedChannelIDs, req.Model)
+		return nil, fmt.Errorf("%w: specified channel IDs %v are not available or do not support model %s", biz.ErrChannelNotAvailable, s.allowedChannelIDs, req.Model)
 	}
 
 	return filtered, nil

--- a/internal/server/chat/channels.go
+++ b/internal/server/chat/channels.go
@@ -70,6 +70,20 @@ func (s *SelectedChannelsSelector) Select(ctx context.Context, req *llm.Request)
 		return ok
 	})
 
+	// 验证：如果指定了渠道ID但没有找到匹配的渠道，返回友好的错误信息
+	if len(filtered) == 0 {
+		// 如果原始channels为空，说明模型本身就没有可用渠道
+		if len(channels) == 0 {
+			return nil, fmt.Errorf("%w: no channels available for model %s", biz.ErrInvalidModel, req.Model)
+		}
+
+		// 否则是指定的渠道ID不存在或不支持该模型
+		if len(s.allowedChannelIDs) == 1 {
+			return nil, fmt.Errorf("指定的渠道 ID %d 不可用或不支持模型 %s", s.allowedChannelIDs[0], req.Model)
+		}
+		return nil, fmt.Errorf("指定的渠道 IDs %v 中没有可用的渠道支持模型 %s", s.allowedChannelIDs, req.Model)
+	}
+
 	return filtered, nil
 }
 

--- a/internal/server/chat/channels_test.go
+++ b/internal/server/chat/channels_test.go
@@ -1129,9 +1129,9 @@ func TestSelectedChannelsSelector_SingleChannelNotFound(t *testing.T) {
 	result, err := filteredSelector.Select(ctx, req)
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "指定的渠道 ID")
+	assert.Contains(t, err.Error(), "specified channel ID")
 	assert.Contains(t, err.Error(), "9999")
-	assert.Contains(t, err.Error(), "不可用或不支持模型")
+	assert.Contains(t, err.Error(), "not available or does not support model")
 
 	t.Logf("Error message: %s", err.Error())
 
@@ -1160,8 +1160,8 @@ func TestSelectedChannelsSelector_MultipleChannelsNotFound(t *testing.T) {
 	result, err := filteredSelector.Select(ctx, req)
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "指定的渠道 IDs")
-	assert.Contains(t, err.Error(), "中没有可用的渠道支持模型")
+	assert.Contains(t, err.Error(), "specified channel IDs")
+	assert.Contains(t, err.Error(), "not available or do not support model")
 
 	t.Logf("Error message: %s", err.Error())
 
@@ -1265,14 +1265,14 @@ func TestSelectedChannelsSelector_ValidateErrorMessages(t *testing.T) {
 			channelIDs:    []int{999},
 			model:         "gpt-4",
 			expectError:   true,
-			errorContains: []string{"指定的渠道 ID", "999", "不可用或不支持模型", "gpt-4"},
+			errorContains: []string{"specified channel ID", "999", "not available or does not support model", "gpt-4"},
 		},
 		{
 			name:          "Multiple invalid channels",
 			channelIDs:    []int{998, 999},
 			model:         "gpt-4",
 			expectError:   true,
-			errorContains: []string{"指定的渠道 IDs", "中没有可用的渠道支持模型", "gpt-4"},
+			errorContains: []string{"specified channel IDs", "not available or do not support model", "gpt-4"},
 		},
 		{
 			name:          "Unsupported model",

--- a/internal/server/chat/completion.go
+++ b/internal/server/chat/completion.go
@@ -260,6 +260,8 @@ func getActiveProfile(profiles *objects.APIKeyProfiles) *objects.APIKeyProfile {
 				return &profiles.Profiles[i]
 			}
 		}
+		// 如果指定的 active profile 未找到,返回 nil 避免静默使用错误的 profile
+		return nil
 	}
 
 	// 否则返回第一个profile作为默认

--- a/internal/server/chat/completion_test.go
+++ b/internal/server/chat/completion_test.go
@@ -1081,11 +1081,11 @@ func TestChatCompletionProcessor_WithSpecifiedChannelID_InvalidChannel(t *testin
 
 	// Verify error
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "指定的渠道 ID", "Error should contain Chinese message about specified channel ID")
+	assert.Contains(t, err.Error(), "specified channel ID", "Error should contain message about specified channel ID")
 	assert.Contains(t, err.Error(), "9999", "Error should contain the invalid channel ID")
-	assert.Contains(t, err.Error(), "不可用或不支持模型", "Error should mention channel unavailable or model not supported")
+	assert.Contains(t, err.Error(), "not available or does not support model", "Error should mention channel unavailable or model not supported")
 
-	t.Logf("✅ Correctly returned Chinese error for invalid channel: %v", err)
+	t.Logf("✅ Correctly returned error for invalid channel: %v", err)
 }
 
 // TestChatCompletionProcessor_ChannelPriority_URLOverridesProfile tests that URL-specified

--- a/internal/server/chat/state.go
+++ b/internal/server/chat/state.go
@@ -32,9 +32,10 @@ type PersistenceState struct {
 	RequestExec *ent.RequestExecution
 
 	// Channel state
-	Channels       []*biz.Channel
-	CurrentChannel *biz.Channel
-	ChannelIndex   int
+	Channels          []*biz.Channel
+	CurrentChannel    *biz.Channel
+	ChannelIndex      int
+	AllowedChannelIDs []int // 允许使用的渠道ID列表（来自URL#后缀或Profile配置）
 
 	Perf *biz.PerformanceRecord
 }


### PR DESCRIPTION
## 功能概述

本次更新新增了 API 密钥限定渠道使用功能，允许用户通过在 API 密钥后附加 `#渠道ID` 的方式来限制请求仅使用指定的渠道。

## 主要改进

### 1. API 密钥渠道限定功能
- 支持在 API 密钥后附加 `#渠道ID` 语法（例如：`sk-abc123#10`）
- 限制请求仅使用指定的渠道进行处理
- 提供更精细的 API 访问控制能力

### 2. 用户文档增强
- 在 API 密钥查看对话框中新增详细的使用说明文档
- 采用分层级的视觉结构，包含：
  - 功能标题和描述（使用 Target 图标）
  - 如何查找渠道 ID 的步骤说明（使用 MapPin 图标）
  - 实际使用示例（使用 Lightbulb 图标）
- 提供清晰的三步操作指引

### 3. 渠道管理优化
- 在渠道管理页面的展开行中显示渠道 ID
- 使用 `extractNumberID()` 工具函数格式化显示 ID
- 方便用户快速查找和引用渠道 ID

### 4. 国际化支持
- 完整支持中英文双语
- 新增以下翻译键：
  - `apikeys.dialogs.view.channelUsage.title`
  - `apikeys.dialogs.view.channelUsage.description`
  - `apikeys.dialogs.view.channelUsage.howToFindId`
  - `apikeys.dialogs.view.channelUsage.step1/step2/step3`
  - `apikeys.dialogs.view.channelUsage.exampleTitle`
  - `apikeys.dialogs.view.channelUsage.example`
  - `channels.expandedRow.channelId`

### 5. UI 改进
- 修复 API 密钥查看对话框的内容溢出问题
- 使用 flexbox 布局确保弹性内容区域正常滚动
- 优化视觉层次和信息展示结构

## 技术实现

- 前端组件：`apikeys-view-dialog.tsx`
- 渠道表格：`channels-table.tsx`
- 国际化文件：`en.json`, `zh.json`
- 使用 shadcn/ui 组件库（Alert, Badge 等）
- 使用 lucide-react 图标库

## 测试说明

- 已验证 API 密钥查看对话框的文档显示
- 已验证渠道 ID 在渠道管理页面正确显示
- 已验证中英文翻译完整性

<img width="697" height="250" alt="image" src="https://github.com/user-attachments/assets/d477b4a2-236d-40d1-b5d9-1f79d88774e4" /><br> 
<img width="853" height="489" alt="image" src="https://github.com/user-attachments/assets/2e69c79d-f5e9-4f43-bc26-77e88363e990" />   <br> 
渠道禁用返回<br> 
<img width="566" height="220" alt="image" src="https://github.com/user-attachments/assets/5bc12a38-0391-4b4a-82ff-6b082f4f4c3d" />   <br> 
<img width="740" height="295" alt="image" src="https://github.com/user-attachments/assets/f4db7185-043d-406e-993a-297abda36663" />   <br> 
完善api页面q渠道使用说明<br> 
<img width="734" height="554" alt="image" src="https://github.com/user-attachments/assets/9c511a6b-02fe-4ef9-8e7e-0bd4776b802d" />   <br> 
