### PR TITLE
fix: 修复 OpenRouter/DeepSeek 思考内容丢失及 Content 字段 Null 值解析错误

### DIFF
--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -166,6 +166,12 @@ func (c MessageContent) MarshalJSON() ([]byte, error) {
 }
 
 func (c *MessageContent) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		c.Content = nil
+		c.MultipleContent = nil
+		return nil
+    }
+	
 	var str string
 
 	err := json.Unmarshal(data, &str)

--- a/llm/transformer/openrouter/model.go
+++ b/llm/transformer/openrouter/model.go
@@ -70,7 +70,7 @@ func (m *Message) ToOpenAIMessage() openai.Message {
 
 		reasoning := reasoningText.String()
 		m.ReasoningContent = &reasoning
-	} else {
+	} else if m.Reasoning != nil {
 		m.ReasoningContent = m.Reasoning
 	}
 


### PR DESCRIPTION
### 描述 (Description)

修复在使用 DeepSeek-R1、GLM-4 等具备思考能力的模型时，遇到的两个影响体验的问题：

1.  **Content 字段 Null 值解析错误**：
    上游接口返回 `"content": null` 时（常见于推理模型正在输出思考内容阶段），原有的 `UnmarshalJSON` 逻辑会将其错误解析为 `""`（指向空字符串的指针）。这导致许多客户端误以为正文生成已开始但为空，从而截断或无法显示“思考中”的状态。

2.  **OpenRouter 思考内容被覆盖**：
    在 OpenRouter 渠道中，如果上游返回了标准的 `reasoning_content` 但未返回 OpenRouter 特有的 `reasoning` 字段，原有的转换逻辑会将 `ReasoningContent` 错误地覆盖为 `nil`，导致思考内容丢失。

### 修改详情 (Changes)

1.  **`llm/transformer/openai/model.go`**:
    - 在 `MessageContent.UnmarshalJSON` 方法中增加了对 `null` 值的显式检查。
    - 当接收到 `null` 时，强制将 `Content` 和 `MultipleContent` 设为 `nil`，确保序列化回 JSON 时保持为 `null`，修复客户端显示问题。

2.  **`llm/transformer/openrouter/model.go`**:
    - 修改了 `ToOpenAIMessage` 方法中的赋值逻辑。
    - 将 `else` 分支修改为 `else if m.Reasoning != nil`。防止当 `m.Reasoning` 为空时，覆盖掉嵌入结构体中原本正确解析的 `ReasoningContent`。

### 测试结果 (Test Result)
- **DeepSeek-R1 (OpenRouter)**: `reasoning_content` 正常透传，不再丢失。
- **客户端显示**: 接收到的 JSON 中 `"content": null` 保持不变，客户端（如 Cherry Studio, NextChat 等）能正常显示“思考中”状态。