### PR TITLE
feat: make requests table animation interval configurable via env var

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,5 +8,8 @@ VITE_API_URL=http://localhost:8090
 # Frontend port (optional, defaults to 5173)
 # VITE_PORT=5173
 
+# Requests table animation interval in milliseconds (optional, defaults to 500)
+# VITE_REQUESTS_ANIMATION_INTERVAL=500
+
 # NOTE: To override for development, create .env.development.local
 # (NOT .env.local, because .env.development has higher priority in dev mode)

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react';
 import useInterval from './useInterval';
 
 const MAX_ITEMS = 50;
-const ANIMATION_INTERVAL = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL || '500', 10);
+const parsedInterval = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL, 10);
+const ANIMATION_INTERVAL = !isNaN(parsedInterval) && parsedInterval > 0 ? parsedInterval : 500;
 
 export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean) {
   const [displayedData, setDisplayedData] = useState<T[]>(data);

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import useInterval from './useInterval';
 
 const MAX_ITEMS = 50;
-const ANIMATION_INTERVAL = 500;
+const ANIMATION_INTERVAL = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL || '500', 10);
 
 export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean) {
   const [displayedData, setDisplayedData] = useState<T[]>(data);


### PR DESCRIPTION
## Summary
- Add `VITE_REQUESTS_ANIMATION_INTERVAL` environment variable to control the stagger speed of new row animations in the requests table
- Default remains 500ms to preserve current behavior
- Allows adjustment without code changes for different performance needs

## Changes
- `frontend/.env.example`: Add `VITE_REQUESTS_ANIMATION_INTERVAL` documentation
- `frontend/src/hooks/useAnimatedList.ts`: Use env var instead of hardcoded constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable animation interval for animated lists via an environment setting (defaults to 500 ms), allowing users to adjust animation timing to their preference and preserve existing behavior when unset or invalid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->