### PR TITLE
fix: require function_call arguments in output items

### DIFF
--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -401,6 +401,18 @@ func (item Item) MarshalJSON() ([]byte, error) {
 		item.Summary = []ReasoningSummary{}
 	}
 
+	if item.Type == "function_call" {
+		type functionCallItem struct {
+			itemAlias
+			Arguments string `json:"arguments"`
+		}
+
+		return json.Marshal(functionCallItem{
+			itemAlias: itemAlias(item),
+			Arguments: item.Arguments,
+		})
+	}
+
 	return json.Marshal(itemAlias(item))
 }
 


### PR DESCRIPTION
- Ensure function_call output items always include arguments as required string in stream events
- Fixes tool-call compatibility issues for clients using @aisdk/openai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of function call responses to ensure arguments are properly handled in API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->