### PR TITLE
fix(frontend): improve mobile responsive layouts

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -970,7 +970,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
               {isEdit ? t('channels.dialogs.edit.description') : t('channels.dialogs.create.description')}
             </DialogDescription>
           </DialogHeader>
-          <div className='flex min-h-0 flex-1 gap-4 overflow-hidden'>
+          <div className='flex min-h-0 flex-1 md:gap-4 overflow-hidden'>
             {/* Main Form Section */}
             <div
               className={`flex min-h-0 flex-1 flex-col overflow-hidden py-1 transition-all duration-300 ${showFetchedModelsPanel || showSupportedModelsPanel ? 'pr-2' : 'pr-0'}`}
@@ -978,8 +978,8 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
               <Form {...form}>
                 <form id='channel-form' onSubmit={form.handleSubmit(onSubmit)} className='flex min-h-0 flex-1 flex-col space-y-6 p-0.5'>
                   {/* Provider Selection - Left Side */}
-                  <div className='flex min-h-0 flex-1 gap-6 overflow-hidden'>
-                    <div className='flex min-h-0 w-60 flex-shrink-0 flex-col'>
+                  <div className='flex min-h-0 flex-1 flex-col gap-4 overflow-hidden md:flex-row md:gap-6'>
+                    <div className='flex max-h-48 min-h-0 w-full flex-shrink-0 flex-col md:max-h-none md:w-60'>
                       <FormItem className='flex min-h-0 flex-1 flex-col space-y-2'>
                         <FormLabel className='text-base font-semibold'>{t('channels.dialogs.fields.provider.label')}</FormLabel>
                         <div
@@ -1025,13 +1025,13 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                     </div>
 
                     {/* Right Side - Form Fields */}
-                    <div className='flex-1 space-y-6 overflow-y-auto pr-4'>
+                    <div className='flex-1 space-y-6 overflow-y-auto md:pr-4'>
                       {selectedProvider !== 'jina' && selectedProvider !== 'codex' && selectedProvider !== 'claudecode' && (
-                        <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                          <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                        <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                          <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                             {t('channels.dialogs.fields.apiFormat.label')}
                           </FormLabel>
-                          <div className='col-span-6 space-y-1'>
+                          <div className='max-w-64 space-y-1 md:col-span-6 md:max-w-none'>
                             <SelectDropdown
                               defaultValue={selectedApiFormat}
                               onValueChange={(value) => handleApiFormatChange(value as ApiFormat)}
@@ -1079,11 +1079,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         </FormItem>
                       )}
                       {selectedProvider === 'codex' && (
-                        <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                          <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                        <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                          <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                             {t('channels.dialogs.fields.apiFormat.label')}
                           </FormLabel>
-                          <div className='col-span-6 space-y-1'>
+                          <div className='md:col-span-6 space-y-1'>
                             <div className='text-sm'>{getApiFormatLabel(OPENAI_RESPONSES)}</div>
                             <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiFormat.editDisabled')}</p>
                           </div>
@@ -1091,11 +1091,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                       )}
 
                       {selectedProvider === 'claudecode' && (
-                        <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                          <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                        <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                          <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                             {t('channels.dialogs.fields.apiFormat.label')}
                           </FormLabel>
-                          <div className='col-span-6 space-y-1'>
+                          <div className='md:col-span-6 space-y-1'>
                             <div className='text-sm'>{getApiFormatLabel(ANTHROPIC_MESSAGES)}</div>
                             <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiFormat.editDisabled')}</p>
                           </div>
@@ -1103,11 +1103,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                       )}
 
                       {selectedProvider === 'antigravity' && (
-                        <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                          <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                        <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                          <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                             {t('channels.dialogs.fields.apiFormat.label')}
                           </FormLabel>
-                          <div className='col-span-6 space-y-1'>
+                          <div className='md:col-span-6 space-y-1'>
                             <div className='text-sm'>{getApiFormatLabel(GEMINI_CONTENTS)}</div>
                             <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiFormat.editDisabled')}</p>
 
@@ -1172,11 +1172,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='name'
                         render={({ field, fieldState }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.name.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               <Input
                                 placeholder={t('channels.dialogs.fields.name.placeholder')}
                                 autoComplete='off'
@@ -1191,9 +1191,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                       />
 
                       {(isCodexType || isClaudeCodeType) && (
-                        <div className='grid grid-cols-8 items-start gap-x-6'>
+                        <div className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
                           <div className='col-span-2' />
-                          <div className='col-span-6 space-y-4'>
+                          <div className='md:col-span-6 space-y-4'>
                             <Tabs
                               value={authMode}
                               onValueChange={(value) => {
@@ -1234,11 +1234,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='baseURL'
                         render={({ field, fieldState }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.baseURL.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               <Input
                                 placeholder={baseURLPlaceholder}
                                 autoComplete='new-password'
@@ -1261,11 +1261,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                           control={form.control}
                           name='credentials.apiKeys'
                           render={({ field, fieldState }) => (
-                            <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                              <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                            <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                              <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                                 {t('channels.dialogs.fields.apiKey.label')}
                               </FormLabel>
-                              <div className='col-span-6 space-y-1'>
+                              <div className='md:col-span-6 space-y-1'>
                                 {isEdit ? (
                                   <div className='relative'>
                                     <Textarea
@@ -1290,7 +1290,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                       }}
                                       readOnly={!showApiKey}
                                       placeholder={t('channels.dialogs.fields.apiKey.editPlaceholder')}
-                                      className='col-span-6 min-h-[80px] resize-y font-mono text-sm pr-10'
+                                      className='md:col-span-6 min-h-[80px] resize-y font-mono text-sm pr-10'
                                       autoComplete='new-password'
                                       data-form-type='other'
                                       aria-invalid={!!fieldState.error}
@@ -1341,7 +1341,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                         field.onBlur();
                                       }}
                                       placeholder={t('channels.dialogs.fields.apiKey.placeholder')}
-                                      className='col-span-6 min-h-[80px] resize-y font-mono text-sm'
+                                      className='md:col-span-6 min-h-[80px] resize-y font-mono text-sm'
                                       autoComplete='new-password'
                                       data-form-type='other'
                                       aria-invalid={!!fieldState.error}
@@ -1363,14 +1363,14 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             control={form.control}
                             name='credentials.gcp.region'
                             render={({ field, fieldState }) => (
-                              <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                                <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                              <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                                <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                                   {t('channels.dialogs.fields.gcpRegion.label')}
                                 </FormLabel>
-                                <div className='col-span-6 space-y-1'>
+                                <div className='md:col-span-6 space-y-1'>
                                   <Input
                                     placeholder={t('channels.dialogs.fields.gcpRegion.placeholder')}
-                                    className='col-span-6'
+                                    className='md:col-span-6'
                                     autoComplete='off'
                                     aria-invalid={!!fieldState.error}
                                     {...field}
@@ -1385,14 +1385,14 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             control={form.control}
                             name='credentials.gcp.projectID'
                             render={({ field, fieldState }) => (
-                              <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                                <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                              <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                                <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                                   {t('channels.dialogs.fields.gcpProjectID.label')}
                                 </FormLabel>
-                                <div className='col-span-6 space-y-1'>
+                                <div className='md:col-span-6 space-y-1'>
                                   <Input
                                     placeholder={t('channels.dialogs.fields.gcpProjectID.placeholder')}
-                                    className='col-span-6'
+                                    className='md:col-span-6'
                                     autoComplete='off'
                                     aria-invalid={!!fieldState.error}
                                     {...field}
@@ -1407,11 +1407,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             control={form.control}
                             name='credentials.gcp.jsonData'
                             render={({ field, fieldState }) => (
-                              <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                                <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                              <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                                <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                                   {t('channels.dialogs.fields.gcpJsonData.label')}
                                 </FormLabel>
-                                <div className='col-span-6 space-y-1'>
+                                <div className='md:col-span-6 space-y-1'>
                                   <div className='relative'>
                                     <Textarea
                                       placeholder={`{
@@ -1427,7 +1427,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/xxx-compute%40developer.gserviceaccount.com",
   "universe_domain": "googleapis.com"
 }`}
-                                      className='col-span-6 min-h-[200px] resize-y pr-10 font-mono text-xs'
+                                      className='md:col-span-6 min-h-[200px] resize-y pr-10 font-mono text-xs'
                                       aria-invalid={!!fieldState.error}
                                       {...field}
                                     />
@@ -1471,11 +1471,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='policies.stream'
                         render={({ field }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.streamPolicy.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               {wrapUnsupported(
                                 isCodexType,
                                 <SelectDropdown
@@ -1499,11 +1499,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         )}
                       />
 
-                      <div className='grid grid-cols-8 items-start gap-x-6'>
-                        <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                      <div className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                        <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                           {t('channels.dialogs.fields.supportedModels.label')}
                         </FormLabel>
-                        <div className='col-span-6 space-y-2'>
+                        <div className='md:col-span-6 space-y-2'>
                           <div className='flex gap-2'>
                             {useFetchedModels && fetchedModels.length > 20 ? (
                               <AutoCompleteSelect
@@ -1647,17 +1647,17 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='defaultTestModel'
                         render={({ field }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.defaultTestModel.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               <SelectDropdown
                                 defaultValue={field.value}
                                 onValueChange={field.onChange}
                                 items={supportedModels.map((model) => ({ value: model, label: model }))}
                                 placeholder={t('channels.dialogs.fields.defaultTestModel.description')}
-                                className='col-span-6'
+                                className='md:col-span-6'
                                 disabled={supportedModels.length === 0}
                                 isControlled={true}
                                 data-testid='default-test-model-select'
@@ -1672,11 +1672,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='tags'
                         render={({ field }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.tags.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               <TagsAutocompleteInput
                                 value={field.value || []}
                                 onChange={field.onChange}
@@ -1695,11 +1695,11 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         control={form.control}
                         name='remark'
                         render={({ field }) => (
-                          <FormItem className='grid grid-cols-8 items-start gap-x-6'>
-                            <FormLabel className='col-span-2 pt-2 text-right font-medium'>
+                          <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                            <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                               {t('channels.dialogs.fields.remark.label')}
                             </FormLabel>
-                            <div className='col-span-6 space-y-1'>
+                            <div className='md:col-span-6 space-y-1'>
                               <Textarea
                                 placeholder={t('channels.dialogs.fields.remark.placeholder')}
                                 className='min-h-[80px] resize-y'

--- a/frontend/src/features/channels/components/channels-model-price-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-price-dialog.tsx
@@ -405,7 +405,77 @@ const PriceCard = memo(function PriceCard({
   return (
     <Card className='overflow-hidden'>
       <CardContent className='pt-6'>
-        <div className='grid grid-cols-[1fr_auto] gap-x-4 gap-y-3 md:grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto]'>
+        {/* Mobile: single column layout */}
+        <div className='flex flex-col gap-3 md:hidden'>
+          <div className='flex h-8 items-center justify-between'>
+            <FormLabel className='truncate pr-2'>{t('price.model')}</FormLabel>
+            <div className='flex gap-1'>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon-sm'
+                onClick={() => onDuplicatePrice(priceIndex)}
+                title={t('common.actions.duplicate')}
+              >
+                <IconCopy size={14} />
+              </Button>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon-sm'
+                className='text-destructive'
+                onClick={() => onRemovePrice(priceIndex)}
+              >
+                <IconTrash size={16} />
+              </Button>
+            </div>
+          </div>
+          <FormField
+            control={control}
+            name={`prices.${priceIndex}.modelId`}
+            render={({ field }) => (
+              <FormItem>
+                <Select
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    onModelSelected(priceIndex, value);
+                  }}
+                  value={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger size='sm' className='h-8 w-full' title={field.value || ''}>
+                      <SelectValue placeholder={t('price.model')} className='truncate' />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {availableModels.map((model) => (
+                      <SelectItem key={model} value={model} title={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className='flex h-8 items-center'>
+            <FormLabel className='truncate'>{t('price.items')}</FormLabel>
+          </div>
+          <ModelPriceEditor
+            control={control}
+            priceIndex={priceIndex}
+            currencyCode={currencyCode}
+            hideHeader
+            onAddItem={onAddItem}
+            onRemoveItem={onRemoveItem}
+            onAddVariant={onAddVariant}
+            onRemoveVariant={onRemoveVariant}
+          />
+        </div>
+
+        {/* Desktop: grid layout */}
+        <div className='hidden md:grid md:grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] md:gap-x-4 md:gap-y-3'>
           <div className='flex h-8 min-w-0 items-center justify-between'>
             <FormLabel className='truncate pr-2'>{t('price.model')}</FormLabel>
             <Button
@@ -467,7 +537,7 @@ const PriceCard = memo(function PriceCard({
             />
           </div>
 
-          <div className='col-span-1 min-w-0 md:col-span-1'>
+          <div className='min-w-0'>
             <ModelPriceEditor
               control={control}
               priceIndex={priceIndex}
@@ -480,7 +550,7 @@ const PriceCard = memo(function PriceCard({
             />
           </div>
 
-          <div className='hidden md:block' />
+          <div />
         </div>
       </CardContent>
     </Card>
@@ -785,8 +855,8 @@ export function ChannelsModelPriceDialog() {
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className='flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden'>
-            <Card className='mb-4 shrink-0'>
-              <CardContent className='pt-4'>
+            <Card className='mb-4 max-h-[15vh] shrink-0 overflow-y-auto md:max-h-none md:overflow-visible'>
+              <CardContent className='pt-0 md:pt-4'>
                 <div className='mb-3 text-xs text-muted-foreground'>
                   {t('price.apply.usdHint')}
                 </div>
@@ -882,7 +952,7 @@ export function ChannelsModelPriceDialog() {
                 </div>
               </CardContent>
             </Card>
-            <ScrollArea className='min-h-0 min-w-0 flex-1 [&>[data-slot=scroll-area-viewport]]:!overflow-x-hidden'>
+            <ScrollArea className='min-h-40 min-w-0 w-full flex-1 md:min-h-0 [&>[data-slot=scroll-area-viewport]]:!overflow-x-hidden'>
               <div className='space-y-4 py-4 pr-4'>
                 {fields.map((field, index) => (
                   <PriceCard

--- a/frontend/src/features/channels/components/channels-override-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-override-dialog.tsx
@@ -389,8 +389,8 @@ export function ChannelsOverrideDialog({ open, onOpenChange, currentRow }: Props
                 <CardDescription>{t('channels.templates.section.description')}</CardDescription>
               </CardHeader>
               <CardContent className='space-y-3'>
-                <div className='flex gap-2'>
-                  <div className='flex-1'>
+                <div className='flex flex-wrap gap-2'>
+                  <div className='min-w-48 flex-1'>
                     <Popover open={templateSearchOpen} onOpenChange={setTemplateSearchOpen}>
                       <PopoverTrigger asChild>
                         <Button

--- a/frontend/src/features/channels/components/channels-primary-buttons.tsx
+++ b/frontend/src/features/channels/components/channels-primary-buttons.tsx
@@ -11,12 +11,12 @@ export function ChannelsPrimaryButtons() {
   const { setOpen } = useChannels();
 
   return (
-    <div className='flex gap-2'>
+    <div className='flex gap-2 overflow-x-auto md:overflow-x-visible'>
       <PermissionGuard requiredScope='read_system'>
         {/* Load Balancing Strategy - navigate to system retry configuration */}
         <Button
           variant='outline'
-          className='space-x-1'
+          className='shrink-0 space-x-1'
           onClick={() => navigate({ to: '/system', search: { tab: 'retry' } })}
         >
           <span>{t('channels.loadBalancingStrategy')}</span> <IconScale size={18} />
@@ -26,22 +26,22 @@ export function ChannelsPrimaryButtons() {
       <PermissionGuard requiredScope='write_channels'>
         <>
           {/* Settings - requires write_channels permission */}
-          <Button variant='outline' className='space-x-1' onClick={() => setOpen('channelSettings')}>
+          <Button variant='outline' className='shrink-0 space-x-1' onClick={() => setOpen('channelSettings')}>
             <span>{t('channels.actions.settings')}</span> <IconSettings size={18} />
           </Button>
 
           {/* Bulk Import - requires write_channels permission */}
-          <Button variant='outline' className='space-x-1' onClick={() => setOpen('bulkImport')}>
+          <Button variant='outline' className='shrink-0 space-x-1' onClick={() => setOpen('bulkImport')}>
             <span>{t('channels.importChannels', '批量导入')}</span> <IconUpload size={18} />
           </Button>
 
           {/* Bulk Ordering - requires write_channels permission */}
-          <Button variant='outline' className='space-x-1' onClick={() => setOpen('bulkOrdering')}>
+          <Button variant='outline' className='shrink-0 space-x-1' onClick={() => setOpen('bulkOrdering')}>
             <span>{t('channels.orderChannels')}</span> <IconArrowsSort size={18} />
           </Button>
 
           {/* Add Channel - requires write_channels permission */}
-          <Button className='space-x-1' onClick={() => setOpen('add')} data-testid='add-channel-button'>
+          <Button className='shrink-0 space-x-1' onClick={() => setOpen('add')} data-testid='add-channel-button'>
             <span>{t('channels.addChannel')}</span> <IconPlus size={18} />
           </Button>
         </>

--- a/frontend/src/features/channels/components/channels-type-tabs.tsx
+++ b/frontend/src/features/channels/components/channels-type-tabs.tsx
@@ -71,7 +71,7 @@ export const ChannelsTypeTabs = memo(function ChannelsTypeTabs({ typeCounts, sel
 
   return (
     <div className='mb-6 w-full'>
-      <div className='hide-scroll flex items-center gap-2 overflow-x-auto overflow-y-hidden scroll-smooth'>
+      <div className='hide-scroll flex flex-wrap items-center gap-2 md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden md:scroll-smooth'>
         {/* All tab */}
         <button
           onClick={() => onTabChange('all')}

--- a/frontend/src/features/channels/components/data-table-toolbar.tsx
+++ b/frontend/src/features/channels/components/data-table-toolbar.tsx
@@ -92,8 +92,8 @@ export function DataTableToolbar<TData>({
   );
 
   return (
-    <div className='flex items-center gap-4'>
-      <div className='relative flex-1'>
+    <div className='flex items-center gap-4 overflow-x-auto pb-2 md:overflow-x-visible md:pb-0'>
+      <div className='relative min-w-48 flex-1'>
         <i className='ph ph-magnifying-glass text-muted-foreground absolute top-2.5 left-3'></i>
         <Input
           placeholder={t('channels.filters.filterByName')}

--- a/frontend/src/features/channels/index.tsx
+++ b/frontend/src/features/channels/index.tsx
@@ -294,8 +294,8 @@ export default function ChannelsManagement() {
   return (
     <ChannelsProvider>
       <Header fixed>
-        <div className='flex flex-1 items-center justify-between'>
-          <div>
+        <div className='flex w-full flex-1 flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-0'>
+          <div className='min-w-0'>
             <h2 className='text-xl font-bold tracking-tight'>{t('channels.title')}</h2>
             <p className='text-sm text-muted-foreground'>{t('channels.description')}</p>
           </div>

--- a/frontend/src/features/models/components/models-action-dialog.tsx
+++ b/frontend/src/features/models/components/models-action-dialog.tsx
@@ -251,9 +251,9 @@ export function ModelsActionDialog() {
 
         <Form {...form}>
           <form id='model-form' onSubmit={form.handleSubmit(onSubmit)} className='flex min-h-0 flex-1 flex-col overflow-hidden'>
-            <div className='flex min-h-0 flex-1 gap-6 overflow-hidden'>
+            <div className='flex min-h-0 flex-1 gap-6 overflow-x-auto overflow-y-hidden md:overflow-hidden'>
               {/* Left Panel - Basic Information */}
-              <div className='min-h-0 w-1/3 flex-shrink-0 overflow-y-auto pr-4'>
+              <div className='min-h-0 w-1/2 md:w-1/3 flex-shrink-0 overflow-y-auto pr-4'>
                 <div className='space-y-4'>
                   <FormField
                     control={form.control}
@@ -409,7 +409,7 @@ export function ModelsActionDialog() {
               </div>
 
               {/* Right Panel - Model Card Fields */}
-              <div className='min-h-0 flex-1 overflow-y-auto border-l pl-6'>
+              <div className='min-h-0 min-w-full md:min-w-0 flex-1 overflow-y-auto border-l pl-6'>
                 <div className='space-y-4 pb-4'>
                   <h3 className='text-lg font-semibold'>{t('models.modelCard.title')}</h3>
 

--- a/frontend/src/features/models/components/models-batch-create-dialog.tsx
+++ b/frontend/src/features/models/components/models-batch-create-dialog.tsx
@@ -322,19 +322,19 @@ export function ModelsBatchCreateDialog() {
           <DialogDescription>{t('models.dialogs.batchCreate.description')}</DialogDescription>
         </DialogHeader>
 
-        <div className='min-h-0 flex-1 overflow-y-auto pr-2'>
-          <div className='space-y-2'>
+        <div className='min-h-0 flex-1 overflow-x-auto overflow-y-auto pr-2 md:overflow-x-hidden'>
+          <div className='min-w-[600px] space-y-2'>
             <div className='flex items-start gap-2 px-2 pb-2'>
-              <div className='flex-[2]'>
+              <div className='min-w-32 flex-[2]'>
                 <Label className='text-sm font-medium'>{t('models.fields.developer')}</Label>
               </div>
-              <div className='flex-[3]'>
+              <div className='min-w-40 flex-[3]'>
                 <Label className='text-sm font-medium'>{t('models.fields.modelId')}</Label>
               </div>
-              <div className='flex-[2]'>
+              <div className='min-w-24 flex-[2]'>
                 <Label className='text-sm font-medium'>{t('models.fields.name')}</Label>
               </div>
-              <div className='flex-[3]'>
+              <div className='min-w-32 flex-[3]'>
                 <Label className='text-sm font-medium'>{t('models.fields.icon')}</Label>
               </div>
               <div className='w-8 flex-shrink-0'></div>
@@ -342,7 +342,7 @@ export function ModelsBatchCreateDialog() {
             {rows.map((row) => (
               <div key={row.id} className='rounded-lg border p-2'>
                 <div className='flex items-start gap-2'>
-                  <div className='flex-[2] space-y-1'>
+                  <div className='min-w-32 flex-[2] space-y-1'>
                     <AutoComplete
                       selectedValue={row.developer}
                       onSelectedValueChange={(value) => {
@@ -361,7 +361,7 @@ export function ModelsBatchCreateDialog() {
                       <p className='text-xs text-red-600'>{t('models.dialogs.batchCreate.required')}</p>
                     )}
                   </div>
-                  <div className='flex-[3] space-y-1'>
+                  <div className='min-w-40 flex-[3] space-y-1'>
                     <AutoComplete
                       selectedValue={row.modelId}
                       onSelectedValueChange={(value) => {
@@ -381,7 +381,7 @@ export function ModelsBatchCreateDialog() {
                       <p className='text-xs text-red-600'>{t('models.dialogs.batchCreate.required')}</p>
                     )}
                   </div>
-                  <div className='flex-[2] space-y-1'>
+                  <div className='min-w-24 flex-[2] space-y-1'>
                     <Input
                       value={row.name}
                       onChange={(e) => {
@@ -392,7 +392,7 @@ export function ModelsBatchCreateDialog() {
                     />
                     {validationErrors[row.id]?.name && <p className='text-xs text-red-600'>{t('models.dialogs.batchCreate.required')}</p>}
                   </div>
-                  <div className='flex-[3] space-y-1'>
+                  <div className='min-w-32 flex-[3] space-y-1'>
                     <AutoCompleteSelect
                       selectedValue={row.icon}
                       onSelectedValueChange={(value) => {

--- a/frontend/src/features/models/index.tsx
+++ b/frontend/src/features/models/index.tsx
@@ -179,7 +179,7 @@ function DetectUnassociatedButton() {
 
 function ActionButtons() {
   return (
-    <div className='flex gap-2'>
+    <div className='flex gap-2 overflow-x-auto md:overflow-x-visible'>
       <PermissionGuard requiredScope='write_channels'>
         <>
           <DetectUnassociatedButton />
@@ -212,8 +212,8 @@ export default function ModelsManagement() {
   return (
     <ModelsProvider>
       <Header fixed>
-        <div className='flex flex-1 items-center justify-between'>
-          <div>
+        <div className='flex w-full flex-1 flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-0'>
+          <div className='min-w-0'>
             <h2 className='text-xl font-bold tracking-tight'>{t('models.title')}</h2>
             <p className='text-muted-foreground text-sm'>{t('models.description')}</p>
           </div>

--- a/frontend/src/features/playground/index.tsx
+++ b/frontend/src/features/playground/index.tsx
@@ -260,16 +260,16 @@ export default function Playground() {
           enabled={true}
         />
       )} */}
-      <div className='bg-background flex h-screen w-full'>
+      <div className='bg-background flex h-screen w-full flex-col md:flex-row'>
         {/* Settings Sidebar */}
 
-        <div className='bg-card shadow-soft border-border m-4 flex w-[340px] max-w-[400px] min-w-[280px] flex-col rounded-2xl border border-r'>
+        <div className='bg-card shadow-soft border-border m-4 flex max-h-[40vh] w-auto flex-col rounded-2xl border border-r md:max-h-none md:w-[340px] md:min-w-[280px] md:max-w-[400px]'>
           <div className='border-b p-4'>
             <h1 className='text-xl font-bold tracking-tight'>{t('playground.title')}</h1>
             <p className='text-muted-foreground mt-1 text-xs leading-relaxed'>{t('playground.description')}</p>
           </div>
 
-          <ScrollArea className='flex-1 p-4'>
+          <ScrollArea className='min-h-0 flex-1 p-4'>
             <div className='space-y-6'>
               <div className='space-y-3'>
                 <Label htmlFor='model' className='text-xs font-semibold'>
@@ -375,7 +375,7 @@ export default function Playground() {
         {/* Chat Area */}
         <div className='flex flex-1 flex-col p-4'>
           <div className='shadow-soft border-border bg-card flex h-full flex-col rounded-2xl border p-6'>
-            <Conversation className='flex-1'>
+            <Conversation className='max-h-[50vh] flex-1 md:max-h-none'>
               <ConversationContent>
                 {messages.length === 0 ? (
                   <ConversationEmptyState

--- a/frontend/src/features/projects/components/projects-table.tsx
+++ b/frontend/src/features/projects/components/projects-table.tsx
@@ -106,7 +106,7 @@ export function ProjectsTable({
   return (
     <div className='flex flex-1 flex-col overflow-hidden' data-testid='projects-table'>
       <DataTableToolbar table={table} />
-      <div className='shadow-soft relative mt-4 flex-1 overflow-auto overflow-x-hidden rounded-2xl border border-[var(--table-border)]'>
+      <div className='shadow-soft relative mt-4 flex-1 overflow-auto md:overflow-x-hidden rounded-2xl border border-[var(--table-border)]'>
         <Table data-testid='projects-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
           <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
             {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
## What
- Fix mobile overflow/stacking issues in Channels/Models dialogs and toolbars.
- Improve small-screen usability for tabs, button groups, and scroll areas.
- Keep desktop behavior intact by scoping layout changes to mobile where needed.

## Why
Several management pages/dialogs were hard to use on small screens due to horizontal overflow and cramped two-column layouts.

## Scope
- Frontend only (`frontend/`).

## Testing
- `pnpm -C frontend build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design across application dialogs and components for improved mobile experience.
  * Adjusted layouts to dynamically adapt between single-column on small viewports and multi-column on larger screens.
  * Improved overflow and scrolling behavior for better usability on constrained devices.
  * Refined spacing and width constraints for consistent alignment across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->