### PR TITLE
fix: allow reasoning_budget without reasoning_effort

### DIFF
--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -43,7 +43,7 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 		req.Metadata = &AnthropicMetadata{UserID: chatReq.Metadata["user_id"]}
 	}
 
-	if chatReq.ReasoningEffort != "" {
+	if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
 		req.Thinking = buildThinking(chatReq, config)
 	}
 


### PR DESCRIPTION
修复 Anthropic transformer 中 reasoning_budget 必须配合 reasoning_effort 才能生效的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reasoning parameter handling for Anthropic API integration. The reasoning feature now activates when either reasoning effort or reasoning budget parameters are provided, offering greater flexibility in controlling model reasoning capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->