### PR TITLE
feat: add alternative paths for anthropic and gemini endpoints

### DIFF
--- a/docs/en/api-reference/unified-api.md
+++ b/docs/en/api-reference/unified-api.md
@@ -206,6 +206,8 @@ AxonHub provides native support for the Gemini API, enabling access to Gemini's 
 **Endpoints:**
 - `POST /gemini/v1beta/models/{model}:generateContent` - Text and multi-modal content generation
 - `POST /v1beta/models/{model}:generateContent` - Text and multi-modal content generation (alternative)
+- `GET /gemini/v1beta/models` - List available models
+- `GET /v1beta/models` - List available models (alternative)
 
 **Example Request:**
 ```go

--- a/docs/en/api-reference/unified-api.md
+++ b/docs/en/api-reference/unified-api.md
@@ -157,6 +157,7 @@ AxonHub also supports the native Anthropic Messages API for applications that pr
 
 **Endpoints:**
 - `POST /anthropic/v1/messages` - Text generation
+- `POST /v1/messages` - Text generation (alternative)
 - `GET /anthropic/v1/models` - List available models
 
 **Example Request:**
@@ -204,6 +205,7 @@ AxonHub provides native support for the Gemini API, enabling access to Gemini's 
 
 **Endpoints:**
 - `POST /gemini/v1beta/models/{model}:generateContent` - Text and multi-modal content generation
+- `POST /v1beta/models/{model}:generateContent` - Text and multi-modal content generation (alternative)
 
 **Example Request:**
 ```go

--- a/docs/en/guides/claude-code-integration.md
+++ b/docs/en/guides/claude-code-integration.md
@@ -20,6 +20,8 @@ AxonHub can act as a drop-in replacement for Anthropic endpoints, letting Claude
    ```bash
    export ANTHROPIC_AUTH_TOKEN="<your-axonhub-api-key>"
    export ANTHROPIC_BASE_URL="http://localhost:8090/anthropic"
+   # Or using the root path:
+   # export ANTHROPIC_BASE_URL="http://localhost:8090"
    ```
 2. Launch Claude Code. It will read the environment variables and route all Anthropic requests through AxonHub.
 3. (Optional) Confirm the integration by triggering a chat completion and checking AxonHub traces.

--- a/docs/en/guides/tracing.md
+++ b/docs/en/guides/tracing.md
@@ -146,7 +146,7 @@ func sendTracedMessage(ctx context.Context, apiKey string) (*anthropic.Message, 
 
 ### Claude Code Trace Support
 - Turn on Claude Code extraction with `server.trace.claude_code_trace_enabled: true` so AxonHub can pick up trace IDs automatically.
-- The `/anthropic/v1/messages` endpoint will reuse the Claude Code `metadata.user_id` as the trace ID while keeping your payload untouched for downstream usage.
+- The `/anthropic/v1/messages` (and `/v1/messages`) endpoint will reuse the Claude Code `metadata.user_id` as the trace ID while keeping your payload untouched for downstream usage.
 - If you already send a trace header, AxonHub keeps your value—manual instrumentation and auto-extraction work together.
 
 ### Codex Trace Support

--- a/docs/zh/api-reference/unified-api.md
+++ b/docs/zh/api-reference/unified-api.md
@@ -151,6 +151,7 @@ AxonHub 还支持原生 Anthropic Messages API，适用于偏好 Anthropic 特�
 
 **端点：**
 - `POST /anthropic/v1/messages` - 文本生成
+- `POST /v1/messages` - 文本生成 (可选)
 - `GET /anthropic/v1/models` - 列出可用模型
 
 **示例请求：**
@@ -198,6 +199,7 @@ AxonHub 原生支持 Gemini API，可访问 Gemini 强大的多模态功能。
 
 **端点：**
 - `POST /gemini/v1beta/models/{model}:generateContent` - 文本和多模态内容生成
+- `POST /v1beta/models/{model}:generateContent` - 文本和多模态内容生成 (可选)
 - `GET /gemini/v1beta/models` - 列出可用模型
 
 **示例请求：**

--- a/docs/zh/api-reference/unified-api.md
+++ b/docs/zh/api-reference/unified-api.md
@@ -201,6 +201,7 @@ AxonHub 原生支持 Gemini API，可访问 Gemini 强大的多模态功能。
 - `POST /gemini/v1beta/models/{model}:generateContent` - 文本和多模态内容生成
 - `POST /v1beta/models/{model}:generateContent` - 文本和多模态内容生成 (可选)
 - `GET /gemini/v1beta/models` - 列出可用模型
+- `GET /v1beta/models` - 列出可用模型 (可选)
 
 **示例请求：**
 ```go

--- a/docs/zh/guides/claude-code-integration.md
+++ b/docs/zh/guides/claude-code-integration.md
@@ -20,6 +20,8 @@ AxonHub 可以作为 Anthropic 接口的直接替代方案，使 Claude Code 能
    ```bash
    export ANTHROPIC_AUTH_TOKEN="<your-axonhub-api-key>"
    export ANTHROPIC_BASE_URL="http://localhost:8090/anthropic"
+   # 或者使用根路径：
+   # export ANTHROPIC_BASE_URL="http://localhost:8090"
    ```
 2. 启动 Claude Code，程序会自动读取上述变量并将所有 Anthropic 请求代理到 AxonHub。
 3. （可选）触发一次对话并在 AxonHub 的 Traces 页面确认流量已成功记录。

--- a/docs/zh/guides/tracing.md
+++ b/docs/zh/guides/tracing.md
@@ -146,7 +146,7 @@ func sendTracedMessage(ctx context.Context, apiKey string) (*anthropic.Message, 
 
 ### Claude Code 追踪支持
 - 将 `server.trace.claude_code_trace_enabled` 设为 `true`，AxonHub 会自动读取 Claude Code 产生的追踪 ID。
-- `/anthropic/v1/messages` 的 `metadata.user_id` 会作为追踪 ID 使用，同时不会影响请求体给后续逻辑的读取。
+- `/anthropic/v1/messages` (及 `/v1/messages`) 的 `metadata.user_id` 会作为追踪 ID 使用，同时不会影响请求体给后续逻辑的读取。
 - 如果请求已经带有追踪请求头，系统会优先使用该值，与自动提取机制兼容。
 
 ### Codex 追踪支持

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -135,7 +135,12 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 }
 
 func tryExtractTraceIDFromClaudeCodeRequest(c *gin.Context, config tracing.Config) (string, error) {
-	if c.Request.Method != http.MethodPost || !strings.HasSuffix(c.Request.URL.Path, "/anthropic/v1/messages") {
+	if c.Request.Method != http.MethodPost {
+		return "", nil
+	}
+
+	path := c.Request.URL.Path
+	if !strings.HasSuffix(path, "/anthropic/v1/messages") && !strings.HasSuffix(path, "/v1/messages") {
 		return "", nil
 	}
 

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -17,6 +17,7 @@ import (
 	"github.com/looplj/axonhub/internal/tracing"
 )
 
+// traceHeaderName returns the name of the header used for trace IDs.
 func traceHeaderName(config tracing.Config) string {
 	if config.TraceHeader != "" {
 		return config.TraceHeader
@@ -25,6 +26,7 @@ func traceHeaderName(config tracing.Config) string {
 	return "AH-Trace-Id"
 }
 
+// getTraceIDFromHeader extracts the trace ID from the request headers.
 func getTraceIDFromHeader(c *gin.Context, config tracing.Config) string {
 	traceID := c.GetHeader(traceHeaderName(config))
 	if traceID != "" {
@@ -41,6 +43,8 @@ func getTraceIDFromHeader(c *gin.Context, config tracing.Config) string {
 	return ""
 }
 
+// tryGetTraceIDFromBody attempts to extract a trace ID from the request body
+// based on the configured ExtraTraceBodyFields.
 func tryGetTraceIDFromBody(c *gin.Context, config tracing.Config) (string, error) {
 	if len(config.ExtraTraceBodyFields) == 0 {
 		return "", nil
@@ -134,18 +138,17 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 	}
 }
 
+// tryExtractTraceIDFromClaudeCodeRequest attempts to extract a trace ID from a Claude Code request.
+// It checks if the request is a POST to the Anthropic messages endpoint and extracts
+// the trace ID from the metadata.user_id field in the request body.
 func tryExtractTraceIDFromClaudeCodeRequest(c *gin.Context, config tracing.Config) (string, error) {
 	if c.Request.Method != http.MethodPost {
 		return "", nil
 	}
 
 	path := c.Request.URL.Path
-	if !strings.HasSuffix(path, "/anthropic/v1/messages") && !strings.HasSuffix(path, "/v1/messages") {
+	if path != "/anthropic/v1/messages" && path != "/v1/messages" {
 		return "", nil
-	}
-
-	if traceID := getTraceIDFromHeader(c, config); traceID != "" {
-		return traceID, nil
 	}
 
 	bodyBytes, err := io.ReadAll(c.Request.Body)
@@ -177,6 +180,8 @@ var claudeUserIDPattern = regexp.MustCompile(`(?i)^user_[0-9a-f]{64}_account__se
 
 const codexTraceHeader = "Session_id"
 
+// extractClaudeTraceID parses the Claude Code user ID format to extract the session ID
+// which is used as the trace ID.
 func extractClaudeTraceID(userID string) string {
 	if !claudeUserIDPattern.MatchString(userID) {
 		return ""
@@ -194,6 +199,7 @@ func extractClaudeTraceID(userID string) string {
 	return strings.TrimSpace(traceID)
 }
 
+// tryExtractTraceIDFromCodexRequest extracts the trace ID from the Codex session header.
 func tryExtractTraceIDFromCodexRequest(c *gin.Context) string {
 	traceID := strings.TrimSpace(c.GetHeader(codexTraceHeader))
 	if traceID == "" {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -127,6 +127,9 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 		openaiGroup.GET("/models", handlers.OpenAI.ListModels)
 		openaiGroup.POST("/embeddings", handlers.OpenAI.CreateEmbedding)
 
+		// OpenAI-compatible Anthropic endpoint
+		openaiGroup.POST("/messages", handlers.Anthropic.CreateMessage)
+
 		// Compatible with OpenAI API
 		openaiGroup.POST("/rerank", handlers.Jina.Rerank)
 	}
@@ -154,5 +157,19 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 
 		geminiGroup.POST("/models/*action", handlers.Gemini.GenerateContent)
 		geminiGroup.GET("/models", handlers.Gemini.ListModels)
+	}
+
+	{
+		// Alias for Gemini API
+		geminiAliasGroup := server.Group("/v1beta",
+			middleware.WithTimeout(server.Config.LLMRequestTimeout),
+			middleware.WithGeminiKeyAuth(services.AuthService),
+			middleware.WithSource(request.SourceAPI),
+			middleware.WithThread(server.Config.Trace, services.ThreadService),
+			middleware.WithTrace(server.Config.Trace, services.TraceService),
+		)
+
+		geminiAliasGroup.POST("/models/*action", handlers.Gemini.GenerateContent)
+		geminiAliasGroup.GET("/models", handlers.Gemini.ListModels)
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -147,6 +147,11 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 	}
 
 	{
+		registerGeminiRoutes := func(group *gin.RouterGroup) {
+			group.POST("/models/*action", handlers.Gemini.GenerateContent)
+			group.GET("/models", handlers.Gemini.ListModels)
+		}
+
 		geminiGroup := server.Group("/gemini/:gemini-api-version",
 			middleware.WithTimeout(server.Config.LLMRequestTimeout),
 			middleware.WithGeminiKeyAuth(services.AuthService),
@@ -155,11 +160,8 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 			middleware.WithTrace(server.Config.Trace, services.TraceService),
 		)
 
-		geminiGroup.POST("/models/*action", handlers.Gemini.GenerateContent)
-		geminiGroup.GET("/models", handlers.Gemini.ListModels)
-	}
+		registerGeminiRoutes(geminiGroup)
 
-	{
 		// Alias for Gemini API
 		geminiAliasGroup := server.Group("/v1beta",
 			middleware.WithTimeout(server.Config.LLMRequestTimeout),
@@ -169,7 +171,6 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 			middleware.WithTrace(server.Config.Trace, services.TraceService),
 		)
 
-		geminiAliasGroup.POST("/models/*action", handlers.Gemini.GenerateContent)
-		geminiAliasGroup.GET("/models", handlers.Gemini.ListModels)
+		registerGeminiRoutes(geminiAliasGroup)
 	}
 }


### PR DESCRIPTION
## Summary
- Added `/v1/messages` as an alternative path for the Anthropic messages API.
- Added `/v1beta` as an alternative path for the Gemini API.
- Updated trace middleware to support trace ID extraction from the new endpoints.
- Updated documentation (EN/ZH) to reflect available endpoint aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible endpoint aliases for Anthropic Messages and Gemini APIs.
  * Extended request tracing to cover the alternative endpoint variants and additional trace sources.

* **Documentation**
  * Updated English and Chinese API references and guides with the new endpoint options and example configuration notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->