### PR TITLE
feat:  restrict channel access via tags for api key profile

### DIFF
--- a/frontend/src/components/ui/tags-input.tsx
+++ b/frontend/src/components/ui/tags-input.tsx
@@ -37,8 +37,9 @@ export const TagsInput = forwardRef<HTMLDivElement, TagsInputProps>(({ value = [
   )
 
   const removeTag = useCallback(
-    (indexToRemove: number) => {
-      onChange(value.filter((_, index) => index !== indexToRemove))
+    (tagToRemove: string) => {
+      // 标签在组件内已去重，按值删除更稳定（避免索引变更导致误删）
+      onChange(value.filter((tag) => tag !== tagToRemove))
     },
     [value, onChange]
   )
@@ -60,12 +61,12 @@ export const TagsInput = forwardRef<HTMLDivElement, TagsInputProps>(({ value = [
       )}
       onClick={() => inputRef.current?.focus()}
     >
-      {value.map((tag, index) => (
-        <div key={index} className='bg-secondary text-secondary-foreground flex items-center gap-1 rounded-sm px-2 py-0.5'>
+      {value.map((tag) => (
+        <div key={tag} className='bg-secondary text-secondary-foreground flex items-center gap-1 rounded-sm px-2 py-0.5'>
           <span className='text-xs'>{tag}</span>
           <button
             type='button'
-            onClick={() => removeTag(index)}
+            onClick={() => removeTag(tag)}
             className='text-secondary-foreground/80 hover:text-secondary-foreground focus:outline-none'
             aria-label={`Remove ${tag} tag`}
           >

--- a/frontend/src/components/ui/tags-input.tsx
+++ b/frontend/src/components/ui/tags-input.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { forwardRef, InputHTMLAttributes, useCallback, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface TagsInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
+  value: string[]
+  onChange: (tags: string[]) => void
+  placeholder?: string
+  className?: string
+}
+
+export const TagsInput = forwardRef<HTMLDivElement, TagsInputProps>(({ value = [], onChange, placeholder, className, ...props }, ref) => {
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value)
+  }, [])
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' || e.key === ',' || e.key === ' ') {
+        e.preventDefault()
+        const newTag = inputValue.trim()
+        if (newTag && !value.includes(newTag)) {
+          onChange([...value, newTag])
+          setInputValue('')
+        }
+      } else if (e.key === 'Backspace' && !inputValue && value.length > 0) {
+        // Remove the last tag when backspace is pressed on empty input
+        onChange(value.slice(0, -1))
+      }
+    },
+    [inputValue, value, onChange]
+  )
+
+  const removeTag = useCallback(
+    (indexToRemove: number) => {
+      onChange(value.filter((_, index) => index !== indexToRemove))
+    },
+    [value, onChange]
+  )
+
+  const handleInputBlur = useCallback(() => {
+    const newTag = inputValue.trim()
+    if (newTag && !value.includes(newTag)) {
+      onChange([...value, newTag])
+    }
+    setInputValue('')
+  }, [inputValue, value, onChange])
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'border-input bg-background ring-offset-background focus-within:ring-ring flex min-h-10 w-full flex-wrap gap-1 rounded-md border px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-offset-2',
+        className
+      )}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {value.map((tag, index) => (
+        <div key={index} className='bg-secondary text-secondary-foreground flex items-center gap-1 rounded-sm px-2 py-0.5'>
+          <span className='text-xs'>{tag}</span>
+          <button
+            type='button'
+            onClick={() => removeTag(index)}
+            className='text-secondary-foreground/80 hover:text-secondary-foreground focus:outline-none'
+            aria-label={`Remove ${tag} tag`}
+          >
+            <X className='h-3 w-3' />
+          </button>
+        </div>
+      ))}
+      <input
+        ref={inputRef}
+        type='text'
+        value={inputValue}
+        onChange={handleInputChange}
+        onKeyDown={handleInputKeyDown}
+        onBlur={handleInputBlur}
+        placeholder={value.length === 0 ? placeholder : ''}
+        className='placeholder:text-muted-foreground min-w-[80px] flex-1 bg-transparent outline-none'
+        {...props}
+      />
+    </div>
+  )
+})
+
+TagsInput.displayName = 'TagsInput'

--- a/frontend/src/features/apikeys/data/apikeys.ts
+++ b/frontend/src/features/apikeys/data/apikeys.ts
@@ -78,6 +78,7 @@ function buildApiKeyQuery(permissions: { canViewUsers: boolean }) {
             name
             modelMappings { from to }
             channelIDs
+            channelTags
           }
         }
       }
@@ -149,6 +150,18 @@ const UPDATE_APIKEY_PROFILES_MUTATION = `
       id
       name
       status
+      profiles {
+        activeProfile
+        profiles {
+          name
+          modelMappings {
+            from
+            to
+          }
+          channelIDs
+          channelTags
+        }
+      }
     }
   }
 `

--- a/frontend/src/features/apikeys/data/schema.ts
+++ b/frontend/src/features/apikeys/data/schema.ts
@@ -28,6 +28,7 @@ export const apiKeySchema = z.object({
             })
           ),
           channelIDs: z.array(z.number()).optional().nullable(),
+          channelTags: z.array(z.string()).optional().nullable(),
         })
       ).nullable(),
     })
@@ -94,6 +95,7 @@ export const apiKeyProfileSchema = z.object({
   name: z.string(),
   modelMappings: z.array(modelMappingSchema),
   channelIDs: z.array(z.number()).optional().nullable(),
+  channelTags: z.array(z.string()).optional().nullable(),
 })
 export type ApiKeyProfile = z.infer<typeof apiKeyProfileSchema>
 
@@ -114,6 +116,7 @@ export const updateApiKeyProfilesInputSchemaFactory = (t: (key: string) => strin
       to: z.string().min(1, t('apikeys.validation.targetModelRequired')),
     })),
     channelIDs: z.array(z.number()).optional().nullable(),
+    channelTags: z.array(z.string()).optional().nullable(),
   })).min(1, t('apikeys.validation.atLeastOneProfile')),
 }).refine(
   (data) => data.profiles.some(profile => profile.name === data.activeProfile),
@@ -142,6 +145,7 @@ export const updateApiKeyProfilesInputSchema = z.object({
       to: z.string().min(1, 'Target model is required'),
     })),
     channelIDs: z.array(z.number()).optional().nullable(),
+    channelTags: z.array(z.string()).optional().nullable(),
   })),
 })
 export type UpdateApiKeyProfilesInput = z.infer<typeof updateApiKeyProfilesInputSchema>

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -18,6 +18,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Textarea } from '@/components/ui/textarea'
 import { AutoCompleteSelect } from '@/components/auto-complete-select'
 import { SelectDropdown } from '@/components/select-dropdown'
+import { TagsInput } from '@/components/ui/tags-input'
 import { useCreateChannel, useUpdateChannel, useFetchModels, useBulkCreateChannels } from '../data/channels'
 import { getDefaultBaseURL, getDefaultModels, CHANNEL_CONFIGS, OPENAI_CHAT_COMPLETIONS } from '../data/config_channels'
 import {
@@ -164,6 +165,7 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
             name: currentRow.name,
             supportedModels: currentRow.supportedModels,
             defaultTestModel: currentRow.defaultTestModel,
+            tags: currentRow.tags || [],
             credentials: {
               apiKey: '', // credentials字段是敏感字段，不从API返回
               aws: {
@@ -197,6 +199,7 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
             },
             supportedModels: [],
             defaultTestModel: '',
+            tags: [],
           },
   })
 
@@ -987,6 +990,28 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
                               isControlled={true}
                               data-testid='default-test-model-select'
                             />
+                            <FormMessage />
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name='tags'
+                      render={({ field }) => (
+                        <FormItem className='grid grid-cols-8 items-start gap-x-6'>
+                          <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                            {t('channels.dialogs.fields.tags.label')}
+                          </FormLabel>
+                          <div className='col-span-6 space-y-1'>
+                            <TagsInput
+                              value={field.value || []}
+                              onChange={field.onChange}
+                              placeholder={t('channels.dialogs.fields.tags.placeholder')}
+                              data-testid='channel-tags-input'
+                            />
+                            <p className='text-muted-foreground text-xs'>{t('channels.dialogs.fields.tags.description')}</p>
                             <FormMessage />
                           </div>
                         </FormItem>

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -318,6 +318,20 @@ export function ChannelsTable({
                                       {channel.remark || '-'}
                                     </span>
                                   </div>
+                                  <div className='flex justify-between items-start'>
+                                    <span className='text-muted-foreground shrink-0'>{t('channels.expandedRow.tags')}:</span>
+                                    <div className='flex flex-wrap gap-1 justify-end max-w-[200px]'>
+                                      {channel.tags && channel.tags.length > 0 ? (
+                                        channel.tags.map((tag) => (
+                                          <Badge key={tag} variant='outline' className='text-xs'>
+                                            {tag}
+                                          </Badge>
+                                        ))
+                                      ) : (
+                                        <span>-</span>
+                                      )}
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
 

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -294,7 +294,7 @@ const BULK_UPDATE_CHANNEL_ORDERING_MUTATION = `
 const ALL_CHANNELS_QUERY = `
   query GetAllChannels {
     channels(
-      first: 1000, 
+      first: 1000,
       orderBy: { field: ORDERING_WEIGHT, direction: DESC }
       where: { statusIn: [enabled, disabled] }
     ) {
@@ -307,6 +307,7 @@ const ALL_CHANNELS_QUERY = `
           status
           baseURL
           orderingWeight
+          tags
         }
       }
     }

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -339,6 +339,7 @@ export const channelOrderingItemSchema = z.object({
   status: channelStatusSchema,
   baseURL: z.string(),
   orderingWeight: z.number(),
+  tags: z.array(z.string()).optional().default([]).nullable(),
 })
 export type ChannelOrderingItem = z.infer<typeof channelOrderingItemSchema>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -407,7 +407,10 @@
       "regexSupported": "Supports regular expressions",
       "allowedChannels": "Allowed Channels",
       "allowedChannelsDescription": "Select channels that this profile can use. If none selected, all channels are allowed.",
-      "noChannelsAvailable": "No channels available"
+      "noChannelsAvailable": "No channels available",
+      "allowedChannelTags": "Allowed Channel Tags",
+      "allowedChannelTagsDescription": "Select tags to filter channels for this profile. Channels with any of the selected tags will be allowed. If none selected, tag filtering is disabled.",
+      "noTagsAvailable": "No tags available"
     }
   },
   "roles": {
@@ -827,6 +830,11 @@
           "label": "Test Model",
           "description": "Default model for testing connections"
         },
+        "tags": {
+          "label": "Tags",
+          "placeholder": "Add tags...",
+          "description": "Add tags to categorize and filter channels. Press Enter, comma, or space to add a tag."
+        },
         "modelName": {
           "label": "Model Name",
           "placeholder": "Enter model name"
@@ -1052,6 +1060,7 @@
       "totalModels": "Total Models",
       "defaultTestModel": "Default Test Model",
       "remark": "Remark",
+      "tags": "Tags",
       "apiFormat": "API Format",
       "noPerformanceData": "No performance data available",
       "more": "more"

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -432,7 +432,10 @@
       "regexSupported": "支持正则表达式",
       "allowedChannels": "允许的渠道",
       "allowedChannelsDescription": "选择此配置可以使用的渠道。如果未选择任何渠道，则允许使用所有渠道。",
-      "noChannelsAvailable": "暂无可用渠道"
+      "noChannelsAvailable": "暂无可用渠道",
+      "allowedChannelTags": "允许的渠道标签",
+      "allowedChannelTagsDescription": "选择标签来过滤此配置可用的渠道。包含任一所选标签的渠道将被允许使用。如果未选择任何标签，则禁用标签过滤。",
+      "noTagsAvailable": "暂无可用标签"
     }
   },
   "roles": {
@@ -855,6 +858,11 @@
           "label": "默认测试模型",
           "description": "用于测试连接的默认模型"
         },
+        "tags": {
+          "label": "标签",
+          "placeholder": "添加标签...",
+          "description": "添加标签来分类和过滤渠道。按回车键、逗号或空格来添加标签。"
+        },
         "modelName": {
           "label": "模型名称",
           "placeholder": "输入模型名称"
@@ -1081,6 +1089,7 @@
       "totalModels": "模型总数",
       "defaultTestModel": "默认测试模型",
       "remark": "备注",
+      "tags": "标签",
       "apiFormat": "API 格式",
       "noPerformanceData": "暂无性能数据",
       "more": "更多"

--- a/internal/objects/apikey.go
+++ b/internal/objects/apikey.go
@@ -9,4 +9,5 @@ type APIKeyProfile struct {
 	Name          string         `json:"name"`
 	ModelMappings []ModelMapping `json:"modelMappings"`
 	ChannelIDs    []int          `json:"channelIDs,omitempty"`
+	ChannelTags   []string       `json:"channelTags,omitempty"` // 渠道标签过滤：包含任意标签的渠道可用
 }

--- a/internal/server/chat/channels_tags_test.go
+++ b/internal/server/chat/channels_tags_test.go
@@ -1,0 +1,411 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/privacy"
+	"github.com/looplj/axonhub/internal/llm"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+)
+
+// setupTagsTest 创建测试环境和测试用的 channels
+func setupTagsTest(t *testing.T) (context.Context, *ent.Client, []*biz.Channel) {
+	t.Helper()
+
+	ctx := context.Background()
+	ctx = privacy.DecisionContext(ctx, privacy.Allow)
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	t.Cleanup(func() { client.Close() })
+	ctx = ent.NewContext(ctx, client)
+
+	// 创建测试渠道
+	// Channel 1: 有 tag1 和 tag2
+	ch1, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel with tag1 and tag2").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-1"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetTags([]string{"tag1", "tag2"}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Channel 2: 只有 tag2
+	ch2, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel with tag2 only").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-2"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetTags([]string{"tag2"}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Channel 3: 只有 tag3
+	ch3, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel with tag3 only").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-3"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetTags([]string{"tag3"}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Channel 4: 没有任何 tags (空数组)
+	ch4, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel without tags").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-4"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetTags([]string{}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Channel 5: tags 未设置 (nil)
+	ch5, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel with nil tags").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-5"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channels := []*biz.Channel{
+		{Channel: ch1},
+		{Channel: ch2},
+		{Channel: ch3},
+		{Channel: ch4},
+		{Channel: ch5},
+	}
+
+	return ctx, client, channels
+}
+
+// TestTagsFilterSelector_EmptyAllowedTags 测试当 allowedTags 为空时返回所有渠道
+func TestTagsFilterSelector_EmptyAllowedTags(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	// 创建返回所有 channels 的 mock selector
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+
+	// 创建 TagsFilterSelector with empty allowedTags
+	selector := NewTagsFilterSelector(mockSelector, []string{})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 应该返回所有 5 个渠道
+	assert.Len(t, result, 5)
+	assert.Equal(t, channels, result)
+}
+
+// TestTagsFilterSelector_NilAllowedTags 测试当 allowedTags 为 nil 时返回所有渠道
+func TestTagsFilterSelector_NilAllowedTags(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+	selector := NewTagsFilterSelector(mockSelector, nil)
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 应该返回所有 5 个渠道
+	assert.Len(t, result, 5)
+}
+
+// TestTagsFilterSelector_SingleMatchingTag 测试单个匹配标签
+func TestTagsFilterSelector_SingleMatchingTag(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 只有 Channel 1 有 tag1
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Channel with tag1 and tag2", result[0].Name)
+}
+
+// TestTagsFilterSelector_MultipleMatchingTags 测试多个匹配标签 (OR 逻辑)
+func TestTagsFilterSelector_MultipleMatchingTags(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+	// 允许 tag1 或 tag2
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1", "tag2"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Channel 1 (tag1, tag2) 和 Channel 2 (tag2) 应该被选中
+	assert.Len(t, result, 2)
+
+	names := []string{result[0].Name, result[1].Name}
+	assert.Contains(t, names, "Channel with tag1 and tag2")
+	assert.Contains(t, names, "Channel with tag2 only")
+}
+
+// TestTagsFilterSelector_NoMatchingTags 测试没有匹配的标签
+func TestTagsFilterSelector_NoMatchingTags(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+	// 使用不存在的标签
+	selector := NewTagsFilterSelector(mockSelector, []string{"nonexistent-tag"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 没有任何渠道匹配
+	assert.Len(t, result, 0)
+}
+
+// TestTagsFilterSelector_ChannelsWithoutTags 测试没有标签的渠道不会被匹配
+func TestTagsFilterSelector_ChannelsWithoutTags(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	// 只保留没有标签的渠道
+	noTagChannels := []*biz.Channel{
+		channels[3], // Channel 4: 空数组
+		channels[4], // Channel 5: nil
+	}
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return noTagChannels, nil
+		},
+	}
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1", "tag2", "tag3"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 没有标签的渠道不应该匹配任何 tag filter
+	assert.Len(t, result, 0)
+}
+
+// TestTagsFilterSelector_ORLogic 明确测试 OR 逻辑
+func TestTagsFilterSelector_ORLogic(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+	// 允许 tag1 或 tag3
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1", "tag3"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Channel 1 (有 tag1) 和 Channel 3 (有 tag3) 应该被选中
+	// Channel 2 (只有 tag2) 不应该被选中
+	assert.Len(t, result, 2)
+
+	names := []string{result[0].Name, result[1].Name}
+	assert.Contains(t, names, "Channel with tag1 and tag2")
+	assert.Contains(t, names, "Channel with tag3 only")
+}
+
+// TestTagsFilterSelector_WithSelectedChannelsSelector 测试与 SelectedChannelsSelector 的集成 (交集逻辑)
+func TestTagsFilterSelector_WithSelectedChannelsSelector(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	// 先创建一个 mock selector 返回所有渠道
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+
+	// 然后用 SelectedChannelsSelector 过滤，只允许 Channel 1 和 Channel 2
+	allowedIDs := []int{channels[0].ID, channels[1].ID}
+	channelIDSelector := NewSelectedChannelsSelector(mockSelector, allowedIDs)
+
+	// 最后用 TagsFilterSelector 过滤，只允许 tag2
+	// Channel 1 有 tag2, Channel 2 也有 tag2
+	// 但 SelectedChannelsSelector 已经只允许这两个，所以应该都被选中
+	tagsSelector := NewTagsFilterSelector(channelIDSelector, []string{"tag2"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := tagsSelector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 两个 selector 的交集：Channel 1 和 Channel 2 都有 tag2 且都在 allowedIDs 中
+	assert.Len(t, result, 2)
+}
+
+// TestTagsFilterSelector_WithSelectedChannelsSelector_NoIntersection 测试 tags 和 IDs 没有交集
+func TestTagsFilterSelector_WithSelectedChannelsSelector_NoIntersection(t *testing.T) {
+	ctx, _, channels := setupTagsTest(t)
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+
+	// 只允许 Channel 1 (有 tag1, tag2)
+	allowedIDs := []int{channels[0].ID}
+	channelIDSelector := NewSelectedChannelsSelector(mockSelector, allowedIDs)
+
+	// 但 tags filter 只允许 tag3 (Channel 1 没有 tag3)
+	tagsSelector := NewTagsFilterSelector(channelIDSelector, []string{"tag3"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := tagsSelector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 交集为空
+	assert.Len(t, result, 0)
+}
+
+// TestTagsFilterSelector_ErrorPropagation 测试错误传播
+func TestTagsFilterSelector_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	// 创建一个会返回错误的 mock selector
+	expectedErr := assert.AnError
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return nil, expectedErr
+		},
+	}
+
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+
+	// 错误应该被传播
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, result)
+}
+
+// TestTagsFilterSelector_CaseSensitive 测试标签是否大小写敏感
+func TestTagsFilterSelector_CaseSensitive(t *testing.T) {
+	ctx := context.Background()
+	ctx = privacy.DecisionContext(ctx, privacy.Allow)
+
+	// 创建一个带有大写标签的渠道
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	t.Cleanup(func() { client.Close() })
+	ctx = ent.NewContext(ctx, client)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Channel with TAG1").
+		SetBaseURL("https://api.example.com/v1").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetTags([]string{"TAG1"}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channels := []*biz.Channel{
+		{Channel: ch},
+	}
+
+	mockSelector := &mockChannelSelector{
+		selectFunc: func(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+			return channels, nil
+		},
+	}
+
+	// 用小写的 tag1 来过滤
+	selector := NewTagsFilterSelector(mockSelector, []string{"tag1"})
+
+	req := &llm.Request{
+		Model: "gpt-4",
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// 标签应该是大小写敏感的，所以不会匹配
+	assert.Len(t, result, 0)
+}

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -173,6 +173,7 @@ input APIKeyProfileInput {
   name: String!
   modelMappings: [ModelMappingInput!]
   channelIDs: [Int!]
+  channelTags: [String!]
 }
 
 type APIKeyProfiles {
@@ -184,6 +185,7 @@ type APIKeyProfile {
   name: String!
   modelMappings: [ModelMapping!]
   channelIDs: [Int!]
+  channelTags: [String!]
 }
 
 input FetchModelsInput {

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -107,6 +107,7 @@ type ComplexityRoot struct {
 
 	APIKeyProfile struct {
 		ChannelIDs    func(childComplexity int) int
+		ChannelTags   func(childComplexity int) int
 		ModelMappings func(childComplexity int) int
 		Name          func(childComplexity int) int
 	}
@@ -1234,6 +1235,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.APIKeyProfile.ChannelIDs(childComplexity), true
+	case "APIKeyProfile.channelTags":
+		if e.complexity.APIKeyProfile.ChannelTags == nil {
+			break
+		}
+
+		return e.complexity.APIKeyProfile.ChannelTags(childComplexity), true
 	case "APIKeyProfile.modelMappings":
 		if e.complexity.APIKeyProfile.ModelMappings == nil {
 			break
@@ -7602,6 +7609,35 @@ func (ec *executionContext) fieldContext_APIKeyProfile_channelIDs(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _APIKeyProfile_channelTags(ctx context.Context, field graphql.CollectedField, obj *objects.APIKeyProfile) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_APIKeyProfile_channelTags,
+		func(ctx context.Context) (any, error) {
+			return obj.ChannelTags, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_APIKeyProfile_channelTags(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "APIKeyProfile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _APIKeyProfiles_activeProfile(ctx context.Context, field graphql.CollectedField, obj *objects.APIKeyProfiles) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -7661,6 +7697,8 @@ func (ec *executionContext) fieldContext_APIKeyProfiles_profiles(_ context.Conte
 				return ec.fieldContext_APIKeyProfile_modelMappings(ctx, field)
 			case "channelIDs":
 				return ec.fieldContext_APIKeyProfile_channelIDs(ctx, field)
+			case "channelTags":
+				return ec.fieldContext_APIKeyProfile_channelTags(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type APIKeyProfile", field.Name)
 		},
@@ -27899,7 +27937,7 @@ func (ec *executionContext) unmarshalInputAPIKeyProfileInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "modelMappings", "channelIDs"}
+	fieldsInOrder := [...]string{"name", "modelMappings", "channelIDs", "channelTags"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -27927,6 +27965,13 @@ func (ec *executionContext) unmarshalInputAPIKeyProfileInput(ctx context.Context
 				return it, err
 			}
 			it.ChannelIDs = data
+		case "channelTags":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("channelTags"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ChannelTags = data
 		}
 	}
 
@@ -42779,6 +42824,8 @@ func (ec *executionContext) _APIKeyProfile(ctx context.Context, sel ast.Selectio
 			out.Values[i] = ec._APIKeyProfile_modelMappings(ctx, field, obj)
 		case "channelIDs":
 			out.Values[i] = ec._APIKeyProfile_channelIDs(ctx, field, obj)
+		case "channelTags":
+			out.Values[i] = ec._APIKeyProfile_channelTags(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}


### PR DESCRIPTION
- 为渠道添加标签管理功能，支持在渠道对话框中使用标签输入组件添加和编辑渠道标签
- 在API密钥配置中增加标签过滤选项，允许通过OR逻辑过滤允许使用的渠道，与现有渠道ID过滤形成组合控制
- 实现后端标签选择器装饰器，支持与渠道ID选择器的链式组合，增强渠道过滤的灵活性
- 新增完整的标签选择器单元测试，覆盖各种过滤场景包括空标签、匹配逻辑、交集操作等
- 更新前后端schema、i18n翻译和GraphQL接口，确保标签数据在系统中完整流转
- 重构API密钥配置对话框，优化表单类型安全性和代码结构，提高可维护性

<img width="613" height="543" alt="image" src="https://github.com/user-attachments/assets/498b65c6-a129-4b2c-b56a-8ef76c2f56de" />
<img width="580" height="271" alt="image" src="https://github.com/user-attachments/assets/bcef089a-efe9-4d0a-ba07-1bb95019c5df" />
<img width="737" height="212" alt="image" src="https://github.com/user-attachments/assets/2de2c32a-9bd0-440a-9cb4-5b1cbbe54d6c" />

