### PR TITLE
fix: handle empty responseId in Gemini streaming with thinkingConfig

### DIFF
--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -11,6 +11,10 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
+// defaultPendingResponseID is used when a chunk has content but no responseID.
+// This provides a consistent ID across all chunks until a real responseID arrives.
+const defaultPendingResponseID = "pending-response"
+
 // streamState tracks state across streaming events.
 type streamState struct {
 	toolCallIndex int
@@ -67,21 +71,18 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		state.responseID = resp.ResponseID
 	}
 
-	// Skip chunks with no meaningful content (empty candidates).
-	// This can happen with intermediate chunks during thinking mode streaming.
-	if len(resp.Candidates) == 0 {
+	// Skip chunks with no meaningful content.
+	// A chunk is meaningful if it has candidates OR usage metadata.
+	// Intermediate chunks during thinking mode may have neither and can be safely skipped.
+	if len(resp.Candidates) == 0 && resp.UsageMetadata == nil {
 		return nil, nil
 	}
 
-	// Use tracked responseID (real or temporary) if current chunk is missing it
-	if resp.ResponseID == "" && state.responseID != "" {
-		resp.ResponseID = state.responseID
-	}
-
-	// If we still have no responseId but have candidates, generate a temporary one
-	// and store it in state for consistency across the stream.
+	// Assign responseID if missing: use tracked ID or generate temporary
 	if resp.ResponseID == "" {
-		state.responseID = "pending-response"
+		if state.responseID == "" {
+			state.responseID = defaultPendingResponseID
+		}
 		resp.ResponseID = state.responseID
 	}
 

--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -62,28 +62,27 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		return nil, err
 	}
 
-	// Track responseID from first chunk that has it
-	if resp.ResponseID != "" && state.responseID == "" {
+	// Update state.responseID if chunk has a real responseID (prefer real over temporary)
+	if resp.ResponseID != "" {
 		state.responseID = resp.ResponseID
 	}
 
-	// Use tracked responseID if current chunk is missing it
+	// Skip chunks with no meaningful content (empty candidates).
+	// This can happen with intermediate chunks during thinking mode streaming.
+	if len(resp.Candidates) == 0 {
+		return nil, nil
+	}
+
+	// Use tracked responseID (real or temporary) if current chunk is missing it
 	if resp.ResponseID == "" && state.responseID != "" {
 		resp.ResponseID = state.responseID
 	}
 
-	// Check if the response is valid.
-	// Skip chunks that have no responseId AND no meaningful content.
-	// This can happen with intermediate chunks during thinking mode streaming.
-	if resp.ResponseID == "" && len(resp.Candidates) == 0 {
-		return nil, nil
-	}
-
 	// If we still have no responseId but have candidates, generate a temporary one
-	// to allow processing to continue. The final aggregated response will use
-	// the responseId from whichever chunk provides it.
+	// and store it in state for consistency across the stream.
 	if resp.ResponseID == "" {
-		resp.ResponseID = "pending-" + string(event.Data[:min(8, len(event.Data))])
+		state.responseID = "pending-response"
+		resp.ResponseID = state.responseID
 	}
 
 	// Convert to unified response format (streaming) with tool call index tracking

--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/samber/lo"
 
@@ -11,14 +12,19 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
-// defaultPendingResponseID is used when a chunk has content but no responseID.
-// This provides a consistent ID across all chunks until a real responseID arrives.
+// ErrMissingResponseID is returned when a meaningful chunk has no responseID
+// and no real responseID has been received from previous chunks.
+var ErrMissingResponseID = errors.New("missing responseID in stream: expected responseID after first event")
+
+// defaultPendingResponseID is used when the first chunk has content but no responseID.
+// This provides a temporary ID until a real responseID arrives.
 const defaultPendingResponseID = "pending-response"
 
 // streamState tracks state across streaming events.
 type streamState struct {
-	toolCallIndex int
-	responseID    string // Track responseID from first valid chunk
+	toolCallIndex          int
+	responseID             string // Track responseID from chunks
+	hasSeenMeaningfulEvent bool   // Track if we've processed at least one meaningful event
 }
 
 // TransformStream transforms the HTTP stream response to the unified response format.
@@ -29,12 +35,15 @@ func (t *OutboundTransformer) TransformStream(
 ) (streams.Stream[*llm.Response], error) {
 	stream = streams.AppendStream(stream, lo.ToPtr(llm.DoneStreamEvent))
 
-	// Track tool call index across stream events
+	// Track state across stream events
 	state := &streamState{}
 
-	return streams.MapErr(stream, func(event *httpclient.StreamEvent) (*llm.Response, error) {
+	mapped := streams.MapErr(stream, func(event *httpclient.StreamEvent) (*llm.Response, error) {
 		return t.transformStreamChunkWithState(event, state)
-	}), nil
+	})
+
+	// Filter out nil responses to ensure stream only returns valid responses
+	return streams.NoNil(mapped), nil
 }
 
 // TransformStreamChunk transforms a single Gemini streaming chunk to unified Response.
@@ -66,7 +75,7 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		return nil, err
 	}
 
-	// Update state.responseID if chunk has a real responseID (prefer real over temporary)
+	// Update state.responseID if chunk has a real responseID
 	if resp.ResponseID != "" {
 		state.responseID = resp.ResponseID
 	}
@@ -78,9 +87,20 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		return nil, nil
 	}
 
-	// Assign responseID if missing: use tracked ID or generate temporary
+	// This is a meaningful event - validate responseID requirements
+	if state.hasSeenMeaningfulEvent {
+		// Not the first event - must have a real responseID by now
+		// (either from a previous chunk or this chunk)
+		if resp.ResponseID == "" && (state.responseID == "" || state.responseID == defaultPendingResponseID) {
+			return nil, ErrMissingResponseID
+		}
+	}
+	state.hasSeenMeaningfulEvent = true
+
+	// Assign responseID if missing from this chunk
 	if resp.ResponseID == "" {
 		if state.responseID == "" {
+			// First event without responseID - use pending
 			state.responseID = defaultPendingResponseID
 		}
 		resp.ResponseID = state.responseID

--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -89,9 +89,8 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 
 	// This is a meaningful event - validate responseID requirements
 	if state.hasSeenMeaningfulEvent {
-		// Not the first event - must have a real responseID by now
-		// (either from a previous chunk or this chunk)
-		if resp.ResponseID == "" && (state.responseID == "" || state.responseID == defaultPendingResponseID) {
+		// Not the first event - error if current chunk has no ID and we're still using pending ID
+		if resp.ResponseID == "" && state.responseID == defaultPendingResponseID {
 			return nil, ErrMissingResponseID
 		}
 	}

--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -9,12 +9,12 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
-	"github.com/looplj/axonhub/llm/transformer"
 )
 
 // streamState tracks state across streaming events.
 type streamState struct {
 	toolCallIndex int
+	responseID    string // Track responseID from first valid chunk
 }
 
 // TransformStream transforms the HTTP stream response to the unified response format.
@@ -62,10 +62,28 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		return nil, err
 	}
 
+	// Track responseID from first chunk that has it
+	if resp.ResponseID != "" && state.responseID == "" {
+		state.responseID = resp.ResponseID
+	}
+
+	// Use tracked responseID if current chunk is missing it
+	if resp.ResponseID == "" && state.responseID != "" {
+		resp.ResponseID = state.responseID
+	}
+
 	// Check if the response is valid.
-	// Gemini response empty event for some time, we should return error instead of continue to process.
+	// Skip chunks that have no responseId AND no meaningful content.
+	// This can happen with intermediate chunks during thinking mode streaming.
+	if resp.ResponseID == "" && len(resp.Candidates) == 0 {
+		return nil, nil
+	}
+
+	// If we still have no responseId but have candidates, generate a temporary one
+	// to allow processing to continue. The final aggregated response will use
+	// the responseId from whichever chunk provides it.
 	if resp.ResponseID == "" {
-		return nil, transformer.ErrInvalidResponse
+		resp.ResponseID = "pending-" + string(event.Data[:min(8, len(event.Data))])
 	}
 
 	// Convert to unified response format (streaming) with tool call index tracking

--- a/llm/transformer/gemini/outbound_stream_test.go
+++ b/llm/transformer/gemini/outbound_stream_test.go
@@ -953,5 +953,262 @@ func mustMarshal(v any) []byte {
 	return data
 }
 
+func TestOutboundTransformer_TransformStream_FiltersNilResponses(t *testing.T) {
+	transformer := &OutboundTransformer{
+		config: Config{
+			BaseURL:    DefaultBaseURL,
+			APIVersion: DefaultAPIVersion,
+		},
+	}
+
+	// Create test stream with empty chunks (no candidates, no usage) that should return nil
+	events := []*httpclient.StreamEvent{
+		{
+			// Empty chunk - should be filtered out
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-filter-1",
+				ModelVersion: "gemini-2.0-flash",
+			}),
+		},
+		{
+			// Valid chunk with content
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-filter-1",
+				ModelVersion: "gemini-2.0-flash",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: "Hello"}},
+						},
+						FinishReason: "STOP",
+					},
+				},
+			}),
+		},
+		{
+			// Another empty chunk - should be filtered out
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-filter-1",
+				ModelVersion: "gemini-2.0-flash",
+			}),
+		},
+	}
+
+	inputStream := streams.SliceStream(events)
+	outputStream, err := transformer.TransformStream(context.Background(), inputStream)
+	require.NoError(t, err)
+
+	// Collect results - nil responses should be filtered out
+	var results []*llm.Response
+	for outputStream.Next() {
+		results = append(results, outputStream.Current())
+	}
+	require.NoError(t, outputStream.Err())
+
+	// Should only have 2 responses: the valid chunk and [DONE]
+	require.Len(t, results, 2)
+	require.Equal(t, "Hello", *results[0].Choices[0].Delta.Content.Content)
+	require.Equal(t, "[DONE]", results[1].Object)
+}
+
+func TestOutboundTransformer_TransformStream_MissingResponseIDAfterFirstEvent(t *testing.T) {
+	transformer := &OutboundTransformer{
+		config: Config{
+			BaseURL:    DefaultBaseURL,
+			APIVersion: DefaultAPIVersion,
+		},
+	}
+
+	// Create test stream where first chunk has no responseID (uses pending),
+	// and second chunk also has no responseID - should error
+	events := []*httpclient.StreamEvent{
+		{
+			// First chunk without responseID - OK, uses pending
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.0-flash",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: "Hello"}},
+						},
+					},
+				},
+			}),
+		},
+		{
+			// Second chunk also without responseID - should error
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.0-flash",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: ", world!"}},
+						},
+						FinishReason: "STOP",
+					},
+				},
+			}),
+		},
+	}
+
+	inputStream := streams.SliceStream(events)
+	outputStream, err := transformer.TransformStream(context.Background(), inputStream)
+	require.NoError(t, err)
+
+	// First call should succeed (first chunk uses pending ID)
+	require.True(t, outputStream.Next())
+	require.NotNil(t, outputStream.Current())
+	require.Equal(t, defaultPendingResponseID, outputStream.Current().ID)
+
+	// Second call should fail with ErrMissingResponseID
+	require.False(t, outputStream.Next())
+	require.ErrorIs(t, outputStream.Err(), ErrMissingResponseID)
+}
+
+func TestOutboundTransformer_TransformStream_ResponseIDArrivesLater(t *testing.T) {
+	transformer := &OutboundTransformer{
+		config: Config{
+			BaseURL:    DefaultBaseURL,
+			APIVersion: DefaultAPIVersion,
+		},
+	}
+
+	// Create test stream where first chunk has no responseID,
+	// but second chunk has a real responseID - should succeed
+	events := []*httpclient.StreamEvent{
+		{
+			// First chunk without responseID - uses pending
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.0-flash",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: "Hello"}},
+						},
+					},
+				},
+			}),
+		},
+		{
+			// Second chunk WITH responseID - should succeed and use this ID
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "real-response-id",
+				ModelVersion: "gemini-2.0-flash",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: ", world!"}},
+						},
+						FinishReason: "STOP",
+					},
+				},
+			}),
+		},
+	}
+
+	inputStream := streams.SliceStream(events)
+	outputStream, err := transformer.TransformStream(context.Background(), inputStream)
+	require.NoError(t, err)
+
+	var results []*llm.Response
+	for outputStream.Next() {
+		results = append(results, outputStream.Current())
+	}
+	require.NoError(t, outputStream.Err())
+
+	// Should have 3 responses: 2 chunks + [DONE]
+	require.Len(t, results, 3)
+	require.Equal(t, defaultPendingResponseID, results[0].ID)
+	require.Equal(t, "real-response-id", results[1].ID)
+}
+
+func TestOutboundTransformer_TransformStream_EmptyChunksSkipped(t *testing.T) {
+	transformer := &OutboundTransformer{
+		config: Config{
+			BaseURL:    DefaultBaseURL,
+			APIVersion: DefaultAPIVersion,
+		},
+	}
+
+	// Simulate thinking mode where empty chunks appear between meaningful ones
+	events := []*httpclient.StreamEvent{
+		{
+			// Valid chunk with responseID
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-empty-test",
+				ModelVersion: "gemini-2.0-flash-thinking",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: "Thinking...", Thought: true}},
+						},
+					},
+				},
+			}),
+		},
+		{
+			// Empty chunk during thinking - no candidates, no usage
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-empty-test",
+				ModelVersion: "gemini-2.0-flash-thinking",
+			}),
+		},
+		{
+			// Another empty chunk
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.0-flash-thinking",
+			}),
+		},
+		{
+			// Final valid chunk
+			Data: mustMarshal(&GenerateContentResponse{
+				ResponseID:   "resp-empty-test",
+				ModelVersion: "gemini-2.0-flash-thinking",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role:  "model",
+							Parts: []*Part{{Text: "The answer is 42."}},
+						},
+						FinishReason: "STOP",
+					},
+				},
+			}),
+		},
+	}
+
+	inputStream := streams.SliceStream(events)
+	outputStream, err := transformer.TransformStream(context.Background(), inputStream)
+	require.NoError(t, err)
+
+	var results []*llm.Response
+	for outputStream.Next() {
+		results = append(results, outputStream.Current())
+	}
+	require.NoError(t, outputStream.Err())
+
+	// Should only have 3 responses: 2 valid chunks + [DONE]
+	// Empty chunks should be filtered out
+	require.Len(t, results, 3)
+	require.NotNil(t, results[0].Choices[0].Delta.ReasoningContent)
+	require.Equal(t, "Thinking...", *results[0].Choices[0].Delta.ReasoningContent)
+	require.NotNil(t, results[1].Choices[0].Delta.Content.Content)
+	require.Equal(t, "The answer is 42.", *results[1].Choices[0].Delta.Content.Content)
+	require.Equal(t, "[DONE]", results[2].Object)
+}
+
 // Ensure lo is used to satisfy linter.
 var _ = lo.ToPtr[string]


### PR DESCRIPTION
When thinkingConfig is enabled, some upstream Gemini API proxies (e.g V-API) send intermediate stream chunks without responseId. This caused the stream to terminate prematurely with "invalid response" error.

Changes:
- Track responseId from first valid chunk and inherit for subsequent chunks
- Skip empty chunks (no responseId AND no candidates)
- Generate temporary ID for chunks with content but no responseId

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed responses now skip empty/metadata-less chunks, propagate real response identifiers when they arrive, and use a temporary placeholder on first event to avoid interruptions when identifiers are missing.
* **Tests**
  * Added tests covering filtering of empty chunks, late-arriving identifiers, missing-identifier error cases, placeholder ID behavior, and proper final completion.
* **Chores**
  * Minor cleanup: removed an unused import and updated comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->