### PR TITLE
feat: support anthropic web search tool

### DIFF
--- a/internal/ent/channel/type.go
+++ b/internal/ent/channel/type.go
@@ -27,3 +27,12 @@ func (t Type) IsOpenAI() bool {
 func (t Type) SupportsGoogleNativeTools() bool {
 	return t == TypeGemini || t == TypeGeminiVertex
 }
+
+// SupportsAnthropicNativeTools returns true if the channel type supports Anthropic native tools.
+// Anthropic native tools (web_search_20250305) are only supported by native Anthropic API
+// format channels (anthropic, anthropic_aws, anthropic_gcp).
+// Channels using Anthropic format but not native Anthropic API (e.g., deepseek_anthropic,
+// moonshot_anthropic) do NOT support these tools.
+func (t Type) SupportsAnthropicNativeTools() bool {
+	return t == TypeAnthropic || t == TypeAnthropicAWS || t == TypeAnthropicGcp
+}

--- a/internal/ent/channel/type.go
+++ b/internal/ent/channel/type.go
@@ -29,10 +29,11 @@ func (t Type) SupportsGoogleNativeTools() bool {
 }
 
 // SupportsAnthropicNativeTools returns true if the channel type supports Anthropic native tools.
-// Anthropic native tools (web_search_20250305) are only supported by native Anthropic API
-// format channels (anthropic, anthropic_aws, anthropic_gcp).
+// Anthropic native tools (web_search_20250305) are only supported by direct Anthropic API.
+// Note: Bedrock (anthropic_aws) and Vertex (anthropic_gcp) do NOT currently support
+// the web search beta feature, so they are excluded from native tool support.
 // Channels using Anthropic format but not native Anthropic API (e.g., deepseek_anthropic,
-// moonshot_anthropic) do NOT support these tools.
+// moonshot_anthropic) also do NOT support these tools.
 func (t Type) SupportsAnthropicNativeTools() bool {
-	return t == TypeAnthropic || t == TypeAnthropicAWS || t == TypeAnthropicGcp
+	return t == TypeAnthropic
 }

--- a/internal/ent/channel/type_test.go
+++ b/internal/ent/channel/type_test.go
@@ -100,3 +100,46 @@ func TestType_SupportsGoogleNativeTools(t *testing.T) {
 		})
 	}
 }
+
+func TestType_SupportsAnthropicNativeTools(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		want bool
+	}{
+		{
+			name: "anthropic",
+			want: true,
+		},
+		{
+			name: "anthropic_aws",
+			want: true,
+		},
+		{
+			name: "anthropic_gcp",
+			want: true,
+		},
+		{
+			name: "deepseek_anthropic",
+			want: false,
+		},
+		{
+			name: "moonshot_anthropic",
+			want: false,
+		},
+		{
+			name: "openai",
+			want: false,
+		},
+		{
+			name: "gemini",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty := channel.Type(tt.name)
+			got := ty.SupportsAnthropicNativeTools()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/ent/channel/type_test.go
+++ b/internal/ent/channel/type_test.go
@@ -112,11 +112,11 @@ func TestType_SupportsAnthropicNativeTools(t *testing.T) {
 		},
 		{
 			name: "anthropic_aws",
-			want: true,
+			want: false, // Bedrock does not support web search beta
 		},
 		{
 			name: "anthropic_gcp",
-			want: true,
+			want: false, // Vertex does not support web search beta
 		},
 		{
 			name: "deepseek_anthropic",

--- a/internal/llm/constants.go
+++ b/internal/llm/constants.go
@@ -27,4 +27,11 @@ const (
 	ToolTypeGoogleCodeExecution = "google_code_execution"
 	// ToolTypeGoogleUrlContext is the URL context grounding tool type for Gemini 2.0+.
 	ToolTypeGoogleUrlContext = "google_url_context"
+
+	// ToolTypeAnthropicWebSearch is the native web search tool type for Anthropic (Beta).
+	// This tool is only supported by native Anthropic API format channels.
+	ToolTypeAnthropicWebSearch = "web_search_20250305"
+	// AnthropicWebSearchFunctionName is the standard function name that triggers
+	// native Anthropic web search tool transformation.
+	AnthropicWebSearchFunctionName = "web_search"
 )

--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -213,3 +213,50 @@ func FilterGoogleNativeTools(tools []Tool) []Tool {
 
 	return filtered
 }
+
+// ContainsAnthropicNativeTools checks if the tools slice contains any Anthropic native tools.
+// Currently, this checks for the web_search function which maps to Anthropic's native
+// web_search_20250305 tool type.
+func ContainsAnthropicNativeTools(tools []Tool) bool {
+	for _, tool := range tools {
+		if IsAnthropicNativeTool(tool) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsAnthropicNativeTool checks if a single tool is an Anthropic native tool.
+// A tool is considered Anthropic native if:
+// 1. It's a function tool with name "web_search" (OpenAI format input), OR
+// 2. It's already transformed to type "web_search_20250305" (Anthropic native format)
+func IsAnthropicNativeTool(tool Tool) bool {
+	// Match function tool with web_search name (OpenAI format input)
+	if tool.Type == ToolType && tool.Function.Name == AnthropicWebSearchFunctionName {
+		return true
+	}
+	// Match already-transformed Anthropic native tool type
+	if tool.Type == ToolTypeAnthropicWebSearch {
+		return true
+	}
+	return false
+}
+
+// FilterAnthropicNativeTools removes Anthropic native tools from the tools slice.
+// This is useful as a fallback when routing to channels that don't support native tools.
+func FilterAnthropicNativeTools(tools []Tool) []Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+
+	filtered := make([]Tool, 0, len(tools))
+
+	for _, tool := range tools {
+		if !IsAnthropicNativeTool(tool) {
+			filtered = append(filtered, tool)
+		}
+	}
+
+	return filtered
+}

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -220,3 +220,208 @@ func TestFilterGoogleNativeTools(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsAnthropicNativeTools(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []llm.Tool
+		want  bool
+	}{
+		{
+			name:  "nil tools",
+			tools: nil,
+			want:  false,
+		},
+		{
+			name:  "empty tools",
+			tools: []llm.Tool{},
+			want:  false,
+		},
+		{
+			name: "only function tools without web_search",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "calculator"}},
+			},
+			want: false,
+		},
+		{
+			name: "contains web_search function",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+			},
+			want: true,
+		},
+		{
+			name: "web_search at the beginning",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+			},
+			want: true,
+		},
+		{
+			name: "only web_search",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+			},
+			want: true,
+		},
+		{
+			name: "web_search with different type (not function)",
+			tools: []llm.Tool{
+				{Type: "not_function", Function: llm.Function{Name: "web_search"}},
+			},
+			want: false,
+		},
+		{
+			name: "contains native web_search_20250305 type",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: llm.ToolTypeAnthropicWebSearch},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.ContainsAnthropicNativeTools(tt.tools)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsAnthropicNativeTool(t *testing.T) {
+	tests := []struct {
+		name string
+		tool llm.Tool
+		want bool
+	}{
+		{
+			name: "function tool with web_search name",
+			tool: llm.Tool{Type: "function", Function: llm.Function{Name: "web_search"}},
+			want: true,
+		},
+		{
+			name: "function tool with other name",
+			tool: llm.Tool{Type: "function", Function: llm.Function{Name: "get_weather"}},
+			want: false,
+		},
+		{
+			name: "non-function tool with web_search name",
+			tool: llm.Tool{Type: "other", Function: llm.Function{Name: "web_search"}},
+			want: false,
+		},
+		{
+			name: "google_search tool",
+			tool: llm.Tool{Type: llm.ToolTypeGoogleSearch},
+			want: false,
+		},
+		{
+			name: "empty tool",
+			tool: llm.Tool{},
+			want: false,
+		},
+		{
+			name: "native web_search_20250305 type (already transformed)",
+			tool: llm.Tool{Type: llm.ToolTypeAnthropicWebSearch},
+			want: true,
+		},
+		{
+			name: "native web_search_20250305 type with name",
+			tool: llm.Tool{Type: llm.ToolTypeAnthropicWebSearch, Function: llm.Function{Name: "web_search"}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.IsAnthropicNativeTool(tt.tool)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterAnthropicNativeTools(t *testing.T) {
+	tests := []struct {
+		name     string
+		tools    []llm.Tool
+		wantLen  int
+		wantType []string
+	}{
+		{
+			name:     "nil tools",
+			tools:    nil,
+			wantLen:  0,
+			wantType: nil,
+		},
+		{
+			name:     "empty tools",
+			tools:    []llm.Tool{},
+			wantLen:  0,
+			wantType: nil,
+		},
+		{
+			name: "only function tools without web_search - no filtering",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "calculator"}},
+			},
+			wantLen:  2,
+			wantType: []string{"function", "function"},
+		},
+		{
+			name: "filter web_search",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "get_weather"}},
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+			},
+			wantLen:  1,
+			wantType: []string{"function"},
+		},
+		{
+			name: "all web_search tools - empty result",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+			},
+			wantLen:  0,
+			wantType: []string{},
+		},
+		{
+			name: "mixed tools",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "fn1"}},
+				{Type: "function", Function: llm.Function{Name: "web_search"}},
+				{Type: "function", Function: llm.Function{Name: "fn2"}},
+			},
+			wantLen:  2,
+			wantType: []string{"function", "function"},
+		},
+		{
+			name: "filter native web_search_20250305 type",
+			tools: []llm.Tool{
+				{Type: "function", Function: llm.Function{Name: "fn1"}},
+				{Type: llm.ToolTypeAnthropicWebSearch},
+			},
+			wantLen:  1,
+			wantType: []string{"function"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llm.FilterAnthropicNativeTools(tt.tools)
+			require.Len(t, got, tt.wantLen)
+
+			if len(tt.wantType) > 0 {
+				gotTypes := make([]string, len(got))
+				for i, tool := range got {
+					gotTypes[i] = tool.Type
+				}
+				require.Equal(t, tt.wantType, gotTypes)
+			}
+		})
+	}
+}

--- a/internal/llm/transformer/anthropic/model.go
+++ b/internal/llm/transformer/anthropic/model.go
@@ -152,12 +152,12 @@ type ToolChoice struct {
 
 // Tool represents a tool definition for Anthropic API.
 type Tool struct {
-	// Ensure the omitempty, otherwise it will be sent empty string to the API, will cause some providers ignore the tool.
-	// For now, we only support function (client tool or custom tool in anthropic) tool, so we can just omit the type.
-	// Type         string          `json:"type,omitempty"`
+	// Type is used for native tools (e.g., "web_search_20250305").
+	// For custom/function tools, this field is omitted.
+	Type         string          `json:"type,omitempty"`
 	Name         string          `json:"name"`
-	Description  string          `json:"description"`
-	InputSchema  json.RawMessage `json:"input_schema"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
 	CacheControl *CacheControl   `json:"cache_control,omitempty"`
 }
 

--- a/internal/llm/transformer/anthropic/outbound.go
+++ b/internal/llm/transformer/anthropic/outbound.go
@@ -182,6 +182,11 @@ func (t *OutboundTransformer) TransformRequest(
 		headers.Set("Anthropic-Version", "2023-06-01")
 	}
 
+	// Add beta header for web search feature when tools are present
+	if len(anthropicReq.Tools) > 0 {
+		headers.Set("Anthropic-Beta", "web-search-2025-03-05")
+	}
+
 	// Prepare authentication
 	var auth *httpclient.AuthConfig
 

--- a/internal/llm/transformer/anthropic/outbound.go
+++ b/internal/llm/transformer/anthropic/outbound.go
@@ -182,8 +182,10 @@ func (t *OutboundTransformer) TransformRequest(
 		headers.Set("Anthropic-Version", "2023-06-01")
 	}
 
-	// Add beta header for web search feature when tools are present
-	if len(anthropicReq.Tools) > 0 {
+	// Add beta header for web search feature only when:
+	// 1. Native web search tool is present, AND
+	// 2. Platform is direct Anthropic API (not Bedrock/Vertex which may not support this beta)
+	if containsNativeWebSearchTool(anthropicReq.Tools) && t.config.Type != PlatformBedrock && t.config.Type != PlatformVertex {
 		headers.Set("Anthropic-Beta", "web-search-2025-03-05")
 	}
 
@@ -413,4 +415,15 @@ func (t *OutboundTransformer) TransformError(ctx context.Context, rawErr *httpcl
 			RequestID: "",
 		},
 	}
+}
+
+// containsNativeWebSearchTool checks if the Anthropic tools slice contains the native web search tool.
+func containsNativeWebSearchTool(tools []Tool) bool {
+	for _, tool := range tools {
+		if tool.Type == ToolTypeWebSearch20250305 {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/llm/transformer/anthropic/outbound_convert.go
+++ b/internal/llm/transformer/anthropic/outbound_convert.go
@@ -82,25 +82,20 @@ func convertTools(tools []llm.Tool) []Tool {
 	anthropicTools := make([]Tool, 0, len(tools))
 
 	for _, tool := range tools {
-		if tool.Type != llm.ToolType {
-			continue
-		}
-
-		if tool.Function.Name == llm.AnthropicWebSearchFunctionName {
+		// Use shared helper to detect Anthropic native tools (web_search)
+		if llm.IsAnthropicNativeTool(tool) {
 			anthropicTools = append(anthropicTools, Tool{
 				Type: ToolTypeWebSearch20250305,
 				Name: llm.AnthropicWebSearchFunctionName,
 			})
-
-			continue
+		} else if tool.Type == llm.ToolType {
+			anthropicTools = append(anthropicTools, Tool{
+				Name:         tool.Function.Name,
+				Description:  tool.Function.Description,
+				InputSchema:  tool.Function.Parameters,
+				CacheControl: convertToAnthropicCacheControl(tool.CacheControl),
+			})
 		}
-
-		anthropicTools = append(anthropicTools, Tool{
-			Name:         tool.Function.Name,
-			Description:  tool.Function.Description,
-			InputSchema:  tool.Function.Parameters,
-			CacheControl: convertToAnthropicCacheControl(tool.CacheControl),
-		})
 	}
 
 	if len(anthropicTools) == 0 {

--- a/internal/llm/transformer/anthropic/outbound_convert.go
+++ b/internal/llm/transformer/anthropic/outbound_convert.go
@@ -9,12 +9,8 @@ import (
 	"github.com/looplj/axonhub/internal/pkg/xurl"
 )
 
-const (
-	// ToolTypeWebSearch20250305 is the native web search tool type for Anthropic (Beta).
-	ToolTypeWebSearch20250305 = "web_search_20250305"
-
-	anthropicWebSearchFunctionName = "web_search"
-)
+// ToolTypeWebSearch20250305 is an alias to llm.ToolTypeAnthropicWebSearch for package compatibility.
+const ToolTypeWebSearch20250305 = llm.ToolTypeAnthropicWebSearch
 
 // convertToAnthropicRequest converts ChatCompletionRequest to Anthropic MessageRequest.
 // Deprecated: Use convertToAnthropicRequestWithConfig instead.
@@ -90,10 +86,10 @@ func convertTools(tools []llm.Tool) []Tool {
 			continue
 		}
 
-		if tool.Function.Name == anthropicWebSearchFunctionName {
+		if tool.Function.Name == llm.AnthropicWebSearchFunctionName {
 			anthropicTools = append(anthropicTools, Tool{
 				Type: ToolTypeWebSearch20250305,
-				Name: anthropicWebSearchFunctionName,
+				Name: llm.AnthropicWebSearchFunctionName,
 			})
 
 			continue

--- a/internal/llm/transformer/anthropic/outbound_test.go
+++ b/internal/llm/transformer/anthropic/outbound_test.go
@@ -742,6 +742,9 @@ func TestOutboundTransformer_ToolUse(t *testing.T) {
 					// but should not cause errors
 					require.NotNil(t, anthropicReq.Tools)
 					require.Len(t, anthropicReq.Tools, 1)
+
+					// Verify beta header is NOT set for regular function tools
+					require.Empty(t, result.Headers.Get("Anthropic-Beta"))
 				},
 			},
 		}

--- a/internal/llm/transformer/anthropic/outbound_test.go
+++ b/internal/llm/transformer/anthropic/outbound_test.go
@@ -988,3 +988,227 @@ func TestOutboundTransformer_TransformRequest_WithTestData(t *testing.T) {
 		})
 	}
 }
+
+func TestOutboundTransformer_WebSearchBetaHeader(t *testing.T) {
+	t.Run("Direct Anthropic API with web_search tool", func(t *testing.T) {
+		transformer, err := NewOutboundTransformer("https://api.anthropic.com", "test-api-key")
+		require.NoError(t, err)
+
+		chatReq := &llm.Request{
+			Model:     "claude-sonnet-4-20250514",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "What's the weather?"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "web_search",
+						Description: "Search the web",
+					},
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		require.Equal(t, "web-search-2025-03-05", result.Headers.Get("Anthropic-Beta"))
+	})
+
+	t.Run("Bedrock platform with web_search tool - no Beta header", func(t *testing.T) {
+		transformer := &OutboundTransformer{
+			config: &Config{},
+		}
+		transformer.ConfigureForBedrock("us-east-1")
+
+		chatReq := &llm.Request{
+			Model:     "anthropic.claude-3-sonnet-20240229-v1:0",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "What's the weather?"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "web_search",
+						Description: "Search the web",
+					},
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		// Bedrock should NOT have Beta header even with web_search tool
+		require.Empty(t, result.Headers.Get("Anthropic-Beta"))
+	})
+
+	t.Run("Vertex platform with web_search tool - no Beta header", func(t *testing.T) {
+		transformer := &OutboundTransformer{
+			config: &Config{},
+		}
+		err := transformer.ConfigureForVertex("us-central1", "my-project")
+		require.NoError(t, err)
+
+		chatReq := &llm.Request{
+			Model:     "claude-sonnet-4-20250514",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "What's the weather?"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "web_search",
+						Description: "Search the web",
+					},
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		// Vertex should NOT have Beta header even with web_search tool
+		require.Empty(t, result.Headers.Get("Anthropic-Beta"))
+	})
+
+	t.Run("Direct Anthropic API with web_search_20250305 type input", func(t *testing.T) {
+		transformer, err := NewOutboundTransformer("https://api.anthropic.com", "test-api-key")
+		require.NoError(t, err)
+
+		chatReq := &llm.Request{
+			Model:     "claude-sonnet-4-20250514",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "What's the weather?"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: llm.ToolTypeAnthropicWebSearch, // Already transformed type
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		// Should still set Beta header for already-transformed tool type
+		require.Equal(t, "web-search-2025-03-05", result.Headers.Get("Anthropic-Beta"))
+
+		// Verify tool is passed through correctly
+		var anthropicReq MessageRequest
+		err = json.Unmarshal(result.Body, &anthropicReq)
+		require.NoError(t, err)
+		require.Len(t, anthropicReq.Tools, 1)
+		require.Equal(t, ToolTypeWebSearch20250305, anthropicReq.Tools[0].Type)
+	})
+
+	t.Run("Direct Anthropic API without web_search tool - no Beta header", func(t *testing.T) {
+		transformer, err := NewOutboundTransformer("https://api.anthropic.com", "test-api-key")
+		require.NoError(t, err)
+
+		chatReq := &llm.Request{
+			Model:     "claude-sonnet-4-20250514",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "Hello"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "calculator",
+						Description: "Perform calculations",
+					},
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		// Regular function tools should NOT trigger Beta header
+		require.Empty(t, result.Headers.Get("Anthropic-Beta"))
+	})
+
+	t.Run("Direct Anthropic API with mixed tools including web_search", func(t *testing.T) {
+		transformer, err := NewOutboundTransformer("https://api.anthropic.com", "test-api-key")
+		require.NoError(t, err)
+
+		chatReq := &llm.Request{
+			Model:     "claude-sonnet-4-20250514",
+			MaxTokens: func() *int64 { v := int64(1024); return &v }(),
+			Messages: []llm.Message{
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: func() *string { s := "Search and calculate"; return &s }(),
+					},
+				},
+			},
+			Tools: []llm.Tool{
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "calculator",
+						Description: "Perform calculations",
+					},
+				},
+				{
+					Type: "function",
+					Function: llm.Function{
+						Name:        "web_search",
+						Description: "Search the web",
+					},
+				},
+			},
+		}
+
+		result, err := transformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+		// Mixed tools with web_search should trigger Beta header
+		require.Equal(t, "web-search-2025-03-05", result.Headers.Get("Anthropic-Beta"))
+
+		// Verify tools are converted correctly
+		var anthropicReq MessageRequest
+		err = json.Unmarshal(result.Body, &anthropicReq)
+		require.NoError(t, err)
+		require.Len(t, anthropicReq.Tools, 2)
+
+		// Find web_search tool and verify conversion
+		var hasWebSearch bool
+		for _, tool := range anthropicReq.Tools {
+			if tool.Type == ToolTypeWebSearch20250305 {
+				hasWebSearch = true
+				require.Equal(t, "web_search", tool.Name)
+			}
+		}
+		require.True(t, hasWebSearch, "web_search tool should be converted to web_search_20250305")
+	})
+}

--- a/internal/server/chat/channels.go
+++ b/internal/server/chat/channels.go
@@ -230,3 +230,51 @@ func (s *GoogleNativeToolsSelector) Select(ctx context.Context, req *llm.Request
 
 	return channels, nil
 }
+
+// AnthropicNativeToolsSelector is a decorator that prioritizes channels supporting Anthropic native tools.
+// When a request contains Anthropic native tools (web_search -> web_search_20250305),
+// this selector filters out channels that don't support these tools (e.g., deepseek_anthropic).
+// If no compatible channels are found, it falls back to all channels (allowing downstream fallback logic).
+type AnthropicNativeToolsSelector struct {
+	wrapped ChannelSelector
+}
+
+// NewAnthropicNativeToolsSelector creates a selector that prioritizes Anthropic native tool compatible channels.
+func NewAnthropicNativeToolsSelector(wrapped ChannelSelector) *AnthropicNativeToolsSelector {
+	return &AnthropicNativeToolsSelector{
+		wrapped: wrapped,
+	}
+}
+
+func (s *AnthropicNativeToolsSelector) Select(ctx context.Context, req *llm.Request) ([]*biz.Channel, error) {
+	channels, err := s.wrapped.Select(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// 如果请求不包含 Anthropic 原生工具，直接返回所有渠道
+	if !llm.ContainsAnthropicNativeTools(req.Tools) {
+		return channels, nil
+	}
+
+	// 过滤：只保留支持 Anthropic 原生工具的渠道
+	compatible := lo.Filter(channels, func(ch *biz.Channel, _ int) bool {
+		return ch.Type.SupportsAnthropicNativeTools()
+	})
+
+	if len(compatible) > 0 {
+		if log.DebugEnabled(ctx) {
+			log.Debug(ctx, "Filtered channels for Anthropic native tools",
+				log.Int("total_channels", len(channels)),
+				log.Int("compatible_channels", len(compatible)))
+		}
+
+		return compatible, nil
+	}
+
+	// 没有兼容渠道时，返回所有渠道（由下游 outbound 进行降级处理）
+	log.Warn(ctx, "No channels support Anthropic native tools, falling back to all channels",
+		log.Int("total_channels", len(channels)))
+
+	return channels, nil
+}

--- a/internal/server/chat/inbound.go
+++ b/internal/server/chat/inbound.go
@@ -279,10 +279,10 @@ func selectChannels(inbound *PersistentInboundTransformer) pipeline.Middleware {
 			selector = NewGoogleNativeToolsSelector(selector)
 		}
 
-		// 应用 Anthropic 原生工具过滤（仅对 Anthropic 原生 API 格式生效）
-		if inbound.APIFormat() == llm.APIFormatAnthropicMessage {
-			selector = NewAnthropicNativeToolsSelector(selector)
-		}
+		// 应用 Anthropic 原生工具过滤（对所有 API 格式生效）
+		// 无论通过 OpenAI 还是 Anthropic 格式入口，只要包含 web_search 工具，
+		// 都需要优先路由到支持 Anthropic 原生工具的渠道
+		selector = NewAnthropicNativeToolsSelector(selector)
 
 		if inbound.state.LoadBalancer != nil {
 			selector = NewLoadBalancedSelector(selector, inbound.state.LoadBalancer)

--- a/internal/server/chat/inbound.go
+++ b/internal/server/chat/inbound.go
@@ -279,6 +279,11 @@ func selectChannels(inbound *PersistentInboundTransformer) pipeline.Middleware {
 			selector = NewGoogleNativeToolsSelector(selector)
 		}
 
+		// 应用 Anthropic 原生工具过滤（仅对 Anthropic 原生 API 格式生效）
+		if inbound.APIFormat() == llm.APIFormatAnthropicMessage {
+			selector = NewAnthropicNativeToolsSelector(selector)
+		}
+
 		if inbound.state.LoadBalancer != nil {
 			selector = NewLoadBalancedSelector(selector, inbound.state.LoadBalancer)
 		}


### PR DESCRIPTION
## 功能概述

本 PR 为 Anthropic 渠道添加原生网络搜索工具 (web_search_20250305) 支持，参考 Gemini 原生工具的实现模式。

## 主要变更

### 1. 核心功能
- **工具类型常量**：在 `llm/constants.go` 添加 `ToolTypeAnthropicWebSearch` 和 `AnthropicWebSearchFunctionName`
- **渠道类型支持检测**：`SupportsAnthropicNativeTools()` 方法判断渠道是否支持原生工具
- **工具检测函数**：`ContainsAnthropicNativeTools()`、`IsAnthropicNativeTool()`、`FilterAnthropicNativeTools()`
- **渠道选择器**：`AnthropicNativeToolsSelector` 装饰器，优先路由到支持原生工具的渠道

### 2. 请求转换
- `web_search` 函数自动转换为 `web_search_20250305` 工具类型
- 支持 `web_search_20250305` 类型的直接输入
- Beta header (`Anthropic-Beta: web-search-2025-03-05`) 仅在以下条件同时满足时注入：
  - 存在原生 web_search 工具
  - 平台为 Direct Anthropic API（排除 Bedrock/Vertex）

### 3. 平台兼容性
- **Direct Anthropic API**：完整支持 web_search 工具
- **Bedrock/Vertex**：不支持 web_search beta 功能，已从 `SupportsAnthropicNativeTools()` 中排除
- **其他 Anthropic 格式渠道**（如 deepseek_anthropic）：不支持原生工具，通过选择器过滤

### 4. API 格式兼容
- 选择器对所有 API 格式生效（OpenAI/Anthropic）
- 无论通过哪种格式入口，包含 web_search 工具的请求都会正确路由

## 文件变更

| 文件 | 变更说明 |
|------|----------|
| `internal/llm/constants.go` | 添加 Anthropic 原生工具常量 |
| `internal/ent/channel/type.go` | 添加 `SupportsAnthropicNativeTools()` 方法 |
| `internal/llm/tools.go` | 添加工具检测和过滤函数 |
| `internal/server/chat/channels.go` | 添加 `AnthropicNativeToolsSelector` 装饰器 |
| `internal/server/chat/inbound.go` | 应用选择器到所有 API 格式 |
| `internal/llm/transformer/anthropic/outbound.go` | Beta header 条件注入 |
| `internal/llm/transformer/anthropic/outbound_convert.go` | 工具类型转换逻辑 |

## 单元测试覆盖

### 新增测试用例

**工具检测测试** (`tools_test.go`)
- `TestContainsAnthropicNativeTools`：nil/空/普通工具/web_search/web_search_20250305
- `TestIsAnthropicNativeTool`：各种工具类型判定
- `TestFilterAnthropicNativeTools`：工具过滤逻辑

**渠道类型测试** (`type_test.go`)
- `TestType_SupportsAnthropicNativeTools`：anthropic/anthropic_aws/anthropic_gcp/deepseek_anthropic 等

**Beta Header 测试** (`outbound_test.go`)
- Direct Anthropic API + web_search → 设置 Beta header
- Bedrock + web_search → 不设置 Beta header
- Vertex + web_search → 不设置 Beta header
- web_search_20250305 直接输入 → 正确设置 Beta header
- 普通 function 工具 → 不设置 Beta header
- 混合工具（含 web_search）→ 设置 Beta header

### 测试覆盖率
- `internal/llm/transformer/anthropic`: **82.0%**
- `containsNativeWebSearchTool`: **100%**
- `convertTools`: **92.3%**

## 测试验证

```bash
# 构建验证
go build ./...

# 单元测试
go test ./internal/llm/... ./internal/ent/channel/... ./internal/server/chat/... -v

# API 测试
curl -s http://localhost:8090/anthropic/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: $API_KEY" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "claude-sonnet-4-20250514",
    "max_tokens": 1024,
    "messages": [{"role": "user", "content": "今天北京天气如何？"}],
    "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}]
  }'
```

## 相关文档

- [Anthropic Web Search Tool](https://platform.claude.com/docs/zh-CN/agents-and-tools/tool-use/web-search-tool)