### PR TITLE
fix: model breaker open probe weight

### DIFF
--- a/internal/server/biz/model_circuit_breaker.go
+++ b/internal/server/biz/model_circuit_breaker.go
@@ -288,7 +288,7 @@ func (m *ModelCircuitBreaker) GetEffectiveWeight(ctx context.Context, channelID 
 		// If current time has passed NextProbeAt, allow only ONE request for probing
 		if time.Now().After(stats.NextProbeAt) {
 			if atomic.LoadInt32(&stats.probingInProgress) == 0 {
-				return 0.01
+				return baseWeight * policy.HalfOpenWeight
 			}
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed circuit breaker weight calculation during probe attempts to align with policy behavior, ensuring more consistent and predictable traffic handling when recovering from failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->