### PR TITLE
refactor(ui): extract channel models list into reusable component

### DIFF
--- a/frontend/src/features/models/components/channel-models-list.tsx
+++ b/frontend/src/features/models/components/channel-models-list.tsx
@@ -1,0 +1,84 @@
+import { Badge } from '@/components/ui/badge';
+import { useTranslation } from 'react-i18next';
+
+interface ChannelModel {
+  requestModel: string;
+}
+
+interface Channel {
+  id: string | number;
+  name: string;
+  type: string;
+  status: string;
+}
+
+interface ChannelModelsListProps {
+  channels: Array<{
+    channel: Channel;
+    models: ChannelModel[];
+  }>;
+  emptyMessage?: string;
+}
+
+export function ChannelModelsList({ channels, emptyMessage }: ChannelModelsListProps) {
+  const { t } = useTranslation();
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'enabled':
+        return 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-400 dark:border-emerald-800';
+      case 'disabled':
+        return 'bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700';
+      case 'archived':
+        return 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800';
+      default:
+        return 'bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700';
+    }
+  };
+
+  const getTypeColor = (type: string) => {
+    const colors = {
+      openai: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-400',
+      anthropic: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950 dark:text-purple-400',
+      deepseek: 'bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-950 dark:text-indigo-400',
+      doubao: 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400',
+      kimi: 'bg-pink-50 text-pink-700 border-pink-200 dark:bg-pink-950 dark:text-pink-400',
+    };
+    return colors[type as keyof typeof colors] || 'bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900 dark:text-gray-400';
+  };
+
+  if (channels.length === 0) {
+    return (
+      <p className='text-muted-foreground py-8 text-center text-sm'>
+        {emptyMessage || t('models.dialogs.association.noConnections')}
+      </p>
+    );
+  }
+
+  return (
+    <div className='space-y-3'>
+      {channels.map((conn) => (
+        <div key={conn.channel.id} className='rounded-lg border p-3'>
+          <div className='mb-2 flex items-start justify-between gap-2'>
+            <div className='flex items-center gap-1.5 flex-wrap'>
+              <span className='text-sm font-medium'>{conn.channel.name}</span>
+              <Badge variant='outline' className={`h-5 px-1.5 text-[10px] font-normal ${getTypeColor(conn.channel.type)}`}>
+                {t(`channels.types.${conn.channel.type}`, conn.channel.type)}
+              </Badge>
+              <Badge variant='outline' className={`h-5 px-1.5 text-[10px] font-normal ${getStatusColor(conn.channel.status)}`}>
+                {t(`channels.status.${conn.channel.status}`)}
+              </Badge>
+            </div>
+          </div>
+          <div className='space-y-1'>
+            {conn.models.map((model) => (
+              <div key={model.requestModel} className='bg-muted rounded px-2 py-1 text-xs'>
+                {model.requestModel}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -22,6 +22,7 @@ import { useQueryModelChannelConnections, ModelAssociationInput, ModelChannelCon
 import { useUpdateModel } from '../data/models';
 import { ModelAssociation } from '../data/schema';
 import { toast } from 'sonner';
+import { ChannelModelsList } from './channel-models-list';
 
 const associationFormSchema = z.object({
   associations: z
@@ -452,30 +453,6 @@ export function ModelsAssociationDialog() {
     });
   }, [append, fields.length]);
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'enabled':
-        return 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-400 dark:border-emerald-800';
-      case 'disabled':
-        return 'bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700';
-      case 'archived':
-        return 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800';
-      default:
-        return 'bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700';
-    }
-  };
-
-  const getTypeColor = (type: string) => {
-    const colors = {
-      openai: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-400',
-      anthropic: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950 dark:text-purple-400',
-      deepseek: 'bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-950 dark:text-indigo-400',
-      doubao: 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400',
-      kimi: 'bg-pink-50 text-pink-700 border-pink-200 dark:bg-pink-950 dark:text-pink-400',
-    };
-    return colors[type as keyof typeof colors] || 'bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900 dark:text-gray-400';
-  };
-
   // Filter connections by channel name
   const filteredConnections = useMemo(() => {
     if (!channelFilter.trim()) return connections;
@@ -547,41 +524,14 @@ export function ModelsAssociationDialog() {
               />
             </div>
             <div className='flex-1 overflow-y-auto'>
-              {filteredConnections.length === 0 ? (
-                <p className='text-muted-foreground py-8 text-center text-sm'>
-                  {channelFilter.trim()
+              <ChannelModelsList
+                channels={filteredConnections}
+                emptyMessage={
+                  channelFilter.trim()
                     ? t('models.dialogs.association.noFilteredConnections')
-                    : t('models.dialogs.association.noConnections')}
-                </p>
-              ) : (
-                <div className='space-y-3'>
-                  {filteredConnections.map((conn) => (
-                    <div key={conn.channel.id} className='rounded-lg border p-3'>
-                      <div className='mb-2 flex items-start justify-between gap-2'>
-                        <div className='flex items-center gap-1.5 flex-wrap'>
-                          <span className='text-sm font-medium'>{conn.channel.name}</span>
-                          <Badge variant='outline' className={`h-5 px-1.5 text-[10px] font-normal ${getTypeColor(conn.channel.type)}`}>
-                            {t(`channels.types.${conn.channel.type}`, conn.channel.type)}
-                          </Badge>
-                          <Badge
-                            variant='outline'
-                            className={`h-5 px-1.5 text-[10px] font-normal ${getStatusColor(conn.channel.status)}`}
-                          >
-                            {t(`channels.status.${conn.channel.status}`)}
-                          </Badge>
-                        </div>
-                      </div>
-                      <div className='space-y-1'>
-                        {conn.models.map((model) => (
-                          <div key={model.requestModel} className='bg-muted rounded px-2 py-1 text-xs'>
-                            {model.requestModel}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
+                    : t('models.dialogs.association.noConnections')
+                }
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/features/models/components/models-unassociated-dialog.tsx
+++ b/frontend/src/features/models/components/models-unassociated-dialog.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useModels } from '../context/models-context';
 import { useQueryUnassociatedChannels } from '../data/models';
+import { ChannelModelsList } from './channel-models-list';
 
 export function ModelsUnassociatedDialog() {
   const { t } = useTranslation();
@@ -41,6 +42,14 @@ export function ModelsUnassociatedDialog() {
       }))
       .filter((info) => info.models.length > 0);
   }, [data, debouncedSearchQuery]);
+
+  const channelsForList = useMemo(() => {
+    if (!filteredData) return [];
+    return filteredData.map((info) => ({
+      channel: info.channel,
+      models: info.models.map((model) => ({ requestModel: model })),
+    }));
+  }, [filteredData]);
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -77,39 +86,16 @@ export function ModelsUnassociatedDialog() {
                 />
               </div>
 
-              {filteredData && filteredData.length > 0 ? (
-                <ScrollArea className='h-[400px] rounded-md border'>
-                  <div className='space-y-4 p-4'>
-                    {filteredData.map((info) => (
-                      <div key={info.channel.id} className='space-y-2 rounded-lg border p-4'>
-                        <div className='flex items-center justify-between'>
-                          <div className='flex items-center gap-2'>
-                            <h4 className='font-semibold'>{info.channel.name}</h4>
-                            <Badge variant='outline' className='text-xs'>
-                              {info.channel.type}
-                            </Badge>
-                            <Badge variant={info.channel.status === 'enabled' ? 'default' : 'secondary'} className='text-xs'>
-                              {info.channel.status}
-                            </Badge>
-                          </div>
-                          <Badge variant='secondary'>{info.models.length} models</Badge>
-                        </div>
-                        <div className='flex flex-wrap gap-2'>
-                          {info.models.map((model) => (
-                            <Badge key={model} variant='outline' className='font-mono text-xs'>
-                              {model}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </ScrollArea>
-              ) : (
-                <div className='flex flex-col items-center justify-center rounded-md border py-8 text-center'>
-                  <div className='text-muted-foreground text-sm'>{t('models.unassociated.noSearchResults')}</div>
-                </div>
-              )}
+              <ScrollArea className='h-[400px] rounded-md border p-4'>
+                <ChannelModelsList
+                  channels={channelsForList}
+                  emptyMessage={
+                    debouncedSearchQuery.trim()
+                      ? t('models.unassociated.noSearchResults')
+                      : t('models.unassociated.noUnassociated')
+                  }
+                />
+              </ScrollArea>
             </>
           ) : (
             <div className='flex flex-col items-center justify-center py-8 text-center'>


### PR DESCRIPTION
#481 
Extract duplicated channel models display logic from models-association-dialog and models-unassociated-dialog into a new shared ChannelModelsList component. This reduces code duplication and improves maintainability by centralizing the rendering logic for channel model lists.