### PR TITLE
fix: support both parameters and parametersJsonSchema in Gemini transformer

### DIFF
--- a/llm/tools.go
+++ b/llm/tools.go
@@ -41,8 +41,11 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 type Function struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
-	Parameters  json.RawMessage `json:"parameters"`
-	Strict      *bool           `json:"strict,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	// ParametersJsonSchema is the newer Gemini format that supports full JSON Schema Draft 2020-12
+	// including const, enum, and other advanced features. This field is mutually exclusive with Parameters.
+	ParametersJsonSchema json.RawMessage `json:"parametersJsonSchema,omitempty"`
+	Strict               *bool           `json:"strict,omitempty"`
 }
 
 // FunctionCall represents a function call (deprecated).

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -147,37 +147,29 @@ func convertGeminiToLLMRequest(geminiReq *GenerateContentRequest) (*llm.Request,
 			// Handle function declarations
 			if tool.FunctionDeclarations != nil {
 				for _, fd := range tool.FunctionDeclarations {
+					// The gemini sdk use UPPER case for type, but the unified format use lower case.
+					transform := func(schema json.RawMessage) json.RawMessage {
+						if schema == nil {
+							return nil
+						}
+						transformed, err := xjson.Transform(schema, func(s *jsonschema.Schema) {
+							s.Type = strings.ToLower(s.Type)
+						})
+						if err != nil {
+							return schema // fallback to original on error
+						}
+						return transformed
+					}
+
 					// Determine which format was used and preserve it
 					var parameters, parametersJsonSchema json.RawMessage
 
 					if fd.Parameters != nil {
-						// Old format: use Parameters field
-						parameters = fd.Parameters
+						// Old format
+						parameters = transform(fd.Parameters)
 					} else if fd.ParametersJsonSchema != nil {
-						// New format: use ParametersJsonSchema field
-						parametersJsonSchema = fd.ParametersJsonSchema
-					}
-
-					// Choose the one that's present for type transformation
-					schemaToTransform := parameters
-					if schemaToTransform == nil {
-						schemaToTransform = parametersJsonSchema
-					}
-
-					// The gemini sdk use UPPER case for type, but the unified format use lower case.
-					transformed, err := xjson.Transform(schemaToTransform, func(s *jsonschema.Schema) {
-						s.Type = strings.ToLower(s.Type)
-					})
-					if err != nil {
-						// If transform failed, keep original
-						transformed = schemaToTransform
-					}
-
-					// Update the appropriate field with the transformed schema
-					if parameters != nil {
-						parameters = transformed
-					} else {
-						parametersJsonSchema = transformed
+						// New format
+						parametersJsonSchema = transform(fd.ParametersJsonSchema)
 					}
 
 					llmTool := llm.Tool{

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -147,26 +147,46 @@ func convertGeminiToLLMRequest(geminiReq *GenerateContentRequest) (*llm.Request,
 			// Handle function declarations
 			if tool.FunctionDeclarations != nil {
 				for _, fd := range tool.FunctionDeclarations {
-					parameters := fd.Parameters
-					if parameters == nil {
-						// If Parameters is not provided, use ParametersJsonSchema.
-						parameters = fd.ParametersJsonSchema
+					// Determine which format was used and preserve it
+					var parameters, parametersJsonSchema json.RawMessage
+
+					if fd.Parameters != nil {
+						// Old format: use Parameters field
+						parameters = fd.Parameters
+					} else if fd.ParametersJsonSchema != nil {
+						// New format: use ParametersJsonSchema field
+						parametersJsonSchema = fd.ParametersJsonSchema
 					}
+
+					// Choose the one that's present for type transformation
+					schemaToTransform := parameters
+					if schemaToTransform == nil {
+						schemaToTransform = parametersJsonSchema
+					}
+
 					// The gemini sdk use UPPER case for type, but the unified format use lower case.
-					parameters, err := xjson.Transform(parameters, func(s *jsonschema.Schema) {
+					transformed, err := xjson.Transform(schemaToTransform, func(s *jsonschema.Schema) {
 						s.Type = strings.ToLower(s.Type)
 					})
 					if err != nil {
-						// If transform failed, fallback to the original parameters.
-						parameters = fd.Parameters
+						// If transform failed, keep original
+						transformed = schemaToTransform
+					}
+
+					// Update the appropriate field with the transformed schema
+					if parameters != nil {
+						parameters = transformed
+					} else {
+						parametersJsonSchema = transformed
 					}
 
 					llmTool := llm.Tool{
 						Type: "function",
 						Function: llm.Function{
-							Name:        fd.Name,
-							Description: fd.Description,
-							Parameters:  parameters,
+							Name:                 fd.Name,
+							Description:          fd.Description,
+							Parameters:           parameters,
+							ParametersJsonSchema: parametersJsonSchema,
 						},
 					}
 					tools = append(tools, llmTool)

--- a/llm/transformer/gemini/integraion_test.go
+++ b/llm/transformer/gemini/integraion_test.go
@@ -266,6 +266,10 @@ func TestTransformRequest_Integration(t *testing.T) {
 			requestFile: "gemini-tools.request.json",
 		},
 		{
+			name:        "tools request with parametersJsonSchema",
+			requestFile: "gemini-tools-jsonschema.request.json",
+		},
+		{
 			name:        "thinking request",
 			requestFile: "gemini-thinking.request.json",
 		},

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -234,22 +234,20 @@ func convertLLMToGeminiRequestWithConfig(chatReq *llm.Request, config *Config) *
 
 				// Handle both parameter formats
 				// Priority: if ParametersJsonSchema is present, use it; otherwise use Parameters
+				cleanSchema := func(schema json.RawMessage) json.RawMessage {
+					cleaned, err := xjson.CleanSchema(schema, "$schema", "additionalProperties")
+					if err != nil {
+						return schema // ignore error and use original
+					}
+					return cleaned
+				}
+
 				if tool.Function.ParametersJsonSchema != nil {
 					// New format: supports full JSON Schema including const, enum, etc.
-					params, err := xjson.CleanSchema(tool.Function.ParametersJsonSchema, "$schema", "additionalProperties")
-					if err != nil {
-						// ignore
-						params = tool.Function.ParametersJsonSchema
-					}
-					fd.ParametersJsonSchema = params
+					fd.ParametersJsonSchema = cleanSchema(tool.Function.ParametersJsonSchema)
 				} else if tool.Function.Parameters != nil {
 					// Old format: limited JSON Schema support
-					params, err := xjson.CleanSchema(tool.Function.Parameters, "$schema", "additionalProperties")
-					if err != nil {
-						// ignore
-						params = tool.Function.Parameters
-					}
-					fd.Parameters = params
+					fd.Parameters = cleanSchema(tool.Function.Parameters)
 				}
 
 				functionDeclarations = append(functionDeclarations, fd)

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -227,19 +227,31 @@ func convertLLMToGeminiRequestWithConfig(chatReq *llm.Request, config *Config) *
 		for _, tool := range chatReq.Tools {
 			switch tool.Type {
 			case "function":
-				params := tool.Function.Parameters
-
-				params, err := xjson.CleanSchema(params, "$schema", "additionalProperties")
-				if err != nil {
-					// ignore
-					params = tool.Function.Parameters
-				}
-
 				fd := &FunctionDeclaration{
 					Name:        tool.Function.Name,
 					Description: tool.Function.Description,
-					Parameters:  params,
 				}
+
+				// Handle both parameter formats
+				// Priority: if ParametersJsonSchema is present, use it; otherwise use Parameters
+				if tool.Function.ParametersJsonSchema != nil {
+					// New format: supports full JSON Schema including const, enum, etc.
+					params, err := xjson.CleanSchema(tool.Function.ParametersJsonSchema, "$schema", "additionalProperties")
+					if err != nil {
+						// ignore
+						params = tool.Function.ParametersJsonSchema
+					}
+					fd.ParametersJsonSchema = params
+				} else if tool.Function.Parameters != nil {
+					// Old format: limited JSON Schema support
+					params, err := xjson.CleanSchema(tool.Function.Parameters, "$schema", "additionalProperties")
+					if err != nil {
+						// ignore
+						params = tool.Function.Parameters
+					}
+					fd.Parameters = params
+				}
+
 				functionDeclarations = append(functionDeclarations, fd)
 
 				if functionTool == nil {

--- a/llm/transformer/gemini/outbound_convert_parameters_test.go
+++ b/llm/transformer/gemini/outbound_convert_parameters_test.go
@@ -1,0 +1,81 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+	"github.com/samber/lo"
+
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertLLMToGeminiRequest_UsesParametersJsonSchema verifies that
+// function declarations use parametersJsonSchema (new format) instead of
+// parameters (old format) to support full JSON Schema including const, enum, etc.
+func TestConvertLLMToGeminiRequest_UsesParametersJsonSchema(t *testing.T) {
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("test"),
+				},
+			},
+		},
+		Tools: []llm.Tool{
+			{
+				Type: "function",
+				Function: llm.Function{
+					Name:        "test_tool",
+					Description: "A test tool",
+					ParametersJsonSchema: json.RawMessage(`{
+						"type": "object",
+						"properties": {
+							"mode": {
+								"type": "string",
+								"const": "strict",
+								"description": "Must be strict"
+							},
+							"options": {
+								"type": "string",
+								"enum": ["opt1", "opt2"],
+								"description": "Available options"
+							}
+						},
+						"required": ["mode"]
+					}`),
+				},
+			},
+		},
+	}
+
+	result := convertLLMToGeminiRequest(req)
+
+	// Verify tools were converted
+	require.NotNil(t, result.Tools)
+	require.Len(t, result.Tools, 1)
+	require.NotNil(t, result.Tools[0].FunctionDeclarations)
+	require.Len(t, result.Tools[0].FunctionDeclarations, 1)
+
+	fd := result.Tools[0].FunctionDeclarations[0]
+	require.Equal(t, "test_tool", fd.Name)
+	require.Equal(t, "A test tool", fd.Description)
+
+	// CRITICAL: Must use ParametersJsonSchema (new format), not Parameters (old format)
+	require.Nil(t, fd.Parameters, "Parameters field (old format) should not be used")
+	require.NotNil(t, fd.ParametersJsonSchema, "ParametersJsonSchema field (new format) must be used")
+
+	// Verify the schema content is correct
+	var schema map[string]any
+	err := json.Unmarshal(fd.ParametersJsonSchema, &schema)
+	require.NoError(t, err)
+
+	// Verify const and enum are preserved
+	props := schema["properties"].(map[string]any)
+	mode := props["mode"].(map[string]any)
+	options := props["options"].(map[string]any)
+
+	require.Equal(t, "strict", mode["const"], "const field must be preserved")
+	require.ElementsMatch(t, []any{"opt1", "opt2"}, options["enum"], "enum field must be preserved")
+}

--- a/llm/transformer/gemini/testdata/gemini-tools-jsonschema.request.json
+++ b/llm/transformer/gemini/testdata/gemini-tools-jsonschema.request.json
@@ -1,0 +1,58 @@
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "What is the weather in San Francisco, CA?"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "name": "get_coordinates",
+          "description": "Accepts a place as an address, then returns the latitude and longitude coordinates.",
+          "parametersJsonSchema": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The location to look up."
+              }
+            },
+            "required": ["location"]
+          }
+        },
+        {
+          "name": "get_weather",
+          "description": "Get the weather at a specific location",
+          "parametersJsonSchema": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "The latitude of the location to check weather."
+              },
+              "long": {
+                "type": "number",
+                "description": "The longitude of the location to check weather."
+              },
+              "unit": {
+                "type": "string",
+                "description": "Unit for the output",
+                "enum": ["celsius", "fahrenheit"]
+              }
+            },
+            "required": ["lat", "long", "unit"]
+          }
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "maxOutputTokens": 1024
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Gemini API translation issue preventing Gemini CLI from working with AxonHub when using advanced JSON Schema features (const, enum, etc.).

## Problem

The Gemini API supports two parameter formats:
- **parameters** (old): OpenAPI 3.03 format with limited JSON Schema support
- **parametersJsonSchema** (new): Full JSON Schema Draft 2020-12 support

The transformer only handled the old format, causing requests using the new format to fail.

## Changes

- Extended `llm.Function` to include both `Parameters` and `ParametersJsonSchema` fields
- Updated inbound/outbound converters to preserve whichever format was present
- Added integration and unit tests for both formats

## Impact

- ✅ Enables Gemini CLI to work with AxonHub
- ✅ Maintains backward compatibility with old format
- ✅ Supports advanced JSON Schema features in new format

## Test plan

- [x] Tested with Gemini CLI - works correctly
- [x] Added integration tests with both parameter formats
- [x] Verified backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)