### PR TITLE
feat(i18n): add translations for channel delete dialog

### DIFF
--- a/frontend/src/features/channels/components/channels-delete-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-delete-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { IconAlertTriangle } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -16,6 +17,7 @@ interface Props {
 }
 
 export function ChannelsDeleteDialog({ open, onOpenChange, currentRow }: Props) {
+  const { t } = useTranslation();
   const [value, setValue] = useState('');
   const deleteChannel = useDeleteChannel();
 
@@ -41,25 +43,26 @@ export function ChannelsDeleteDialog({ open, onOpenChange, currentRow }: Props) 
       disabled={value.trim() !== currentRow.name || deleteChannel.isPending}
       title={
         <span className='text-destructive'>
-          <IconAlertTriangle className='stroke-destructive mr-1 inline-block' size={18} /> 删除 Channel
+          <IconAlertTriangle className='stroke-destructive mr-1 inline-block' size={18} /> {t('channels.dialogs.delete.title')}
         </span>
       }
       desc={
         <div className='space-y-4'>
           <Alert variant='destructive'>
             <IconAlertTriangle className='h-4 w-4' />
-            <AlertTitle>警告</AlertTitle>
-            <AlertDescription>此操作无法撤销。这将永久删除 Channel 及其所有相关数据。</AlertDescription>
+            <AlertTitle>{t('channels.dialogs.delete.warning')}</AlertTitle>
+            <AlertDescription>{t('channels.dialogs.delete.warningTitle')}</AlertDescription>
           </Alert>
           <div className='space-y-2'>
             <Label htmlFor='channel-name'>
-              请输入 Channel 名称 <strong>{currentRow.name}</strong> 以确认删除：
+              {t('channels.dialogs.delete.confirmLabel')} <strong>{currentRow.name}</strong> {t('channels.dialogs.delete.confirmLabelStrong')}
             </Label>
             <Input id='channel-name' placeholder={currentRow.name} value={value} onChange={(e) => setValue(e.target.value)} />
           </div>
         </div>
       }
-      confirmText={deleteChannel.isPending ? '删除中...' : '删除 Channel'}
+      confirmText={deleteChannel.isPending ? t('channels.dialogs.delete.deletingButton') : t('channels.dialogs.delete.confirmButton')}
+      cancelBtnText={t('common.buttons.cancel')}
     />
   );
 }

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -553,6 +553,15 @@
         "warning": "Warning: This action cannot be undone",
         "warningDetail": "This will permanently delete all selected channels and their related data. This cannot be recovered."
       },
+      "delete": {
+        "title": "Delete Channel",
+        "warning": "Warning",
+        "warningTitle": "This action cannot be undone. This will permanently delete the Channel and all its related data.",
+        "confirmLabel": "Please enter Channel name",
+        "confirmLabelStrong": "to confirm deletion:",
+        "confirmButton": "Delete Channel",
+        "deletingButton": "Deleting..."
+      },
       "errorResolved": {
         "title": "Resolve Channel Error",
         "description": "Are you sure you want to resolve the error for channel \"{{channelName}}\"? This will clear the error message: \"{{errorMessage}}\"",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -555,6 +555,15 @@
         "warning": "警告：此操作无法撤销",
         "warningDetail": "这将永久删除所有选中的渠道及其相关数据。删除后无法恢复。"
       },
+      "delete": {
+        "title": "删除渠道",
+        "warning": "警告",
+        "warningTitle": "此操作无法撤销。这将永久删除渠道及其所有相关数据。",
+        "confirmLabel": "请输入渠道名称",
+        "confirmLabelStrong": "以确认删除：",
+        "confirmButton": "删除渠道",
+        "deletingButton": "删除中..."
+      },
       "errorResolved": {
         "title": "解决渠道错误",
         "description": "确定要解决渠道 \"{{channelName}}\" 的错误吗？这将清除错误消息：\"{{errorMessage}}\"",


### PR DESCRIPTION
- Replace hardcoded Chinese text with i18n translation keys
- Add English and Chinese translations for delete dialog
- Include translations for title, warning, confirm labels, and buttons
- Add cancel button translation using common translation key