### PR TITLE
fix: remove constraint keywords from nested properties in antigravity sanitizer

### DIFF
--- a/llm/transformer/antigravity/sanitizer.go
+++ b/llm/transformer/antigravity/sanitizer.go
@@ -56,6 +56,11 @@ var unsupportedConstraints = []string{
 
 // UNSUPPORTED_KEYWORDS that should be removed after hint extraction.
 var unsupportedKeywords = []string{
+	// Include all constraints that were moved to description
+	"minLength", "maxLength", "exclusiveMinimum", "exclusiveMaximum",
+	"pattern", "minItems", "maxItems", "format",
+	"default", "examples",
+	// Other unsupported keywords
 	"$schema", "$defs", "definitions", "const", "$ref", "additionalProperties",
 	"propertyNames", "title", "$id", "$comment",
 }

--- a/llm/transformer/antigravity/sanitizer_test.go
+++ b/llm/transformer/antigravity/sanitizer_test.go
@@ -89,6 +89,28 @@ func TestSanitizeJSONSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "Remove constraint keywords from nested properties",
+			input: `{
+				"type": "object",
+				"properties": {
+					"max_turns": {
+						"type": "integer",
+						"description": "Maximum number of agentic turns",
+						"exclusiveMinimum": 0
+					}
+				}
+			}`,
+			expected: `{
+				"type": "object",
+				"properties": {
+					"max_turns": {
+						"type": "integer",
+						"description": "Maximum number of agentic turns (exclusiveMinimum: 0)"
+					}
+				}
+			}`,
+		},
+		{
 			name: "Merge allOf",
 			input: `{
 				"allOf": [


### PR DESCRIPTION
Add constraint keywords (minLength, maxLength, exclusiveMinimum, etc.) to unsupportedKeywords list so they are properly removed after being moved to description hints. This ensures nested properties don't retain unsupported constraint fields that were already converted to descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced constraint keyword handling by consolidating validation keywords (minLength, maxLength, exclusiveMinimum, exclusiveMaximum, pattern, minItems, maxItems, format, default, examples) into property descriptions for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->