### PR TITLE
feat: 为API密钥配置文件添加折叠功能并改进URL显示

### DIFF
--- a/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
@@ -375,8 +375,10 @@ function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels,
               type='button'
               variant='ghost'
               size='sm'
-              onClick={() => setIsCollapsed(!isCollapsed)}
+              onClick={() => setIsCollapsed((prev) => !prev)}
               className='hover:bg-accent'
+              aria-expanded={!isCollapsed}
+              aria-label={isCollapsed ? t('apikeys.profiles.expand') : t('apikeys.profiles.collapse')}
             >
               {isCollapsed ? <IconChevronDown className='h-4 w-4' /> : <IconChevronUp className='h-4 w-4' />}
             </Button>

--- a/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { IconPlus, IconTrash, IconSettings } from '@tabler/icons-react'
+import { IconPlus, IconTrash, IconSettings, IconChevronDown, IconChevronUp } from '@tabler/icons-react'
 import { useQueryModels } from '@/gql/models'
 import { useTranslation } from 'react-i18next'
 import { useDebounce } from '@/hooks/use-debounce'
@@ -287,6 +287,7 @@ interface ProfileCardProps {
 
 function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels, t }: ProfileCardProps) {
   const [localProfileName, setLocalProfileName] = useState('')
+  const [isCollapsed, setIsCollapsed] = useState(false)
   const { data: channelsData } = useAllChannelsForOrdering({ enabled: true })
 
   const debouncedProfileName = useDebounce(localProfileName, 500)
@@ -344,8 +345,8 @@ function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels,
   return (
     <Card>
       <CardHeader className='pb-3'>
-        <div className='flex items-center justify-between'>
-          <CardTitle className='text-base'>
+        <div className='flex items-center justify-between gap-2'>
+          <CardTitle className='text-base flex-1 min-w-0'>
             <FormField
               control={form.control}
               name={`profiles.${profileIndex}.name`}
@@ -361,7 +362,7 @@ function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels,
                       }}
                       onBlur={field.onBlur}
                       placeholder={t('apikeys.profiles.profileName')}
-                      className='font-medium'
+                      className='font-medium w-full md:w-[12em]'
                     />
                   </FormControl>
                   <FormMessage />
@@ -369,90 +370,103 @@ function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels,
               )}
             />
           </CardTitle>
-          {canRemove && (
-            <Button type='button' variant='ghost' size='sm' onClick={onRemove} className='text-destructive hover:text-destructive'>
-              <IconTrash className='h-4 w-4' />
+          <div className='flex items-center gap-1 shrink-0'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => setIsCollapsed(!isCollapsed)}
+              className='hover:bg-accent'
+            >
+              {isCollapsed ? <IconChevronDown className='h-4 w-4' /> : <IconChevronUp className='h-4 w-4' />}
             </Button>
-          )}
+            {canRemove && (
+              <Button type='button' variant='ghost' size='sm' onClick={onRemove} className='text-destructive hover:text-destructive'>
+                <IconTrash className='h-4 w-4' />
+              </Button>
+            )}
+          </div>
         </div>
       </CardHeader>
-      <CardContent className='space-y-4'>
-        <div className='flex items-center justify-between'>
-          <h4 className='text-sm font-medium'>{t('apikeys.profiles.modelMappings')}</h4>
-          <Button type='button' variant='outline' size='sm' onClick={addMapping} className='flex items-center gap-2'>
-            <IconPlus className='h-4 w-4' />
-            {t('apikeys.profiles.addMapping')}
-          </Button>
-        </div>
+      {!isCollapsed && (
+        <CardContent className='space-y-4'>
+          <div className='flex items-center justify-between'>
+            <h4 className='text-sm font-medium'>{t('apikeys.profiles.modelMappings')}</h4>
+            <Button type='button' variant='outline' size='sm' onClick={addMapping} className='flex items-center gap-2'>
+              <IconPlus className='h-4 w-4' />
+              {t('apikeys.profiles.addMapping')}
+            </Button>
+          </div>
 
-        {mappingFields.length === 0 && <p className='text-muted-foreground py-4 text-center text-sm'>{t('apikeys.profiles.noMappings')}</p>}
+          {mappingFields.length === 0 && <p className='text-muted-foreground py-4 text-center text-sm'>{t('apikeys.profiles.noMappings')}</p>}
 
-        <div className='space-y-3'>
-          {mappingFields.map((mapping, mappingIndex) => (
-            <MappingRow
-              key={mapping.id}
-              profileIndex={profileIndex}
-              mappingIndex={mappingIndex}
-              form={form}
-              onRemove={() => removeMapping(mappingIndex)}
-              availableModels={availableModels}
-              t={t}
+          <div className='space-y-3'>
+            {mappingFields.map((mapping, mappingIndex) => (
+              <MappingRow
+                key={mapping.id}
+                profileIndex={profileIndex}
+                mappingIndex={mappingIndex}
+                form={form}
+                onRemove={() => removeMapping(mappingIndex)}
+                availableModels={availableModels}
+                t={t}
+              />
+            ))}
+          </div>
+
+          {/* Channel Restrictions Section */}
+          <div className='border-t pt-4'>
+            <h4 className='text-sm font-medium mb-3'>{t('apikeys.profiles.allowedChannels')}</h4>
+            <p className='text-muted-foreground text-xs mb-3'>{t('apikeys.profiles.allowedChannelsDescription')}</p>
+            <FormField
+              control={form.control}
+              name={`profiles.${profileIndex}.channelIDs`}
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <div className='grid grid-cols-2 gap-2 max-h-40 overflow-y-auto border rounded-md p-2'>
+                      {channelsData?.edges?.map((edge) => {
+                        const channel = edge.node
+                        const channelId = parseInt(extractNumberID(channel.id), 10)
+                        const isChecked = (field.value || []).includes(channelId)
+                        return (
+                          <div key={channel.id} className='flex items-center space-x-2'>
+                            <Checkbox
+                              id={`channel-${profileIndex}-${channel.id}`}
+                              checked={isChecked}
+                              onCheckedChange={(checked) => {
+                                const currentValue: number[] = field.value || []
+                                if (checked) {
+                                  field.onChange([...currentValue, channelId])
+                                } else {
+                                  field.onChange(currentValue.filter((id) => id !== channelId))
+                                }
+                              }}
+                            />
+                            <Label
+                              htmlFor={`channel-${profileIndex}-${channel.id}`}
+                              className='text-sm font-normal cursor-pointer truncate'
+                              title={channel.name}
+                            >
+                              {channel.name}
+                            </Label>
+                          </div>
+                        )
+                      })}
+                      {(!channelsData?.edges || channelsData.edges.length === 0) && (
+                        <p className='text-muted-foreground text-sm col-span-2 text-center py-2'>
+                          {t('apikeys.profiles.noChannelsAvailable')}
+                        </p>
+                      )}
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          ))}
-        </div>
-
-        {/* Channel Restrictions Section */}
-        <div className='border-t pt-4'>
-          <h4 className='text-sm font-medium mb-3'>{t('apikeys.profiles.allowedChannels')}</h4>
-          <p className='text-muted-foreground text-xs mb-3'>{t('apikeys.profiles.allowedChannelsDescription')}</p>
-          <FormField
-            control={form.control}
-            name={`profiles.${profileIndex}.channelIDs`}
-            render={({ field }) => (
-              <FormItem>
-                <FormControl>
-                  <div className='grid grid-cols-2 gap-2 max-h-40 overflow-y-auto border rounded-md p-2'>
-                    {channelsData?.edges?.map((edge) => {
-                      const channel = edge.node
-                      const channelId = parseInt(extractNumberID(channel.id), 10)
-                      const isChecked = (field.value || []).includes(channelId)
-                      return (
-                        <div key={channel.id} className='flex items-center space-x-2'>
-                          <Checkbox
-                            id={`channel-${profileIndex}-${channel.id}`}
-                            checked={isChecked}
-                            onCheckedChange={(checked) => {
-                              const currentValue: number[] = field.value || []
-                              if (checked) {
-                                field.onChange([...currentValue, channelId])
-                              } else {
-                                field.onChange(currentValue.filter((id) => id !== channelId))
-                              }
-                            }}
-                          />
-                          <Label
-                            htmlFor={`channel-${profileIndex}-${channel.id}`}
-                            className='text-sm font-normal cursor-pointer truncate'
-                            title={channel.name}
-                          >
-                            {channel.name}
-                          </Label>
-                        </div>
-                      )
-                    })}
-                    {(!channelsData?.edges || channelsData.edges.length === 0) && (
-                      <p className='text-muted-foreground text-sm col-span-2 text-center py-2'>
-                        {t('apikeys.profiles.noChannelsAvailable')}
-                      </p>
-                    )}
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-      </CardContent>
+          </div>
+        </CardContent>
+      )}
     </Card>
   )
 }

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -280,7 +280,7 @@ export function ChannelsTable({
                     </TableRow>
                     {row.getIsExpanded() && (
                       <TableRow key={`${row.id}-expanded`} className='bg-muted/30 hover:bg-muted/50'>
-                        <TableCell colSpan={columns.length} className='p-6'>
+                        <TableCell colSpan={columns.length} className='p-6 whitespace-normal'>
                           <div className='space-y-6'>
                             {/* Top Section: Basic Info + Performance (2 columns) */}
                             <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
@@ -288,11 +288,11 @@ export function ChannelsTable({
                               <div className='space-y-3'>
                                 <h4 className='text-sm font-semibold'>{t('channels.expandedRow.basicInfo')}</h4>
                                 <div className='space-y-2 text-sm'>
-                                  <div className='flex justify-between gap-4'>
-                                    <span className='text-muted-foreground shrink-0'>{t('channels.columns.baseURL')}:</span>
-                                    <span className='font-mono text-xs break-all text-right'>
-                                      {channel.baseURL}
+                                  <div className='flex items-start gap-2'>
+                                    <span className='text-muted-foreground shrink-0'>
+                                      {t('channels.columns.baseURL')}:
                                     </span>
+                                    <span className='flex-1 min-w-0 font-mono text-xs break-all text-right'>{channel.baseURL}</span>
                                   </div>
                                   <div className='flex justify-between items-center'>
                                     <span className='text-muted-foreground'>{t('channels.columns.type')}:</span>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -391,6 +391,8 @@
     },
     "profiles": {
       "title": "API Key Profiles",
+      "expand": "Expand Profile",
+      "collapse": "Collapse Profile",
       "description": "Configure model mapping profiles for {{name}}. When an active profile has model mappings configured, the system will automatically map requested models to their target models during API requests.",
       "profilesTitle": "Profiles",
       "addProfile": "Add Profile",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -416,6 +416,8 @@
     },
     "profiles": {
       "title": "配置文件管理",
+      "expand": "展开配置",
+      "collapse": "收起配置",
       "description": "为以下 API Key {{name}} 配置模型映射, 当一个活动配置有模型映射配置时, 系统将自动在 API 请求时将请求模型映射到目标模型",
       "profilesTitle": "配置文件",
       "addProfile": "新增配置",


### PR DESCRIPTION
- 为每个配置文件卡片添加折叠/展开切换功能，便于在管理多个配置时减少视觉混乱
- 配置文件标题区域重新设计布局，将折叠按钮和删除按钮分组排列
- 改进了Channels表格中扩展行的URL显示，现在使用更灵活的布局避免换行问题
- 配置文件名称输入框添加响应式宽度设置，在不同屏幕尺寸下显示更合理

未修复前url重叠</br>
<img width="718" height="338" alt="image" src="https://github.com/user-attachments/assets/23ca3207-f2e0-41b5-93ce-268ccc4c4753" /></br>
修复后</br>
<img width="701" height="290" alt="Snipaste_2025-12-13_01-19-05" src="https://github.com/user-attachments/assets/6aa4a86a-463e-41f7-b329-81e1e5877232" />
配置文件增加折叠按钮</br>
<img width="887" height="357" alt="Snipaste_2025-12-13_01-19-15" src="https://github.com/user-attachments/assets/cbf3a551-afd5-4a34-9d06-5b95242c53f7" />



