### PR TITLE
feat: add search for channel action dialog model list

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -13,9 +13,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Textarea } from '@/components/ui/textarea'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { AutoCompleteSelect } from '@/components/auto-complete-select'
 import { SelectDropdown } from '@/components/select-dropdown'
 import { TagsInput } from '@/components/ui/tags-input'
@@ -56,6 +56,7 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
   const [showFetchedModelsPanel, setShowFetchedModelsPanel] = useState(false)
   const [showSupportedModelsPanel, setShowSupportedModelsPanel] = useState(false)
   const [fetchedModelsSearch, setFetchedModelsSearch] = useState('')
+  const [supportedModelsSearch, setSupportedModelsSearch] = useState('')
   const [selectedFetchedModels, setSelectedFetchedModels] = useState<string[]>([])
   const [showAddedModelsOnly, setShowAddedModelsOnly] = useState(false)
   const [supportedModelsExpanded, setSupportedModelsExpanded] = useState(false)
@@ -519,9 +520,19 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
     return supportedModels.slice(0, MAX_MODELS_DISPLAY)
   }, [supportedModels])
 
+  // Filtered supported models based on search
+  const filteredSupportedModels = useMemo(() => {
+    if (!supportedModelsSearch.trim()) {
+      return supportedModels
+    }
+    const search = supportedModelsSearch.toLowerCase()
+    return supportedModels.filter((model) => model.toLowerCase().includes(search))
+  }, [supportedModels, supportedModelsSearch])
+
   return (
-    <Dialog
-      open={open}
+    <>
+      <Dialog
+        open={open}
       onOpenChange={(state) => {
         if (!state) {
           form.reset()
@@ -533,6 +544,7 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
           setShowFetchedModelsPanel(false)
           setShowSupportedModelsPanel(false)
           setFetchedModelsSearch('')
+          setSupportedModelsSearch('')
           setSelectedFetchedModels([])
           setShowAddedModelsOnly(false)
           setSupportedModelsExpanded(false)
@@ -1151,30 +1163,40 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
                 </div>
                 <Popover open={showClearAllPopover} onOpenChange={setShowClearAllPopover}>
                   <PopoverTrigger asChild>
-                    <Button type='button' variant='ghost' size='sm' disabled={supportedModels.length === 0}>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      disabled={supportedModels.length === 0}
+                    >
                       <X className='h-4 w-4' />
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className='w-72 p-4' align='end'>
+                  <PopoverContent className='w-80 border-destructive/50 bg-background' align='end'>
                     <div className='space-y-3'>
-                      <div>
-                        <h4 className='font-medium'>{t('channels.dialogs.fields.supportedModels.clearAllTitle')}</h4>
+                      <div className='space-y-1'>
+                        <h4 className='font-medium leading-none'>{t('channels.dialogs.fields.supportedModels.clearAllTitle')}</h4>
                         <p className='text-muted-foreground text-sm'>
                           {t('channels.dialogs.fields.supportedModels.clearAllDescription', { count: supportedModels.length })}
                         </p>
                       </div>
-                      <div className='flex gap-2'>
-                        <Button variant='outline' size='sm' onClick={() => setShowClearAllPopover(false)} className='flex-1'>
+                      <div className='flex justify-end gap-2'>
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='sm'
+                          onClick={() => setShowClearAllPopover(false)}
+                        >
                           {t('common.buttons.cancel')}
                         </Button>
                         <Button
+                          type='button'
                           variant='destructive'
                           size='sm'
                           onClick={() => {
                             handleClearAllSupportedModels()
                             setShowClearAllPopover(false)
                           }}
-                          className='flex-1'
                         >
                           {t('channels.dialogs.buttons.clearAll')}
                         </Button>
@@ -1184,10 +1206,21 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
                 </Popover>
               </div>
 
+              {/* Search */}
+              <div className='relative mb-3'>
+                <Search className='text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2' />
+                <Input
+                  placeholder={t('channels.dialogs.fields.supportedModels.searchPlaceholder')}
+                  value={supportedModelsSearch}
+                  onChange={(e) => setSupportedModelsSearch(e.target.value)}
+                  className='h-8 pl-8 text-sm'
+                />
+              </div>
+
               {/* Model List */}
               <div className='-mr-2 max-h-[400px] flex-1 overflow-y-auto pr-2'>
                 <div className='space-y-1'>
-                  {supportedModels.map((model) => (
+                  {filteredSupportedModels.map((model) => (
                     <div key={model} className='hover:bg-accent flex items-center justify-between gap-2 rounded-md p-2 text-sm'>
                       <span className='flex-1 truncate'>{model}</span>
                       <Button
@@ -1224,5 +1257,6 @@ export function ChannelsActionDialog({ currentRow, open, onOpenChange, showModel
         </DialogFooter>
       </DialogContent>
     </Dialog>
+    </>
   )
 }

--- a/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
@@ -438,6 +438,11 @@ export function ChannelsModelMappingDialog({ open, onOpenChange, currentRow }: P
                   >
                     <Plus size={16} />
                   </Button>
+                  {(newMapping.from.trim() || newMapping.to.trim()) && (
+                    <Button type='button' variant='outline' size='sm' onClick={() => setNewMapping({ from: '', to: '' })}>
+                      <X size={16} />
+                    </Button>
+                  )}
                 </div>
 
                 {/* 显示表单错误 */}


### PR DESCRIPTION
- 在渠道支持的模型列表中添加搜索输入框，允许用户过滤模型
- 为渠道管理清空全部模型Popover 更新样式
- 为模型映射对话框的新映射表单添加清除按钮，方便用户重置输入

渠道管理页面全部模型处新增搜索框</br>
<img width="356" height="297" alt="image" src="https://github.com/user-attachments/assets/676ccb2e-0afa-4f6f-acaf-f26df954ff4f" /></br>
修复在模型别名列表未输入别名时无法保存的问题</br>
<img width="750" height="421" alt="image" src="https://github.com/user-attachments/assets/27713063-44db-49ce-a878-2c76accaf1c7" /></br>
增加一个删除按钮</br>
<img width="430" height="70" alt="image" src="https://github.com/user-attachments/assets/0e7d2f5e-5c14-4b4d-b945-ba9e65d5d3c8" /></br>
调整清空模型对话框配色
<img width="358" height="211" alt="image" src="https://github.com/user-attachments/assets/37931e6d-6a8c-4439-bdf1-ff5b27671c81" />
<img width="368" height="173" alt="image" src="https://github.com/user-attachments/assets/6840f42e-f23a-4fad-8dfb-5a3d213e6027" />


