### PR TITLE
fix: respect user timezone in daily overview widget

### DIFF
--- a/frontend/src/features/dashboard/components/daily-requests-stats.tsx
+++ b/frontend/src/features/dashboard/components/daily-requests-stats.tsx
@@ -16,6 +16,7 @@ export function DailyRequestStats() {
   const isLoading = isStatsLoading || isSettingsLoading;
 
   const currencyCode = generalSettings?.currencyCode || 'USD';
+  const timezone = generalSettings?.timezone || 'UTC';
   const locale = i18n.language.startsWith('zh') ? 'zh-CN' : 'en-US';
 
   const formatCurrency = useCallback(
@@ -60,15 +61,21 @@ export function DailyRequestStats() {
 
   // Transform data for the chart
   const chartData =
-    dailyStats?.map((stat) => ({
-      name: new Date(stat.date).toLocaleDateString(i18n.language.startsWith('zh') ? 'zh-CN' : 'en-US', {
-        month: '2-digit',
-        day: '2-digit',
-      }),
-      requests: stat.count,
-      tokens: stat.tokens,
-      cost: stat.cost,
-    })) || [];
+    dailyStats?.map((stat) => {
+      // Parse YYYY-MM-DD as local date to avoid UTC interpretation
+      const [year, month, day] = stat.date.split('-').map(Number);
+      const date = new Date(year, month - 1, day);
+      return {
+        name: date.toLocaleDateString(locale, {
+          month: '2-digit',
+          day: '2-digit',
+          timeZone: timezone,
+        }),
+        requests: stat.count,
+        tokens: stat.tokens,
+        cost: stat.cost,
+      };
+    }) || [];
 
   // Calculate max values for Y-axis domains
   const maxRequests = Math.max(...chartData.map((d) => d.requests), 0);


### PR DESCRIPTION
# Fix Timezone Issue in Daily Overview Widget

## English Description

This PR fixes a timezone issue where the daily overview widget was displaying the wrong date (e.g., Feb 04 instead of Feb 05) when the user's timezone was set to a region behind UTC (e.g., America/Chicago).

### Problem
The backend sends date strings in "YYYY-MM-DD" format representing dates in the user's local timezone. However, `new Date("2024-02-05")` interprets the string as midnight UTC. When `toLocaleDateString()` is called, it converts this UTC time to the user's local timezone, showing the previous day.

### Solution
- Retrieve the user's configured timezone from `generalSettings.timezone`
- Parse "YYYY-MM-DD" strings as local dates using `new Date(year, month - 1, day)` instead of `new Date(dateString)`
- Pass the user's timezone to `toLocaleDateString()` for consistent display

### Changes
- Modified: `frontend/src/features/dashboard/components/daily-requests-stats.tsx`

### Testing
- Verified with timezone set to America/Chicago - displays correct current date
- Build successful with no errors or warnings

---

## 中文描述

此 PR 修复了每日概览小部件的时区问题，当用户的时区设置为 UTC 之后的区域（例如 America/Chicago）时，会显示错误的日期（例如显示 2 月 4 日而不是 2 月 5 日）。

### 问题
后端以 "YYYY-MM-DD" 格式发送日期字符串，代表用户本地时区的日期。但是 `new Date("2024-02-05")` 会将该字符串解释为午夜 UTC。当调用 `toLocaleDateString()` 时，它将 UTC 时间转换为用户的本地时区，从而显示前一天。

### 解决方案
- 从 `generalSettings.timezone` 获取用户配置的时区
- 使用 `new Date(year, month - 1, day)` 将 "YYYY-MM-DD" 字符串解析为本地日期，而不是 `new Date(dateString)`
- 将用户的时区传递给 `toLocaleDateString()` 以保持一致的显示

### 更改内容
- 修改文件：`frontend/src/features/dashboard/components/daily-requests-stats.tsx`

### 测试
- 在时区设置为 America/Chicago 的情况下验证正确显示当前日期
- 构建成功，无错误或警告

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date display in daily request statistics so charts respect the configured timezone, ensuring displayed dates match user settings.
  * Improved locale-aware date formatting for chart labels to present dates consistently across timezones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->