### PR TITLE
Add citation and annotation support for completion responses

### DIFF
--- a/llm/model.go
+++ b/llm/model.go
@@ -328,6 +328,26 @@ type Message struct {
 	// CacheControl is used for provider-specific cache control (e.g., Anthropic).
 	// This field is not serialized in JSON.
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
+
+	// Annotations contains citation information for the message.
+	// This is used by providers like Perplexity to provide source URLs.
+	Annotations []Annotation `json:"annotations,omitempty"`
+}
+
+// Annotation represents a citation or reference annotation in a message.
+type Annotation struct {
+	// Type is the type of annotation, e.g., "url_citation"
+	Type string `json:"type,omitempty"`
+	// URLCitation contains URL citation details when Type is "url_citation"
+	URLCitation *URLCitation `json:"url_citation,omitempty"`
+}
+
+// URLCitation represents a URL-based citation.
+type URLCitation struct {
+	// URL is the citation URL
+	URL string `json:"url,omitempty"`
+	// Title is the title of the cited source
+	Title string `json:"title,omitempty"`
 }
 
 type MessageContent struct {

--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -23,6 +23,19 @@ type choiceAggregator struct {
 	annotations      map[string]llm.Annotation // Map to track unique annotations by URL
 }
 
+// addAnnotations adds annotations from a message to the choice aggregator,
+// deduplicating by URL.
+func (ca *choiceAggregator) addAnnotations(msg *Message) {
+	if msg == nil || len(msg.Annotations) == 0 {
+		return
+	}
+	for _, annotation := range msg.Annotations {
+		if annotation.URLCitation != nil && annotation.URLCitation.URL != "" {
+			ca.annotations[annotation.URLCitation.URL] = annotation.ToLLMAnnotation()
+		}
+	}
+}
+
 type ChunkTransformFunc func(ctx context.Context, chunk *httpclient.StreamEvent) (*Response, error)
 
 func DefaultTransformChunk(ctx context.Context, chunk *httpclient.StreamEvent) (*Response, error) {
@@ -135,23 +148,9 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 				}
 			}
 
-			// Handle annotations from Delta (streaming)
-			if choice.Delta != nil && len(choice.Delta.Annotations) > 0 {
-				for _, annotation := range choice.Delta.Annotations {
-					if annotation.URLCitation != nil && annotation.URLCitation.URL != "" {
-						choiceAgg.annotations[annotation.URLCitation.URL] = annotation.ToLLMAnnotation()
-					}
-				}
-			}
-
-			// Handle annotations from Message (non-streaming chunks)
-			if choice.Message != nil && len(choice.Message.Annotations) > 0 {
-				for _, annotation := range choice.Message.Annotations {
-					if annotation.URLCitation != nil && annotation.URLCitation.URL != "" {
-						choiceAgg.annotations[annotation.URLCitation.URL] = annotation.ToLLMAnnotation()
-					}
-				}
-			}
+			// Handle annotations from Delta (streaming) and Message (non-streaming chunks)
+			choiceAgg.addAnnotations(choice.Delta)
+			choiceAgg.addAnnotations(choice.Message)
 
 			// Capture finish reason
 			if choice.FinishReason != nil {

--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -46,6 +46,8 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		systemFingerprint string
 		// Map to track choices by their index
 		choicesAggs = make(map[int]*choiceAggregator)
+		// Map to track unique citations
+		citationsMap = make(map[string]struct{})
 	)
 
 	for _, chunk := range chunks {
@@ -142,6 +144,11 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 			usage = chunk.Usage
 		}
 
+		// Collect citations from chunk
+		for _, citation := range chunk.Citations {
+			citationsMap[citation] = struct{}{}
+		}
+
 		// Keep the first non-empty system fingerprint
 		if systemFingerprint == "" && chunk.SystemFingerprint != "" {
 			systemFingerprint = chunk.SystemFingerprint
@@ -218,6 +225,17 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		SystemFingerprint: systemFingerprint,
 		Choices:           choices,
 		Usage:             usage.ToLLMUsage(),
+	}
+
+	// Add citations to response if any were collected
+	if len(citationsMap) > 0 {
+		citations := make([]string, 0, len(citationsMap))
+		for citation := range citationsMap {
+			citations = append(citations, citation)
+		}
+		response.TransformerMetadata = map[string]any{
+			TransformerMetadataKeyCitations: citations,
+		}
 	}
 
 	data, err := json.Marshal(response)

--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -260,9 +261,12 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		for citation := range citationsMap {
 			citations = append(citations, citation)
 		}
-		response.TransformerMetadata = map[string]any{
-			TransformerMetadataKeyCitations: citations,
+		sort.Strings(citations)
+
+		if response.TransformerMetadata == nil {
+			response.TransformerMetadata = make(map[string]any)
 		}
+		response.TransformerMetadata[TransformerMetadataKeyCitations] = citations
 	}
 
 	data, err := json.Marshal(response)

--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -20,6 +20,7 @@ type choiceAggregator struct {
 	toolCalls        map[int]*llm.ToolCall // Map to track tool calls by their index within the choice
 	finishReason     *string
 	role             string
+	annotations      map[string]llm.Annotation // Map to track unique annotations by URL
 }
 
 type ChunkTransformFunc func(ctx context.Context, chunk *httpclient.StreamEvent) (*Response, error)
@@ -68,9 +69,10 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 			// Initialize choice aggregator if it doesn't exist
 			if _, ok := choicesAggs[choiceIndex]; !ok {
 				choicesAggs[choiceIndex] = &choiceAggregator{
-					index:     choiceIndex,
-					toolCalls: make(map[int]*llm.ToolCall),
-					role:      "assistant",
+					index:       choiceIndex,
+					toolCalls:   make(map[int]*llm.ToolCall),
+					annotations: make(map[string]llm.Annotation),
+					role:        "assistant",
 				}
 			}
 
@@ -129,6 +131,24 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 						if deltaToolCall.Type != "" {
 							choiceAgg.toolCalls[toolCallIndex].Type = deltaToolCall.Type
 						}
+					}
+				}
+			}
+
+			// Handle annotations from Delta (streaming)
+			if choice.Delta != nil && len(choice.Delta.Annotations) > 0 {
+				for _, annotation := range choice.Delta.Annotations {
+					if annotation.URLCitation != nil && annotation.URLCitation.URL != "" {
+						choiceAgg.annotations[annotation.URLCitation.URL] = annotation.ToLLMAnnotation()
+					}
+				}
+			}
+
+			// Handle annotations from Message (non-streaming chunks)
+			if choice.Message != nil && len(choice.Message.Annotations) > 0 {
+				for _, annotation := range choice.Message.Annotations {
+					if annotation.URLCitation != nil && annotation.URLCitation.URL != "" {
+						choiceAgg.annotations[annotation.URLCitation.URL] = annotation.ToLLMAnnotation()
 					}
 				}
 			}
@@ -197,6 +217,14 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		// Set tool calls if available (can coexist with content)
 		if len(finalToolCalls) > 0 {
 			message.ToolCalls = finalToolCalls
+		}
+
+		// Set annotations if available
+		if len(choiceAgg.annotations) > 0 {
+			message.Annotations = make([]llm.Annotation, 0, len(choiceAgg.annotations))
+			for _, annotation := range choiceAgg.annotations {
+				message.Annotations = append(message.Annotations, annotation)
+			}
 		}
 
 		// Determine finish reason

--- a/llm/transformer/openai/aggregator_test.go
+++ b/llm/transformer/openai/aggregator_test.go
@@ -228,3 +228,69 @@ func TestAggregateStreamChunks_WithoutCitations(t *testing.T) {
 	// Verify no citations in metadata
 	require.Nil(t, got.TransformerMetadata)
 }
+
+func TestAggregateStreamChunks_WithAnnotations(t *testing.T) {
+	// Create chunks with annotations in the Message field (as seen in Perplexity responses)
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"sonar-deep-research","choices":[{"index":0,"delta":{"role":"assistant","content":"The meaning"},"message":{"role":"assistant","content":"The meaning","annotations":[{"type":"url_citation","url_citation":{"url":"https://en.wikipedia.org/wiki/Meaning_of_life","title":"Meaning of life - Wikipedia"}}]}}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"sonar-deep-research","choices":[{"index":0,"delta":{"content":" of life"},"message":{"role":"assistant","content":"The meaning of life","annotations":[{"type":"url_citation","url_citation":{"url":"https://plato.stanford.edu/entries/life-meaning/","title":"Stanford Encyclopedia"}}]}}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"sonar-deep-research","choices":[{"index":0,"delta":{"content":" is..."},"finish_reason":"stop"}]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	// Verify the aggregated content
+	require.Equal(t, "chatcmpl-123", got.ID)
+	require.Equal(t, "chat.completion", got.Object)
+	require.Len(t, got.Choices, 1)
+	require.NotNil(t, got.Choices[0].Message)
+	require.Equal(t, "assistant", got.Choices[0].Message.Role)
+	require.NotNil(t, got.Choices[0].Message.Content.Content)
+	require.Equal(t, "The meaning of life is...", *got.Choices[0].Message.Content.Content)
+
+	// Verify annotations are aggregated and deduplicated
+	require.Len(t, got.Choices[0].Message.Annotations, 2)
+
+	// Check first annotation
+	require.Equal(t, "url_citation", got.Choices[0].Message.Annotations[0].Type)
+	require.NotNil(t, got.Choices[0].Message.Annotations[0].URLCitation)
+
+	// Check second annotation
+	require.Equal(t, "url_citation", got.Choices[0].Message.Annotations[1].Type)
+	require.NotNil(t, got.Choices[0].Message.Annotations[1].URLCitation)
+}
+
+func TestAggregateStreamChunks_WithAnnotationsInMessage(t *testing.T) {
+	// Test annotations that come in the Message field (non-streaming style chunks)
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"sonar-deep-research","choices":[{"index":0,"message":{"role":"assistant","content":"The meaning of life...","annotations":[{"type":"url_citation","url_citation":{"url":"https://example.com/source1","title":"Source 1"}}]}}]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	// Verify annotations from Message field are captured
+	require.Len(t, got.Choices, 1)
+	require.NotNil(t, got.Choices[0].Message)
+	require.Len(t, got.Choices[0].Message.Annotations, 1)
+	require.Equal(t, "url_citation", got.Choices[0].Message.Annotations[0].Type)
+	require.NotNil(t, got.Choices[0].Message.Annotations[0].URLCitation)
+	require.Equal(t, "https://example.com/source1", got.Choices[0].Message.Annotations[0].URLCitation.URL)
+}

--- a/llm/transformer/openai/aggregator_test.go
+++ b/llm/transformer/openai/aggregator_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 )
 
 func TestAggregateStreamChunks(t *testing.T) {
@@ -155,4 +156,75 @@ func TestAggregateStreamChunks_EmptyChunks(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, llm.Response{}, got)
+}
+
+func TestAggregateStreamChunks_WithCitations(t *testing.T) {
+	// Create chunks with citations spread across them
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-3.1-sonar-small-128k-online","choices":[{"index":0,"delta":{"role":"assistant","content":"The meaning"}}],"citations":["https://example.com/source1" ]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-3.1-sonar-small-128k-online","choices":[{"index":0,"delta":{"content":" of life"}}],"citations":["https://example.com/source2" ]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-3.1-sonar-small-128k-online","choices":[{"index":0,"delta":{"content":" is..."},"finish_reason":"stop"}],"citations":["https://example.com/source1" ]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	// Verify the aggregated content
+	require.Equal(t, "chatcmpl-123", got.ID)
+	require.Equal(t, "chat.completion", got.Object)
+	require.Len(t, got.Choices, 1)
+	require.NotNil(t, got.Choices[0].Message)
+	require.Equal(t, "assistant", got.Choices[0].Message.Role)
+	require.NotNil(t, got.Choices[0].Message.Content.Content)
+	require.Equal(t, "The meaning of life is...", *got.Choices[0].Message.Content.Content)
+
+	// Verify citations are aggregated and deduplicated
+	require.NotNil(t, got.TransformerMetadata)
+	citationsRaw, ok := got.TransformerMetadata[TransformerMetadataKeyCitations]
+	require.True(t, ok)
+
+	// After JSON marshaling/unmarshaling, the citations will be []interface{}
+	citationsSlice, ok := citationsRaw.([]interface{})
+	require.True(t, ok)
+	require.Len(t, citationsSlice, 2)
+
+	// Convert to []string for easier assertion
+	citations := make([]string, len(citationsSlice))
+	for i, v := range citationsSlice {
+		citations[i] = v.(string)
+	}
+	require.Contains(t, citations, "https://example.com/source1")
+	require.Contains(t, citations, "https://example.com/source2")
+}
+
+func TestAggregateStreamChunks_WithoutCitations(t *testing.T) {
+	// Create chunks without citations
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-4","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	// Verify no citations in metadata
+	require.Nil(t, got.TransformerMetadata)
 }

--- a/llm/transformer/openai/aggregator_test.go
+++ b/llm/transformer/openai/aggregator_test.go
@@ -294,3 +294,28 @@ func TestAggregateStreamChunks_WithAnnotationsInMessage(t *testing.T) {
 	require.NotNil(t, got.Choices[0].Message.Annotations[0].URLCitation)
 	require.Equal(t, "https://example.com/source1", got.Choices[0].Message.Annotations[0].URLCitation.URL)
 }
+
+func TestAggregateStreamChunks_WithInvalidAnnotations(t *testing.T) {
+	// Test that annotations with nil URLCitation or empty URL are skipped
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"sonar-deep-research","choices":[{"index":0,"message":{"role":"assistant","content":"Test content","annotations":[{"type":"url_citation","url_citation":null},{"type":"url_citation","url_citation":{"url":"","title":"Empty URL"}},{"type":"url_citation","url_citation":{"url":"https://example.com/valid","title":"Valid Source"}}]}}]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	// Verify only the valid annotation is captured
+	require.Len(t, got.Choices, 1)
+	require.NotNil(t, got.Choices[0].Message)
+	require.Len(t, got.Choices[0].Message.Annotations, 1)
+	require.Equal(t, "url_citation", got.Choices[0].Message.Annotations[0].Type)
+	require.NotNil(t, got.Choices[0].Message.Annotations[0].URLCitation)
+	require.Equal(t, "https://example.com/valid", got.Choices[0].Message.Annotations[0].URLCitation.URL)
+	require.Equal(t, "Valid Source", got.Choices[0].Message.Annotations[0].URLCitation.Title)
+}

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -196,6 +196,13 @@ func ResponseFromLLM(r *llm.Response) *Response {
 		}
 	}
 
+	// Extract citations from TransformerMetadata if present
+	if r.TransformerMetadata != nil {
+		if citations, ok := r.TransformerMetadata[TransformerMetadataKeyCitations].([]string); ok {
+			resp.Citations = citations
+		}
+	}
+
 	return resp
 }
 

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -221,7 +221,7 @@ func ResponseFromLLM(r *llm.Response) *Response {
 
 	// Extract citations from TransformerMetadata if present
 	if r.TransformerMetadata != nil {
-		if citations, ok := r.TransformerMetadata[TransformerMetadataKeyCitations].([]string); ok {
+		if citations, ok := r.TransformerMetadata[TransformerMetadataKeyCitations].([]string); ok && len(citations) > 0 {
 			resp.Citations = citations
 		}
 	}

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -121,7 +121,30 @@ func (m Message) ToLLMMessage() llm.Message {
 		})
 	}
 
+	// Convert Annotations
+	if len(m.Annotations) > 0 {
+		msg.Annotations = lo.Map(m.Annotations, func(a Annotation, _ int) llm.Annotation {
+			return a.ToLLMAnnotation()
+		})
+	}
+
 	return msg
+}
+
+// ToLLMAnnotation converts OpenAI Annotation to unified llm.Annotation.
+func (a Annotation) ToLLMAnnotation() llm.Annotation {
+	annotation := llm.Annotation{
+		Type: a.Type,
+	}
+
+	if a.URLCitation != nil {
+		annotation.URLCitation = &llm.URLCitation{
+			URL:   a.URLCitation.URL,
+			Title: a.URLCitation.Title,
+		}
+	}
+
+	return annotation
 }
 
 // ToLLMContent converts OpenAI MessageContent to unified llm.MessageContent.

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -598,3 +598,109 @@ func TestInboundTransformer_TransformError(t *testing.T) {
 		})
 	}
 }
+
+func TestInboundTransformer_TransformResponse_WithCitations(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	tests := []struct {
+		name     string
+		response *llm.Response
+		validate func(*httpclient.Response) bool
+	}{
+		{
+			name: "response with citations in metadata",
+			response: &llm.Response{
+				ID:      "chatcmpl-123",
+				Object:  "chat.completion",
+				Created: 1677652288,
+				Model:   "llama-3.1-sonar-small-128k-online",
+				Choices: []llm.Choice{
+					{
+						Index: 0,
+						Message: &llm.Message{
+							Role: "assistant",
+							Content: llm.MessageContent{
+								Content: lo.ToPtr("The meaning of life is..."),
+							},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+				TransformerMetadata: map[string]any{
+					TransformerMetadataKeyCitations: []string{
+						"https://www.theatlantic.com/family/archive/2021/10/meaning-life-macronutrients-purpose-search/620440/",
+						"https://en.wikipedia.org/wiki/Meaning_of_life",
+					},
+				},
+			},
+			validate: func(resp *httpclient.Response) bool {
+				if resp.StatusCode != http.StatusOK {
+					return false
+				}
+
+				// Parse the response body
+				var chatResp Response
+				err := json.Unmarshal(resp.Body, &chatResp)
+				if err != nil {
+					return false
+				}
+
+				// Verify citations are present
+				if len(chatResp.Citations) != 2 {
+					return false
+				}
+
+				return chatResp.Citations[0] == "https://www.theatlantic.com/family/archive/2021/10/meaning-life-macronutrients-purpose-search/620440/" &&
+					chatResp.Citations[1] == "https://en.wikipedia.org/wiki/Meaning_of_life"
+			},
+		},
+		{
+			name: "response without citations in metadata",
+			response: &llm.Response{
+				ID:      "chatcmpl-123",
+				Object:  "chat.completion",
+				Created: 1677652288,
+				Model:   "gpt-4",
+				Choices: []llm.Choice{
+					{
+						Index: 0,
+						Message: &llm.Message{
+							Role: "assistant",
+							Content: llm.MessageContent{
+								Content: lo.ToPtr("Hello!"),
+							},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+			},
+			validate: func(resp *httpclient.Response) bool {
+				if resp.StatusCode != http.StatusOK {
+					return false
+				}
+
+				// Parse the response body
+				var chatResp Response
+				err := json.Unmarshal(resp.Body, &chatResp)
+				if err != nil {
+					return false
+				}
+
+				// Citations should be nil/empty when not present in metadata
+				return len(chatResp.Citations) == 0
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := transformer.TransformResponse(t.Context(), tt.response)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			if tt.validate != nil {
+				require.True(t, tt.validate(result), "Validation failed for result")
+			}
+		})
+	}
+}

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -599,6 +599,64 @@ func TestInboundTransformer_TransformError(t *testing.T) {
 	}
 }
 
+func TestMessageFromLLM_WithAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		llmMsg   llm.Message
+		validate func(*testing.T, Message)
+	}{
+		{
+			name: "message with annotations",
+			llmMsg: llm.Message{
+				Role:    "assistant",
+				Content: llm.MessageContent{Content: lo.ToPtr("The meaning of life...")},
+				Annotations: []llm.Annotation{
+					{
+						Type: "url_citation",
+						URLCitation: &llm.URLCitation{
+							URL:   "https://en.wikipedia.org/wiki/Meaning_of_life",
+							Title: "Meaning of life - Wikipedia",
+						},
+					},
+					{
+						Type: "url_citation",
+						URLCitation: &llm.URLCitation{
+							URL:   "https://plato.stanford.edu/entries/life-meaning/",
+							Title: "The Meaning of Life - Stanford Encyclopedia",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, msg Message) {
+				require.Equal(t, "assistant", msg.Role)
+				require.Len(t, msg.Annotations, 2)
+				require.Equal(t, "url_citation", msg.Annotations[0].Type)
+				require.NotNil(t, msg.Annotations[0].URLCitation)
+				require.Equal(t, "https://en.wikipedia.org/wiki/Meaning_of_life", msg.Annotations[0].URLCitation.URL)
+				require.Equal(t, "Meaning of life - Wikipedia", msg.Annotations[0].URLCitation.Title)
+			},
+		},
+		{
+			name: "message without annotations",
+			llmMsg: llm.Message{
+				Role:    "assistant",
+				Content: llm.MessageContent{Content: lo.ToPtr("Hello!")},
+			},
+			validate: func(t *testing.T, msg Message) {
+				require.Equal(t, "assistant", msg.Role)
+				require.Nil(t, msg.Annotations)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MessageFromLLM(tt.llmMsg)
+			tt.validate(t, result)
+		})
+	}
+}
+
 func TestInboundTransformer_TransformResponse_WithCitations(t *testing.T) {
 	transformer := NewInboundTransformer()
 

--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -7,6 +7,9 @@ import (
 	"github.com/looplj/axonhub/llm"
 )
 
+// TransformerMetadataKeyCitations is the key used to store citations in TransformerMetadata.
+const TransformerMetadataKeyCitations = "citations"
+
 // Request represents an OpenAI chat completion request.
 // This is a clean OpenAI-specific model without helper fields.
 type Request struct {
@@ -236,6 +239,9 @@ type Response struct {
 
 	SystemFingerprint string `json:"system_fingerprint,omitempty"`
 	ServiceTier       string `json:"service_tier,omitempty"`
+
+	// Citations is a list of sources for the completion, present in some models like Perplexity.
+	Citations []string `json:"citations,omitempty"`
 
 	Error *OpenAIError `json:"error,omitempty"`
 }

--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -155,6 +155,26 @@ type Message struct {
 
 	// ReasoningContent for deepseek-reasoner support.
 	ReasoningContent *string `json:"reasoning_content,omitempty"`
+
+	// Annotations contains citation information for the message.
+	// This is used by providers like Perplexity to provide source URLs.
+	Annotations []Annotation `json:"annotations,omitempty"`
+}
+
+// Annotation represents a citation or reference annotation in a message.
+type Annotation struct {
+	// Type is the type of annotation, e.g., "url_citation"
+	Type string `json:"type,omitempty"`
+	// URLCitation contains URL citation details when Type is "url_citation"
+	URLCitation *URLCitation `json:"url_citation,omitempty"`
+}
+
+// URLCitation represents a URL-based citation.
+type URLCitation struct {
+	// URL is the citation URL
+	URL string `json:"url,omitempty"`
+	// Title is the title of the cited source
+	Title string `json:"title,omitempty"`
 }
 
 // MessageContent represents message content (string or array of parts).

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -112,7 +112,30 @@ func MessageFromLLM(m llm.Message) Message {
 		})
 	}
 
+	// Convert Annotations
+	if len(m.Annotations) > 0 {
+		msg.Annotations = lo.Map(m.Annotations, func(a llm.Annotation, _ int) Annotation {
+			return AnnotationFromLLM(a)
+		})
+	}
+
 	return msg
+}
+
+// AnnotationFromLLM creates OpenAI Annotation from unified llm.Annotation.
+func AnnotationFromLLM(a llm.Annotation) Annotation {
+	annotation := Annotation{
+		Type: a.Type,
+	}
+
+	if a.URLCitation != nil {
+		annotation.URLCitation = &URLCitation{
+			URL:   a.URLCitation.URL,
+			Title: a.URLCitation.Title,
+		}
+	}
+
+	return annotation
 }
 
 // MessageContentFromLLM creates OpenAI MessageContent from unified llm.MessageContent.

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -213,6 +213,14 @@ func (r *Response) ToLLMResponse() *llm.Response {
 		}
 	}
 
+	// Store citations in TransformerMetadata if present
+	if len(r.Citations) > 0 {
+		if resp.TransformerMetadata == nil {
+			resp.TransformerMetadata = make(map[string]any)
+		}
+		resp.TransformerMetadata[TransformerMetadataKeyCitations] = r.Citations
+	}
+
 	return resp
 }
 

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -169,3 +169,102 @@ func TestResponse_ToLLMResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestResponse_ToLLMResponse_WithCitations(t *testing.T) {
+	tests := []struct {
+		name     string
+		oaiResp  *Response
+		validate func(*testing.T, *llm.Response)
+	}{
+		{
+			name: "response with citations",
+			oaiResp: &Response{
+				ID:      "chatcmpl-123",
+				Object:  "chat.completion",
+				Created: 1677652288,
+				Model:   "llama-3.1-sonar-small-128k-online",
+				Choices: []Choice{
+					{
+						Index: 0,
+						Message: &Message{
+							Role:    "assistant",
+							Content: MessageContent{Content: lo.ToPtr("The meaning of life is...")},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+				Citations: []string{
+					"https://www.theatlantic.com/family/archive/2021/10/meaning-life-macronutrients-purpose-search/620440/",
+					"https://en.wikipedia.org/wiki/Meaning_of_life",
+					"https://greatergood.berkeley.edu/article/item/three_ways_to_see_meaning_in_your_life",
+				},
+			},
+			validate: func(t *testing.T, resp *llm.Response) {
+				require.NotNil(t, resp)
+				require.NotNil(t, resp.TransformerMetadata)
+				citations, ok := resp.TransformerMetadata[TransformerMetadataKeyCitations].([]string)
+				require.True(t, ok)
+				require.Len(t, citations, 3)
+				require.Contains(t, citations, "https://www.theatlantic.com/family/archive/2021/10/meaning-life-macronutrients-purpose-search/620440/")
+				require.Contains(t, citations, "https://en.wikipedia.org/wiki/Meaning_of_life")
+				require.Contains(t, citations, "https://greatergood.berkeley.edu/article/item/three_ways_to_see_meaning_in_your_life")
+			},
+		},
+		{
+			name: "response without citations",
+			oaiResp: &Response{
+				ID:      "chatcmpl-123",
+				Object:  "chat.completion",
+				Created: 1677652288,
+				Model:   "gpt-4",
+				Choices: []Choice{
+					{
+						Index: 0,
+						Message: &Message{
+							Role:    "assistant",
+							Content: MessageContent{Content: lo.ToPtr("Hello!")},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+			},
+			validate: func(t *testing.T, resp *llm.Response) {
+				require.NotNil(t, resp)
+				// TransformerMetadata should be nil when no citations
+				require.Nil(t, resp.TransformerMetadata)
+			},
+		},
+		{
+			name: "response with empty citations",
+			oaiResp: &Response{
+				ID:      "chatcmpl-123",
+				Object:  "chat.completion",
+				Created: 1677652288,
+				Model:   "gpt-4",
+				Choices: []Choice{
+					{
+						Index: 0,
+						Message: &Message{
+							Role:    "assistant",
+							Content: MessageContent{Content: lo.ToPtr("Hello!")},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+				Citations: []string{},
+			},
+			validate: func(t *testing.T, resp *llm.Response) {
+				require.NotNil(t, resp)
+				// TransformerMetadata should be nil when citations are empty
+				require.Nil(t, resp.TransformerMetadata)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.oaiResp.ToLLMResponse()
+			tt.validate(t, result)
+		})
+	}
+}

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -170,6 +170,76 @@ func TestResponse_ToLLMResponse(t *testing.T) {
 	}
 }
 
+func TestMessage_ToLLMMessage_WithAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		oaiMsg   Message
+		validate func(*testing.T, llm.Message)
+	}{
+		{
+			name: "message with annotations",
+			oaiMsg: Message{
+				Role:    "assistant",
+				Content: MessageContent{Content: lo.ToPtr("The meaning of life...")},
+				Annotations: []Annotation{
+					{
+						Type: "url_citation",
+						URLCitation: &URLCitation{
+							URL:   "https://en.wikipedia.org/wiki/Meaning_of_life",
+							Title: "Meaning of life - Wikipedia",
+						},
+					},
+					{
+						Type: "url_citation",
+						URLCitation: &URLCitation{
+							URL:   "https://plato.stanford.edu/entries/life-meaning/",
+							Title: "The Meaning of Life - Stanford Encyclopedia",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, msg llm.Message) {
+				require.Equal(t, "assistant", msg.Role)
+				require.Len(t, msg.Annotations, 2)
+				require.Equal(t, "url_citation", msg.Annotations[0].Type)
+				require.NotNil(t, msg.Annotations[0].URLCitation)
+				require.Equal(t, "https://en.wikipedia.org/wiki/Meaning_of_life", msg.Annotations[0].URLCitation.URL)
+				require.Equal(t, "Meaning of life - Wikipedia", msg.Annotations[0].URLCitation.Title)
+			},
+		},
+		{
+			name: "message without annotations",
+			oaiMsg: Message{
+				Role:    "assistant",
+				Content: MessageContent{Content: lo.ToPtr("Hello!")},
+			},
+			validate: func(t *testing.T, msg llm.Message) {
+				require.Equal(t, "assistant", msg.Role)
+				require.Nil(t, msg.Annotations)
+			},
+		},
+		{
+			name: "message with empty annotations",
+			oaiMsg: Message{
+				Role:        "assistant",
+				Content:     MessageContent{Content: lo.ToPtr("Hello!")},
+				Annotations: []Annotation{},
+			},
+			validate: func(t *testing.T, msg llm.Message) {
+				require.Equal(t, "assistant", msg.Role)
+				require.Nil(t, msg.Annotations)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.oaiMsg.ToLLMMessage()
+			tt.validate(t, result)
+		})
+	}
+}
+
 func TestResponse_ToLLMResponse_WithCitations(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
This PR adds support for processing citation and annotation fields in completion responses, enabling providers like Perplexity that include citation URLs to have those preserved through the transformation pipeline.
## Changes
### Features
- **Citations support** : Add Citations field to OpenAI Response, store in TransformerMetadata, aggregate from streaming chunks
- **Annotations support**: Add Annotation/URLCitation structs, convert during transformations, aggregate with deduplication

- Add consistent nil/empty checks
- Add negative tests for invalid annotation data
## Testing
All tests pass including new tests for citations, annotations, and edge cases."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now support citation annotations with URL metadata for referencing sources.
  * Responses include a list of citations for end-user reference.
  * Annotations are aggregated and deduplicated across streaming message chunks.

* **Tests**
  * Added comprehensive tests covering annotation handling, citation extraction, aggregation, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->