### PR TITLE
Fix Vertex AI URL format in outbound.go

### DIFF
--- a/internal/llm/transformer/gemini/outbound.go
+++ b/internal/llm/transformer/gemini/outbound.go
@@ -180,10 +180,14 @@ func (t *OutboundTransformer) buildFullRequestURL(llmReq *llm.Request) string {
 	}
 
 	// For Vertex AI platform, use different URL format:
-	// Users should provide the full path including /v1 prefix in BaseURL.
 	// https://${API_ENDPOINT}/v1/publishers/google/models/${MODEL_ID}:${ACTION}?key=${API_KEY}
+	// If base URL starts with Cloudflare gateway, don't add /v1 prefix
 	if t.config.PlatformType == PlatformVertex {
-return fmt.Sprintf("%s/publishers/google/models/%s:%s", strings.TrimSuffix(t.config.BaseURL, "/"), llmReq.Model, action)
+		baseURL := strings.TrimSuffix(t.config.BaseURL, "/")
+		if strings.HasPrefix(baseURL, "https://gateway.ai.cloudflare.com") {
+			return fmt.Sprintf("%s/publishers/google/models/%s:%s", baseURL, llmReq.Model, action)
+		}
+		return fmt.Sprintf("%s/v1/publishers/google/models/%s:%s", baseURL, llmReq.Model, action)
 	}
 
 	// Format: /base_url/{version}/models/{model}:generateContent

--- a/internal/llm/transformer/gemini/outbound.go
+++ b/internal/llm/transformer/gemini/outbound.go
@@ -183,7 +183,7 @@ func (t *OutboundTransformer) buildFullRequestURL(llmReq *llm.Request) string {
 	// Users should provide the full path including /v1 prefix in BaseURL.
 	// https://${API_ENDPOINT}/v1/publishers/google/models/${MODEL_ID}:${ACTION}?key=${API_KEY}
 	if t.config.PlatformType == PlatformVertex {
-		return fmt.Sprintf("%s/publishers/google/models/%s:%s", t.config.BaseURL, llmReq.Model, action)
+return fmt.Sprintf("%s/publishers/google/models/%s:%s", strings.TrimSuffix(t.config.BaseURL, "/"), llmReq.Model, action)
 	}
 
 	// Format: /base_url/{version}/models/{model}:generateContent

--- a/internal/llm/transformer/gemini/outbound.go
+++ b/internal/llm/transformer/gemini/outbound.go
@@ -180,9 +180,10 @@ func (t *OutboundTransformer) buildFullRequestURL(llmReq *llm.Request) string {
 	}
 
 	// For Vertex AI platform, use different URL format:
+	// Users should provide the full path including /v1 prefix in BaseURL.
 	// https://${API_ENDPOINT}/v1/publishers/google/models/${MODEL_ID}:${ACTION}?key=${API_KEY}
 	if t.config.PlatformType == PlatformVertex {
-		return fmt.Sprintf("%s/v1/publishers/google/models/%s:%s", t.config.BaseURL, llmReq.Model, action)
+		return fmt.Sprintf("%s/publishers/google/models/%s:%s", t.config.BaseURL, llmReq.Model, action)
 	}
 
 	// Format: /base_url/{version}/models/{model}:generateContent


### PR DESCRIPTION
通过Cloudflare AI 网关，配置base url为
```
https://gateway.ai.cloudflare.com/v1/222222323232312/cosr/google-vertex-ai/v1/projects/premium-trainer-2213131/locations/global
```
但是测试发送的是
```
v1/projects/premium-trainer-222222/locations/global/v1/publishers/google/models/gemini-2.0-flash-lite:generateContent
```
而Cloudflare AI 网关调用示例为
```
https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent
```
地区后面直接跟publishers不需要再拼接v1

用户按照输入框默认配置的`https://aiplatform.googleapis.com/v1`   则不影响调用

<img width="834" height="388" alt="image" src="https://github.com/user-attachments/assets/7e611789-0b80-4ee8-89d3-660597cd5b94" />
<img width="1104" height="496" alt="image" src="https://github.com/user-attachments/assets/2c226b85-1575-49cd-9d8c-da3cc961cbef" />
