### PR TITLE
feat: hide archived items in requests filters by default

### DIFF
--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -18,6 +18,7 @@ interface DataTableFacetedFilterProps<TData, TValue> {
     icon?: React.ComponentType<{ className?: string }>;
   }[];
   singleSelect?: boolean;
+  footer?: React.ReactNode;
 }
 
 export function DataTableFacetedFilter<TData, TValue>({
@@ -25,6 +26,7 @@ export function DataTableFacetedFilter<TData, TValue>({
   title,
   options = [],
   singleSelect = false,
+  footer,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
 
@@ -107,6 +109,12 @@ export function DataTableFacetedFilter<TData, TValue>({
                 );
               })}
             </CommandGroup>
+            {footer && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>{footer}</CommandGroup>
+              </>
+            )}
             {selectedValues.size > 0 && (
               <>
                 <CommandSeparator />

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -47,6 +47,42 @@ export function DataTableToolbar<TData>({
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
 
+  // Handler to toggle show archived API keys and prune hidden IDs from filters
+  const handleToggleShowArchivedApiKeys = (checked: boolean) => {
+    setShowArchivedApiKeys(checked === true);
+
+    if (checked === false) {
+      // When turning off show archived, prune any archived IDs from the filter
+      const currentFilter = table.getColumn('apiKey')?.getFilterValue() as string[] | undefined;
+      if (currentFilter && currentFilter.length > 0) {
+        // Keep only IDs that are still in the current options (non-archived)
+        const visibleIds = new Set(apiKeyOptions.map((opt) => opt.value));
+        const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
+        table
+          .getColumn('apiKey')
+          ?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
+      }
+    }
+  };
+
+  // Handler to toggle show archived channels and prune hidden IDs from filters
+  const handleToggleShowArchivedChannels = (checked: boolean) => {
+    setShowArchivedChannels(checked === true);
+
+    if (checked === false) {
+      // When turning off show archived, prune any archived IDs from the filter
+      const currentFilter = table.getColumn('channel')?.getFilterValue() as string[] | undefined;
+      if (currentFilter && currentFilter.length > 0) {
+        // Keep only IDs that are still in the current options (non-archived)
+        const visibleIds = new Set(channelOptions.map((opt) => opt.value));
+        const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
+        table
+          .getColumn('channel')
+          ?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
+      }
+    }
+  };
+
   const { user: authUser } = useAuthStore((state) => state.auth);
   const { data: meData } = useMe();
   const user = meData || authUser;
@@ -175,7 +211,7 @@ export function DataTableToolbar<TData>({
                 <Checkbox
                   id='show-archived-channels'
                   checked={showArchivedChannels}
-                  onCheckedChange={(checked) => setShowArchivedChannels(checked === true)}
+                  onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                 />
@@ -200,7 +236,7 @@ export function DataTableToolbar<TData>({
                 <Checkbox
                   id='show-archived-api-keys'
                   checked={showArchivedApiKeys}
-                  onCheckedChange={(checked) => setShowArchivedApiKeys(checked === true)}
+                  onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                 />

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -56,39 +56,39 @@ export function DataTableToolbar<TData>({
   const canViewChannels = isOwner || userScopes.includes('*') || userScopes.includes('read_channels');
   const canViewApiKeys = isOwner || userScopes.includes('*') || userScopes.includes('read_api_keys');
 
-  const { data: channelsData } = useQueryChannels(
-    {
-      first: 100,
-      orderBy: { field: 'CREATED_AT', direction: 'DESC' },
-      where: showArchivedChannels
-        ? {
-            statusIn: ['enabled', 'disabled', 'archived'],
-          }
-        : {
-            statusIn: ['enabled', 'disabled'],
-          },
-    },
-    {
-      disableAutoFetch: !canViewChannels,
-    }
-  );
+   const { data: channelsData, isFetching: isFetchingChannels } = useQueryChannels(
+     {
+       first: 100,
+       orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+       where: showArchivedChannels
+         ? {
+             statusIn: ['enabled', 'disabled', 'archived'],
+           }
+         : {
+             statusIn: ['enabled', 'disabled'],
+           },
+     },
+     {
+       disableAutoFetch: !canViewChannels,
+     }
+   );
 
-  const { data: apiKeysData } = useApiKeys(
-    {
-      first: 100,
-      orderBy: { field: 'CREATED_AT', direction: 'DESC' },
-      where: showArchivedApiKeys
-        ? {
-            statusIn: ['enabled', 'disabled', 'archived'],
-          }
-        : {
-            statusIn: ['enabled', 'disabled'],
-          },
-    },
-    {
-      disableAutoFetch: !canViewApiKeys,
-    }
-  );
+   const { data: apiKeysData, isFetching: isFetchingApiKeys } = useApiKeys(
+     {
+       first: 100,
+       orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+       where: showArchivedApiKeys
+         ? {
+             statusIn: ['enabled', 'disabled', 'archived'],
+           }
+         : {
+             statusIn: ['enabled', 'disabled'],
+           },
+     },
+     {
+       disableAutoFetch: !canViewApiKeys,
+     }
+   );
 
   const channelOptions = useMemo(() => {
     if (!canViewChannels || !channelsData?.edges) return [];
@@ -161,7 +161,7 @@ export function DataTableToolbar<TData>({
             options={requestSources}
           />
         )} */}
-        {canViewChannels && table.getColumn('channel') && channelOptions.length > 0 && (
+         {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
           <DataTableFacetedFilter
             column={table.getColumn('channel')}
             title={t('requests.filters.channel')}
@@ -186,7 +186,7 @@ export function DataTableToolbar<TData>({
             }
           />
         )}
-        {canViewApiKeys && table.getColumn('apiKey') && apiKeyOptions.length > 0 && (
+         {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
           <DataTableFacetedFilter
             column={table.getColumn('apiKey')}
             title={t('requests.filters.apiKey')}

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
 import { RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
@@ -41,6 +42,8 @@ export function DataTableToolbar<TData>({
   onAutoRefreshChange,
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
+  const [showArchivedApiKeys, setShowArchivedApiKeys] = useState(false);
+  const [showArchivedChannels, setShowArchivedChannels] = useState(false);
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
 
@@ -57,6 +60,13 @@ export function DataTableToolbar<TData>({
     {
       first: 100,
       orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+      where: showArchivedChannels
+        ? {
+            statusIn: ['enabled', 'disabled', 'archived'],
+          }
+        : {
+            statusIn: ['enabled', 'disabled'],
+          },
     },
     {
       disableAutoFetch: !canViewChannels,
@@ -67,6 +77,13 @@ export function DataTableToolbar<TData>({
     {
       first: 100,
       orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+      where: showArchivedApiKeys
+        ? {
+            statusIn: ['enabled', 'disabled', 'archived'],
+          }
+        : {
+            statusIn: ['enabled', 'disabled'],
+          },
     },
     {
       disableAutoFetch: !canViewApiKeys,
@@ -145,10 +162,54 @@ export function DataTableToolbar<TData>({
           />
         )} */}
         {canViewChannels && table.getColumn('channel') && channelOptions.length > 0 && (
-          <DataTableFacetedFilter column={table.getColumn('channel')} title={t('requests.filters.channel')} options={channelOptions} />
+          <DataTableFacetedFilter
+            column={table.getColumn('channel')}
+            title={t('requests.filters.channel')}
+            options={channelOptions}
+            footer={
+              <div
+                className='flex items-center space-x-2 px-2 py-1.5'
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  id='show-archived-channels'
+                  checked={showArchivedChannels}
+                  onCheckedChange={(checked) => setShowArchivedChannels(checked === true)}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                />
+                <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                  {t('common.showArchived')}
+                </label>
+              </div>
+            }
+          />
         )}
         {canViewApiKeys && table.getColumn('apiKey') && apiKeyOptions.length > 0 && (
-          <DataTableFacetedFilter column={table.getColumn('apiKey')} title={t('requests.filters.apiKey')} options={apiKeyOptions} />
+          <DataTableFacetedFilter
+            column={table.getColumn('apiKey')}
+            title={t('requests.filters.apiKey')}
+            options={apiKeyOptions}
+            footer={
+              <div
+                className='flex items-center space-x-2 px-2 py-1.5'
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  id='show-archived-api-keys'
+                  checked={showArchivedApiKeys}
+                  onCheckedChange={(checked) => setShowArchivedApiKeys(checked === true)}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                />
+                <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                  {t('common.showArchived')}
+                </label>
+              </div>
+            }
+          />
         )}
         <DateRangePicker value={dateRange} onChange={onDateRangeChange} />
         {hasDateRange && (

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -55,8 +55,12 @@ export function DataTableToolbar<TData>({
       // When turning off show archived, prune any archived IDs from the filter
       const currentFilter = table.getColumn('apiKey')?.getFilterValue() as string[] | undefined;
       if (currentFilter && currentFilter.length > 0) {
-        // Keep only IDs that are still in the current options (non-archived)
-        const visibleIds = new Set(apiKeyOptions.map((opt) => opt.value));
+        // Compute visible IDs from raw data (filtering for non-archived status)
+        const visibleIds = new Set(
+          apiKeysData?.edges
+            ?.filter((edge) => edge.node.status !== 'archived')
+            ?.map((edge) => edge.node.id) ?? []
+        );
         const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
         table
           .getColumn('apiKey')
@@ -73,8 +77,12 @@ export function DataTableToolbar<TData>({
       // When turning off show archived, prune any archived IDs from the filter
       const currentFilter = table.getColumn('channel')?.getFilterValue() as string[] | undefined;
       if (currentFilter && currentFilter.length > 0) {
-        // Keep only IDs that are still in the current options (non-archived)
-        const visibleIds = new Set(channelOptions.map((opt) => opt.value));
+        // Compute visible IDs from raw data (filtering for non-archived status)
+        const visibleIds = new Set(
+          channelsData?.edges
+            ?.filter((edge) => edge.node.status !== 'archived')
+            ?.map((edge) => edge.node.id) ?? []
+        );
         const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
         table
           .getColumn('channel')

--- a/frontend/src/locales/en/base.json
+++ b/frontend/src/locales/en/base.json
@@ -70,6 +70,7 @@
   "common.close": "Close",
   "common.refresh": "Refresh",
   "common.autoRefresh": "Auto Refresh",
+  "common.showArchived": "Show archived",
   "common.selected": "selected",
   "common.selectedItems": "{{count}} selected",
   "common.noResultsFound": "No results found",

--- a/frontend/src/locales/zh-CN/base.json
+++ b/frontend/src/locales/zh-CN/base.json
@@ -115,6 +115,7 @@
   "common.close": "关闭",
   "common.refresh": "刷新",
   "common.autoRefresh": "自动刷新",
+  "common.showArchived": "显示已归档",
   "common.selected": "已选择",
   "common.selectedItems": "已选择 {{count}} 项",
   "common.noResultsFound": "未找到结果",


### PR DESCRIPTION
## Summary
This PR adds an option to hide archived API keys and channels in the requests page filter dropdowns, keeping them consistent with the management pages.

![Screenshot from 2026-02-06 13-18-34](https://github.com/user-attachments/assets/e33d33ec-5790-46b8-ac42-945060e6b1d8)
![Screenshot from 2026-02-06 13-18-44](https://github.com/user-attachments/assets/a7742641-682c-4a29-aee6-00e09afff3e4)

## Background
Previously, the requests page filter dropdowns showed all items including archived ones, while the management pages (api-keys, channels) only showed enabled/disabled items. This inconsistency could be confusing.

## Changes
- **Default behavior**: Filter dropdowns now hide archived items by default, matching the management pages
- **Show archived toggle**: Added a \"Show archived\" checkbox in the footer of both filter dropdowns
- **Opt-in**: Users can explicitly choose to view archived items when needed
- **Filter pruning**: When turning off \"Show archived\", any selected archived IDs are automatically pruned from the active filters to prevent phantom invisible selections
- **Translations**: Added EN and ZH translations for the toggle label

## Behavior
| Page | Before | After |
|------|--------|-------|
| Requests filters | Show all (enabled + disabled + archived) | Show enabled + disabled only (archived hidden by default) |
| Management pages | Show enabled + disabled | Show enabled + disabled (unchanged) |

## Technical Details
- Modified `DataTableFacetedFilter` to accept optional footer content
- Added state management for show/hide archived toggles
- Conditional query filtering based on toggle state
- Added handlers (`handleToggleShowArchivedApiKeys`, `handleToggleShowArchivedChannels`) that prune hidden IDs from column filters when toggling off

## Code Review Feedback Applied
- Fixed stale data issue: pruning logic now computes visible IDs directly from raw GraphQL data (`apiKeysData`/`channelsData`) instead of memoized options to ensure accurate filtering when toggling off
- Added `isFetching` check to render conditions to prevent popover from closing during refetch operations

---

## 摘要
此 PR 在请求页面过滤器下拉菜单中添加了隐藏已归档 API 密钥和渠道的选项，使其与管理页面保持一致。

## 背景
之前，请求页面过滤器下拉菜单显示所有项目（包括已归档的），而管理页面（api-keys、渠道）只显示启用/禁用的项目。这种不一致可能会造成困扰。

## 更改
- **默认行为**：过滤器下拉菜单现在默认隐藏已归档项目，与管理页面保持一致
- **显示已归档切换**：在两个过滤器下拉菜单的页脚中添加了\"显示已归档\"复选框
- **用户选择**：用户可以根据需要明确选择查看已归档项目
- **过滤器修剪**：关闭\"显示已归档\"时，自动从活动过滤器中修剪任何已选中的已归档 ID，防止出现幻影不可见选择
- **翻译**：为切换标签添加了英文和中文翻译

## 行为
| 页面 | 之前 | 之后 |
|------|------|------|
| 请求过滤器 | 显示全部（启用 + 禁用 + 已归档） | 仅显示启用 + 禁用（默认隐藏已归档） |
| 管理页面 | 显示启用 + 禁用 | 显示启用 + 禁用（未更改） |

## 技术细节
- 修改 `DataTableFacetedFilter` 以接受可选的页脚内容
- 为显示/隐藏已归档切换添加状态管理
- 根据切换状态进行条件查询过滤
- 添加处理程序（`handleToggleShowArchivedApiKeys`、`handleToggleShowArchivedChannels`），在关闭切换时从列过滤器中修剪隐藏的 ID

## 代码审查反馈已应用
- 修复了数据过期问题：修剪逻辑现在直接从原始 GraphQL 数据（`apiKeysData`/`channelsData`）计算可见 ID，而不是使用记忆化的选项，以确保在关闭切换时准确过滤
- 在渲染条件中添加了 `isFetching` 检查，以防止在重新获取操作期间关闭弹出窗口