### PR TITLE
fix: requests page filtering not working with auto refresh enabled

### DIFF
--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -118,24 +118,16 @@ export function RequestsTable({
     const apiKeyFilterValue = newFilters.find((filter: any) => filter.id === 'apiKey')?.value;
 
     const statusFilterArray = Array.isArray(statusFilterValue) ? statusFilterValue : [];
-    if (JSON.stringify(statusFilterArray.sort()) !== JSON.stringify(statusFilter.sort())) {
-      onStatusFilterChange(statusFilterArray);
-    }
+    onStatusFilterChange(statusFilterArray);
 
     const sourceFilterArray = Array.isArray(sourceFilterValue) ? sourceFilterValue : [];
-    if (JSON.stringify(sourceFilterArray.sort()) !== JSON.stringify(sourceFilter.sort())) {
-      onSourceFilterChange(sourceFilterArray);
-    }
+    onSourceFilterChange(sourceFilterArray);
 
     const channelFilterArray = Array.isArray(channelFilterValue) ? channelFilterValue : [];
-    if (JSON.stringify(channelFilterArray.sort()) !== JSON.stringify(channelFilter.sort())) {
-      onChannelFilterChange(channelFilterArray);
-    }
+    onChannelFilterChange(channelFilterArray);
 
     const apiKeyFilterArray = Array.isArray(apiKeyFilterValue) ? apiKeyFilterValue : [];
-    if (JSON.stringify(apiKeyFilterArray.sort()) !== JSON.stringify(apiKeyFilter.sort())) {
-      onApiKeyFilterChange(apiKeyFilterArray);
-    }
+    onApiKeyFilterChange(apiKeyFilterArray);
   };
 
   // Initialize filters in column filters if they exist

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -84,8 +84,7 @@ function RequestsContent() {
       setStatusFilter(filters);
       resetCursor();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [resetCursor]
   );
 
   const handleSourceFilterChange = useCallback(
@@ -93,8 +92,7 @@ function RequestsContent() {
       setSourceFilter(filters);
       resetCursor();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [resetCursor]
   );
 
   const handleChannelFilterChange = useCallback(
@@ -102,8 +100,7 @@ function RequestsContent() {
       setChannelFilter(filters);
       resetCursor();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [resetCursor]
   );
 
   const handleApiKeyFilterChange = useCallback(
@@ -111,8 +108,7 @@ function RequestsContent() {
       setApiKeyFilter(filters);
       resetCursor();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [resetCursor]
   );
 
   const handleDateRangeChange = useCallback(
@@ -120,8 +116,7 @@ function RequestsContent() {
       setDateRange(range);
       resetCursor();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [resetCursor]
   );
 
   return (

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -26,7 +26,18 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
       const currentIds = new Set(currentDisplayed.map((r) => r.id));
       const newDataMap = new Map(data.map((r) => [r.id, r]));
 
-      const hasRemovedItems = currentDisplayed.some((item) => !newDataMap.has(item.id));
+      // Compute the minimum timestamp from incoming data to establish the time window
+      const minTimestampOfNewData =
+        data.length > 0 ? Math.min(...data.map((item) => getTimestamp(item.createdAt))) : 0;
+
+      // Only flag removals when the removed item is still within the new data's time window
+      // Items pushed off by pagination (older than minTimestampOfNewData) should not trigger a reset
+      const hasRemovedItems = currentDisplayed.some((item) => {
+        const isMissingFromNewData = !newDataMap.has(item.id);
+        const itemTimestamp = getTimestamp(item.createdAt);
+        return isMissingFromNewData && itemTimestamp >= minTimestampOfNewData;
+      });
+
       const shouldResetToNewData = hasRemovedItems || data.length !== prevDataLengthRef.current;
 
       if (shouldResetToNewData) {

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -8,6 +8,7 @@ const ANIMATION_INTERVAL = !isNaN(parsedInterval) && parsedInterval > 0 ? parsed
 export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean) {
   const [displayedData, setDisplayedData] = useState<T[]>(data);
   const queueRef = useRef<T[]>([]);
+  const prevDataLengthRef = useRef<number>(data.length);
 
   const getTimestamp = (date: Date | string): number => {
     return date instanceof Date ? date.getTime() : new Date(date).getTime();
@@ -17,12 +18,22 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
     if (!autoRefresh) {
       setDisplayedData(data);
       queueRef.current = [];
+      prevDataLengthRef.current = data.length;
       return;
     }
 
     setDisplayedData((currentDisplayed) => {
       const currentIds = new Set(currentDisplayed.map((r) => r.id));
       const newDataMap = new Map(data.map((r) => [r.id, r]));
+
+      const hasRemovedItems = currentDisplayed.some((item) => !newDataMap.has(item.id));
+      const shouldResetToNewData = hasRemovedItems || data.length !== prevDataLengthRef.current;
+
+      if (shouldResetToNewData) {
+        prevDataLengthRef.current = data.length;
+        queueRef.current = [];
+        return data;
+      }
 
       const updatedDisplayed = currentDisplayed.map((item) => {
         const newItem = newDataMap.get(item.id);
@@ -45,6 +56,7 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
         }
       });
 
+      prevDataLengthRef.current = data.length;
       return updatedDisplayed;
     });
   }, [data, autoRefresh]);


### PR DESCRIPTION
## Summary

Fixed a bug where filtering on the requests page (by API key, channel) did not apply the filter when auto refresh was enabled.

## Changes

### 1. `frontend/src/features/requests/components/requests-table.tsx`
- Removed JSON comparison checks that prevented filter updates from propagating
- Filter changes are now always propagated to the parent component

### 2. `frontend/src/features/requests/index.tsx`
- Fixed callback dependencies from empty arrays to `[resetCursor]`
- Ensures proper behavior with auto-refresh

### 3. `frontend/src/hooks/useAnimatedList.ts`
- Added logic to detect when data size changes (filters applied) vs when new items should be animated in
- When filters are applied, the list immediately shows filtered items without animation
- Auto-refresh continues to animate new items correctly
- **Fixed:** Pagination-evicted items no longer trigger unnecessary resets; only true removals reset the list
  - Computes minimum timestamp from incoming data to establish the valid time window
  - Only flags items as removed when they're missing from new data AND their timestamp is within the time window
  - Items naturally pushed off by pagination (older than minTimestampOfNewData) are ignored

## Testing

- Applied filter while auto-refresh is ON → List shows filtered items immediately
- Applied filter while auto-refresh is OFF → List shows filtered items correctly
- Auto-refresh adds new items → Items animate in correctly
- Pagination with auto-refresh → Items pushed off the tail do not trigger a reset; insert animations continue

---

## 摘要

修复了在请求页面（通过 API 密钥、频道进行筛选）时，自动刷新启用的情况下筛选器不生效的 bug。

## 更改

### 1. `frontend/src/features/requests/components/requests-table.tsx`
- 移除了阻止筛选器更新的 JSON 比较检查
- 筛选器更改现在始终传播到父组件

### 2. `frontend/src/features/requests/index.tsx`
- 将回调依赖从空数组修复为 `[resetCursor]`
- 确保自动刷新的正确行为

### 3. `frontend/src/hooks/useAnimatedList.ts`
- 添加了逻辑来检测数据大小变化（筛选应用）与应添加新项目动画的时机
- 当应用筛选器时，列表立即显示筛选后的项目而无需动画
- 自动刷新继续正确地动画新项目
- **修复：** 分页排除的项目不再触发不必要的重置；只有真正的删除才会重置列表
  - 计算传入数据的最小时间戳以建立有效时间窗口
  - 仅当项目从新数据中缺失且其时间戳在时间窗口内时，才将其标记为已删除
  - 由分页自然推挤出尾部（早于 minTimestampOfNewData）的项目被忽略

## 测试

- 在自动刷新开启时应用筛选器 → 列表立即显示筛选后的项目
- 在自动刷新关闭时应用筛选器 → 列表正确显示筛选后的项目
- 自动刷新添加新项目 → 项目正确动画进入
- 带自动刷新的分页 → 从尾部推挤出的项目不会触发重置；插入动画继续

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filters now update and apply reliably on every change to avoid stale filter states.
  * Animated lists handle added/removed items more robustly, resetting or preserving display as needed for smoother transitions.

* **Refactor**
  * Improved internal filter handler synchronization and list update tracking to enhance responsiveness and reduce unexpected UI resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->