### PR TITLE
fix: do not allow change email by user self

### DIFF
--- a/frontend/src/features/settings/profile/profile-form.tsx
+++ b/frontend/src/features/settings/profile/profile-form.tsx
@@ -74,7 +74,6 @@ export default function ProfileForm() {
     mutationFn: async (data: ProfileFormValues) => {
       const response = (await graphqlRequest(UPDATE_ME_MUTATION, {
         input: {
-          email: data.email,
           firstName: data.firstName,
           lastName: data.lastName,
           preferLanguage: data.preferLanguage,
@@ -89,7 +88,6 @@ export default function ProfileForm() {
         ...auth.user!,
         firstName: updatedUser.firstName,
         lastName: updatedUser.lastName,
-        email: updatedUser.email,
         preferLanguage: updatedUser.preferLanguage,
         avatar: updatedUser.avatar,
       });
@@ -198,9 +196,9 @@ export default function ProfileForm() {
             <FormItem>
               <FormLabel>{t('profile.form.fields.email.label')}</FormLabel>
               <FormControl>
-                <Input type='email' placeholder={t('profile.form.fields.email.placeholder')} {...field} />
+                <Input type='email' placeholder={t('profile.form.fields.email.placeholder')} {...field} disabled />
               </FormControl>
-              <FormDescription>{t('profile.form.fields.email.description')}</FormDescription>
+              <FormDescription>{t('profile.form.fields.email.disabled_description')}</FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/src/locales/en/profile.json
+++ b/frontend/src/locales/en/profile.json
@@ -14,6 +14,7 @@
   "profile.form.fields.email.label": "Email",
   "profile.form.fields.email.placeholder": "Enter your email address",
   "profile.form.fields.email.description": "Your email address for account notifications and login.",
+  "profile.form.fields.email.disabled_description": "Email address cannot be changed.",
   "profile.form.fields.preferLanguage.label": "Preferred Language",
   "profile.form.fields.preferLanguage.placeholder": "Select your preferred language",
   "profile.form.fields.preferLanguage.description": "Choose your preferred language for the interface.",

--- a/frontend/src/locales/zh-CN/profile.json
+++ b/frontend/src/locales/zh-CN/profile.json
@@ -14,6 +14,7 @@
   "profile.form.fields.email.label": "邮箱",
   "profile.form.fields.email.placeholder": "输入您的邮箱地址",
   "profile.form.fields.email.description": "用于账户通知和登录的邮箱地址。",
+  "profile.form.fields.email.disabled_description": "邮箱地址不可更改。",
   "profile.form.fields.preferLanguage.label": "首选语言",
   "profile.form.fields.preferLanguage.placeholder": "选择您的首选语言",
   "profile.form.fields.preferLanguage.description": "选择界面的首选语言。",

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -58586,20 +58586,13 @@ func (ec *executionContext) unmarshalInputUpdateMeInput(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email", "firstName", "lastName", "preferLanguage", "avatar"}
+	fieldsInOrder := [...]string{"firstName", "lastName", "preferLanguage", "avatar"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "email":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Email = data
 		case "firstName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firstName"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/internal/server/gql/me.graphql
+++ b/internal/server/gql/me.graphql
@@ -29,7 +29,6 @@ extend type Query {
 }
 
 input UpdateMeInput {
-  email: String
   firstName: String
   lastName: String
   preferLanguage: String

--- a/internal/server/gql/me.resolvers.go
+++ b/internal/server/gql/me.resolvers.go
@@ -27,7 +27,6 @@ func (r *mutationResolver) UpdateMe(ctx context.Context, input UpdateMeInput) (*
 	}
 
 	return r.userService.UpdateUser(ctx, user.ID, ent.UpdateUserInput{
-		Email:          input.Email,
 		FirstName:      input.FirstName,
 		LastName:       input.LastName,
 		PreferLanguage: input.PreferLanguage,

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -272,7 +272,6 @@ type UpdateDefaultDataStorageInput struct {
 }
 
 type UpdateMeInput struct {
-	Email          *string `json:"email,omitempty"`
 	FirstName      *string `json:"firstName,omitempty"`
 	LastName       *string `json:"lastName,omitempty"`
 	PreferLanguage *string `json:"preferLanguage,omitempty"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email field in profile form is disabled—email can no longer be changed via profile settings.
  * Profile updates no longer modify the stored email when saving other profile details.

* **Documentation**
  * Added disabled-specific help text for the email field (English and Chinese).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->