### PR TITLE
fix: expand channel with many models cause ui bug

### DIFF
--- a/frontend/src/features/channels/components/channel-expanded-row.tsx
+++ b/frontend/src/features/channels/components/channel-expanded-row.tsx
@@ -106,11 +106,16 @@ export const ChannelExpandedRow = memo(({ channel, columnsLength, getApiFormatLa
           <div className='space-y-3'>
             <h4 className='text-sm font-semibold'>{t('channels.expandedRow.supportedModels')}</h4>
             <div className='flex flex-wrap gap-2'>
-              {channel.supportedModels.map((model) => (
+              {channel.supportedModels.slice(0, 5).map((model) => (
                 <Badge key={model} variant='secondary' className='font-mono text-xs'>
                   {model}
                 </Badge>
               ))}
+              {channel.supportedModels.length > 5 && (
+                <span className='text-muted-foreground flex items-center text-xs italic'>
+                  {t('channels.expandedRow.moreModels', { count: channel.supportedModels.length - 5 })}
+                </span>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -424,6 +424,7 @@
   "channels.expandedRow.tags": "Tags",
   "channels.expandedRow.apiFormat": "API Format",
   "channels.expandedRow.noPerformanceData": "No performance data available",
+  "channels.expandedRow.moreModels": "...and {{count}} more models, please check in the edit dialog",
   "channels.templates.section.title": "Templates",
   "channels.templates.section.description": "Load saved override configurations or save current settings as a template for reuse",
   "channels.templates.selectTemplate": "Select template...",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -427,6 +427,7 @@
   "channels.expandedRow.tags": "标签",
   "channels.expandedRow.apiFormat": "API 格式",
   "channels.expandedRow.noPerformanceData": "暂无性能数据",
+  "channels.expandedRow.moreModels": "...以及另外 {{count}} 个模型，请在编辑对话框中查看",
   "channels.templates.section.title": "模板",
   "channels.templates.section.description": "加载已保存的覆盖配置或将当前设置保存为模板以供重复使用",
   "channels.templates.selectTemplate": "选择模板...",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel expanded rows now display the first five supported models with a "more models" indicator when additional options are available, allowing users to discover all options via the edit dialog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->