### PR TITLE
fix: preserve stream flag for TTFT persistence

### DIFF
--- a/internal/server/orchestrator/performance.go
+++ b/internal/server/orchestrator/performance.go
@@ -54,12 +54,19 @@ func (m *performanceRecording) OnOutboundRawRequest(ctx context.Context, request
 		return request, nil
 	}
 
+	// Preserve Stream flag from existing PerformanceRecord (set in OnInboundLlmRequest)
+	var streamFlag bool
+	if m.outbound.state.Perf != nil {
+		streamFlag = m.outbound.state.Perf.Stream
+	}
+
 	// Create a new PerformanceRecord instance for each request.
 	perf := biz.PerformanceRecord{}
 	perf.StartTime = time.Now()
 	perf.ChannelID = channel.ID
 	perf.Success = false
 	perf.RequestCompleted = false
+	perf.Stream = streamFlag
 
 	// Get the API key used for this request from context (set by TraceStickyKeyProvider)
 	if apiKey, ok := contexts.GetChannelAPIKey(ctx); ok {

--- a/internal/server/orchestrator/performance_test.go
+++ b/internal/server/orchestrator/performance_test.go
@@ -1,0 +1,339 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// mockChannelService is a mock implementation of ChannelService for testing
+type mockChannelService struct{}
+
+func (m *mockChannelService) AsyncRecordPerformance(ctx context.Context, perf *biz.PerformanceRecord) {
+	// No-op for testing
+}
+
+// TestPerformanceRecording_OnInboundLlmRequest_SetsStreamFlag verifies that
+// the Stream flag is correctly set based on the request's Stream field.
+func TestPerformanceRecording_OnInboundLlmRequest_SetsStreamFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		streamValue  *bool
+		expectedFlag bool
+	}{
+		{
+			name:         "streaming request - Stream is true",
+			streamValue:  boolPtr(true),
+			expectedFlag: true,
+		},
+		{
+			name:         "non-streaming request - Stream is false",
+			streamValue:  boolPtr(false),
+			expectedFlag: false,
+		},
+		{
+			name:         "nil stream value defaults to false",
+			streamValue:  nil,
+			expectedFlag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			state := &PersistenceState{
+				Perf: nil,
+			}
+			outbound := &PersistentOutboundTransformer{
+				state: state,
+			}
+			middleware := &performanceRecording{
+				outbound: outbound,
+			}
+
+			request := &llm.Request{
+				Model:  "gpt-4",
+				Stream: tt.streamValue,
+			}
+			ctx := context.Background()
+
+			// Execute
+			result, err := middleware.OnInboundLlmRequest(ctx, request)
+
+			// Assert
+			require.NoError(t, err)
+			assert.Equal(t, request, result)
+			assert.NotNil(t, state.Perf)
+			assert.Equal(t, tt.expectedFlag, state.Perf.Stream)
+		})
+	}
+}
+
+// TestPerformanceRecording_OnOutboundRawRequest_PreservesStreamFlag verifies that
+// the Stream flag set in OnInboundLlmRequest is preserved when OnOutboundRawRequest
+// creates a new PerformanceRecord. This test would FAIL if the bug were reverted.
+func TestPerformanceRecording_OnOutboundRawRequest_PreservesStreamFlag(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialStreamFlag bool
+		expectedStream    bool
+	}{
+		{
+			name:              "streaming request preserves Stream=true",
+			initialStreamFlag: true,
+			expectedStream:    true,
+		},
+		{
+			name:              "non-streaming request preserves Stream=false",
+			initialStreamFlag: false,
+			expectedStream:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			channel := &biz.Channel{
+				Channel: &ent.Channel{
+					ID:   1,
+					Name: "test-channel",
+				},
+				Outbound: &mockTransformer{},
+			}
+
+			// Simulate that OnInboundLlmRequest already set the Stream flag
+			state := &PersistenceState{
+				Perf: &biz.PerformanceRecord{
+					Stream: tt.initialStreamFlag,
+				},
+				CurrentCandidate: &ChannelModelsCandidate{
+					Channel: channel,
+				},
+			}
+			outbound := &PersistentOutboundTransformer{
+				state: state,
+			}
+			middleware := &performanceRecording{
+				outbound: outbound,
+			}
+
+			request := &httpclient.Request{
+				Method: "POST",
+				URL:    "https://api.example.com/v1/chat/completions",
+			}
+			ctx := context.Background()
+
+			// Execute - this is where the bug would cause Stream flag to be lost
+			result, err := middleware.OnOutboundRawRequest(ctx, request)
+
+			// Assert
+			require.NoError(t, err)
+			assert.Equal(t, request, result)
+			assert.NotNil(t, state.Perf)
+
+			// CRITICAL: This assertion verifies the fix. If the bug were reverted
+			// (i.e., creating a new PerformanceRecord without preserving Stream),
+			// this test would FAIL.
+			assert.Equal(t, tt.expectedStream, state.Perf.Stream,
+				"Stream flag should be preserved from OnInboundLlmRequest through OnOutboundRawRequest. "+
+					"If this fails, the bug has been reverted!")
+		})
+	}
+}
+
+// TestPerformanceRecording_FullLifecycle_StreamFlagPreserved tests the complete
+// middleware lifecycle to ensure Stream flag is preserved end-to-end.
+func TestPerformanceRecording_FullLifecycle_StreamFlagPreserved(t *testing.T) {
+	// Setup
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "test-channel",
+		},
+		Outbound: &mockTransformer{},
+	}
+
+	state := &PersistenceState{
+		CurrentCandidate: &ChannelModelsCandidate{
+			Channel: channel,
+		},
+	}
+	outbound := &PersistentOutboundTransformer{
+		state: state,
+	}
+	middleware := &performanceRecording{
+		outbound: outbound,
+	}
+
+	ctx := context.Background()
+	streamValue := true
+
+	// Step 1: Inbound request processing
+	llmRequest := &llm.Request{
+		Model:  "gpt-4",
+		Stream: &streamValue,
+	}
+	_, err := middleware.OnInboundLlmRequest(ctx, llmRequest)
+	require.NoError(t, err)
+	require.NotNil(t, state.Perf)
+	assert.True(t, state.Perf.Stream, "Stream flag should be true after OnInboundLlmRequest")
+
+	// Step 2: Outbound request processing (this is where the bug occurred)
+	httpRequest := &httpclient.Request{
+		Method: "POST",
+		URL:    "https://api.example.com/v1/chat/completions",
+	}
+	_, err = middleware.OnOutboundRawRequest(ctx, httpRequest)
+	require.NoError(t, err)
+	require.NotNil(t, state.Perf)
+
+	// CRITICAL: Stream flag must still be true after OnOutboundRawRequest
+	assert.True(t, state.Perf.Stream,
+		"Stream flag should be preserved through OnOutboundRawRequest. "+
+			"This assertion would FAIL if the bug (8afd95c3) were reverted.")
+}
+
+// TestPerformanceRecording_OnOutboundRawRequest_NoExistingPerf verifies that
+// OnOutboundRawRequest works correctly even if OnInboundLlmRequest wasn't called
+// (edge case where Perf is nil).
+func TestPerformanceRecording_OnOutboundRawRequest_NoExistingPerf(t *testing.T) {
+	// Setup
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "test-channel",
+		},
+		Outbound: &mockTransformer{},
+	}
+
+	state := &PersistenceState{
+		Perf: nil, // No existing PerformanceRecord
+		CurrentCandidate: &ChannelModelsCandidate{
+			Channel: channel,
+		},
+	}
+	outbound := &PersistentOutboundTransformer{
+		state: state,
+	}
+	middleware := &performanceRecording{
+		outbound: outbound,
+	}
+
+	request := &httpclient.Request{
+		Method: "POST",
+		URL:    "https://api.example.com/v1/chat/completions",
+	}
+	ctx := context.Background()
+
+	// Execute
+	result, err := middleware.OnOutboundRawRequest(ctx, request)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, request, result)
+	assert.NotNil(t, state.Perf)
+	assert.False(t, state.Perf.Stream, "Stream should default to false when no existing Perf")
+}
+
+// TestPerformanceRecording_OnOutboundRawRequest_NoChannel verifies that
+// OnOutboundRawRequest returns early when there's no channel.
+func TestPerformanceRecording_OnOutboundRawRequest_NoChannel(t *testing.T) {
+	// Setup
+	state := &PersistenceState{
+		Perf:             &biz.PerformanceRecord{Stream: true},
+		CurrentCandidate: nil, // No channel
+	}
+	outbound := &PersistentOutboundTransformer{
+		state: state,
+	}
+	middleware := &performanceRecording{
+		outbound: outbound,
+	}
+
+	request := &httpclient.Request{
+		Method: "POST",
+		URL:    "https://api.example.com/v1/chat/completions",
+	}
+	ctx := context.Background()
+
+	// Execute
+	result, err := middleware.OnOutboundRawRequest(ctx, request)
+
+	// Assert - should return early without modifying Perf
+	require.NoError(t, err)
+	assert.Equal(t, request, result)
+	// Perf should remain unchanged since we returned early
+	assert.True(t, state.Perf.Stream)
+}
+
+// TestPerformanceRecording_StreamFlagBugRegression is specifically designed to
+// catch the regression if the fix is reverted. It documents the exact bug scenario.
+func TestPerformanceRecording_StreamFlagBugRegression(t *testing.T) {
+	// This test documents the bug introduced in commit 8afd95c3:
+	// "feat: trace stikcy api key for multiple api keys channel"
+	//
+	// The bug: OnOutboundRawRequest() was creating a new PerformanceRecord without
+	// preserving the Stream flag that was set in OnInboundLlmRequest().
+	//
+	// The fix: Preserve the Stream flag before creating the new PerformanceRecord.
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "test-channel",
+		},
+		Outbound: &mockTransformer{},
+	}
+
+	// Simulate the state after OnInboundLlmRequest was called with stream=true
+	state := &PersistenceState{
+		Perf: &biz.PerformanceRecord{
+			Stream: true, // Set by OnInboundLlmRequest
+		},
+		CurrentCandidate: &ChannelModelsCandidate{
+			Channel: channel,
+		},
+	}
+	outbound := &PersistentOutboundTransformer{
+		state: state,
+	}
+	middleware := &performanceRecording{
+		outbound: outbound,
+	}
+
+	ctx := context.Background()
+	request := &httpclient.Request{
+		Method: "POST",
+		URL:    "https://api.example.com/v1/chat/completions",
+	}
+
+	// Execute OnOutboundRawRequest
+	_, err := middleware.OnOutboundRawRequest(ctx, request)
+	require.NoError(t, err)
+
+	// The bug would cause this assertion to fail because:
+	// 1. OnInboundLlmRequest set Perf.Stream = true
+	// 2. OnOutboundRawRequest created a new PerformanceRecord{}
+	// 3. The new PerformanceRecord had Stream = false (zero value)
+	// 4. This overwrote the Perf pointer, losing the Stream flag
+	//
+	// The fix preserves Stream from the old Perf before creating the new one.
+	assert.True(t, state.Perf.Stream,
+		"BUG REGRESSION DETECTED: Stream flag was lost in OnOutboundRawRequest. "+
+			"This indicates the fix from commit 8afd95c3 has been reverted.")
+}
+
+// TestRecordPerformanceStream_MarksFirstToken verifies that recordPerformanceStream
+// correctly marks the first token time.
+
+// Helper function for creating bool pointers
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
## Summary
This PR fixes a bug where TTFT (Time To First Token) latency values were not being persisted and displayed for streaming requests.

### The Problem
In commit 8afd95c3 ("feat: trace sticky api key for multiple api keys channel"), the code was refactored to create a new `PerformanceRecord` instance for each outbound request. While this change was intended to support multiple API keys per channel, it inadvertently broke TTFT tracking.

The issue occurred because:
1. The `Stream` flag was correctly set in `OnInboundLlmRequest()` when processing the initial LLM request
2. However, `OnOutboundRawRequest()` was creating a **brand new** `PerformanceRecord` instance
3. This new instance overwrote the entire struct, including the `Stream` field
4. Without `Stream = true`, the frontend UI gating (`request.stream && metricsFirstTokenLatencyMs`) would fail to display TTFT values

### The Fix
The fix preserves the `Stream` flag from the existing `PerformanceRecord` (if any) before creating the new instance. This ensures that the streaming flag set during inbound request processing is carried through to the performance metrics.

## 问题描述 (Chinese)
此 PR 修复了流式请求的 TTFT（首Token时间）延迟值未被持久化和显示的问题。

### 问题原因
在提交 8afd95c3（"feat: trace sticky api key for multiple api keys channel"）中，代码被重构为为每个出站请求创建新的 `PerformanceRecord` 实例。虽然此更改旨在支持每个渠道的多个 API 密钥，但它无意中破坏了 TTFT 跟踪。

问题发生的原因：
1. `Stream` 标志在处理初始 LLM 请求时在 `OnInboundLlmRequest()` 中被正确设置
2. 但是，`OnOutboundRawRequest()` 正在创建一个**全新的** `PerformanceRecord` 实例
3. 这个新实例覆盖了整个结构，包括 `Stream` 字段
4. 没有 `Stream = true`，前端 UI 条件（`request.stream && metricsFirstTokenLatencyMs`）将无法显示 TTFT 值

### 修复方案
修复方案在创建新实例之前从现有的 `PerformanceRecord`（如果有）中保留 `Stream` 标志。这确保了在入站请求处理期间设置的流式标志被传递到性能指标。

## Root Cause
The root cause is in `internal/server/orchestrator/performance.go`:

**Before (buggy code):**
```go
// Create a new PerformanceRecord instance for each request.
perf := biz.PerformanceRecord{}
perf.StartTime = time.Now()
// ... set other fields
m.outbound.state.Perf = &perf  // This overwrites the Stream flag!
```

**After (fixed code):**
```go
// Preserve Stream flag from existing PerformanceRecord (set in OnInboundLlmRequest)
var streamFlag bool
if m.outbound.state.Perf != nil {
    streamFlag = m.outbound.state.Perf.Stream
}

// Create a new PerformanceRecord instance for each request.
perf := biz.PerformanceRecord{}
perf.StartTime = time.Now()
// ... set other fields
perf.Stream = streamFlag  // Preserve the Stream flag
m.outbound.state.Perf = &perf
```

## Test Coverage
Added comprehensive tests in `internal/server/orchestrator/performance_test.go` to verify:
1. Stream flag is correctly set in `OnInboundLlmRequest()`
2. Stream flag is preserved through `OnOutboundRawRequest()`
3. Non-streaming requests have Stream = false
4. The bug would be caught by the tests if the fix were reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved and propagated the stream preference across request processing so performance tracking consistently respects the original stream setting.

* **Tests**
  * Added comprehensive unit tests validating stream-flag handling across inbound/outbound stages, lifecycle preservation, edge cases, and a regression check to prevent loss of the stream preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
