### PR TITLE
fix(anthropic): support image content blocks in tool_result

### DIFF
--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -11,6 +11,42 @@ import (
 	"github.com/looplj/axonhub/llm"
 )
 
+func convertImageSourceToLLMImageURLPart(source *ImageSource, cacheControl *CacheControl) (llm.MessageContentPart, bool) {
+	if source == nil {
+		return llm.MessageContentPart{}, false
+	}
+
+	part := llm.MessageContentPart{
+		Type:         "image_url",
+		CacheControl: convertToLLMCacheControl(cacheControl),
+	}
+
+	if source.Type == "base64" {
+		if source.Data == "" {
+			return llm.MessageContentPart{}, false
+		}
+
+		mediaType := source.MediaType
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+
+		// Convert Anthropic image format to OpenAI format
+		imageURL := fmt.Sprintf("data:%s;base64,%s", mediaType, source.Data)
+		part.ImageURL = &llm.ImageURL{URL: imageURL}
+
+		return part, true
+	}
+
+	if source.URL == "" {
+		return llm.MessageContentPart{}, false
+	}
+
+	part.ImageURL = &llm.ImageURL{URL: source.URL}
+
+	return part, true
+}
+
 // convertToLLMRequest converts Anthropic MessageRequest to ChatCompletionRequest.
 //
 //nolint:maintidx // TODO: fix.
@@ -115,23 +151,7 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 					})
 					hasContent = true
 				case "image":
-					if block.Source != nil {
-						part := llm.MessageContentPart{
-							Type:         "image_url",
-							CacheControl: convertToLLMCacheControl(block.CacheControl),
-						}
-						if block.Source.Type == "base64" {
-							// Convert Anthropic image format to OpenAI format
-							imageURL := fmt.Sprintf("data:%s;base64,%s", block.Source.MediaType, block.Source.Data)
-							part.ImageURL = &llm.ImageURL{
-								URL: imageURL,
-							}
-						} else {
-							part.ImageURL = &llm.ImageURL{
-								URL: block.Source.URL,
-							}
-						}
-
+					if part, ok := convertImageSourceToLLMImageURLPart(block.Source, block.CacheControl); ok {
 						contentParts = append(contentParts, part)
 						hasContent = true
 					}
@@ -164,27 +184,21 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 										CacheControl: convertToLLMCacheControl(contentBlock.CacheControl),
 									})
 								case "image":
-									if contentBlock.Source != nil {
-										part := llm.MessageContentPart{
-											Type:         "image_url",
-											CacheControl: convertToLLMCacheControl(contentBlock.CacheControl),
-										}
-
-										if contentBlock.Source.Type == "base64" {
-											// Convert Anthropic image format to OpenAI format
-											imageURL := fmt.Sprintf("data:%s;base64,%s", contentBlock.Source.MediaType, contentBlock.Source.Data)
-											part.ImageURL = &llm.ImageURL{URL: imageURL}
-										} else {
-											part.ImageURL = &llm.ImageURL{URL: contentBlock.Source.URL}
-										}
-
+									if part, ok := convertImageSourceToLLMImageURLPart(contentBlock.Source, contentBlock.CacheControl); ok {
 										toolContentParts = append(toolContentParts, part)
 									}
 								}
 							}
 
-							toolMsg.Content = llm.MessageContent{
-								MultipleContent: toolContentParts,
+							if len(toolContentParts) > 0 {
+								toolMsg.Content = llm.MessageContent{
+									MultipleContent: toolContentParts,
+								}
+							} else {
+								// Ensure tool message content is not null for downstream conversions.
+								toolMsg.Content = llm.MessageContent{
+									Content: lo.ToPtr(""),
+								}
 							}
 						}
 

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -156,11 +156,30 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 							// Keep as MultipleContent to preserve the original format
 							toolContentParts := make([]llm.MessageContentPart, 0, len(block.Content.MultipleContent))
 							for _, contentBlock := range block.Content.MultipleContent {
-								if contentBlock.Type == "text" {
+								switch contentBlock.Type {
+								case "text":
 									toolContentParts = append(toolContentParts, llm.MessageContentPart{
-										Type: "text",
-										Text: contentBlock.Text,
+										Type:         "text",
+										Text:         contentBlock.Text,
+										CacheControl: convertToLLMCacheControl(contentBlock.CacheControl),
 									})
+								case "image":
+									if contentBlock.Source != nil {
+										part := llm.MessageContentPart{
+											Type:         "image_url",
+											CacheControl: convertToLLMCacheControl(contentBlock.CacheControl),
+										}
+
+										if contentBlock.Source.Type == "base64" {
+											// Convert Anthropic image format to OpenAI format
+											imageURL := fmt.Sprintf("data:%s;base64,%s", contentBlock.Source.MediaType, contentBlock.Source.Data)
+											part.ImageURL = &llm.ImageURL{URL: imageURL}
+										} else {
+											part.ImageURL = &llm.ImageURL{URL: contentBlock.Source.URL}
+										}
+
+										toolContentParts = append(toolContentParts, part)
+									}
 								}
 							}
 


### PR DESCRIPTION
## 背景
Anthropic Messages 请求里的 `tool_result.content` 可能是一个数组，并包含 `type="image"` 的 content block（例如工具返回的图片数据）。

## 问题
当前 Anthropic 入站转换在解析 `tool_result` 时只保留 `text` content block，会忽略 `image` content block，导致 tool message 在统一模型里可能变成空内容。
后续再转换回 Anthropic 请求时，可能生成不合法/不完整的 `tool_result` payload，从而被上游拒绝并返回 HTTP 400。

## 变更
- 在 Anthropic 入站转换中解析并保留 `tool_result.content` 里的：
  - `text` content block
  - `image` content block（base64 转为 data URL，url 直接透传），统一映射为 `image_url`
- 保留 content block 上的 `cache_control`（如有）
- 补充回归测试：覆盖 `tool_result` 携带 base64 `image` content block 的场景

## 测试
- `go test ./...`

## 影响范围
- 仅影响 Anthropic Messages 的入站解析，且只在 `tool_result.content` 出现 `image` content block 时生效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool results now support image content (embedded base64 and URL-based), preserving image sources and cache-control when displayed or relayed.
  * Responses reconstruct image blocks when converting back to the public format to maintain original image data.

* **Bug Fixes**
  * Tool messages with no remaining parts are now returned as well-formed empty content to avoid null content issues.

* **Tests**
  * Added unit test coverage for tool result image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->