### PR TITLE
fix(channel): use completion tokens for TPS calculation instead of total tokens

### DIFF
--- a/internal/server/biz/channel_probe_test.go
+++ b/internal/server/biz/channel_probe_test.go
@@ -69,6 +69,7 @@ func TestChannelProbeService_ComputeChannelProbeStats_UsageLogCreatedAfterWindow
 		SetChannelID(ch.ID).
 		SetModelID("gpt-4o-mini").
 		SetTotalTokens(300).
+		SetCompletionTokens(200).
 		SetCreatedAt(startTime.Add(15 * time.Second)).
 		SetUpdatedAt(startTime.Add(15 * time.Second)).
 		Save(ctx)
@@ -105,6 +106,7 @@ func TestChannelProbeService_ComputeChannelProbeStats_UsageLogCreatedAfterWindow
 		SetChannelID(ch.ID).
 		SetModelID("gpt-4o-mini").
 		SetTotalTokens(100).
+		SetCompletionTokens(100).
 		SetCreatedAt(startTime.Add(25 * time.Second)).
 		SetUpdatedAt(startTime.Add(25 * time.Second)).
 		Save(ctx)
@@ -122,7 +124,7 @@ func TestChannelProbeService_ComputeChannelProbeStats_UsageLogCreatedAfterWindow
 	require.Equal(t, 2, stats.total)
 	require.Equal(t, 2, stats.success)
 	require.NotNil(t, stats.avgTokensPerSecond)
-	require.InDelta(t, 133.333333, *stats.avgTokensPerSecond, 0.0001)
+	require.InDelta(t, 100.0, *stats.avgTokensPerSecond, 0.0001)
 	require.NotNil(t, stats.avgTimeToFirstTokenMs)
 	require.InDelta(t, 500.0, *stats.avgTimeToFirstTokenMs, 0.0001)
 }


### PR DESCRIPTION
## Summary
This PR fixes the TPS (Tokens Per Second) calculation in channel probes to use completion tokens instead of total tokens.

### Related
This is a replacement for the previously closed PR #752, which had unrelated commits mixed in. This PR contains only the TPS calculation fix on a clean branch based on the latest unstable.

### Problem
The TPS calculation was using total_tokens (prompt + completion), which caused inflated TPS values when prompts were large. For example:
- completion_tokens: 416
- total_tokens: 65354
- Inflation: ~157x higher than actual generation speed

### Solution
Changed the SQL aggregation from FieldTotalTokens to FieldCompletionTokens in computeAllChannelProbeStats().

### Changes
- internal/server/biz/channel_probe.go: Use completion tokens for TPS calculation
- internal/server/biz/channel_probe_test.go: Updated test data to include completion tokens

### Impact
- More accurate TPS metrics for channel health monitoring
- Better reflection of actual generation performance
- No breaking changes to API or database schema

---

## 问题描述 (Chinese)

### 相关问题
此 PR 替代了之前关闭的 PR #752，后者混入了不相关的提交。此 PR 仅包含 TPS 计算修复，基于最新的 unstable 分支。

### 问题
TPS 计算使用了 total_tokens（提示词 + 完成），当提示词很大时会导致 TPS 值虚高。例如：
- completion_tokens: 416
- total_tokens: 65354
- 虚高倍数：比实际生成速度高约 157 倍

### 解决方案
在 computeAllChannelProbeStats() 中将 SQL 聚合从 FieldTotalTokens 更改为 FieldCompletionTokens。

### 更改
- internal/server/biz/channel_probe.go: 使用完成 tokens 计算 TPS
- internal/server/biz/channel_probe_test.go: 更新测试数据以包含完成 tokens

### 影响
- 更准确的渠道健康监控 TPS 指标
- 更好地反映实际生成性能
- 对 API 或数据库架构无破坏性更改

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel metrics calculation to use completion tokens instead of total tokens when computing average tokens per second.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->