### PR TITLE
feat(chat): 优先选择原生 Gemini 渠道处理 Google 原生工具

### DIFF
--- a/internal/ent/channel/type.go
+++ b/internal/ent/channel/type.go
@@ -19,3 +19,11 @@ func (t Type) IsGemini() bool {
 func (t Type) IsOpenAI() bool {
 	return !t.IsAnthropicLike() && !t.IsAnthropic() && !t.IsGemini()
 }
+
+// SupportsGoogleNativeTools returns true if the channel type supports Google native tools.
+// Google native tools (google_search, google_url_context, google_code_execution) are only
+// supported by native Gemini API format channels (gemini, gemini_vertex).
+// OpenAI-compatible endpoints (gemini_openai) do NOT support these tools.
+func (t Type) SupportsGoogleNativeTools() bool {
+	return t == TypeGemini || t == TypeGeminiVertex
+}

--- a/internal/ent/channel/type_test.go
+++ b/internal/ent/channel/type_test.go
@@ -61,3 +61,42 @@ func TestType_IsAnthropicLike(t *testing.T) {
 		})
 	}
 }
+
+func TestType_SupportsGoogleNativeTools(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		want bool
+	}{
+		{
+			name: "gemini",
+			want: true,
+		},
+		{
+			name: "gemini_vertex",
+			want: true,
+		},
+		{
+			name: "gemini_openai",
+			want: false,
+		},
+		{
+			name: "openai",
+			want: false,
+		},
+		{
+			name: "anthropic",
+			want: false,
+		},
+		{
+			name: "deepseek",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty := channel.Type(tt.name)
+			got := ty.SupportsGoogleNativeTools()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -174,3 +174,45 @@ type GoogleCodeExecution struct{}
 // GoogleUrlContext represents URL context grounding tool for Gemini 2.0+.
 // This allows the model to fetch and process content from specified URLs.
 type GoogleUrlContext struct{}
+
+// ContainsGoogleNativeTools checks if the tools slice contains any Google native tools.
+// Google native tools include GoogleSearch, GoogleCodeExecution, and GoogleUrlContext.
+// These tools are only supported by native Gemini API format (gemini/gemini_vertex),
+// not by OpenAI-compatible endpoints (gemini_openai).
+func ContainsGoogleNativeTools(tools []Tool) bool {
+	for _, tool := range tools {
+		if IsGoogleNativeTool(tool) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsGoogleNativeTool checks if a single tool is a Google native tool.
+func IsGoogleNativeTool(tool Tool) bool {
+	switch tool.Type {
+	case ToolTypeGoogleSearch, ToolTypeGoogleCodeExecution, ToolTypeGoogleUrlContext:
+		return true
+	}
+
+	return false
+}
+
+// FilterGoogleNativeTools removes Google native tools from the tools slice.
+// This is useful as a fallback when routing to channels that don't support native tools.
+func FilterGoogleNativeTools(tools []Tool) []Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+
+	filtered := make([]Tool, 0, len(tools))
+
+	for _, tool := range tools {
+		if !IsGoogleNativeTool(tool) {
+			filtered = append(filtered, tool)
+		}
+	}
+
+	return filtered
+}

--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 // Tool represents a function tool.
@@ -190,13 +191,9 @@ func ContainsGoogleNativeTools(tools []Tool) bool {
 }
 
 // IsGoogleNativeTool checks if a single tool is a Google native tool.
+// Google native tools follow the naming convention "google_*".
 func IsGoogleNativeTool(tool Tool) bool {
-	switch tool.Type {
-	case ToolTypeGoogleSearch, ToolTypeGoogleCodeExecution, ToolTypeGoogleUrlContext:
-		return true
-	}
-
-	return false
+	return strings.HasPrefix(tool.Type, "google_")
 }
 
 // FilterGoogleNativeTools removes Google native tools from the tools slice.

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -1,0 +1,221 @@
+package llm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/llm"
+)
+
+func TestContainsGoogleNativeTools(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []llm.Tool
+		want  bool
+	}{
+		{
+			name:  "nil tools",
+			tools: nil,
+			want:  false,
+		},
+		{
+			name:  "empty tools",
+			tools: []llm.Tool{},
+			want:  false,
+		},
+		{
+			name: "only function tools",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "search"}},
+			},
+			want: false,
+		},
+		{
+			name: "contains google_search",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+			},
+			want: true,
+		},
+		{
+			name: "contains google_url_context",
+			tools: []llm.Tool{
+				{Type: llm.ToolTypeGoogleUrlContext, Google: &llm.GoogleTools{UrlContext: &llm.GoogleUrlContext{}}},
+			},
+			want: true,
+		},
+		{
+			name: "contains google_code_execution",
+			tools: []llm.Tool{
+				{Type: llm.ToolTypeGoogleCodeExecution, Google: &llm.GoogleTools{CodeExecution: &llm.GoogleCodeExecution{}}},
+			},
+			want: true,
+		},
+		{
+			name: "contains multiple google native tools",
+			tools: []llm.Tool{
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+				{Type: llm.ToolTypeGoogleUrlContext, Google: &llm.GoogleTools{UrlContext: &llm.GoogleUrlContext{}}},
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+			},
+			want: true,
+		},
+		{
+			name: "google native tool at the end",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "fn1"}},
+				{Type: "function", Function: llm.Function{Name: "fn2"}},
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.ContainsGoogleNativeTools(tt.tools)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsGoogleNativeTool(t *testing.T) {
+	tests := []struct {
+		name string
+		tool llm.Tool
+		want bool
+	}{
+		{
+			name: "function tool",
+			tool: llm.Tool{Type: "function"},
+			want: false,
+		},
+		{
+			name: "image_generation tool",
+			tool: llm.Tool{Type: llm.ToolTypeImageGeneration},
+			want: false,
+		},
+		{
+			name: "google_search tool",
+			tool: llm.Tool{Type: llm.ToolTypeGoogleSearch},
+			want: true,
+		},
+		{
+			name: "google_url_context tool",
+			tool: llm.Tool{Type: llm.ToolTypeGoogleUrlContext},
+			want: true,
+		},
+		{
+			name: "google_code_execution tool",
+			tool: llm.Tool{Type: llm.ToolTypeGoogleCodeExecution},
+			want: true,
+		},
+		{
+			name: "empty type",
+			tool: llm.Tool{Type: ""},
+			want: false,
+		},
+		{
+			name: "unknown type",
+			tool: llm.Tool{Type: "unknown_tool_type"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.IsGoogleNativeTool(tt.tool)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterGoogleNativeTools(t *testing.T) {
+	tests := []struct {
+		name     string
+		tools    []llm.Tool
+		wantLen  int
+		wantType []string
+	}{
+		{
+			name:     "nil tools",
+			tools:    nil,
+			wantLen:  0,
+			wantType: nil,
+		},
+		{
+			name:     "empty tools",
+			tools:    []llm.Tool{},
+			wantLen:  0,
+			wantType: nil,
+		},
+		{
+			name: "only function tools - no filtering",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "search"}},
+			},
+			wantLen:  2,
+			wantType: []string{"function", "function"},
+		},
+		{
+			name: "filter google_search",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+			},
+			wantLen:  1,
+			wantType: []string{"function"},
+		},
+		{
+			name: "filter all google native tools",
+			tools: []llm.Tool{
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: llm.ToolTypeGoogleUrlContext, Google: &llm.GoogleTools{UrlContext: &llm.GoogleUrlContext{}}},
+				{Type: llm.ToolTypeGoogleCodeExecution, Google: &llm.GoogleTools{CodeExecution: &llm.GoogleCodeExecution{}}},
+			},
+			wantLen:  1,
+			wantType: []string{"function"},
+		},
+		{
+			name: "all google native tools - empty result",
+			tools: []llm.Tool{
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+				{Type: llm.ToolTypeGoogleUrlContext, Google: &llm.GoogleTools{UrlContext: &llm.GoogleUrlContext{}}},
+			},
+			wantLen:  0,
+			wantType: []string{},
+		},
+		{
+			name: "mixed tools with multiple function tools",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "fn1"}},
+				{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+				{Type: "function", Function: llm.Function{Name: "fn2"}},
+				{Type: llm.ToolTypeGoogleCodeExecution, Google: &llm.GoogleTools{CodeExecution: &llm.GoogleCodeExecution{}}},
+				{Type: "function", Function: llm.Function{Name: "fn3"}},
+			},
+			wantLen:  3,
+			wantType: []string{"function", "function", "function"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.FilterGoogleNativeTools(tt.tools)
+			require.Len(t, got, tt.wantLen)
+
+			if len(tt.wantType) > 0 {
+				gotTypes := make([]string, len(got))
+				for i, tool := range got {
+					gotTypes[i] = tool.Type
+				}
+				require.Equal(t, tt.wantType, gotTypes)
+			}
+		})
+	}
+}

--- a/internal/server/chat/channels_test.go
+++ b/internal/server/chat/channels_test.go
@@ -1108,3 +1108,226 @@ func TestSelectedChannelsSelector_WithEmptyFilter(t *testing.T) {
 	assert.Contains(t, channelIDs, channels[1].ID)
 	assert.Contains(t, channelIDs, channels[2].ID)
 }
+
+// createGeminiTestChannels creates test channels including Gemini channels for Google native tools testing.
+func createGeminiTestChannels(t *testing.T, ctx context.Context, client *ent.Client) []*ent.Channel {
+	t.Helper()
+
+	channels := make([]*ent.Channel, 0)
+
+	// Channel 0: gemini (native format, supports Google native tools)
+	ch0, err := client.Channel.Create().
+		SetType(channel.TypeGemini).
+		SetName("Gemini Native").
+		SetBaseURL("https://generativelanguage.googleapis.com").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-1"}).
+		SetSupportedModels([]string{"gemini-2.0-flash", "gemini-2.5-pro"}).
+		SetDefaultTestModel("gemini-2.0-flash").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+	channels = append(channels, ch0)
+
+	// Channel 1: gemini_openai (OpenAI format, does NOT support Google native tools)
+	ch1, err := client.Channel.Create().
+		SetType(channel.TypeGeminiOpenai).
+		SetName("Gemini OpenAI").
+		SetBaseURL("https://generativelanguage.googleapis.com").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-2"}).
+		SetSupportedModels([]string{"gemini-2.0-flash", "gemini-2.5-pro"}).
+		SetDefaultTestModel("gemini-2.0-flash").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+	channels = append(channels, ch1)
+
+	// Channel 2: gemini_vertex (Vertex AI, supports Google native tools)
+	ch2, err := client.Channel.Create().
+		SetType(channel.TypeGeminiVertex).
+		SetName("Gemini Vertex").
+		SetBaseURL("https://us-central1-aiplatform.googleapis.com").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key-3"}).
+		SetSupportedModels([]string{"gemini-2.0-flash", "gemini-2.5-pro"}).
+		SetDefaultTestModel("gemini-2.0-flash").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+	channels = append(channels, ch2)
+
+	return channels
+}
+
+// TestGoogleNativeToolsSelector_Select_WithGoogleNativeTools tests filtering when request contains Google native tools.
+func TestGoogleNativeToolsSelector_Select_WithGoogleNativeTools(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	channels := createGeminiTestChannels(t, ctx, client)
+
+	channelService := newTestChannelServiceForChannels(client)
+	baseSelector := NewDefaultSelector(channelService)
+	selector := NewGoogleNativeToolsSelector(baseSelector)
+
+	// Request with Google native tools
+	req := &llm.Request{
+		Model: "gemini-2.0-flash",
+		Tools: []llm.Tool{
+			{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+			{Type: "function", Function: llm.Function{Name: "get_weather"}},
+		},
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Should return only channels that support Google native tools (gemini, gemini_vertex)
+	require.Len(t, result, 2)
+
+	channelIDs := make([]int, len(result))
+	for i, ch := range result {
+		channelIDs[i] = ch.ID
+	}
+
+	assert.Contains(t, channelIDs, channels[0].ID, "Gemini native channel should be included")
+	assert.Contains(t, channelIDs, channels[2].ID, "Gemini Vertex channel should be included")
+	assert.NotContains(t, channelIDs, channels[1].ID, "Gemini OpenAI channel should be excluded")
+}
+
+// TestGoogleNativeToolsSelector_Select_WithoutGoogleNativeTools tests that all channels are returned when no Google native tools.
+func TestGoogleNativeToolsSelector_Select_WithoutGoogleNativeTools(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	channels := createGeminiTestChannels(t, ctx, client)
+
+	channelService := newTestChannelServiceForChannels(client)
+	baseSelector := NewDefaultSelector(channelService)
+	selector := NewGoogleNativeToolsSelector(baseSelector)
+
+	// Request without Google native tools (only function tools)
+	req := &llm.Request{
+		Model: "gemini-2.0-flash",
+		Tools: []llm.Tool{
+			{Type: "function", Function: llm.Function{Name: "get_weather"}},
+			{Type: "function", Function: llm.Function{Name: "search"}},
+		},
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Should return all channels when no Google native tools
+	require.Len(t, result, 3)
+
+	channelIDs := make([]int, len(result))
+	for i, ch := range result {
+		channelIDs[i] = ch.ID
+	}
+
+	assert.Contains(t, channelIDs, channels[0].ID, "Gemini native channel should be included")
+	assert.Contains(t, channelIDs, channels[1].ID, "Gemini OpenAI channel should be included")
+	assert.Contains(t, channelIDs, channels[2].ID, "Gemini Vertex channel should be included")
+}
+
+// TestGoogleNativeToolsSelector_Select_NoCompatibleChannels tests fallback when no compatible channels exist.
+func TestGoogleNativeToolsSelector_Select_NoCompatibleChannels(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	// Create only gemini_openai channel (does not support Google native tools)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeGeminiOpenai).
+		SetName("Gemini OpenAI Only").
+		SetBaseURL("https://generativelanguage.googleapis.com").
+		SetCredentials(&objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gemini-2.0-flash"}).
+		SetDefaultTestModel("gemini-2.0-flash").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelService := newTestChannelServiceForChannels(client)
+	baseSelector := NewDefaultSelector(channelService)
+	selector := NewGoogleNativeToolsSelector(baseSelector)
+
+	// Request with Google native tools
+	req := &llm.Request{
+		Model: "gemini-2.0-flash",
+		Tools: []llm.Tool{
+			{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+		},
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Should fallback to all channels when no compatible channels exist
+	// (downstream outbound will handle the fallback)
+	require.Len(t, result, 1)
+	assert.Equal(t, ch.ID, result[0].ID)
+}
+
+// TestGoogleNativeToolsSelector_Select_EmptyTools tests that all channels are returned when tools are empty.
+func TestGoogleNativeToolsSelector_Select_EmptyTools(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	channels := createGeminiTestChannels(t, ctx, client)
+
+	channelService := newTestChannelServiceForChannels(client)
+	baseSelector := NewDefaultSelector(channelService)
+	selector := NewGoogleNativeToolsSelector(baseSelector)
+
+	// Request with no tools
+	req := &llm.Request{
+		Model: "gemini-2.0-flash",
+		Tools: []llm.Tool{},
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Should return all channels when no tools
+	require.Len(t, result, 3)
+
+	channelIDs := make([]int, len(result))
+	for i, ch := range result {
+		channelIDs[i] = ch.ID
+	}
+
+	assert.Contains(t, channelIDs, channels[0].ID)
+	assert.Contains(t, channelIDs, channels[1].ID)
+	assert.Contains(t, channelIDs, channels[2].ID)
+}
+
+// TestGoogleNativeToolsSelector_Select_MultipleGoogleNativeTools tests filtering with multiple Google native tools.
+func TestGoogleNativeToolsSelector_Select_MultipleGoogleNativeTools(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	channels := createGeminiTestChannels(t, ctx, client)
+
+	channelService := newTestChannelServiceForChannels(client)
+	baseSelector := NewDefaultSelector(channelService)
+	selector := NewGoogleNativeToolsSelector(baseSelector)
+
+	// Request with multiple Google native tools
+	req := &llm.Request{
+		Model: "gemini-2.0-flash",
+		Tools: []llm.Tool{
+			{Type: llm.ToolTypeGoogleSearch, Google: &llm.GoogleTools{Search: &llm.GoogleSearch{}}},
+			{Type: llm.ToolTypeGoogleUrlContext, Google: &llm.GoogleTools{UrlContext: &llm.GoogleUrlContext{}}},
+			{Type: "function", Function: llm.Function{Name: "get_weather"}},
+		},
+	}
+
+	result, err := selector.Select(ctx, req)
+	require.NoError(t, err)
+
+	// Should return only channels that support Google native tools
+	require.Len(t, result, 2)
+
+	channelIDs := make([]int, len(result))
+	for i, ch := range result {
+		channelIDs[i] = ch.ID
+	}
+
+	assert.Contains(t, channelIDs, channels[0].ID, "Gemini native channel should be included")
+	assert.Contains(t, channelIDs, channels[2].ID, "Gemini Vertex channel should be included")
+	assert.NotContains(t, channelIDs, channels[1].ID, "Gemini OpenAI channel should be excluded")
+}

--- a/internal/server/chat/inbound.go
+++ b/internal/server/chat/inbound.go
@@ -274,8 +274,10 @@ func selectChannels(inbound *PersistentInboundTransformer) pipeline.Middleware {
 			}
 		}
 
-		// 应用 Google 原生工具过滤（优先选择支持原生工具的渠道）
-		selector = NewGoogleNativeToolsSelector(selector)
+		// 应用 Google 原生工具过滤（仅对 Gemini 原生 API 格式生效）
+		if inbound.APIFormat() == llm.APIFormatGeminiContents {
+			selector = NewGoogleNativeToolsSelector(selector)
+		}
 
 		if inbound.state.LoadBalancer != nil {
 			selector = NewLoadBalancedSelector(selector, inbound.state.LoadBalancer)

--- a/internal/server/chat/inbound.go
+++ b/internal/server/chat/inbound.go
@@ -274,6 +274,9 @@ func selectChannels(inbound *PersistentInboundTransformer) pipeline.Middleware {
 			}
 		}
 
+		// 应用 Google 原生工具过滤（优先选择支持原生工具的渠道）
+		selector = NewGoogleNativeToolsSelector(selector)
+
 		if inbound.state.LoadBalancer != nil {
 			selector = NewLoadBalancedSelector(selector, inbound.state.LoadBalancer)
 		}


### PR DESCRIPTION
## 问题描述

当用户通过 `/gemini` 路径发送包含 Google 原生工具（如 `google_search`、`google_url_context`、`google_code_execution`）的请求时，如果内部被路由到 `gemini_openai` 渠道（使用 OpenAI 兼容格式），会触发以下错误：

```
Invalid input: expected 'function'
```

**根本原因**：`gemini_openai` 渠道使用 OpenAI 兼容的 API 格式，该格式只支持 `function` 类型的工具，不支持 Google 原生工具类型。

## 解决方案

采用 **渠道优先过滤 + 降级策略** 的组合方案：

### 1. 渠道优先过滤（方案 B）

在渠道选择阶段，当检测到请求包含 Google 原生工具时：
- 优先选择支持原生 Gemini API 格式的渠道（`gemini`、`gemini_vertex`）
- 过滤掉不支持原生工具的渠道（`gemini_openai`）

### 2. 降级策略（方案 C）

当没有兼容渠道可用时，在 `gemini_openai` 的 outbound transformer 中：
- 自动过滤掉不支持的 Google 原生工具
- 保留所有 `function` 类型的工具
- 处理过滤后 `tools` 为空的情况（置为 `nil` 并重置 `ToolChoice`）

## 代码变更

| 文件 | 变更说明 |
|------|----------|
| `internal/llm/tools.go` | 新增辅助函数：`ContainsGoogleNativeTools`、`IsGoogleNativeTool`、`FilterGoogleNativeTools` |
| `internal/llm/tools_test.go` | 新增单元测试，覆盖各种工具组合场景 |
| `internal/ent/channel/type.go` | 新增 `SupportsGoogleNativeTools()` 方法 |
| `internal/ent/channel/type_test.go` | 新增对应测试用例 |
| `internal/server/chat/channels.go` | 新增 `GoogleNativeToolsSelector` 装饰器 |
| `internal/server/chat/channels_test.go` | 新增选择器测试用例 |
| `internal/server/chat/inbound.go` | 集成 `GoogleNativeToolsSelector` 到渠道选择链 |
| `internal/llm/transformer/gemini/openai/outbound.go` | 新增降级过滤逻辑 |

## 测试情况

### 单元测试结果

**1. 工具辅助函数测试 (`internal/llm/tools_test.go`)**

```
=== RUN   TestContainsGoogleNativeTools
    --- PASS: TestContainsGoogleNativeTools/nil_tools
    --- PASS: TestContainsGoogleNativeTools/empty_tools
    --- PASS: TestContainsGoogleNativeTools/only_function_tools
    --- PASS: TestContainsGoogleNativeTools/contains_google_search
    --- PASS: TestContainsGoogleNativeTools/contains_google_url_context
    --- PASS: TestContainsGoogleNativeTools/contains_google_code_execution
    --- PASS: TestContainsGoogleNativeTools/contains_multiple_google_native_tools
    --- PASS: TestContainsGoogleNativeTools/google_native_tool_at_the_end
--- PASS: TestContainsGoogleNativeTools

=== RUN   TestIsGoogleNativeTool
    --- PASS: TestIsGoogleNativeTool/function_tool
    --- PASS: TestIsGoogleNativeTool/image_generation_tool
    --- PASS: TestIsGoogleNativeTool/google_search_tool
    --- PASS: TestIsGoogleNativeTool/google_url_context_tool
    --- PASS: TestIsGoogleNativeTool/google_code_execution_tool
    --- PASS: TestIsGoogleNativeTool/empty_type
    --- PASS: TestIsGoogleNativeTool/unknown_type
--- PASS: TestIsGoogleNativeTool

=== RUN   TestFilterGoogleNativeTools
    --- PASS: TestFilterGoogleNativeTools/nil_tools
    --- PASS: TestFilterGoogleNativeTools/empty_tools
    --- PASS: TestFilterGoogleNativeTools/only_function_tools_-_no_filtering
    --- PASS: TestFilterGoogleNativeTools/filter_google_search
    --- PASS: TestFilterGoogleNativeTools/filter_all_google_native_tools
    --- PASS: TestFilterGoogleNativeTools/all_google_native_tools_-_empty_result
    --- PASS: TestFilterGoogleNativeTools/mixed_tools_with_multiple_function_tools
--- PASS: TestFilterGoogleNativeTools
```

**2. 渠道类型测试 (`internal/ent/channel/type_test.go`)**

```
=== RUN   TestType_SupportsGoogleNativeTools
    --- PASS: TestType_SupportsGoogleNativeTools/gemini (支持)
    --- PASS: TestType_SupportsGoogleNativeTools/gemini_vertex (支持)
    --- PASS: TestType_SupportsGoogleNativeTools/gemini_openai (不支持)
    --- PASS: TestType_SupportsGoogleNativeTools/openai (不支持)
    --- PASS: TestType_SupportsGoogleNativeTools/anthropic (不支持)
    --- PASS: TestType_SupportsGoogleNativeTools/deepseek (不支持)
--- PASS: TestType_SupportsGoogleNativeTools
```

**3. 渠道选择器测试 (`internal/server/chat/channels_test.go`)**

```
=== RUN   TestGoogleNativeToolsSelector_Select_WithGoogleNativeTools
--- PASS: (验证：包含原生工具时只返回兼容渠道)

=== RUN   TestGoogleNativeToolsSelector_Select_WithoutGoogleNativeTools
--- PASS: (验证：不包含原生工具时返回所有渠道)

=== RUN   TestGoogleNativeToolsSelector_Select_NoCompatibleChannels
--- PASS: (验证：无兼容渠道时回退到所有渠道，由下游降级处理)

=== RUN   TestGoogleNativeToolsSelector_Select_EmptyTools
--- PASS: (验证：空工具列表时返回所有渠道)

=== RUN   TestGoogleNativeToolsSelector_Select_MultipleGoogleNativeTools
--- PASS: (验证：多个原生工具时正确过滤)
```

### 降级策略验证

| 场景 | 输入工具 | 输出工具 | 结果 |
|------|----------|----------|------|
| 混合工具 | 1 function + 1 google_search | 1 function | ✅ Function 保留 |
| 多个原生工具 | 1 function + 3 google_native | 1 function | ✅ Function 保留 |
| 多个 Function | 3 functions + 2 google_native | 3 functions | ✅ 全部 Function 保留 |
| 仅原生工具 | 2 google_native | 空 (nil) | ✅ 正确置空 |

### 编译验证

```
$ make build-backend
Building axonhub backend...
go build -tags=nomsgpack -o axonhub ./cmd/axonhub
Backend build completed!
```

## 行为说明

1. **正常路径**：请求包含 Google 原生工具 → 优先路由到 `gemini`/`gemini_vertex` 渠道 → 原生工具正常工作
2. **降级路径**：无兼容渠道 → 路由到 `gemini_openai` → 自动过滤原生工具，保留 function 工具 → 请求继续执行（功能降级但不报错）

## 相关 Issue

修复 Google 原生工具路由到 OpenAI 兼容端点时的 "Invalid input: expected 'function'" 错误