### PR TITLE
feat(responses): 添加 Item 的 MarshalJSON 方法以处理 reasoning 项目的 summary 字段

### DIFF
--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -391,6 +391,32 @@ type Item struct {
 	EncryptedContent *string `json:"encrypted_content,omitempty"`
 }
 
+// MarshalJSON omits summary for non-reasoning items and forces an empty array for reasoning items.
+func (item Item) MarshalJSON() ([]byte, error) {
+	type itemAlias Item
+
+	raw, err := json.Marshal(itemAlias(item))
+	if err != nil {
+		return nil, err
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+
+	if item.Type == "reasoning" {
+		if item.Summary == nil {
+			obj["summary"] = []any{}
+		}
+
+		return json.Marshal(obj)
+	}
+
+	delete(obj, "summary")
+	return json.Marshal(obj)
+}
+
 // isOutputMessageContent checks if Content.Items contains output message content items.
 func (item Item) isOutputMessageContent() bool {
 	if item.Content == nil || len(item.Content.Items) == 0 {

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -395,26 +395,13 @@ type Item struct {
 func (item Item) MarshalJSON() ([]byte, error) {
 	type itemAlias Item
 
-	raw, err := json.Marshal(itemAlias(item))
-	if err != nil {
-		return nil, err
+	if item.Type != "reasoning" {
+		item.Summary = nil
+	} else if item.Summary == nil {
+		item.Summary = []ReasoningSummary{}
 	}
 
-	var obj map[string]any
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return nil, err
-	}
-
-	if item.Type == "reasoning" {
-		if item.Summary == nil {
-			obj["summary"] = []any{}
-		}
-
-		return json.Marshal(obj)
-	}
-
-	delete(obj, "summary")
-	return json.Marshal(obj)
+	return json.Marshal(itemAlias(item))
 }
 
 // isOutputMessageContent checks if Content.Items contains output message content items.

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -1,0 +1,27 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemMarshalJSON_OmitsSummaryForNonReasoning(t *testing.T) {
+	item := Item{
+		Role: "user",
+		Content: &Input{
+			Items: []Item{
+				{
+					Type: "input_text",
+					Text: lo.ToPtr("hello"),
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), `"summary"`)
+}


### PR DESCRIPTION
# PR: Fix OpenAI Responses input summary field

## Before
- Outbound requests to the OpenAI Responses API serialized `summary` on all items, including input items.
- OpenAI rejected the request with: `Unknown parameter: 'input[0].summary'.`

## After
- `summary` is omitted for non-reasoning items; reasoning items still include `summary` (empty array when unset).
- Added a regression test to ensure input items do not serialize `summary`.

## Tests
- `go test ./llm/transformer/openai/responses`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted JSON serialization for item responses: reasoning items now include Summary as an empty array when absent; non-reasoning items omit Summary entirely.
* **Tests**
  * Added unit tests to verify Summary is included or omitted correctly based on item type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->