### PR TITLE
refactor(ui): flatten channel info layout in models association dialog

### DIFF
--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -557,19 +557,17 @@ export function ModelsAssociationDialog() {
                   {filteredConnections.map((conn) => (
                     <div key={conn.channel.id} className='rounded-lg border p-3'>
                       <div className='mb-2 flex items-start justify-between gap-2'>
-                        <div className='flex flex-col gap-1.5'>
+                        <div className='flex items-center gap-1.5 flex-wrap'>
                           <span className='text-sm font-medium'>{conn.channel.name}</span>
-                          <div className='flex items-center gap-1.5'>
-                            <Badge variant='outline' className={`h-5 px-1.5 text-[10px] font-normal ${getTypeColor(conn.channel.type)}`}>
-                              {t(`channels.types.${conn.channel.type}`, conn.channel.type)}
-                            </Badge>
-                            <Badge
-                              variant='outline'
-                              className={`h-5 px-1.5 text-[10px] font-normal ${getStatusColor(conn.channel.status)}`}
-                            >
-                              {t(`channels.status.${conn.channel.status}`)}
-                            </Badge>
-                          </div>
+                          <Badge variant='outline' className={`h-5 px-1.5 text-[10px] font-normal ${getTypeColor(conn.channel.type)}`}>
+                            {t(`channels.types.${conn.channel.type}`, conn.channel.type)}
+                          </Badge>
+                          <Badge
+                            variant='outline'
+                            className={`h-5 px-1.5 text-[10px] font-normal ${getStatusColor(conn.channel.status)}`}
+                          >
+                            {t(`channels.status.${conn.channel.status}`)}
+                          </Badge>
                         </div>
                       </div>
                       <div className='space-y-1'>


### PR DESCRIPTION
Simplify the channel information display by removing nested flex container and moving badges to the same flex row as the channel name. This creates a more compact layout with flex-wrap to handle overflow gracefully.
关闭：#435
<img width="214" height="444" alt="image" src="https://github.com/user-attachments/assets/f8e98f24-76b0-4d4d-87af-8a2bbfbe8948" />
