### PR TITLE
fix: auto complete can not scroll in dialog

### DIFF
--- a/frontend/src/components/auto-complete-select.tsx
+++ b/frontend/src/components/auto-complete-select.tsx
@@ -6,6 +6,7 @@ import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '.
 import { Input } from './ui/input'
 import { Popover, PopoverAnchor, PopoverContent } from './ui/popover'
 import { Skeleton } from './ui/skeleton'
+import { TruncatedText } from './truncated-text'
 
 type Props<T extends string> = {
   selectedValue: T
@@ -97,16 +98,15 @@ export function AutoCompleteSelect<T extends string>({
           </PopoverAnchor>
           {!open && <CommandList aria-hidden='true' className='hidden' />}
           <PopoverContent
-            asChild
             onOpenAutoFocus={(e) => e.preventDefault()}
             onInteractOutside={(e) => {
               if (e.target instanceof Element && e.target.hasAttribute('cmdk-input')) {
                 e.preventDefault()
               }
             }}
-            className='w-[var(--radix-popover-trigger-width)] max-w-[var(--radix-popover-trigger-width)] overflow-hidden p-0'
+            className='w-[var(--radix-popover-trigger-width)] max-w-[var(--radix-popover-trigger-width)] p-0'
           >
-            <CommandList className='max-h-72 overflow-auto'>
+            <CommandList>
               {isLoading && (
                 <CommandPrimitive.Loading>
                   <div className='p-1'>
@@ -125,7 +125,7 @@ export function AutoCompleteSelect<T extends string>({
                       className='max-w-full w-full min-w-0'
                     >
                       <Check className={cn('mr-2 h-4 w-4', selectedValue === option.value ? 'opacity-100' : 'opacity-0')} />
-                      <span className='truncate flex-1 min-w-0'>{option.label}</span>
+                      <TruncatedText className='flex-1 min-w-0'>{option.label}</TruncatedText>
                     </CommandItem>
                   ))}
                 </CommandGroup>

--- a/frontend/src/components/auto-complete.tsx
+++ b/frontend/src/components/auto-complete.tsx
@@ -39,6 +39,8 @@ type Props<T extends string> = {
   isLoading?: boolean
   emptyMessage?: string
   placeholder?: string
+  /** 指定 Popover Portal 的容器元素，用于解决在 Dialog 内无法滚动的问题 */
+  portalContainer?: HTMLElement | null
 }
 
 export function AutoComplete<T extends string>({
@@ -50,6 +52,7 @@ export function AutoComplete<T extends string>({
   isLoading,
   emptyMessage = 'No items.',
   placeholder = 'Search...',
+  portalContainer,
 }: Props<T>) {
   const [open, setOpen] = useState(false)
 
@@ -115,16 +118,16 @@ export function AutoComplete<T extends string>({
           </PopoverAnchor>
           {!open && <CommandList aria-hidden='true' className='hidden' />}
           <PopoverContent
-            asChild
             onOpenAutoFocus={(e) => e.preventDefault()}
             onInteractOutside={(e) => {
               if (e.target instanceof Element && e.target.hasAttribute('cmdk-input')) {
                 e.preventDefault()
               }
             }}
-            className='w-[var(--radix-popover-trigger-width)] max-w-[var(--radix-popover-trigger-width)] overflow-hidden p-0'
+            className='w-[var(--radix-popover-trigger-width)] max-w-[var(--radix-popover-trigger-width)] p-0'
+            container={portalContainer}
           >
-            <CommandList className='max-h-72 overflow-auto'>
+            <CommandList>
               {isLoading && (
                 <CommandPrimitive.Loading>
                   <div className='p-1'>

--- a/frontend/src/components/truncated-text.tsx
+++ b/frontend/src/components/truncated-text.tsx
@@ -1,0 +1,44 @@
+import { useRef, useState, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+
+interface TruncatedTextProps {
+  children: string
+  className?: string
+}
+
+/**
+ * 智能截断文本组件
+ * 仅当文本被截断时才显示 title 悬浮提示
+ */
+export function TruncatedText({ children, className }: TruncatedTextProps) {
+  const textRef = useRef<HTMLSpanElement>(null)
+  const [title, setTitle] = useState<string | undefined>(undefined)
+
+  // 在鼠标进入时检测是否被截断
+  const handleMouseEnter = useCallback(() => {
+    const element = textRef.current
+    if (!element) return
+
+    // scrollWidth > clientWidth 表示文本被截断了
+    if (element.scrollWidth > element.clientWidth) {
+      setTitle(children)
+    }
+  }, [children])
+
+  // 鼠标离开时清除 title
+  const handleMouseLeave = useCallback(() => {
+    setTitle(undefined)
+  }, [])
+
+  return (
+    <span
+      ref={textRef}
+      className={cn('truncate', className)}
+      title={title}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/components/truncated-text.tsx
+++ b/frontend/src/components/truncated-text.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
 
 interface TruncatedTextProps {
@@ -9,34 +9,36 @@ interface TruncatedTextProps {
 /**
  * 智能截断文本组件
  * 仅当文本被截断时才显示 title 悬浮提示
+ * 使用 ResizeObserver 动态检测截断状态，确保在容器大小变化时也能正确响应
  */
 export function TruncatedText({ children, className }: TruncatedTextProps) {
   const textRef = useRef<HTMLSpanElement>(null)
-  const [title, setTitle] = useState<string | undefined>(undefined)
+  const [isTruncated, setIsTruncated] = useState(false)
 
-  // 在鼠标进入时检测是否被截断
-  const handleMouseEnter = useCallback(() => {
+  useEffect(() => {
     const element = textRef.current
     if (!element) return
 
-    // scrollWidth > clientWidth 表示文本被截断了
-    if (element.scrollWidth > element.clientWidth) {
-      setTitle(children)
+    // 检测文本是否被截断
+    const checkTruncation = () => {
+      setIsTruncated(element.scrollWidth > element.clientWidth)
     }
-  }, [children])
 
-  // 鼠标离开时清除 title
-  const handleMouseLeave = useCallback(() => {
-    setTitle(undefined)
-  }, [])
+    // 初始检测
+    checkTruncation()
+
+    // 监听容器尺寸变化
+    const resizeObserver = new ResizeObserver(checkTruncation)
+    resizeObserver.observe(element)
+
+    return () => resizeObserver.disconnect()
+  }, [children])
 
   return (
     <span
       ref={textRef}
       className={cn('truncate', className)}
-      title={title}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      title={isTruncated ? children : undefined}
     >
       {children}
     </span>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -46,24 +46,23 @@ function DialogOverlay({
   )
 }
 
-function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
-}) {
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentProps<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
+        ref={ref}
         data-slot="dialog-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
-         onInteractOutside={(e) => {
+        onInteractOutside={(e) => {
           e.preventDefault()
         }}
         {...props}
@@ -81,7 +80,7 @@ function DialogContent({
       </DialogPrimitive.Content>
     </DialogPortal>
   )
-}
+})
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -18,10 +18,13 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container']
+}) {
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Content
         data-slot='popover-content'
         align={align}

--- a/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
@@ -19,6 +19,8 @@ import { updateApiKeyProfilesInputSchemaFactory, type UpdateApiKeyProfilesInput,
 import { useAllChannelsForOrdering } from '@/features/channels/data/channels'
 import { extractNumberID } from '@/lib/utils'
 
+type DialogContentRef = HTMLDivElement | null
+
 interface ApiKeyProfilesDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -34,6 +36,8 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
   const { t } = useTranslation()
   const { selectedApiKey } = useApiKeysContext()
   const { data: availableModels, mutateAsync: fetchModels } = useQueryModels()
+  // 用于解决 Dialog 内 Popover 无法滚动的问题
+  const dialogContentRef = useRef<DialogContentRef>(null)
 
   useEffect(() => {
     if (open) {
@@ -162,7 +166,7 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='flex max-h-[90vh] flex-col sm:max-w-4xl'>
+      <DialogContent ref={dialogContentRef} className='flex max-h-[90vh] flex-col sm:max-w-4xl'>
         <DialogHeader className='shrink-0 text-left'>
           <DialogTitle className='flex items-center gap-2'>
             <IconSettings className='h-5 w-5' />
@@ -208,6 +212,7 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
                             availableModels={availableModels?.map((model) => model.id) || []}
                             t={t}
                             defaultExpanded={profileIndex === 0}
+                            portalContainer={dialogContentRef.current}
                           />
                         </div>
                       ))}
@@ -285,9 +290,11 @@ interface ProfileCardProps {
   availableModels: string[]
   t: (key: string) => string
   defaultExpanded?: boolean
+  /** Popover Portal 容器元素，解决 Dialog 内无法滚动的问题 */
+  portalContainer?: HTMLElement | null
 }
 
-function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels, t, defaultExpanded = false }: ProfileCardProps) {
+function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels, t, defaultExpanded = false, portalContainer }: ProfileCardProps) {
   const [localProfileName, setLocalProfileName] = useState('')
   const [isCollapsed, setIsCollapsed] = useState(!defaultExpanded)
   const { data: channelsData } = useAllChannelsForOrdering({ enabled: true })
@@ -425,6 +432,7 @@ function ProfileCard({ profileIndex, form, onRemove, canRemove, availableModels,
                 onRemove={() => removeMapping(mappingIndex)}
                 availableModels={availableModels}
                 t={t}
+                portalContainer={portalContainer}
               />
             ))}
           </div>
@@ -543,9 +551,11 @@ interface MappingRowProps {
   onRemove: () => void
   availableModels: string[]
   t: (key: string) => string
+  /** Popover Portal 容器元素，解决 Dialog 内无法滚动的问题 */
+  portalContainer?: HTMLElement | null
 }
 
-function MappingRow({ profileIndex, mappingIndex, form, onRemove, availableModels, t }: MappingRowProps) {
+function MappingRow({ profileIndex, mappingIndex, form, onRemove, availableModels, t, portalContainer }: MappingRowProps) {
   const [fromSearch, setFromSearch] = useState('')
   const [toSearch, setToSearch] = useState('')
 
@@ -591,6 +601,7 @@ function MappingRow({ profileIndex, mappingIndex, form, onRemove, availableModel
                 items={filteredFromModels}
                 placeholder={t('apikeys.profiles.sourceModel')}
                 emptyMessage={t('apikeys.profiles.noModelsFound')}
+                portalContainer={portalContainer}
               />
             </FormControl>
             {/* <div className='text-muted-foreground mt-1 text-xs'>{t('apikeys.profiles.regexSupported')}</div> */}
@@ -616,6 +627,7 @@ function MappingRow({ profileIndex, mappingIndex, form, onRemove, availableModel
                 items={filteredToModels}
                 placeholder={t('apikeys.profiles.targetModel')}
                 emptyMessage={t('apikeys.profiles.noModelsFound')}
+                portalContainer={portalContainer}
               />
             </FormControl>
             <FormMessage />

--- a/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-profiles-dialog.tsx
@@ -37,7 +37,7 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
   const { selectedApiKey } = useApiKeysContext()
   const { data: availableModels, mutateAsync: fetchModels } = useQueryModels()
   // 用于解决 Dialog 内 Popover 无法滚动的问题
-  const dialogContentRef = useRef<DialogContentRef>(null)
+  const [dialogContent, setDialogContent] = useState<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (open) {
@@ -166,7 +166,7 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent ref={dialogContentRef} className='flex max-h-[90vh] flex-col sm:max-w-4xl'>
+      <DialogContent ref={setDialogContent} className='flex max-h-[90vh] flex-col sm:max-w-4xl'>
         <DialogHeader className='shrink-0 text-left'>
           <DialogTitle className='flex items-center gap-2'>
             <IconSettings className='h-5 w-5' />
@@ -212,7 +212,7 @@ export function ApiKeyProfilesDialog({ open, onOpenChange, onSubmit, loading = f
                             availableModels={availableModels?.map((model) => model.id) || []}
                             t={t}
                             defaultExpanded={profileIndex === 0}
-                            portalContainer={dialogContentRef.current}
+                            portalContainer={dialogContent}
                           />
                         </div>
                       ))}


### PR DESCRIPTION
- 新增 TruncatedText 组件，实现智能文本截断提示功能，仅当文本被截断时才显示悬浮提示
- 为 AutoComplete 和 AutoCompleteSelect 组件添加 portalContainer 属性，解决在 Dialog 内无法滚动的问题
- 修改 PopoverContent 组件以支持容器指定，允许在对话框等复杂布局中正确处理弹出层
- 在 API 密钥配置对话框中集成 portalContainer，修复模型映射选择器的滚动问题
- 优化了自动完成组件的列表样式，移除固定高度，使其更灵活适应不同内容

修复在apikey密钥配置文件模型映射模型下拉列表无法滚动的问题</br>
<img width="463" height="249" alt="image" src="https://github.com/user-attachments/assets/9439a88f-dccb-496e-ac9e-3b0021900f30" /></br>
修复测试场模型名称过长被截断问题，增加悬浮组件显示完整名称</br>
<img width="503" height="469" alt="image" src="https://github.com/user-attachments/assets/7c73d9a6-5cbb-4c68-9ff7-cbcbb30c8cc2" /></br>

