### PR TITLE
fix(api): implement channel-based model access control for API key profiles

### DIFF
--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -393,11 +393,15 @@ func (svc *ModelService) ListConfiguredModels(ctx context.Context, statusIn []mo
 // When QueryAllChannelModels in system settings is false, it returns configured models instead.
 // If an API key is present in context and has an active profile with modelIDs configured,
 // only those models will be returned.
+// If an API key has channelIDs or channelTags configured, only models from those channels will be returned.
 func (svc *ModelService) ListEnabledModels(ctx context.Context) []ModelFacade {
-	// Check if API key has restricted model IDs
+	// Check if API key has restrictions
+	var profile *objects.APIKeyProfile
 	if apiKey, ok := contexts.GetAPIKey(ctx); ok && apiKey != nil {
-		if profile := apiKey.GetActiveProfile(); profile != nil && len(profile.ModelIDs) > 0 {
-			// Return only the models specified in the profile
+		profile = apiKey.GetActiveProfile()
+
+		// If modelIDs are explicitly configured, return only those models
+		if profile != nil && len(profile.ModelIDs) > 0 {
 			result := make([]ModelFacade, 0, len(profile.ModelIDs))
 			for _, modelID := range profile.ModelIDs {
 				result = append(result, ModelFacade{
@@ -418,13 +422,67 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) []ModelFacade {
 	queryAllChannels := settings.QueryAllChannelModels
 
 	if !queryAllChannels {
-		// Return configured models when queryAllChannels is false
+		// When queryAllChannels is false, return configured models
+		// But still need to filter by channelIDs/channelTags if specified in profile
 		configuredModels, err := svc.ListConfiguredModels(ctx, nil)
 		if err != nil {
 			log.Warn(ctx, "failed to list configured models", log.Cause(err))
 			return nil
 		}
 
+		// If profile has channelIDs or channelTags restrictions, we need to filter
+		// the configured models to only include those from allowed channels
+		if profile != nil && (len(profile.ChannelIDs) > 0 || len(profile.ChannelTags) > 0) {
+			// Get all enabled channels and apply filtering
+			channels := svc.channelService.GetEnabledChannels()
+
+			// Filter by channelIDs
+			if len(profile.ChannelIDs) > 0 {
+				channels = lo.Filter(channels, func(ch *Channel, _ int) bool {
+					return lo.Contains(profile.ChannelIDs, ch.ID)
+				})
+			}
+
+			// Filter by channelTags (intersect with existing filtered channels)
+			if len(profile.ChannelTags) > 0 {
+				channels = lo.Filter(channels, func(ch *Channel, _ int) bool {
+					// Channel must have at least one tag that matches the profile's allowed tags
+					for _, tag := range ch.Tags {
+						if lo.Contains(profile.ChannelTags, tag) {
+							return true
+						}
+					}
+					return false
+				})
+			}
+
+			// Build a set of models from allowed channels
+			allowedModels := make(map[string]bool)
+			for _, ch := range channels {
+				entries := ch.GetModelEntries()
+				for requestModel := range entries {
+					allowedModels[requestModel] = true
+				}
+			}
+
+			// Filter configured models to only include those in allowed channels
+			result := make([]ModelFacade, 0)
+			for _, m := range configuredModels {
+				if allowedModels[m.ID] {
+					result = append(result, ModelFacade{
+						ID:          m.ID,
+						DisplayName: m.ID,
+						CreatedAt:   time.Time{},
+						Created:     0,
+						OwnedBy:     "configured",
+					})
+				}
+			}
+
+			return result
+		}
+
+		// No channel restrictions, return all configured models
 		result := make([]ModelFacade, 0, len(configuredModels))
 		for _, m := range configuredModels {
 			result = append(result, ModelFacade{
@@ -439,9 +497,35 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) []ModelFacade {
 		return result
 	}
 
+	// Get all enabled channels
+	channels := svc.channelService.GetEnabledChannels()
+
+	// Apply channel filtering if profile has channelIDs or channelTags
+	if profile != nil {
+		// Filter by channelIDs
+		if len(profile.ChannelIDs) > 0 {
+			channels = lo.Filter(channels, func(ch *Channel, _ int) bool {
+				return lo.Contains(profile.ChannelIDs, ch.ID)
+			})
+		}
+
+		// Filter by channelTags (intersect with existing filtered channels)
+		if len(profile.ChannelTags) > 0 {
+			channels = lo.Filter(channels, func(ch *Channel, _ int) bool {
+				// Channel must have at least one tag that matches the profile's allowed tags
+				for _, tag := range ch.Tags {
+					if lo.Contains(profile.ChannelTags, tag) {
+						return true
+					}
+				}
+				return false
+			})
+		}
+	}
+
 	modelSet := make(map[string]ModelFacade)
 
-	for _, ch := range svc.channelService.GetEnabledChannels() {
+	for _, ch := range channels {
 		entries := ch.GetModelEntries()
 
 		for requestModel := range entries {

--- a/internal/server/biz/model_test.go
+++ b/internal/server/biz/model_test.go
@@ -845,6 +845,242 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 		require.True(t, resultMap["gpt-3.5-turbo"], "gpt-3.5-turbo should be in result")
 		require.True(t, resultMap["claude-3-opus-20240229"], "claude-3-opus-20240229 should be in result")
 	})
+
+	t.Run("API key with ChannelIDs filters models by channels", func(t *testing.T) {
+		// Create API key with channelIDs restriction (only channel 1 - OpenAI)
+		apiKey := &ent.APIKey{
+			ID:   7,
+			Name: "test-api-key-7",
+			Profiles: &objects.APIKeyProfiles{
+				ActiveProfile: "channel-restricted",
+				Profiles: []objects.APIKeyProfile{
+					{
+						Name:       "channel-restricted",
+						ChannelIDs: []int{1}, // Only OpenAI channel
+					},
+				},
+			},
+		}
+
+		ctx := contexts.WithAPIKey(ctx, apiKey)
+
+		result := modelSvc.ListEnabledModels(ctx)
+
+		resultMap := make(map[string]bool)
+		for _, model := range result {
+			resultMap[model.ID] = true
+		}
+
+		// Should only include models from channel 1 (OpenAI)
+		require.True(t, resultMap["gpt-4"], "gpt-4 should be in result")
+		require.True(t, resultMap["gpt-3.5-turbo"], "gpt-3.5-turbo should be in result")
+		// Should not include models from other channels
+		require.False(t, resultMap["claude-3-opus-20240229"], "claude-3-opus-20240229 should not be in result")
+		require.False(t, resultMap["deepseek-chat"], "deepseek-chat should not be in result")
+	})
+
+	t.Run("API key with ChannelTags filters models by channel tags", func(t *testing.T) {
+		// Create channels with tags
+		ch1, err := client.Channel.UpdateOneID(1).SetTags([]string{"premium", "openai"}).Save(ctx)
+		require.NoError(t, err)
+		ch2, err := client.Channel.UpdateOneID(2).SetTags([]string{"premium", "anthropic"}).Save(ctx)
+		require.NoError(t, err)
+		_, err = client.Channel.UpdateOneID(3).SetTags([]string{"standard", "other"}).Save(ctx)
+		require.NoError(t, err)
+
+		// Reload channels after updating tags
+		err = channelSvc.loadChannels(ctx)
+		require.NoError(t, err)
+
+		// Create API key with channelTags restriction
+		apiKey := &ent.APIKey{
+			ID:   8,
+			Name: "test-api-key-8",
+			Profiles: &objects.APIKeyProfiles{
+				ActiveProfile: "tag-restricted",
+				Profiles: []objects.APIKeyProfile{
+					{
+						Name:        "tag-restricted",
+						ChannelTags: []string{"premium"}, // Only premium channels
+					},
+				},
+			},
+		}
+
+		ctx := contexts.WithAPIKey(ctx, apiKey)
+
+		result := modelSvc.ListEnabledModels(ctx)
+
+		resultMap := make(map[string]bool)
+		for _, model := range result {
+			resultMap[model.ID] = true
+		}
+
+		// Should include models from premium channels (ch1 and ch2)
+		require.True(t, resultMap["gpt-4"], "gpt-4 should be in result (from premium channel)")
+		require.True(t, resultMap["claude-3-opus-20240229"], "claude-3-opus-20240229 should be in result (from premium channel)")
+		// Should not include models from non-premium channels
+		require.False(t, resultMap["deepseek-chat"], "deepseek-chat should not be in result (not premium)")
+
+		// Verify channels still have tags for next test
+		require.ElementsMatch(t, []string{"premium", "openai"}, ch1.Tags)
+		require.ElementsMatch(t, []string{"premium", "anthropic"}, ch2.Tags)
+	})
+
+	t.Run("API key with both ChannelIDs and ChannelTags applies intersection", func(t *testing.T) {
+		// Ensure tags are still set from previous test
+		err := channelSvc.loadChannels(ctx)
+		require.NoError(t, err)
+
+		// Create API key with both restrictions (intersection)
+		apiKey := &ent.APIKey{
+			ID:   9,
+			Name: "test-api-key-9",
+			Profiles: &objects.APIKeyProfiles{
+				ActiveProfile: "combined-restricted",
+				Profiles: []objects.APIKeyProfile{
+					{
+						Name:        "combined-restricted",
+						ChannelIDs:  []int{1, 2, 3},      // All three channels
+						ChannelTags: []string{"premium"}, // But only premium tag
+					},
+				},
+			},
+		}
+
+		ctx := contexts.WithAPIKey(ctx, apiKey)
+
+		result := modelSvc.ListEnabledModels(ctx)
+
+		resultMap := make(map[string]bool)
+		for _, model := range result {
+			resultMap[model.ID] = true
+		}
+
+		// Should only include models from channels that are in ChannelIDs AND have premium tag
+		// That's channel 1 and 2 (both have premium tag and are in ChannelIDs)
+		require.True(t, resultMap["gpt-4"], "gpt-4 should be in result")
+		require.True(t, resultMap["claude-3-opus-20240229"], "claude-3-opus-20240229 should be in result")
+		// Channel 3 has "standard" tag, not "premium", so excluded
+		require.False(t, resultMap["deepseek-chat"], "deepseek-chat should not be in result (no premium tag)")
+	})
+
+	t.Run("API key with ModelIDs takes precedence over ChannelIDs/Tags", func(t *testing.T) {
+		// Create API key with both ModelIDs and ChannelIDs
+		// ModelIDs should take precedence
+		apiKey := &ent.APIKey{
+			ID:   10,
+			Name: "test-api-key-10",
+			Profiles: &objects.APIKeyProfiles{
+				ActiveProfile: "model-precedence",
+				Profiles: []objects.APIKeyProfile{
+					{
+						Name:       "model-precedence",
+						ModelIDs:   []string{"gpt-4", "specific-model"},
+						ChannelIDs: []int{1, 2, 3}, // This should be ignored
+					},
+				},
+			},
+		}
+
+		ctx := contexts.WithAPIKey(ctx, apiKey)
+
+		result := modelSvc.ListEnabledModels(ctx)
+
+		// Should only return the specific models from ModelIDs
+		require.Len(t, result, 2, "Should only return 2 models from ModelIDs")
+
+		resultMap := make(map[string]bool)
+		for _, model := range result {
+			resultMap[model.ID] = true
+		}
+
+		require.True(t, resultMap["gpt-4"], "gpt-4 should be in result")
+		require.True(t, resultMap["specific-model"], "specific-model should be in result")
+		require.False(t, resultMap["gpt-3.5-turbo"], "gpt-3.5-turbo should not be in result")
+	})
+
+	t.Run("QueryAllChannelModels=false with ChannelIDs filters configured models", func(t *testing.T) {
+		// Create a system config with QueryAllChannelModels=false
+		systemSvcNoQuery := &SystemService{
+			AbstractService: &AbstractService{
+				db: client,
+			},
+			Cache: xcache.NewFromConfig[ent.System](xcache.Config{Mode: xcache.ModeMemory}),
+		}
+
+		// Set QueryAllChannelModels to false
+		err := systemSvcNoQuery.SetModelSettings(ctx, ModelSettings{
+			QueryAllChannelModels:             false,
+			FallbackToChannelsOnModelNotFound: true,
+		})
+		require.NoError(t, err)
+
+		modelSvcNoQuery := &ModelService{
+			AbstractService: &AbstractService{
+				db: client,
+			},
+			channelService: channelSvc,
+			systemService:  systemSvcNoQuery,
+		}
+
+		// Create configured models
+		_, err = client.Model.Create().
+			SetDeveloper("openai").
+			SetModelID("gpt-4").
+			SetName("GPT-4").
+			SetIcon("").
+			SetGroup("").
+			SetModelCard(&objects.ModelCard{}).
+			SetSettings(&objects.ModelSettings{}).
+			SetType("chat").
+			SetStatus("enabled").
+			Save(ctx)
+		require.NoError(t, err)
+
+		_, err = client.Model.Create().
+			SetDeveloper("anthropic").
+			SetModelID("claude-3-opus").
+			SetName("Claude 3 Opus").
+			SetIcon("").
+			SetGroup("").
+			SetModelCard(&objects.ModelCard{}).
+			SetSettings(&objects.ModelSettings{}).
+			SetType("chat").
+			SetStatus("enabled").
+			Save(ctx)
+		require.NoError(t, err)
+
+		// API key with channelIDs restriction
+		apiKey := &ent.APIKey{
+			ID:   11,
+			Name: "test-api-key-11",
+			Profiles: &objects.APIKeyProfiles{
+				ActiveProfile: "channel-restricted",
+				Profiles: []objects.APIKeyProfile{
+					{
+						Name:       "channel-restricted",
+						ChannelIDs: []int{1}, // Only channel 1 (OpenAI)
+					},
+				},
+			},
+		}
+
+		ctxWithKey := contexts.WithAPIKey(ctx, apiKey)
+
+		result := modelSvcNoQuery.ListEnabledModels(ctxWithKey)
+
+		resultMap := make(map[string]bool)
+		for _, model := range result {
+			resultMap[model.ID] = true
+		}
+
+		// Should only include gpt-4 from channel 1
+		require.True(t, resultMap["gpt-4"], "gpt-4 should be in result (from allowed channel)")
+		// Should not include claude-3-opus from channel 2
+		require.False(t, resultMap["claude-3-opus"], "claude-3-opus should not be in result (from disallowed channel)")
+	})
+
 }
 
 func TestFindUnassociatedChannels(t *testing.T) {


### PR DESCRIPTION
Enhance ListEnabledModels to respect channel restrictions defined in API key profiles. Profiles can now limit model visibility using either channel identifiers or tag-based selection. When both constraints are present, only channels matching all criteria are considered.

The existing modelIDs restriction mechanism remains the highest priority filter. Channel-level filtering operates as a secondary constraint that applies across both dynamic (queryAllChannels=true) and static (queryAllChannels=false) model discovery modes.

Test coverage includes:
- Channel ID-based model restriction scenarios
- Tag-based channel selection logic
- Combined ID and tag filtering with intersection behavior
- Priority verification when modelIDs coexist with channel filters
- Static configuration mode with channel constraints applied