### PR TITLE
fix: bulk create channel

### DIFF
--- a/internal/server/biz/channel_bulk.go
+++ b/internal/server/biz/channel_bulk.go
@@ -42,15 +42,16 @@ func (svc *ChannelService) BulkUpdateChannelOrdering(ctx context.Context, items 
 
 // BulkCreateChannelsInput represents input for bulk creating channels.
 type BulkCreateChannelsInput struct {
-	Type             channel.Type
-	Name             string
-	Tags             []string
-	BaseURL          *string
-	APIKeys          []string
-	SupportedModels  []string
-	DefaultTestModel string
-	Policies         *objects.ChannelPolicies
-	Settings         *objects.ChannelSettings
+	Type                     channel.Type
+	Name                     string
+	Tags                     []string
+	BaseURL                  *string
+	APIKeys                  []string
+	SupportedModels          []string
+	AutoSyncSupportedModels  *bool
+	DefaultTestModel         string
+	Policies                 *objects.ChannelPolicies
+	Settings                 *objects.ChannelSettings
 }
 
 // BulkCreateChannels creates multiple channels with the same configuration but different API keys.
@@ -102,15 +103,16 @@ func (svc *ChannelService) BulkCreateChannels(ctx context.Context, input BulkCre
 
 		// Create channel input
 		createInput := ent.CreateChannelInput{
-			Type:             input.Type,
-			BaseURL:          input.BaseURL,
-			Name:             channelName,
-			Credentials:      &objects.ChannelCredentials{APIKey: apiKey},
-			SupportedModels:  input.SupportedModels,
-			Tags:             tagsToUse,
-			DefaultTestModel: input.DefaultTestModel,
-			Policies:         input.Policies,
-			Settings:         input.Settings,
+			Type:                    input.Type,
+			BaseURL:                 input.BaseURL,
+			Name:                    channelName,
+			Credentials:             &objects.ChannelCredentials{APIKey: apiKey},
+			SupportedModels:         input.SupportedModels,
+			AutoSyncSupportedModels: input.AutoSyncSupportedModels,
+			Tags:                    tagsToUse,
+			DefaultTestModel:        input.DefaultTestModel,
+			Policies:                input.Policies,
+			Settings:                input.Settings,
 		}
 
 		// Create the channel without reload

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -200,8 +200,10 @@ input BulkCreateChannelsInput {
   baseURL: String
   apiKeys: [String!]!
   supportedModels: [String!]!
+  autoSyncSupportedModels: Boolean
   defaultTestModel: String!
   settings: ChannelSettingsInput
+  policies: ChannelPoliciesInput
 }
 
 input ChannelOrderingItem {

--- a/internal/server/gql/axonhub.resolvers.go
+++ b/internal/server/gql/axonhub.resolvers.go
@@ -499,25 +499,14 @@ func (r *traceResolver) UsageMetadata(ctx context.Context, obj *ent.Trace) (*biz
 	return r.traceService.UsageMetadata(ctx, obj.ID)
 }
 
-// AutoSyncSupportedModels is the resolver for the autoSyncSupportedModels field.
-func (r *bulkCreateChannelsInputResolver) AutoSyncSupportedModels(ctx context.Context, obj *biz.BulkCreateChannelsInput, data *bool) error {
-	panic(fmt.Errorf("not implemented: AutoSyncSupportedModels - autoSyncSupportedModels"))
-}
-
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 
 // Segment returns SegmentResolver implementation.
 func (r *Resolver) Segment() SegmentResolver { return &segmentResolver{r} }
 
-// BulkCreateChannelsInput returns BulkCreateChannelsInputResolver implementation.
-func (r *Resolver) BulkCreateChannelsInput() BulkCreateChannelsInputResolver {
-	return &bulkCreateChannelsInputResolver{r}
-}
-
 type mutationResolver struct{ *Resolver }
 type segmentResolver struct{ *Resolver }
-type bulkCreateChannelsInputResolver struct{ *Resolver }
 
 // !!! WARNING !!!
 // The code below was going to be deleted when updating resolvers. It has been copied here so you have
@@ -526,12 +515,11 @@ type bulkCreateChannelsInputResolver struct{ *Resolver }
 //    it when you're done.
 //  - You have helper methods in this file. Move them out to keep these resolver files clean.
 /*
-	func (r *mutationResolver) CreateLLMAPIKey(ctx context.Context, name string) (*ent.APIKey, error) {
-	ownerKey, ok := contexts.GetAPIKey(ctx)
-	if !ok || ownerKey == nil {
-		return nil, fmt.Errorf("api key not found in context")
-	}
-
-	return r.apiKeyService.CreateLLMAPIKey(ctx, ownerKey, name)
+	func (r *bulkCreateChannelsInputResolver) AutoSyncSupportedModels(ctx context.Context, obj *biz.BulkCreateChannelsInput, data *bool) error {
+	panic(fmt.Errorf("not implemented: AutoSyncSupportedModels - autoSyncSupportedModels"))
 }
+func (r *Resolver) BulkCreateChannelsInput() BulkCreateChannelsInputResolver {
+	return &bulkCreateChannelsInputResolver{r}
+}
+type bulkCreateChannelsInputResolver struct{ *Resolver }
 */

--- a/internal/server/gql/axonhub.resolvers.go
+++ b/internal/server/gql/axonhub.resolvers.go
@@ -499,14 +499,25 @@ func (r *traceResolver) UsageMetadata(ctx context.Context, obj *ent.Trace) (*biz
 	return r.traceService.UsageMetadata(ctx, obj.ID)
 }
 
+// AutoSyncSupportedModels is the resolver for the autoSyncSupportedModels field.
+func (r *bulkCreateChannelsInputResolver) AutoSyncSupportedModels(ctx context.Context, obj *biz.BulkCreateChannelsInput, data *bool) error {
+	panic(fmt.Errorf("not implemented: AutoSyncSupportedModels - autoSyncSupportedModels"))
+}
+
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 
 // Segment returns SegmentResolver implementation.
 func (r *Resolver) Segment() SegmentResolver { return &segmentResolver{r} }
 
+// BulkCreateChannelsInput returns BulkCreateChannelsInputResolver implementation.
+func (r *Resolver) BulkCreateChannelsInput() BulkCreateChannelsInputResolver {
+	return &bulkCreateChannelsInputResolver{r}
+}
+
 type mutationResolver struct{ *Resolver }
 type segmentResolver struct{ *Resolver }
+type bulkCreateChannelsInputResolver struct{ *Resolver }
 
 // !!! WARNING !!!
 // The code below was going to be deleted when updating resolvers. It has been copied here so you have

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -84,6 +84,7 @@ type ResolverRoot interface {
 	User() UserResolver
 	UserProject() UserProjectResolver
 	UserRole() UserRoleResolver
+	BulkCreateChannelsInput() BulkCreateChannelsInputResolver
 }
 
 type DirectiveRoot struct {
@@ -1684,6 +1685,10 @@ type UserRoleResolver interface {
 	ID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
 	UserID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
 	RoleID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
+}
+
+type BulkCreateChannelsInputResolver interface {
+	AutoSyncSupportedModels(ctx context.Context, obj *biz.BulkCreateChannelsInput, data *bool) error
 }
 
 type executableSchema struct {
@@ -42959,7 +42964,7 @@ func (ec *executionContext) unmarshalInputBulkCreateChannelsInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "name", "tags", "baseURL", "apiKeys", "supportedModels", "defaultTestModel", "settings"}
+	fieldsInOrder := [...]string{"type", "name", "tags", "baseURL", "apiKeys", "supportedModels", "autoSyncSupportedModels", "defaultTestModel", "settings"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -43008,6 +43013,15 @@ func (ec *executionContext) unmarshalInputBulkCreateChannelsInput(ctx context.Co
 				return it, err
 			}
 			it.SupportedModels = data
+		case "autoSyncSupportedModels":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("autoSyncSupportedModels"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			if err = ec.resolvers.BulkCreateChannelsInput().AutoSyncSupportedModels(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "defaultTestModel":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultTestModel"))
 			data, err := ec.unmarshalNString2string(ctx, v)

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -84,7 +84,6 @@ type ResolverRoot interface {
 	User() UserResolver
 	UserProject() UserProjectResolver
 	UserRole() UserRoleResolver
-	BulkCreateChannelsInput() BulkCreateChannelsInputResolver
 }
 
 type DirectiveRoot struct {
@@ -1685,10 +1684,6 @@ type UserRoleResolver interface {
 	ID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
 	UserID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
 	RoleID(ctx context.Context, obj *ent.UserRole) (*objects.GUID, error)
-}
-
-type BulkCreateChannelsInputResolver interface {
-	AutoSyncSupportedModels(ctx context.Context, obj *biz.BulkCreateChannelsInput, data *bool) error
 }
 
 type executableSchema struct {
@@ -42964,7 +42959,7 @@ func (ec *executionContext) unmarshalInputBulkCreateChannelsInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "name", "tags", "baseURL", "apiKeys", "supportedModels", "autoSyncSupportedModels", "defaultTestModel", "settings"}
+	fieldsInOrder := [...]string{"type", "name", "tags", "baseURL", "apiKeys", "supportedModels", "autoSyncSupportedModels", "defaultTestModel", "settings", "policies"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -43019,9 +43014,7 @@ func (ec *executionContext) unmarshalInputBulkCreateChannelsInput(ctx context.Co
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.BulkCreateChannelsInput().AutoSyncSupportedModels(ctx, &it, data); err != nil {
-				return it, err
-			}
+			it.AutoSyncSupportedModels = data
 		case "defaultTestModel":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultTestModel"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -43036,6 +43029,13 @@ func (ec *executionContext) unmarshalInputBulkCreateChannelsInput(ctx context.Co
 				return it, err
 			}
 			it.Settings = data
+		case "policies":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("policies"))
+			data, err := ec.unmarshalOChannelPoliciesInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋobjectsᚐChannelPolicies(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Policies = data
 		}
 	}
 


### PR DESCRIPTION
在使用“OpenRouter”服务商“添加渠道”中，操作有“批量添加”模型（用逗号分隔），然后点“创建“按钮会报错”批量创建失败：unknown field“。
同样的方法使用‘v0.8.2’的版本没有出现上述问题。
我这样修改后问题解决了。
请评估，谢谢。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk channel creation now supports an optional auto-sync flag for supported models
  * Bulk channel creation now accepts optional policies configuration during batch operations

* **Improvements**
  * GraphQL input handling and validation expanded for complex, nullable, and list fields to improve reliability and schema compliance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->