### PR TITLE
docs: clarify regex pattern anchoring in model associations

### DIFF
--- a/docs/en/guides/model-management.md
+++ b/docs/en/guides/model-management.md
@@ -100,7 +100,7 @@ Matches all models matching the regex pattern in a specific channel.
 **Pattern Syntax**: Patterns are automatically anchored with `^` and `$` to match the entire model string. Use `.*` for flexible matching:
 - `gpt-4.*` - Matches `gpt-4`, `gpt-4-turbo`, `gpt-4-vision-preview`
 - `.*flash.*` - Matches `gemini-2.5-flash-preview`, `gemini-flash-2.0`
-- `claude-3-.*-sonnet` - Matches `claude-3-5-sonnet`, `claude-3-7-sonnet-20250219`
+- `claude-3-.*-sonnet` - Matches `claude-3-5-sonnet`, `claude-3-opus-sonnet`
 
 **Use Cases**:
 - Channel supports multiple model variants

--- a/docs/en/guides/model-management.md
+++ b/docs/en/guides/model-management.md
@@ -97,6 +97,11 @@ Matches all models matching the regex pattern in a specific channel.
 }
 ```
 
+**Pattern Syntax**: Patterns are automatically anchored with `^` and `$` to match the entire model string. Use `.*` for flexible matching:
+- `gpt-4.*` - Matches `gpt-4`, `gpt-4-turbo`, `gpt-4-vision-preview`
+- `.*flash.*` - Matches `gemini-2.5-flash-preview`, `gemini-flash-2.0`
+- `claude-3-.*-sonnet` - Matches `claude-3-5-sonnet`, `claude-3-7-sonnet-20250219`
+
 **Use Cases**:
 - Channel supports multiple model variants
 - Need flexible model name matching

--- a/docs/zh/guides/model-management.md
+++ b/docs/zh/guides/model-management.md
@@ -100,7 +100,7 @@ AxonHub 中的模型是抽象的模型定义，包含：
 **模式语法**：模式会自动添加 `^` 和 `$` 锚点来匹配完整模型字符串。使用 `.*` 进行灵活匹配：
 - `gpt-4.*` - 匹配 `gpt-4`、`gpt-4-turbo`、`gpt-4-vision-preview`
 - `.*flash.*` - 匹配 `gemini-2.5-flash-preview`、`gemini-flash-2.0`
-- `claude-3-.*-sonnet` - 匹配 `claude-3-5-sonnet`、`claude-3-7-sonnet-20250219`
+- `claude-3-.*-sonnet` - 匹配 `claude-3-5-sonnet`、`claude-3-opus-sonnet`
 
 **使用场景**：
 - 渠道支持多个模型变体

--- a/docs/zh/guides/model-management.md
+++ b/docs/zh/guides/model-management.md
@@ -97,6 +97,11 @@ AxonHub 中的模型是抽象的模型定义，包含：
 }
 ```
 
+**模式语法**：模式会自动添加 `^` 和 `$` 锚点来匹配完整模型字符串。使用 `.*` 进行灵活匹配：
+- `gpt-4.*` - 匹配 `gpt-4`、`gpt-4-turbo`、`gpt-4-vision-preview`
+- `.*flash.*` - 匹配 `gemini-2.5-flash-preview`、`gemini-flash-2.0`
+- `claude-3-.*-sonnet` - 匹配 `claude-3-5-sonnet`、`claude-3-7-sonnet-20250219`
+
 **使用场景**：
 - 渠道支持多个模型变体
 - 需要灵活匹配模型名称


### PR DESCRIPTION
## Summary

- Added pattern syntax documentation to model management guide (English and Chinese)
- Clarifies that regex patterns are automatically anchored with `^` and `$` to match the entire model string
- Provides practical examples using `.*` for flexible matching

**Example**: To match `gemini-3-flash-preview`, use:
- `gemini.*` - matches models starting with "gemini"
- `.*flash.*` - matches models containing "flash" anywhere

**Before**: Users expected `*gemini*` to work (like shell wildcards), but regex `*` means "zero or more of preceding character"

**After**: Clear documentation with real examples showing correct usage

## Related Files

- `docs/en/guides/model-management.md` - Added "Pattern Syntax" section
- `docs/zh/guides/model-management.md` - Chinese translation of pattern syntax docs

## Testing

- Documentation only (no code changes)
- Examples verified against `internal/pkg/xregexp/match.go` implementation