### PR TITLE
refactor: transformer use api key provider instead of static api key

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/oauth"
 	"github.com/looplj/axonhub/llm/pipeline"
@@ -168,8 +169,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 	switch c.Type {
 	case channel.TypeDoubao, channel.TypeVolcengine:
 		transformer, err := doubao.NewOutboundTransformerWithConfig(&doubao.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -177,28 +178,40 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeOpenrouter, channel.TypeCerebras:
-		transformer, err := openrouter.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := openrouter.NewOutboundTransformerWithConfig(&openrouter.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZai, channel.TypeZhipu:
-		transformer, err := zai.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := zai.NewOutboundTransformerWithConfig(&zai.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeDeepseek:
-		transformer, err := deepseek.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := deepseek.NewOutboundTransformerWithConfig(&deepseek.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeMoonshot:
-		transformer, err := moonshot.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := moonshot.NewOutboundTransformerWithConfig(&moonshot.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
@@ -206,7 +219,10 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 
 	case channel.TypeXai:
-		transformer, err := xai.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := xai.NewOutboundTransformerWithConfig(&xai.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
@@ -214,9 +230,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeLongcatAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformLongCat,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformLongCat,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -225,9 +241,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeAnthropic, channel.TypeMinimaxAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformDirect,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformDirect,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -299,9 +315,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeDeepseekAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformDeepSeek,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformDeepSeek,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -310,9 +326,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeDoubaoAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformDoubao,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformDoubao,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -321,9 +337,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeMoonshotAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformMoonshot,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformMoonshot,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -332,9 +348,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZhipuAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformZhipu,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformZhipu,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -343,9 +359,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeZaiAnthropic:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformZai,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformZai,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -355,9 +371,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 
 	case channel.TypeAnthropicAWS:
 		transformer, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
-			Type:    anthropic.PlatformBedrock,
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			Type:           anthropic.PlatformBedrock,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -399,8 +415,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		}, nil
 	case channel.TypeModelscope:
 		transformer, err := modelscope.NewOutboundTransformerWithConfig(&modelscope.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -409,8 +425,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeGeminiOpenai:
 		transformer, err := geminioai.NewOutboundTransformerWithConfig(&geminioai.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -418,7 +434,10 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeLongcat:
-		transformer, err := longcat.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := longcat.NewOutboundTransformerWithConfig(&longcat.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
@@ -426,8 +445,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeBailian:
 		transformer, err := bailian.NewOutboundTransformerWithConfig(&bailian.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -504,9 +523,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		channel.TypePpio, channel.TypeSiliconflow,
 		channel.TypeVercel, channel.TypeAihubmix, channel.TypeBurncloud, channel.TypeGithub:
 		transformer, err := openai.NewOutboundTransformerWithConfig(&openai.Config{
-			PlatformType: openai.PlatformOpenAI,
-			BaseURL:      c.BaseURL,
-			APIKey:       c.Credentials.APIKey,
+			PlatformType:   openai.PlatformOpenAI,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -515,8 +534,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeOpenaiResponses:
 		transformer, err := responses.NewOutboundTransformerWithConfig(&responses.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -525,8 +544,8 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeGemini:
 		transformer, err := gemini.NewOutboundTransformerWithConfig(gemini.Config{
-			BaseURL: c.BaseURL,
-			APIKey:  c.Credentials.APIKey,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -535,9 +554,9 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeGeminiVertex:
 		transformer, err := gemini.NewOutboundTransformerWithConfig(gemini.Config{
-			BaseURL:      c.BaseURL,
-			APIKey:       c.Credentials.APIKey,
-			PlatformType: gemini.PlatformVertex,
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+			PlatformType:   gemini.PlatformVertex,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
@@ -545,7 +564,10 @@ func (svc *ChannelService) buildChannel(c *ent.Channel) (*Channel, error) {
 
 		return buildChannelWithTransformer(c, transformer, httpClient), nil
 	case channel.TypeJina:
-		transformer, err := jina.NewOutboundTransformer(c.BaseURL, c.Credentials.APIKey)
+		transformer, err := jina.NewOutboundTransformerWithConfig(&jina.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(c.Credentials.APIKey),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}

--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -16,6 +16,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/usagelog"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/anthropic"
@@ -723,32 +724,26 @@ func getOutboundTransformer(format llm.APIFormat) (transformer.Outbound, error) 
 	switch format {
 	case llm.APIFormatOpenAIChatCompletion:
 		config := &openai.Config{
-			PlatformType: openai.PlatformOpenAI,
-			BaseURL:      "https://api.openai.com/v1",
-			APIKey:       "dummy",
+			PlatformType:   openai.PlatformOpenAI,
+			BaseURL:        "https://api.openai.com/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("dummy"),
 		}
 
 		return openai.NewOutboundTransformerWithConfig(config)
 	case llm.APIFormatOpenAIResponse:
-		config := &openai.Config{
-			PlatformType: openai.PlatformOpenAI,
-			BaseURL:      "https://api.openai.com/v1",
-			APIKey:       "dummy",
-		}
-
-		return responses.NewOutboundTransformer(config.BaseURL, config.APIKey)
+		return responses.NewOutboundTransformer("https://api.openai.com/v1", "dummy")
 	case llm.APIFormatAnthropicMessage:
 		config := &anthropic.Config{
-			Type:    anthropic.PlatformDirect,
-			BaseURL: "https://api.anthropic.com",
-			APIKey:  "dummy",
+			Type:           anthropic.PlatformDirect,
+			BaseURL:        "https://api.anthropic.com",
+			APIKeyProvider: auth.NewStaticKeyProvider("dummy"),
 		}
 
 		return anthropic.NewOutboundTransformerWithConfig(config)
 	case llm.APIFormatGeminiContents:
 		config := gemini.Config{
-			BaseURL: "https://generativelanguage.googleapis.com",
-			APIKey:  "dummy",
+			BaseURL:        "https://generativelanguage.googleapis.com",
+			APIKeyProvider: auth.NewStaticKeyProvider("dummy"),
 		}
 
 		return gemini.NewOutboundTransformerWithConfig(config)

--- a/llm/auth/api_key_provider.go
+++ b/llm/auth/api_key_provider.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"context"
+)
+
+// APIKeyProvider provides API keys for authentication.
+// Implementations can support single or multiple API keys with various selection strategies.
+type APIKeyProvider interface {
+	// Get returns an API key for the given context.
+	// The context may contain hints (e.g., trace ID, session ID) that implementations
+	// can use to ensure consistent key selection for related requests.
+	Get(ctx context.Context) string
+}
+
+// StaticKeyProvider is a simple APIKeyProvider that always returns the same API key.
+type StaticKeyProvider struct {
+	apiKey string
+}
+
+// NewStaticKeyProvider creates a new StaticKeyProvider with the given API key.
+func NewStaticKeyProvider(apiKey string) *StaticKeyProvider {
+	return &StaticKeyProvider{apiKey: apiKey}
+}
+
+// Get returns the static API key.
+func (p *StaticKeyProvider) Get(_ context.Context) string {
+	return p.apiKey
+}

--- a/llm/transformer/anthropic/outbound_test.go
+++ b/llm/transformer/anthropic/outbound_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -1193,7 +1194,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://custom.api.com/v1",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 				RawURL:  true,
 			},
 			request: &llm.Request{
@@ -1216,7 +1217,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://custom.api.com/v100#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1238,7 +1239,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://custom.api.com/v1/messages#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1260,7 +1261,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://api.anthropic.com",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 				RawURL:  false,
 			},
 			request: &llm.Request{
@@ -1283,7 +1284,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://api.anthropic.com/v1",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 				RawURL:  false,
 			},
 			request: &llm.Request{
@@ -1306,7 +1307,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://custom-endpoint.com/api/llm#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1328,7 +1329,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDirect,
 				BaseURL: "https://custom.api.com/v1#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1351,7 +1352,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDeepSeek,
 				BaseURL: "https://api.deepseek.com/v1#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "deepseek-chat",
@@ -1373,7 +1374,7 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 			config: &Config{
 				Type:    PlatformDoubao,
 				BaseURL: "https://ark.cn-beijing.volces.com/v20#",
-				APIKey:  "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model:     "doubao-pro-4k",

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -55,10 +55,7 @@ type Transformer struct {
 // NewTransformer creates a new Antigravity Transformer.
 func NewTransformer(config Config, opts ...Option) (*Transformer, error) {
 	// Initialize a Gemini transformer for internal use
-	gt, err := gemini.NewOutboundTransformerWithConfig(gemini.Config{
-		BaseURL: config.BaseURL,
-		APIKey:  config.APIKey,
-	})
+	gt, err := gemini.NewOutboundTransformer(config.BaseURL, config.APIKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create internal gemini transformer: %w", err)
 	}

--- a/llm/transformer/bailian/outbound_test.go
+++ b/llm/transformer/bailian/outbound_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
 func TestBailianTransformRequest_MergeConsecutiveToolCalls(t *testing.T) {
 	transformer, err := NewOutboundTransformerWithConfig(&Config{
-		BaseURL: "https://example.com",
-		APIKey:  "test-key",
+		BaseURL:        "https://example.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	})
 	require.NoError(t, err)
 

--- a/llm/transformer/deepseek/outbound_test.go
+++ b/llm/transformer/deepseek/outbound_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
 func TestOutboundTransformer_TransformRequest_ResponseFormat(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.deepseek.com/v1",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.deepseek.com/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -115,8 +116,8 @@ func TestOutboundTransformer_TransformRequest_ResponseFormat(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_Thinking(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.deepseek.com/v1",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.deepseek.com/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -206,8 +207,8 @@ func TestOutboundTransformer_TransformRequest_URL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &Config{
-				BaseURL: tt.baseURL,
-				APIKey:  "test-api-key",
+				BaseURL:        tt.baseURL,
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			}
 
 			transformer, err := NewOutboundTransformerWithConfig(config)

--- a/llm/transformer/doubao/outbound_test.go
+++ b/llm/transformer/doubao/outbound_test.go
@@ -1,6 +1,7 @@
 package doubao
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -79,30 +81,30 @@ func TestNewOutboundTransformerWithConfig(t *testing.T) {
 		{
 			name: "valid config",
 			config: &Config{
-				BaseURL: "https://ark.cn-beijing.volces.com/api/v3",
-				APIKey:  "test-api-key",
+				BaseURL:        "https://ark.cn-beijing.volces.com/api/v3",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr: false,
 			validate: func(t *OutboundTransformer) bool {
-				return t.BaseURL == "https://ark.cn-beijing.volces.com/api/v3" && t.APIKey == "test-api-key"
+				return t.BaseURL == "https://ark.cn-beijing.volces.com/api/v3" && t.APIKeyProvider.Get(context.Background()) == "test-api-key"
 			},
 		},
 		{
 			name: "valid config with trailing slash",
 			config: &Config{
-				BaseURL: "https://ark.cn-beijing.volces.com/api/v3/",
-				APIKey:  "test-api-key",
+				BaseURL:        "https://ark.cn-beijing.volces.com/api/v3/",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr: false,
 			validate: func(t *OutboundTransformer) bool {
-				return t.BaseURL == "https://ark.cn-beijing.volces.com/api/v3" && t.APIKey == "test-api-key"
+				return t.BaseURL == "https://ark.cn-beijing.volces.com/api/v3" && t.APIKeyProvider.Get(context.Background()) == "test-api-key"
 			},
 		},
 		{
 			name: "nil config",
 			config: &Config{
-				BaseURL: "",
-				APIKey:  "",
+				BaseURL:        "",
+				APIKeyProvider: nil,
 			},
 			wantErr:   true,
 			errString: "base URL is required",
@@ -110,20 +112,20 @@ func TestNewOutboundTransformerWithConfig(t *testing.T) {
 		{
 			name: "empty base URL",
 			config: &Config{
-				BaseURL: "",
-				APIKey:  "test-api-key",
+				BaseURL:        "",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr:   true,
 			errString: "base URL is required",
 		},
 		{
-			name: "empty API key",
+			name: "empty API key provider",
 			config: &Config{
-				BaseURL: "https://ark.cn-beijing.volces.com/api/v3",
-				APIKey:  "",
+				BaseURL:        "https://ark.cn-beijing.volces.com/api/v3",
+				APIKeyProvider: nil,
 			},
 			wantErr:   true,
-			errString: "API key is required",
+			errString: "API key provider is required",
 		},
 	}
 

--- a/llm/transformer/gemini/openai/outbound_test.go
+++ b/llm/transformer/gemini/openai/outbound_test.go
@@ -1,6 +1,7 @@
 package geminioai
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -35,11 +37,11 @@ func TestNewOutboundTransformer(t *testing.T) {
 			errString: "base URL is required",
 		},
 		{
-			name:      "empty API key",
+			name:      "empty API key provider",
 			baseURL:   "https://generativelanguage.googleapis.com",
 			apiKey:    "",
 			wantErr:   true,
-			errString: "API key is required",
+			errString: "API key provider is required",
 		},
 		{
 			name:    "base URL with trailing slash",
@@ -79,42 +81,42 @@ func TestNewOutboundTransformerWithConfig(t *testing.T) {
 		{
 			name: "valid config",
 			config: &Config{
-				BaseURL: "https://generativelanguage.googleapis.com",
-				APIKey:  "test-api-key",
+				BaseURL:        "https://generativelanguage.googleapis.com",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr: false,
 			validate: func(t *OutboundTransformer) bool {
-				return t.BaseURL == "https://generativelanguage.googleapis.com/v1beta/openai" && t.APIKey == "test-api-key"
+				return t.BaseURL == "https://generativelanguage.googleapis.com/v1beta/openai" && t.APIKeyProvider.Get(context.Background()) == "test-api-key"
 			},
 		},
 		{
 			name: "valid config with trailing slash",
 			config: &Config{
-				BaseURL: "https://generativelanguage.googleapis.com/",
-				APIKey:  "test-api-key",
+				BaseURL:        "https://generativelanguage.googleapis.com/",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr: false,
 			validate: func(t *OutboundTransformer) bool {
-				return t.BaseURL == "https://generativelanguage.googleapis.com/v1beta/openai" && t.APIKey == "test-api-key"
+				return t.BaseURL == "https://generativelanguage.googleapis.com/v1beta/openai" && t.APIKeyProvider.Get(context.Background()) == "test-api-key"
 			},
 		},
 		{
 			name: "empty base URL",
 			config: &Config{
-				BaseURL: "",
-				APIKey:  "test-api-key",
+				BaseURL:        "",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			},
 			wantErr:   true,
 			errString: "base URL is required",
 		},
 		{
-			name: "empty API key",
+			name: "empty API key provider",
 			config: &Config{
-				BaseURL: "https://generativelanguage.googleapis.com",
-				APIKey:  "",
+				BaseURL:        "https://generativelanguage.googleapis.com",
+				APIKeyProvider: nil,
 			},
 			wantErr:   true,
-			errString: "API key is required",
+			errString: "API key provider is required",
 		},
 	}
 

--- a/llm/transformer/gemini/outbound_test.go
+++ b/llm/transformer/gemini/outbound_test.go
@@ -91,12 +91,10 @@ func TestClenupConfig(t *testing.T) {
 			name: "complete config",
 			input: Config{
 				BaseURL:    "https://custom.api.com",
-				APIKey:     "test-key",
 				APIVersion: "v1",
 			},
 			expected: Config{
 				BaseURL:    "https://custom.api.com",
-				APIKey:     "test-key",
 				APIVersion: "v1",
 			},
 		},
@@ -275,7 +273,6 @@ func TestNewOutboundTransformerWithConfig(t *testing.T) {
 			name: "valid config",
 			config: Config{
 				BaseURL:    "https://generativelanguage.googleapis.com",
-				APIKey:     "test-key",
 				APIVersion: "v1beta",
 			},
 			wantErr: false,

--- a/llm/transformer/jina/embedding_test.go
+++ b/llm/transformer/jina/embedding_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -242,8 +243,8 @@ func TestEmbeddingInboundTransformer_TransformRequest(t *testing.T) {
 func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 	t.Run("valid embedding request with /v1 suffix", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -274,8 +275,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("valid embedding request without /v1 suffix", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -295,8 +296,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("embedding request with explicit task", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -322,8 +323,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("embedding request with empty task defaults to text-matching", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -349,8 +350,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("embedding request nil llm request", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -362,8 +363,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("embedding request missing embedding in request", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -380,8 +381,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 	t.Run("embedding request wrong request type", func(t *testing.T) {
 		config := &Config{
-			BaseURL: "https://api.jina.ai/v1",
-			APIKey:  "test-key",
+			BaseURL:        "https://api.jina.ai/v1",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -399,8 +400,8 @@ func TestOutboundTransformer_TransformRequest_Embedding(t *testing.T) {
 
 func TestOutboundTransformer_TransformResponse_Embedding(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.jina.ai/v1",
-		APIKey:  "test-key",
+		BaseURL:        "https://api.jina.ai/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -541,8 +542,8 @@ func TestEmbeddingTransformers_APIFormat(t *testing.T) {
 	require.Equal(t, llm.APIFormatJinaEmbedding, inbound.APIFormat())
 
 	config := &Config{
-		BaseURL: "https://api.jina.ai/v1",
-		APIKey:  "test-key",
+		BaseURL:        "https://api.jina.ai/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	outbound, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -551,8 +552,8 @@ func TestEmbeddingTransformers_APIFormat(t *testing.T) {
 
 func TestOutboundTransformer_TransformError_Embedding(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.jina.ai/v1",
-		APIKey:  "test-key",
+		BaseURL:        "https://api.jina.ai/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -589,8 +590,8 @@ func TestOutboundTransformer_TransformError_Embedding(t *testing.T) {
 
 func TestOutboundTransformer_StreamNotSupported_Embedding(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.jina.ai/v1",
-		APIKey:  "test-key",
+		BaseURL:        "https://api.jina.ai/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -634,8 +635,8 @@ func TestOutboundTransformer_URLBuilding_Embedding(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			config := &Config{
-				BaseURL: tc.baseURL,
-				APIKey:  "test-key",
+				BaseURL:        tc.baseURL,
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			}
 			transformer, err := NewOutboundTransformerWithConfig(config)
 			require.NoError(t, err)

--- a/llm/transformer/longcat/outbound.go
+++ b/llm/transformer/longcat/outbound.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
@@ -20,10 +21,22 @@ type OutboundTransformer struct {
 
 // NewOutboundTransformer creates a new Longcat OutboundTransformer.
 func NewOutboundTransformer(baseURL, apiKey string) (transformer.Outbound, error) {
+	return NewOutboundTransformerWithConfig(&Config{
+		BaseURL:        baseURL,
+		APIKeyProvider: auth.NewStaticKeyProvider(apiKey),
+	})
+}
+
+type Config struct {
+	BaseURL        string
+	APIKeyProvider auth.APIKeyProvider
+}
+
+func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, error) {
 	oaiTransformer, err := openai.NewOutboundTransformerWithConfig(&openai.Config{
-		PlatformType: openai.PlatformOpenAI,
-		BaseURL:      baseURL,
-		APIKey:       apiKey,
+		PlatformType:   openai.PlatformOpenAI,
+		BaseURL:        config.BaseURL,
+		APIKeyProvider: config.APIKeyProvider,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create longcat outbound transformer: %w", err)

--- a/llm/transformer/moonshot/outbound.go
+++ b/llm/transformer/moonshot/outbound.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
@@ -15,23 +16,23 @@ import (
 // Config holds all configuration for the Moonshot outbound transformer.
 type Config struct {
 	// API configuration
-	BaseURL string `json:"base_url,omitempty"` // Custom base URL (optional)
-	APIKey  string `json:"api_key,omitempty"`  // API key
+	BaseURL        string              `json:"base_url,omitempty"` // Custom base URL (optional)
+	APIKeyProvider auth.APIKeyProvider `json:"-"`                  // API key provider
 }
 
 // OutboundTransformer implements transformer.Outbound for Moonshot format.
 type OutboundTransformer struct {
 	transformer.Outbound
 
-	BaseURL string
-	APIKey  string
+	BaseURL        string
+	APIKeyProvider auth.APIKeyProvider
 }
 
 // NewOutboundTransformer creates a new Moonshot OutboundTransformer with legacy parameters.
 func NewOutboundTransformer(baseURL, apiKey string) (transformer.Outbound, error) {
 	config := &Config{
-		BaseURL: baseURL,
-		APIKey:  apiKey,
+		BaseURL:        baseURL,
+		APIKeyProvider: auth.NewStaticKeyProvider(apiKey),
 	}
 
 	return NewOutboundTransformerWithConfig(config)
@@ -39,7 +40,13 @@ func NewOutboundTransformer(baseURL, apiKey string) (transformer.Outbound, error
 
 // NewOutboundTransformerWithConfig creates a new Moonshot OutboundTransformer with unified configuration.
 func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, error) {
-	t, err := openai.NewOutboundTransformer(config.BaseURL, config.APIKey)
+	oaiConfig := &openai.Config{
+		PlatformType:   openai.PlatformOpenAI,
+		BaseURL:        config.BaseURL,
+		APIKeyProvider: config.APIKeyProvider,
+	}
+
+	t, err := openai.NewOutboundTransformerWithConfig(oaiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Moonshot transformer configuration: %w", err)
 	}
@@ -47,9 +54,9 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 	baseURL := transformer.NormalizeBaseURL(config.BaseURL, "v1")
 
 	return &OutboundTransformer{
-		BaseURL:  baseURL,
-		APIKey:   config.APIKey,
-		Outbound: t,
+		BaseURL:        baseURL,
+		APIKeyProvider: config.APIKeyProvider,
+		Outbound:       t,
 	}, nil
 }
 
@@ -88,9 +95,12 @@ func (t *OutboundTransformer) TransformRequest(
 	headers.Set("Content-Type", "application/json")
 	headers.Set("Accept", "application/json")
 
+	// Get API key from provider
+	apiKey := t.APIKeyProvider.Get(ctx)
+
 	auth := &httpclient.AuthConfig{
 		Type:   "bearer",
-		APIKey: t.APIKey,
+		APIKey: apiKey,
 	}
 
 	url := t.BaseURL + "/chat/completions"

--- a/llm/transformer/moonshot/outbound_test.go
+++ b/llm/transformer/moonshot/outbound_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
 func TestOutboundTransformer_TransformRequest_ResponseFormat(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.moonshot.cn/v1",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.moonshot.cn/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -134,8 +135,8 @@ func TestOutboundTransformer_TransformRequest_URL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &Config{
-				BaseURL: tt.baseURL,
-				APIKey:  "test-api-key",
+				BaseURL:        tt.baseURL,
+				APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 			}
 
 			transformer, err := NewOutboundTransformerWithConfig(config)
@@ -164,8 +165,8 @@ func TestOutboundTransformer_TransformRequest_URL(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_Basic(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.moonshot.cn/v1",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.moonshot.cn/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -206,8 +207,8 @@ func TestOutboundTransformer_TransformRequest_Basic(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_Errors(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.moonshot.cn/v1",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.moonshot.cn/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)

--- a/llm/transformer/openai/embedding.go
+++ b/llm/transformer/openai/embedding.go
@@ -39,7 +39,7 @@ type EmbeddingUsage struct {
 
 // transformEmbeddingRequest transforms unified llm.Request to HTTP embedding request.
 func (t *OutboundTransformer) transformEmbeddingRequest(
-	_ context.Context,
+	ctx context.Context,
 	llmReq *llm.Request,
 ) (*httpclient.Request, error) {
 	if llmReq == nil {
@@ -72,6 +72,9 @@ func (t *OutboundTransformer) transformEmbeddingRequest(
 	// Build URL, reuse same logic as chat
 	url := t.buildEmbeddingURL()
 
+	// Get API key from provider
+	apiKey := t.config.APIKeyProvider.Get(ctx)
+
 	// Build auth config
 	var auth *httpclient.AuthConfig
 
@@ -80,13 +83,13 @@ func (t *OutboundTransformer) transformEmbeddingRequest(
 	case PlatformAzure:
 		auth = &httpclient.AuthConfig{
 			Type:      "api_key",
-			APIKey:    t.config.APIKey,
+			APIKey:    apiKey,
 			HeaderKey: "Api-Key",
 		}
 	default:
 		auth = &httpclient.AuthConfig{
 			Type:   "bearer",
-			APIKey: t.config.APIKey,
+			APIKey: apiKey,
 		}
 	}
 

--- a/llm/transformer/openai/embedding_test.go
+++ b/llm/transformer/openai/embedding_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -268,7 +269,7 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 		config := &Config{
 			PlatformType: PlatformOpenAI,
 			BaseURL:      "https://api.openai.com/v1",
-			APIKey:       "test-key",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -297,7 +298,7 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 		config := &Config{
 			PlatformType: PlatformOpenAI,
 			BaseURL:      "https://api.openai.com/v1",
-			APIKey:       "test-key",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -311,7 +312,7 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 		config := &Config{
 			PlatformType: PlatformOpenAI,
 			BaseURL:      "https://api.openai.com/v1",
-			APIKey:       "test-key",
+			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
 		require.NoError(t, err)
@@ -331,7 +332,7 @@ func TestEmbeddingOutboundTransformer_TransformResponse(t *testing.T) {
 	config := &Config{
 		PlatformType: PlatformOpenAI,
 		BaseURL:      "https://api.openai.com/v1",
-		APIKey:       "test-key",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -567,7 +568,7 @@ func TestEmbeddingTransformers_APIFormat(t *testing.T) {
 	config := &Config{
 		PlatformType: PlatformOpenAI,
 		BaseURL:      "https://api.openai.com/v1",
-		APIKey:       "test-key",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	outbound, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -578,7 +579,7 @@ func TestEmbeddingOutboundTransformer_TransformError(t *testing.T) {
 	config := &Config{
 		PlatformType: PlatformOpenAI,
 		BaseURL:      "https://api.openai.com/v1",
-		APIKey:       "test-key",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)
@@ -667,7 +668,7 @@ func TestEmbeddingOutboundTransformer_URLBuilding(t *testing.T) {
 			config := &Config{
 				PlatformType: PlatformOpenAI,
 				BaseURL:      tc.baseURL,
-				APIKey:       "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			}
 			transformer, err := NewOutboundTransformerWithConfig(config)
 			require.NoError(t, err)
@@ -699,7 +700,7 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 			config: &Config{
 				PlatformType: PlatformOpenAI,
 				BaseURL:      "https://custom.api.com/v100#",
-				APIKey:       "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				RequestType: llm.RequestTypeEmbedding,
@@ -717,7 +718,7 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 			config: &Config{
 				PlatformType: PlatformOpenAI,
 				BaseURL:      "https://custom.api.com/v20#",
-				APIKey:       "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				RequestType: llm.RequestTypeEmbedding,
@@ -735,7 +736,7 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 			config: &Config{
 				PlatformType: PlatformOpenAI,
 				BaseURL:      "https://api.openai.com",
-				APIKey:       "test-key",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 				RawURL:       false,
 			},
 			request: &llm.Request{

--- a/llm/transformer/openai/image_outbound_test.go
+++ b/llm/transformer/openai/image_outbound_test.go
@@ -95,7 +95,7 @@ func TestBuildImageGenerateRequest_BasicPrompt(t *testing.T) {
 		},
 	}
 
-	httpReq, err := ot.buildImageGenerateRequest(req)
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
 	require.NoError(t, err)
 	require.NotNil(t, httpReq)
 
@@ -134,7 +134,7 @@ func TestBuildImageGenerateRequest_WithParameters(t *testing.T) {
 		},
 	}
 
-	httpReq, err := ot.buildImageGenerateRequest(req)
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
 	require.NoError(t, err)
 
 	// Verify body
@@ -162,7 +162,7 @@ func TestBuildImageGenerateRequest_NoPrompt(t *testing.T) {
 		},
 	}
 
-	_, err = ot.buildImageGenerateRequest(req)
+	_, err = ot.buildImageGenerateRequest(req, "test-key")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt is required")
 }
@@ -186,7 +186,7 @@ func TestBuildImageEditRequest_WithImage(t *testing.T) {
 		},
 	}
 
-	httpReq, err := ot.buildImageEditRequest(req)
+	httpReq, err := ot.buildImageEditRequest(req, "test-key")
 	require.NoError(t, err)
 	require.NotNil(t, httpReq)
 
@@ -212,7 +212,7 @@ func TestBuildImageEditRequest_NoImage(t *testing.T) {
 		},
 	}
 
-	_, err = ot.buildImageEditRequest(req)
+	_, err = ot.buildImageEditRequest(req, "test-key")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one image is required")
 }
@@ -233,7 +233,7 @@ func TestBuildImageEditRequest_NoPrompt(t *testing.T) {
 		},
 	}
 
-	_, err = ot.buildImageEditRequest(req)
+	_, err = ot.buildImageEditRequest(req, "test-key")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt is required")
 }
@@ -252,7 +252,7 @@ func TestBuildImageGenerationAPIRequest_RoutesToGenerate(t *testing.T) {
 		},
 	}
 
-	httpReq, err := ot.buildImageGenerationAPIRequest(req)
+	httpReq, err := ot.buildImageGenerationAPIRequest(context.Background(), req)
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.openai.com/v1/images/generations", httpReq.URL)
 	assert.Equal(t, string(llm.APIFormatOpenAIImageGeneration), httpReq.APIFormat)
@@ -272,7 +272,7 @@ func TestBuildImageGenerationAPIRequest_RoutesToGeneration(t *testing.T) {
 		},
 	}
 
-	httpReq, err := ot.buildImageGenerationAPIRequest(req)
+	httpReq, err := ot.buildImageGenerationAPIRequest(context.Background(), req)
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.openai.com/v1/images/generations", httpReq.URL)
 	assert.Equal(t, string(llm.APIFormatOpenAIImageGeneration), httpReq.APIFormat)

--- a/llm/transformer/openai/outbound_test.go
+++ b/llm/transformer/openai/outbound_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -525,8 +526,9 @@ func TestOutboundTransformer_SetAPIKey(t *testing.T) {
 	newKey := "new-api-key"
 	transformer.SetAPIKey(newKey)
 
-	if transformer.config.APIKey != newKey {
-		t.Errorf("SetAPIKey() failed, got %v, want %v", transformer.config.APIKey, newKey)
+	apiKey := transformer.config.APIKeyProvider.Get(context.Background())
+	if apiKey != newKey {
+		t.Errorf("SetAPIKey() failed, got %v, want %v", apiKey, newKey)
 	}
 }
 
@@ -591,10 +593,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL enabled with Config",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom.api.com/v1",
-				APIKey:       "test-key",
-				RawURL:       true,
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom.api.com/v1",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+				RawURL:         true,
 			},
 			request: &llm.Request{
 				Model: "gpt-4",
@@ -613,9 +615,9 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL auto-enabled with # suffix",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom.api.com/v100#",
-				APIKey:       "test-key",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom.api.com/v100#",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model: "gpt-4",
@@ -634,9 +636,9 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with full path",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom.api.com/v1/chat/completions#",
-				APIKey:       "test-key",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom.api.com/v1/chat/completions#",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model: "gpt-4",
@@ -655,10 +657,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL false with standard URL",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://api.openai.com",
-				APIKey:       "test-key",
-				RawURL:       false,
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://api.openai.com",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+				RawURL:         false,
 			},
 			request: &llm.Request{
 				Model: "gpt-4",
@@ -677,10 +679,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL false with v1 already in URL",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://api.openai.com/v1",
-				APIKey:       "test-key",
-				RawURL:       false,
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://api.openai.com/v1",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+				RawURL:         false,
 			},
 			request: &llm.Request{
 				Model: "gpt-4",
@@ -699,9 +701,9 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with custom endpoint without version",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom-endpoint.com/api/llm#",
-				APIKey:       "test-key",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom-endpoint.com/api/llm#",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
 				Model: "gpt-4",

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -57,7 +58,7 @@ func TestNewOutboundTransformer(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, transformer)
-				require.Equal(t, tt.apiKey, transformer.config.APIKey)
+				require.Equal(t, tt.apiKey, transformer.config.APIKeyProvider.Get(context.Background()))
 				// Base URL should be normalized with v1 version
 				require.Equal(t, "https://api.openai.com/v1", transformer.config.BaseURL)
 			}
@@ -115,9 +116,9 @@ func TestOutboundTransformer_buildFullRequestURL(t *testing.T) {
 				transformer, err = NewOutboundTransformer(tt.baseURL, "test-key")
 			} else {
 				transformer, err = NewOutboundTransformerWithConfig(&Config{
-					BaseURL: tt.baseURL,
-					APIKey:  "test-key",
-					RawURL:  tt.rawURL,
+					BaseURL:        tt.baseURL,
+					APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+					RawURL:         tt.rawURL,
 				})
 			}
 

--- a/llm/transformer/xai/outbound_test.go
+++ b/llm/transformer/xai/outbound_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/streams"
 )
 
@@ -440,8 +441,8 @@ func TestOutboundTransformer_TransformStream_FilterEmptyEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a mock transformer
 			config := &Config{
-				BaseURL: DefaultBaseURL,
-				APIKey:  "test-key",
+				BaseURL:        DefaultBaseURL,
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			}
 			transformer, err := NewOutboundTransformerWithConfig(config)
 			require.NoError(t, err)
@@ -498,8 +499,8 @@ func TestOutboundTransformer_TransformStream_RealXAIEmptyEvent(t *testing.T) {
 
 	// Create transformer
 	config := &Config{
-		BaseURL: DefaultBaseURL,
-		APIKey:  "test-key",
+		BaseURL:        DefaultBaseURL,
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
 	require.NoError(t, err)

--- a/llm/transformer/zai/image_test.go
+++ b/llm/transformer/zai/image_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
 func TestBuildImageGenerationAPIRequest(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.example.com/v4",
-		APIKey:  "test-key",
+		BaseURL:        "https://api.example.com/v4",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -111,7 +112,7 @@ func TestBuildImageGenerationAPIRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := transformer.(*OutboundTransformer).buildImageGenerationAPIRequest(tt.chatReq)
+			req, err := transformer.(*OutboundTransformer).buildImageGenerationAPIRequest(t.Context(), tt.chatReq)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -217,5 +218,3 @@ func TestTransformImageGenerationResponse(t *testing.T) {
 		})
 	}
 }
-
-

--- a/llm/transformer/zai/outbound_test.go
+++ b/llm/transformer/zai/outbound_test.go
@@ -10,14 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 )
 
 func TestOutboundTransformer_TransformRequest_URL(t *testing.T) {
 	// Helper function to create transformer
 	createTransformer := func(baseURL, apiKey string) *OutboundTransformer {
 		config := &Config{
-			BaseURL: baseURL,
-			APIKey:  apiKey,
+			BaseURL:        baseURL,
+			APIKeyProvider: auth.NewStaticKeyProvider(apiKey),
 		}
 
 		transformerInterface, err := NewOutboundTransformerWithConfig(config)
@@ -196,8 +197,8 @@ func TestOutboundTransformer_TransformRequest_URL(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_WithMetadata(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.zai.com/v4",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.zai.com/v4",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -240,8 +241,8 @@ func TestOutboundTransformer_TransformRequest_WithMetadata(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_WithThinking(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.zai.com",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.zai.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -280,8 +281,8 @@ func TestOutboundTransformer_TransformRequest_WithThinking(t *testing.T) {
 
 func TestOutboundTransformer_TransformRequest_ResponseFormat(t *testing.T) {
 	config := &Config{
-		BaseURL: "https://api.zai.com/v4",
-		APIKey:  "test-api-key",
+		BaseURL:        "https://api.zai.com/v4",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
 	}
 
 	transformer, err := NewOutboundTransformerWithConfig(config)

--- a/llm/transformer/zai/thinking_test.go
+++ b/llm/transformer/zai/thinking_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
@@ -39,8 +40,8 @@ func TestReasoningEffortToThinking(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a ZAI transformer to test the transformation
 			config := &Config{
-				BaseURL: "https://api.example.com",
-				APIKey:  "test-key",
+				BaseURL:        "https://api.example.com",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			}
 
 			transformer, err := NewOutboundTransformerWithConfig(config)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched many LLM connectors to a provider-based API key model for runtime credential retrieval, centralizing and standardizing auth handling across transformers.
  * Image and request flows now retrieve keys at execution time (context-aware) for more flexible credential management.
  * No public API surface changes for callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->