### PR TITLE
feat: auto optimize anthropic cache control

### DIFF
--- a/llm/simulator/simulator_test.go
+++ b/llm/simulator/simulator_test.go
@@ -120,13 +120,17 @@ func TestSimulator_OpenAIToAnthropic_ContentTextSemantic(t *testing.T) {
 	err = json.Unmarshal(finalBodyBytes, &anthropicReqBody)
 	require.NoError(t, err)
 
-	messages := anthropicReqBody["messages"].([]any)
+	messages, ok := anthropicReqBody["messages"].([]any)
+	require.True(t, ok, "anthropic messages 应为数组")
 	require.Len(t, messages, 1)
-	msg := messages[0].(map[string]any)
+	msg, ok := messages[0].(map[string]any)
+	require.True(t, ok, "anthropic message 元素应为对象")
 
-	content := msg["content"].([]any)
+	content, ok := msg["content"].([]any)
+	require.True(t, ok, "anthropic content 应为数组")
 	require.NotEmpty(t, content)
-	block := content[0].(map[string]any)
+	block, ok := content[0].(map[string]any)
+	require.True(t, ok, "anthropic content block 应为对象")
 	assert.Equal(t, "Hello, how are you?", block["text"])
 }
 

--- a/llm/simulator/simulator_test.go
+++ b/llm/simulator/simulator_test.go
@@ -72,7 +72,62 @@ func TestSimulator_OpenAIToAnthropic(t *testing.T) {
 	assert.Len(t, messages, 1)
 	msg := messages[0].(map[string]any)
 	assert.Equal(t, "user", msg["role"])
-	assert.Equal(t, "Hello, how are you?", msg["content"])
+
+	content, ok := msg["content"].([]any)
+	require.True(t, ok, "anthropic outbound content 应为 content block 数组")
+	require.NotEmpty(t, content)
+
+	block, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "text", block["type"])
+	assert.Equal(t, "Hello, how are you?", block["text"])
+}
+
+func TestSimulator_OpenAIToAnthropic_ContentTextSemantic(t *testing.T) {
+	// 1. Setup Transformers
+	inbound := openai.NewInboundTransformer()
+	outbound, err := anthropic.NewOutboundTransformer("https://api.anthropic.com/v1", "sk-ant-test")
+	require.NoError(t, err)
+
+	// 2. Create Simulator
+	sim := NewSimulator(inbound, outbound)
+
+	// 3. Create a raw OpenAI request (what the client sends)
+	openAIReqBody := map[string]any{
+		"model": "gpt-4",
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "Hello, how are you?",
+			},
+		},
+	}
+	bodyBytes, _ := json.Marshal(openAIReqBody)
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:8090/v1/chat/completions", bytes.NewReader(bodyBytes))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	// 4. Run Simulation
+	ctx := context.Background()
+	finalReq, err := sim.Simulate(ctx, req)
+	require.NoError(t, err)
+
+	// 5. Verify semantic text remains unchanged
+	finalBodyBytes, err := io.ReadAll(finalReq.Body)
+	require.NoError(t, err)
+
+	var anthropicReqBody map[string]any
+	err = json.Unmarshal(finalBodyBytes, &anthropicReqBody)
+	require.NoError(t, err)
+
+	messages := anthropicReqBody["messages"].([]any)
+	require.Len(t, messages, 1)
+	msg := messages[0].(map[string]any)
+
+	content := msg["content"].([]any)
+	require.NotEmpty(t, content)
+	block := content[0].(map[string]any)
+	assert.Equal(t, "Hello, how are you?", block["text"])
 }
 
 func TestSimulator_GeminiToOpenAI(t *testing.T) {

--- a/llm/transformer/anthropic/cache_control_test.go
+++ b/llm/transformer/anthropic/cache_control_test.go
@@ -397,10 +397,8 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.NotNil(t, anthropicReq.System)
 		require.Len(t, anthropicReq.System.MultiplePrompts, 2)
 
-		// Check first system prompt has cache control
-		require.NotNil(t, anthropicReq.System.MultiplePrompts[0].CacheControl)
-		require.Equal(t, "ephemeral", anthropicReq.System.MultiplePrompts[0].CacheControl.Type)
-		require.Equal(t, "5m", anthropicReq.System.MultiplePrompts[0].CacheControl.TTL)
+		// strict mode 下仅保留 system 最后一个结构锚点
+		require.Nil(t, anthropicReq.System.MultiplePrompts[0].CacheControl)
 
 		// Check second system prompt has cache control
 		require.NotNil(t, anthropicReq.System.MultiplePrompts[1].CacheControl)
@@ -486,7 +484,7 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.Len(t, anthropicReq.Tools, 1)
 		require.NotNil(t, anthropicReq.Tools[0].CacheControl)
 		require.Equal(t, "ephemeral", anthropicReq.Tools[0].CacheControl.Type)
-		require.Equal(t, "1h", anthropicReq.Tools[0].CacheControl.TTL)
+		require.Empty(t, anthropicReq.Tools[0].CacheControl.TTL)
 	})
 
 	t.Run("tool result with cache control", func(t *testing.T) {
@@ -566,6 +564,6 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.Equal(t, "image", block.Type)
 		require.NotNil(t, block.CacheControl)
 		require.Equal(t, "ephemeral", block.CacheControl.Type)
-		require.Equal(t, "5m", block.CacheControl.TTL)
+		require.Empty(t, block.CacheControl.TTL)
 	})
 }

--- a/llm/transformer/anthropic/claudecode/utils.go
+++ b/llm/transformer/anthropic/claudecode/utils.go
@@ -194,15 +194,13 @@ func mergeBetasIntoHeader(baseBetas string, extraBetas []string) string {
 	return strings.Join(parts, ",")
 }
 
-// injectClaudeCodeSystemMessageStructured prepends the Claude Code system message with cache_control.
+// injectClaudeCodeSystemMessageStructured prepends the Claude Code system message.
+// 注意：不在此处设置 cache_control，缓存策略由 ensureCacheControl 统一管理。
 func injectClaudeCodeSystemMessageStructured(llmReq *llm.Request) *llm.Request {
 	claudeCodeMsg := llm.Message{
 		Role: "system",
 		Content: llm.MessageContent{
 			Content: func() *string { s := claudeCodeSystemMessage; return &s }(),
-		},
-		CacheControl: &llm.CacheControl{
-			Type: "ephemeral",
 		},
 	}
 

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -1,0 +1,283 @@
+package anthropic
+
+// maxCacheControlBreakpoints is the maximum number of cache_control breakpoints allowed by Anthropic.
+// See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.
+const maxCacheControlBreakpoints = 4
+const adaptiveCacheControlBlockWindow = 20
+
+// ensureCacheControl 统一自动修复 cache_control：
+//   - count == 0: 自动注入推荐断点
+//   - count > 4: 仅保留最近 4 个断点（从后往前）
+//   - 长内容按 block 密度补充断点（仍受 4 个上限约束）
+func ensureCacheControl(req *MessageRequest) {
+	if countCacheControls(req) == 0 {
+		injectOptimalCacheControls(req)
+	}
+
+	trimCacheControlsToLastN(req, maxCacheControlBreakpoints)
+	injectAdaptiveCacheControls(req)
+	trimCacheControlsToLastN(req, maxCacheControlBreakpoints)
+}
+
+func injectAdaptiveCacheControls(req *MessageRequest) {
+	target := desiredCacheControlBreakpoints(req)
+	current := countCacheControls(req)
+	if current >= target || current >= maxCacheControlBreakpoints {
+		return
+	}
+
+	need := min(target-current, maxCacheControlBreakpoints-current)
+	if need <= 0 {
+		return
+	}
+
+	candidates := collectMessageBlockRefs(req)
+	if len(candidates) == 0 {
+		return
+	}
+
+	for boundary := len(candidates) - 1; boundary >= 0 && need > 0; boundary -= adaptiveCacheControlBlockWindow {
+		lower := max(boundary-adaptiveCacheControlBlockWindow+1, 0)
+		for i := boundary; i >= lower; i-- {
+			if *candidates[i] == nil {
+				*candidates[i] = &CacheControl{Type: "ephemeral"}
+				need--
+				break
+			}
+		}
+	}
+}
+
+func desiredCacheControlBreakpoints(req *MessageRequest) int {
+	totalBlocks := countCacheableBlocks(req)
+	if totalBlocks <= adaptiveCacheControlBlockWindow {
+		return 0
+	}
+
+	target := (totalBlocks + adaptiveCacheControlBlockWindow - 1) / adaptiveCacheControlBlockWindow
+	if target > maxCacheControlBreakpoints {
+		target = maxCacheControlBreakpoints
+	}
+	return target
+}
+
+func countCacheableBlocks(req *MessageRequest) int {
+	total := len(req.Tools)
+
+	if req.System != nil {
+		switch {
+		case len(req.System.MultiplePrompts) > 0:
+			total += len(req.System.MultiplePrompts)
+		case req.System.Prompt != nil && *req.System.Prompt != "":
+			total++
+		}
+	}
+
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		if len(msg.Content.MultipleContent) > 0 {
+			total += len(msg.Content.MultipleContent)
+			continue
+		}
+		if msg.Content.Content != nil && *msg.Content.Content != "" {
+			total++
+		}
+	}
+
+	return total
+}
+
+func trimCacheControlsToLastN(req *MessageRequest, n int) {
+	if n <= 0 {
+		clearCacheControls(req)
+		return
+	}
+
+	all := collectCacheControlRefs(req)
+	if len(all) <= n {
+		return
+	}
+
+	for i := 0; i < len(all)-n; i++ {
+		*all[i] = nil
+	}
+}
+
+func collectCacheControlRefs(req *MessageRequest) []**CacheControl {
+	all := make([]**CacheControl, 0, countCacheControls(req))
+
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			all = append(all, &req.Tools[i].CacheControl)
+		}
+	}
+
+	if req.System != nil {
+		for i := range req.System.MultiplePrompts {
+			if req.System.MultiplePrompts[i].CacheControl != nil {
+				all = append(all, &req.System.MultiplePrompts[i].CacheControl)
+			}
+		}
+	}
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
+				all = append(all, &req.Messages[i].Content.MultipleContent[j].CacheControl)
+			}
+		}
+	}
+
+	return all
+}
+
+func collectMessageBlockRefs(req *MessageRequest) []**CacheControl {
+	refs := make([]**CacheControl, 0)
+
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		if len(msg.Content.MultipleContent) > 0 {
+			for j := range msg.Content.MultipleContent {
+				refs = append(refs, &msg.Content.MultipleContent[j].CacheControl)
+			}
+			continue
+		}
+
+		if msg.Content.Content != nil && *msg.Content.Content != "" {
+			text := *msg.Content.Content
+			msg.Content.Content = nil
+			msg.Content.MultipleContent = []MessageContentBlock{{
+				Type: "text",
+				Text: &text,
+			}}
+			refs = append(refs, &msg.Content.MultipleContent[0].CacheControl)
+		}
+	}
+
+	return refs
+}
+
+// clearCacheControls removes all cache_control breakpoints from tools/system/messages.
+func clearCacheControls(req *MessageRequest) {
+	for i := range req.Tools {
+		req.Tools[i].CacheControl = nil
+	}
+
+	if req.System != nil {
+		for i := range req.System.MultiplePrompts {
+			req.System.MultiplePrompts[i].CacheControl = nil
+		}
+	}
+
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		for j := range msg.Content.MultipleContent {
+			msg.Content.MultipleContent[j].CacheControl = nil
+		}
+	}
+}
+
+// countCacheControls counts all cache_control breakpoints in tools/system/messages.
+func countCacheControls(req *MessageRequest) int {
+	count := 0
+
+	// Count tools.
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			count++
+		}
+	}
+
+	// Count system prompts.
+	if req.System != nil {
+		for i := range req.System.MultiplePrompts {
+			if req.System.MultiplePrompts[i].CacheControl != nil {
+				count++
+			}
+		}
+	}
+
+	// Count message content blocks.
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		for j := range msg.Content.MultipleContent {
+			if msg.Content.MultipleContent[j].CacheControl != nil {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// injectOptimalCacheControls injects Anthropic-recommended breakpoints:
+//  1. last tool
+//  2. last system prompt
+//  3. last content block of the second-to-last user turn
+func injectOptimalCacheControls(req *MessageRequest) {
+	// 1. Last tool.
+	if len(req.Tools) > 0 {
+		req.Tools[len(req.Tools)-1].CacheControl = &CacheControl{Type: "ephemeral"}
+	}
+
+	// 2. Last system prompt.
+	if req.System != nil {
+		// 如果 system 是纯字符串形式，先归一化为 MultiplePrompts 数组格式，
+		// 这样 cache_control 才能正确注入到数组元素上。
+		if req.System.Prompt != nil && len(req.System.MultiplePrompts) == 0 {
+			text := *req.System.Prompt
+			req.System.Prompt = nil
+			req.System.MultiplePrompts = []SystemPromptPart{
+				{Type: "text", Text: text},
+			}
+		}
+
+		if len(req.System.MultiplePrompts) > 0 {
+			last := len(req.System.MultiplePrompts) - 1
+			req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
+		}
+	}
+
+	// 3. Last content block of second-to-last user turn.
+	injectUserTurnCacheControl(req, &CacheControl{Type: "ephemeral"})
+}
+
+// injectUserTurnCacheControl injects cache_control into the last block of the second-to-last user turn.
+// At least two user turns are required.
+func injectUserTurnCacheControl(req *MessageRequest, cc *CacheControl) {
+	// Collect all user turn indices.
+	var userIndices []int
+	for i := range req.Messages {
+		if req.Messages[i].Role == "user" {
+			userIndices = append(userIndices, i)
+		}
+	}
+
+	// Need at least two user turns.
+	if len(userIndices) < 2 {
+		return
+	}
+
+	secondToLastIdx := userIndices[len(userIndices)-2]
+	msg := &req.Messages[secondToLastIdx]
+
+	// If content is array-based, set cache_control on the last block.
+	if len(msg.Content.MultipleContent) > 0 {
+		last := len(msg.Content.MultipleContent) - 1
+		msg.Content.MultipleContent[last].CacheControl = cc
+		return
+	}
+
+	// If content is plain text, convert to block format first.
+	if msg.Content.Content != nil && *msg.Content.Content != "" {
+		text := *msg.Content.Content
+		msg.Content.Content = nil
+		msg.Content.MultipleContent = []MessageContentBlock{
+			{
+				Type:         "text",
+				Text:         &text,
+				CacheControl: cc,
+			},
+		}
+	}
+}

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -2,155 +2,182 @@ package anthropic
 
 // maxCacheControlBreakpoints is the maximum number of cache_control breakpoints allowed by Anthropic.
 // See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.
-const maxCacheControlBreakpoints = 4
-const adaptiveCacheControlBlockWindow = 20
+const (
+	maxCacheControlBreakpoints      = 4
+	adaptiveCacheControlBlockWindow = 20
+)
 
 // ensureCacheControl 统一自动修复 cache_control：
-//   - count == 0: 自动注入推荐断点
-//   - count > 4: 仅保留最近 4 个断点（从后往前）
-//   - 长内容按 block 密度补充断点（仍受 4 个上限约束）
+//   - strict mode：先清空全部断点，再按固定规划重建，避免历史断点造成抖动
+//   - 强制结构锚点：tools(last) + system(last)
+//   - 消息锚点策略：短内容 1 个、长内容 2 个（受 4 个上限约束）
+//   - 消息首选“最后一条消息的最后一个可缓存块”，更贴近官方示例
+//   - 第 2 个消息锚点优先落在“距离末尾约 20 块”的窗口边界
+//   - thinking 与空 text 不允许打点
 func ensureCacheControl(req *MessageRequest) {
-	if countCacheControls(req) == 0 {
-		injectOptimalCacheControls(req)
-	}
+	// 统一归一化：将 Content 字符串形式转为 MultipleContent 数组，
+	// 后续所有函数只处理数组格式，消除隐式结构改写副作用。
+	normalizeMessageContents(req)
+	clearCacheControls(req)
 
-	trimCacheControlsToLastN(req, maxCacheControlBreakpoints)
-	injectAdaptiveCacheControls(req)
-	trimCacheControlsToLastN(req, maxCacheControlBreakpoints)
-}
+	structural := ensureStructuralCacheControls(req)
 
-func injectAdaptiveCacheControls(req *MessageRequest) {
-	target := desiredCacheControlBreakpoints(req)
-	current := countCacheControls(req)
-	if current >= target || current >= maxCacheControlBreakpoints {
+	remaining := maxCacheControlBreakpoints - structural
+	if remaining <= 0 {
 		return
 	}
 
-	need := min(target-current, maxCacheControlBreakpoints-current)
-	if need <= 0 {
-		return
-	}
+	refs := collectMessageBlockRefs(req)
+	messageAnchors := min(desiredMessageCacheAnchors(len(refs)), remaining)
+	injectPlannedMessageCacheControls(refs, messageAnchors)
 
-	candidates := collectMessageBlockRefs(req)
-	if len(candidates) == 0 {
-		return
-	}
-
-	for boundary := len(candidates) - 1; boundary >= 0 && need > 0; boundary -= adaptiveCacheControlBlockWindow {
-		lower := max(boundary-adaptiveCacheControlBlockWindow+1, 0)
-		for i := boundary; i >= lower; i-- {
-			if *candidates[i] == nil {
-				*candidates[i] = &CacheControl{Type: "ephemeral"}
-				need--
-				break
-			}
-		}
-	}
+	// 最终安全检查：确保 thinking 和空 text 块上不会被意外注入 cache_control。
+	sanitizeUnsupportedCacheControls(req)
 }
 
-func desiredCacheControlBreakpoints(req *MessageRequest) int {
-	totalBlocks := countCacheableBlocks(req)
-	if totalBlocks <= adaptiveCacheControlBlockWindow {
-		return 0
-	}
-
-	target := (totalBlocks + adaptiveCacheControlBlockWindow - 1) / adaptiveCacheControlBlockWindow
-	if target > maxCacheControlBreakpoints {
-		target = maxCacheControlBreakpoints
-	}
-	return target
-}
-
-func countCacheableBlocks(req *MessageRequest) int {
-	total := len(req.Tools)
-
-	if req.System != nil {
-		switch {
-		case len(req.System.MultiplePrompts) > 0:
-			total += len(req.System.MultiplePrompts)
-		case req.System.Prompt != nil && *req.System.Prompt != "":
-			total++
-		}
-	}
-
+// normalizeMessageContents 将 Messages 中的纯字符串 Content 统一归一化为 MultipleContent 数组格式。
+// 必须在其他操作之前调用一次，避免后续函数产生隐式结构改写副作用。
+func normalizeMessageContents(req *MessageRequest) {
 	for i := range req.Messages {
 		msg := &req.Messages[i]
-		if len(msg.Content.MultipleContent) > 0 {
-			total += len(msg.Content.MultipleContent)
-			continue
-		}
-		if msg.Content.Content != nil && *msg.Content.Content != "" {
-			total++
-		}
-	}
-
-	return total
-}
-
-func trimCacheControlsToLastN(req *MessageRequest, n int) {
-	if n <= 0 {
-		clearCacheControls(req)
-		return
-	}
-
-	all := collectCacheControlRefs(req)
-	if len(all) <= n {
-		return
-	}
-
-	for i := 0; i < len(all)-n; i++ {
-		*all[i] = nil
-	}
-}
-
-func collectCacheControlRefs(req *MessageRequest) []**CacheControl {
-	all := make([]**CacheControl, 0, countCacheControls(req))
-
-	for i := range req.Tools {
-		if req.Tools[i].CacheControl != nil {
-			all = append(all, &req.Tools[i].CacheControl)
-		}
-	}
-
-	if req.System != nil {
-		for i := range req.System.MultiplePrompts {
-			if req.System.MultiplePrompts[i].CacheControl != nil {
-				all = append(all, &req.System.MultiplePrompts[i].CacheControl)
-			}
-		}
-	}
-
-	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
-				all = append(all, &req.Messages[i].Content.MultipleContent[j].CacheControl)
-			}
-		}
-	}
-
-	return all
-}
-
-func collectMessageBlockRefs(req *MessageRequest) []**CacheControl {
-	refs := make([]**CacheControl, 0)
-
-	for i := range req.Messages {
-		msg := &req.Messages[i]
-		if len(msg.Content.MultipleContent) > 0 {
-			for j := range msg.Content.MultipleContent {
-				refs = append(refs, &msg.Content.MultipleContent[j].CacheControl)
-			}
-			continue
-		}
-
-		if msg.Content.Content != nil && *msg.Content.Content != "" {
+		if len(msg.Content.MultipleContent) == 0 && msg.Content.Content != nil && *msg.Content.Content != "" {
 			text := *msg.Content.Content
 			msg.Content.Content = nil
 			msg.Content.MultipleContent = []MessageContentBlock{{
 				Type: "text",
 				Text: &text,
 			}}
-			refs = append(refs, &msg.Content.MultipleContent[0].CacheControl)
+		}
+	}
+}
+
+// ensureStructuralCacheControls 确保 tools 和 system 的最后一个元素有 cache_control，
+// 返回实际注入的结构锚点数量。
+// 这些位置内容稳定、每次请求重复发送，是 Anthropic 推荐的缓存锚点。
+func ensureStructuralCacheControls(req *MessageRequest) int {
+	count := 0
+
+	if len(req.Tools) > 0 {
+		req.Tools[len(req.Tools)-1].CacheControl = &CacheControl{Type: "ephemeral"}
+		count++
+	}
+
+	if req.System == nil {
+		return count
+	}
+
+	if len(req.System.MultiplePrompts) > 0 {
+		last := len(req.System.MultiplePrompts) - 1
+		req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
+		count++
+
+		return count
+	}
+
+	// system 是字符串形式时归一化为 MultiplePrompts 数组格式，
+	// 以便 cache_control 正确注入到数组元素上。
+	if req.System.Prompt != nil && *req.System.Prompt != "" {
+		text := *req.System.Prompt
+		req.System.Prompt = nil
+		req.System.MultiplePrompts = []SystemPromptPart{{
+			Type:         "text",
+			Text:         text,
+			CacheControl: &CacheControl{Type: "ephemeral"},
+		}}
+		count++
+	}
+
+	return count
+}
+
+// sanitizeUnsupportedCacheControls 清理不允许设置 cache_control 的内容块。
+// Anthropic 不允许在 thinking 类型和空 text 块上设置 cache_control。
+// 在 strict mode 下用作最终安全检查，防止注入逻辑意外命中不可缓存块。
+func sanitizeUnsupportedCacheControls(req *MessageRequest) {
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			block := &req.Messages[i].Content.MultipleContent[j]
+			if !isCacheableMessageBlock(*block) && block.CacheControl != nil {
+				block.CacheControl = nil
+			}
+		}
+	}
+}
+
+func desiredMessageCacheAnchors(cacheableBlocks int) int {
+	if cacheableBlocks == 0 {
+		return 0
+	}
+
+	if cacheableBlocks >= adaptiveCacheControlBlockWindow {
+		return 2
+	}
+
+	return 1
+}
+
+func injectPlannedMessageCacheControls(refs []**CacheControl, target int) {
+	if target <= 0 || len(refs) == 0 {
+		return
+	}
+
+	// 第一优先级：最后一个可缓存块（官方推荐会话末尾断点）。
+	*refs[len(refs)-1] = &CacheControl{Type: "ephemeral"}
+
+	// 第二优先级（仅需要多个消息锚点时）：末尾前 20 blocks 的窗口边界。
+	if target > 1 {
+		idx := pickWindowAnchorIndex(refs, adaptiveCacheControlBlockWindow)
+		if idx >= 0 {
+			*refs[idx] = &CacheControl{Type: "ephemeral"}
+		}
+	}
+}
+
+// pickWindowAnchorIndex 在 refs 中选择距离末尾 window 个位置的未标记锚点。
+// 优先选择目标位置左侧（更靠近稳定前缀），找不到时向右回退。
+func pickWindowAnchorIndex(refs []**CacheControl, window int) int {
+	if len(refs) == 0 {
+		return -1
+	}
+
+	if window < 0 {
+		window = 0
+	}
+
+	target := max(len(refs)-1-window, 0)
+
+	// 优先选择目标窗口左侧（更靠近稳定前缀）
+	for i := target; i >= 0; i-- {
+		if *refs[i] != nil {
+			continue
+		}
+
+		return i
+	}
+
+	for i := target + 1; i < len(refs); i++ {
+		if *refs[i] != nil {
+			continue
+		}
+
+		return i
+	}
+
+	return -1
+}
+
+// collectMessageBlockRefs 收集所有消息中可缓存块的 CacheControl 指针引用。
+// 调用前必须先执行 normalizeMessageContents，本函数不做结构改写。
+func collectMessageBlockRefs(req *MessageRequest) []**CacheControl {
+	refs := make([]**CacheControl, 0)
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			if !isCacheableMessageBlock(req.Messages[i].Content.MultipleContent[j]) {
+				continue
+			}
+
+			refs = append(refs, &req.Messages[i].Content.MultipleContent[j].CacheControl)
 		}
 	}
 
@@ -201,7 +228,7 @@ func countCacheControls(req *MessageRequest) int {
 	for i := range req.Messages {
 		msg := &req.Messages[i]
 		for j := range msg.Content.MultipleContent {
-			if msg.Content.MultipleContent[j].CacheControl != nil {
+			if isCacheableMessageBlock(msg.Content.MultipleContent[j]) && msg.Content.MultipleContent[j].CacheControl != nil {
 				count++
 			}
 		}
@@ -210,74 +237,13 @@ func countCacheControls(req *MessageRequest) int {
 	return count
 }
 
-// injectOptimalCacheControls injects Anthropic-recommended breakpoints:
-//  1. last tool
-//  2. last system prompt
-//  3. last content block of the second-to-last user turn
-func injectOptimalCacheControls(req *MessageRequest) {
-	// 1. Last tool.
-	if len(req.Tools) > 0 {
-		req.Tools[len(req.Tools)-1].CacheControl = &CacheControl{Type: "ephemeral"}
-	}
-
-	// 2. Last system prompt.
-	if req.System != nil {
-		// 如果 system 是纯字符串形式，先归一化为 MultiplePrompts 数组格式，
-		// 这样 cache_control 才能正确注入到数组元素上。
-		if req.System.Prompt != nil && len(req.System.MultiplePrompts) == 0 {
-			text := *req.System.Prompt
-			req.System.Prompt = nil
-			req.System.MultiplePrompts = []SystemPromptPart{
-				{Type: "text", Text: text},
-			}
-		}
-
-		if len(req.System.MultiplePrompts) > 0 {
-			last := len(req.System.MultiplePrompts) - 1
-			req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
-		}
-	}
-
-	// 3. Last content block of second-to-last user turn.
-	injectUserTurnCacheControl(req, &CacheControl{Type: "ephemeral"})
-}
-
-// injectUserTurnCacheControl injects cache_control into the last block of the second-to-last user turn.
-// At least two user turns are required.
-func injectUserTurnCacheControl(req *MessageRequest, cc *CacheControl) {
-	// Collect all user turn indices.
-	var userIndices []int
-	for i := range req.Messages {
-		if req.Messages[i].Role == "user" {
-			userIndices = append(userIndices, i)
-		}
-	}
-
-	// Need at least two user turns.
-	if len(userIndices) < 2 {
-		return
-	}
-
-	secondToLastIdx := userIndices[len(userIndices)-2]
-	msg := &req.Messages[secondToLastIdx]
-
-	// If content is array-based, set cache_control on the last block.
-	if len(msg.Content.MultipleContent) > 0 {
-		last := len(msg.Content.MultipleContent) - 1
-		msg.Content.MultipleContent[last].CacheControl = cc
-		return
-	}
-
-	// If content is plain text, convert to block format first.
-	if msg.Content.Content != nil && *msg.Content.Content != "" {
-		text := *msg.Content.Content
-		msg.Content.Content = nil
-		msg.Content.MultipleContent = []MessageContentBlock{
-			{
-				Type:         "text",
-				Text:         &text,
-				CacheControl: cc,
-			},
-		}
+func isCacheableMessageBlock(block MessageContentBlock) bool {
+	switch block.Type {
+	case "thinking", "redacted_thinking":
+		return false
+	case "text":
+		return block.Text != nil && *block.Text != ""
+	default:
+		return true
 	}
 }

--- a/llm/transformer/anthropic/ensure_cache_control_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_test.go
@@ -1,0 +1,503 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- countCacheControls ---
+
+func TestCountCacheControls(t *testing.T) {
+	t.Run("空请求返回 0", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+		assert.Equal(t, 0, countCacheControls(req))
+	})
+
+	t.Run("tools 中有断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "a"},
+				{Name: "b", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("system 中有断点", func(t *testing.T) {
+		req := &MessageRequest{
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "a", CacheControl: &CacheControl{Type: "ephemeral"}},
+					{Type: "text", Text: "b", CacheControl: &CacheControl{Type: "ephemeral"}},
+				},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+		assert.Equal(t, 2, countCacheControls(req))
+	})
+
+	t.Run("messages 内容块中有断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("a"), CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("b")},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("混合场景统计所有断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "sys", CacheControl: &CacheControl{Type: "ephemeral"}},
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("msg"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "tool_result", ToolUseID: lo.ToPtr("id1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, 4, countCacheControls(req))
+	})
+}
+
+// --- ensureCacheControl ---
+
+func TestEnsureCacheControl_ZeroBreakpoints_AutoInjects(t *testing.T) {
+	t.Run("有 tools + system + 多个 user turn 时注入 3 个断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "tool_a"},
+				{Name: "tool_b"},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "prompt_1"},
+					{Type: "text", Text: "prompt_2"},
+				},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("first user msg")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("response")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("second user msg")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// tools 最后一个被注入
+		assert.Nil(t, req.Tools[0].CacheControl)
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		assert.Equal(t, "ephemeral", req.Tools[1].CacheControl.Type)
+
+		// system 最后一个被注入
+		assert.Nil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
+		assert.Equal(t, "ephemeral", req.System.MultiplePrompts[1].CacheControl.Type)
+
+		// 倒数第二个 user turn（索引 0）被转为数组格式并注入
+		assert.Len(t, req.Messages[0].Content.MultipleContent, 1)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.Messages[0].Content.MultipleContent[0].CacheControl.Type)
+
+		// 总计 3 个断点
+		assert.Equal(t, 3, countCacheControls(req))
+	})
+
+	t.Run("没有 tools 和 system 时只注入 messages 断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("first")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("second")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("只有 1 个 user turn 时不注入 messages 断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{{Name: "t1"}},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("only one")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// 只有 tools 被注入
+		assert.Equal(t, 1, countCacheControls(req))
+		assert.NotNil(t, req.Tools[0].CacheControl)
+	})
+
+	t.Run("user turn 是数组格式内容时在最后一个块上注入", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("part1")},
+							{Type: "text", Text: lo.ToPtr("part2")},
+						},
+					},
+				},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("latest")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// 倒数第二个 user turn 的最后一个内容块被注入
+		blocks := req.Messages[0].Content.MultipleContent
+		assert.Nil(t, blocks[0].CacheControl)
+		assert.NotNil(t, blocks[1].CacheControl)
+		assert.Equal(t, "ephemeral", blocks[1].CacheControl.Type)
+	})
+}
+
+func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
+	t.Run("客户端设了 1 个断点不做修改", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("客户端设了 4 个断点不做修改", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "s1", CacheControl: &CacheControl{Type: "ephemeral"}},
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("a"), CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("b"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 4, countCacheControls(req))
+	})
+}
+
+func TestEnsureCacheControl_ExistingBreakpoints_KeepAsIs(t *testing.T) {
+	req := &MessageRequest{
+		Messages: []MessageParam{
+			{Role: "user", Content: MessageContent{Content: lo.ToPtr("first")}},
+			{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+			{Role: "user", Content: MessageContent{Content: lo.ToPtr("second")}},
+		},
+	}
+
+	ensureCacheControl(req)
+	assert.Equal(t, 1, countCacheControls(req))
+}
+
+func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
+	t.Run("5 个断点会自动裁剪为最近 4 个", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "tool_a", CacheControl: &CacheControl{Type: "ephemeral"}},
+				{Name: "tool_b", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "sys1", CacheControl: &CacheControl{Type: "ephemeral"}},
+					{Type: "text", Text: "sys2"},
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("turn1-a"), CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("turn1-b")},
+						},
+					},
+				},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("turn2"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// 保留从后往前最近的 4 个：应删除最早的 tool_a 断点
+		assert.Nil(t, req.Tools[0].CacheControl)
+		assert.NotNil(t, req.Tools[1].CacheControl)
+
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.Nil(t, req.System.MultiplePrompts[1].CacheControl)
+
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
+
+		assert.Equal(t, 4, countCacheControls(req))
+	})
+
+	t.Run("6 个断点也会自动裁剪为最近 4 个", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "tool_a", CacheControl: &CacheControl{Type: "ephemeral"}},
+				{Name: "tool_b", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "sys1", CacheControl: &CacheControl{Type: "ephemeral"}},
+					{Type: "text", Text: "sys2", CacheControl: &CacheControl{Type: "ephemeral"}},
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("turn1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("turn1-b"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("turn2")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 4, countCacheControls(req))
+		assert.Nil(t, req.Tools[0].CacheControl)
+		assert.Nil(t, req.Tools[1].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+	})
+}
+
+func TestEnsureCacheControl_AdaptiveBreakpoints_ByBlockDensity(t *testing.T) {
+	t.Run(">20 blocks 时会按密度补充断点（上限 4）", func(t *testing.T) {
+		blocks := make([]MessageContentBlock, 0, 65)
+		for i := 0; i < 65; i++ {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("latest")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		assert.Equal(t, 4, countCacheControls(req))
+
+		marked := 0
+		for i := range req.Messages[0].Content.MultipleContent {
+			if req.Messages[0].Content.MultipleContent[i].CacheControl != nil {
+				marked++
+			}
+		}
+		assert.GreaterOrEqual(t, marked, 3)
+	})
+
+	t.Run("单个 user turn 的长内容也能补齐到 4 个断点", func(t *testing.T) {
+		blocks := make([]MessageContentBlock, 0, 65)
+		for i := 0; i < 65; i++ {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 4, countCacheControls(req))
+	})
+}
+
+// --- System.Prompt 字符串形式归一化 ---
+
+func TestEnsureCacheControl_SystemPromptStringForm(t *testing.T) {
+	t.Run("System.Prompt 字符串形式也能被注入 cache_control", func(t *testing.T) {
+		req := &MessageRequest{
+			System: &SystemPrompt{
+				Prompt: lo.ToPtr("You are a helpful assistant."),
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// System.Prompt 应被归一化为 MultiplePrompts，并注入 cache_control
+		assert.Nil(t, req.System.Prompt)
+		require.Len(t, req.System.MultiplePrompts, 1)
+		assert.Equal(t, "You are a helpful assistant.", req.System.MultiplePrompts[0].Text)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.System.MultiplePrompts[0].CacheControl.Type)
+	})
+
+	t.Run("已有断点时也能处理 System.Prompt 字符串形式", func(t *testing.T) {
+		req := &MessageRequest{
+			System: &SystemPrompt{
+				Prompt: lo.ToPtr("System prompt text"),
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		assert.Nil(t, req.System.Prompt)
+		require.Len(t, req.System.MultiplePrompts, 1)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+	})
+}
+
+// --- 边界用例 ---
+
+func TestEnsureCacheControl_EdgeCases(t *testing.T) {
+	t.Run("user turn 内容为空字符串时不注入 messages 断点", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("second")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		// 空字符串内容不会被转为数组格式，所以倒数第二个 user turn 不注入
+		assert.Equal(t, 0, countCacheControls(req))
+	})
+
+	t.Run("user turn Content 为 nil 且 MultipleContent 为空时不注入", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("second")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 0, countCacheControls(req))
+	})
+}
+
+// --- OpenCode 插件场景复现 ---
+
+func TestEnsureCacheControl_OpenCodePluginScenario(t *testing.T) {
+	t.Run("客户端已设置 4 个断点（模拟 opencode-dynamic-context-pruning 插件）不会超限", func(t *testing.T) {
+		// 模拟插件设置的 4 个断点：tools 末尾 + system 末尾 + 2 个 message 内容块
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "bash"},
+				{Name: "edit", CacheControl: &CacheControl{Type: "ephemeral"}}, // 断点 1
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "You are Claude Code."},
+					{Type: "text", Text: "System instructions.", CacheControl: &CacheControl{Type: "ephemeral"}}, // 断点 2
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("context data"), CacheControl: &CacheControl{Type: "ephemeral"}}, // 断点 3
+						},
+					},
+				},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("ok")}},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "tool_result", ToolUseID: lo.ToPtr("id1"), CacheControl: &CacheControl{Type: "ephemeral"}}, // 断点 4
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, 4, countCacheControls(req))
+	})
+}

--- a/llm/transformer/anthropic/ensure_cache_control_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_test.go
@@ -132,10 +132,10 @@ func TestEnsureCacheControl_ZeroBreakpoints_AutoInjects(t *testing.T) {
 		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
 		assert.Equal(t, "ephemeral", req.System.MultiplePrompts[1].CacheControl.Type)
 
-		// 倒数第二个 user turn（索引 0）被转为数组格式并注入
-		assert.Len(t, req.Messages[0].Content.MultipleContent, 1)
-		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
-		assert.Equal(t, "ephemeral", req.Messages[0].Content.MultipleContent[0].CacheControl.Type)
+		// 会话末尾（最后一条消息）被转为数组格式并注入
+		assert.Len(t, req.Messages[2].Content.MultipleContent, 1)
+		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.Messages[2].Content.MultipleContent[0].CacheControl.Type)
 
 		// 总计 3 个断点
 		assert.Equal(t, 3, countCacheControls(req))
@@ -154,7 +154,7 @@ func TestEnsureCacheControl_ZeroBreakpoints_AutoInjects(t *testing.T) {
 		assert.Equal(t, 1, countCacheControls(req))
 	})
 
-	t.Run("只有 1 个 user turn 时不注入 messages 断点", func(t *testing.T) {
+	t.Run("只有 1 个 user turn 时会注入 1 个消息断点", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{{Name: "t1"}},
 			Messages: []MessageParam{
@@ -164,8 +164,8 @@ func TestEnsureCacheControl_ZeroBreakpoints_AutoInjects(t *testing.T) {
 
 		ensureCacheControl(req)
 
-		// 只有 tools 被注入
-		assert.Equal(t, 1, countCacheControls(req))
+		// tools 结构锚点 + 1 个消息锚点
+		assert.Equal(t, 2, countCacheControls(req))
 		assert.NotNil(t, req.Tools[0].CacheControl)
 	})
 
@@ -188,16 +188,15 @@ func TestEnsureCacheControl_ZeroBreakpoints_AutoInjects(t *testing.T) {
 
 		ensureCacheControl(req)
 
-		// 倒数第二个 user turn 的最后一个内容块被注入
-		blocks := req.Messages[0].Content.MultipleContent
-		assert.Nil(t, blocks[0].CacheControl)
-		assert.NotNil(t, blocks[1].CacheControl)
-		assert.Equal(t, "ephemeral", blocks[1].CacheControl.Type)
+		// 会话末尾（最后一条消息）优先注入
+		require.Len(t, req.Messages[2].Content.MultipleContent, 1)
+		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.Messages[2].Content.MultipleContent[0].CacheControl.Type)
 	})
 }
 
 func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
-	t.Run("客户端设了 1 个断点不做修改", func(t *testing.T) {
+	t.Run("客户端设了 1 个断点时会补齐策略性断点", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{
 				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
@@ -208,10 +207,10 @@ func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 1, countCacheControls(req))
+		assert.Equal(t, 2, countCacheControls(req))
 	})
 
-	t.Run("客户端设了 4 个断点不做修改", func(t *testing.T) {
+	t.Run("客户端设了 4 个断点时会按策略重排并去重", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{
 				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
@@ -235,7 +234,7 @@ func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 3, countCacheControls(req))
 	})
 }
 
@@ -289,18 +288,18 @@ func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
 
 		ensureCacheControl(req)
 
-		// 保留从后往前最近的 4 个：应删除最早的 tool_a 断点
+		// strict 模式按新策略重建：结构锚点 + 会话末尾消息锚点。
 		assert.Nil(t, req.Tools[0].CacheControl)
 		assert.NotNil(t, req.Tools[1].CacheControl)
 
-		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
-		assert.Nil(t, req.System.MultiplePrompts[1].CacheControl)
+		assert.Nil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
 
-		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
 		assert.Nil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
 		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
 
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 3, countCacheControls(req))
 	})
 
 	t.Run("6 个断点也会自动裁剪为最近 4 个", func(t *testing.T) {
@@ -331,20 +330,23 @@ func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 3, countCacheControls(req))
 		assert.Nil(t, req.Tools[0].CacheControl)
-		assert.Nil(t, req.Tools[1].CacheControl)
-		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		assert.Nil(t, req.System.MultiplePrompts[0].CacheControl)
 		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
-		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
-		assert.NotNil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+		require.Len(t, req.Messages[2].Content.MultipleContent, 1)
+		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
 	})
 }
 
 func TestEnsureCacheControl_AdaptiveBreakpoints_ByBlockDensity(t *testing.T) {
 	t.Run(">20 blocks 时会按密度补充断点（上限 4）", func(t *testing.T) {
 		blocks := make([]MessageContentBlock, 0, 65)
-		for i := 0; i < 65; i++ {
+
+		for range 65 {
 			text := "chunk"
 			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
 		}
@@ -359,20 +361,23 @@ func TestEnsureCacheControl_AdaptiveBreakpoints_ByBlockDensity(t *testing.T) {
 
 		ensureCacheControl(req)
 
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 2, countCacheControls(req))
 
 		marked := 0
+
 		for i := range req.Messages[0].Content.MultipleContent {
 			if req.Messages[0].Content.MultipleContent[i].CacheControl != nil {
 				marked++
 			}
 		}
-		assert.GreaterOrEqual(t, marked, 3)
+
+		assert.GreaterOrEqual(t, marked, 1)
 	})
 
-	t.Run("单个 user turn 的长内容也能补齐到 4 个断点", func(t *testing.T) {
+	t.Run("单个 user turn 的长内容会补齐到 2 个消息断点", func(t *testing.T) {
 		blocks := make([]MessageContentBlock, 0, 65)
-		for i := 0; i < 65; i++ {
+
+		for range 65 {
 			text := "chunk"
 			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
 		}
@@ -384,7 +389,36 @@ func TestEnsureCacheControl_AdaptiveBreakpoints_ByBlockDensity(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 2, countCacheControls(req))
+	})
+
+	t.Run(">40 blocks 时第二个消息锚点应落在末尾前20窗口边界", func(t *testing.T) {
+		blocks := make([]MessageContentBlock, 0, 50)
+
+		for range 50 {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		assert.Equal(t, 2, countCacheControls(req))
+
+		marked := make([]int, 0, 2)
+
+		for i := range req.Messages[0].Content.MultipleContent {
+			if req.Messages[0].Content.MultipleContent[i].CacheControl != nil {
+				marked = append(marked, i)
+			}
+		}
+
+		require.Equal(t, []int{29, 49}, marked)
 	})
 }
 
@@ -432,7 +466,7 @@ func TestEnsureCacheControl_SystemPromptStringForm(t *testing.T) {
 // --- 边界用例 ---
 
 func TestEnsureCacheControl_EdgeCases(t *testing.T) {
-	t.Run("user turn 内容为空字符串时不注入 messages 断点", func(t *testing.T) {
+	t.Run("user turn 内容为空字符串时仍可在后续可缓存块注入 1 个消息断点", func(t *testing.T) {
 		req := &MessageRequest{
 			Messages: []MessageParam{
 				{Role: "user", Content: MessageContent{Content: lo.ToPtr("")}},
@@ -442,11 +476,10 @@ func TestEnsureCacheControl_EdgeCases(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		// 空字符串内容不会被转为数组格式，所以倒数第二个 user turn 不注入
-		assert.Equal(t, 0, countCacheControls(req))
+		assert.Equal(t, 1, countCacheControls(req))
 	})
 
-	t.Run("user turn Content 为 nil 且 MultipleContent 为空时不注入", func(t *testing.T) {
+	t.Run("user turn Content 为 nil 且 MultipleContent 为空时仍可在后续可缓存块注入", func(t *testing.T) {
 		req := &MessageRequest{
 			Messages: []MessageParam{
 				{Role: "user", Content: MessageContent{}},
@@ -456,7 +489,453 @@ func TestEnsureCacheControl_EdgeCases(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 0, countCacheControls(req))
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+}
+
+// --- 结构锚点补齐 ---
+
+func TestEnsureCacheControl_StructuralAnchors(t *testing.T) {
+	t.Run("客户端仅在 messages 设了断点时 tools 和 system 应被补齐", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "bash"},
+				{Name: "edit"},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "You are helpful."},
+				},
+			},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("context"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("ok")}},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("question"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// tools 最后一个应被补齐
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		assert.Equal(t, "ephemeral", req.Tools[1].CacheControl.Type)
+
+		// system 最后一个应被补齐
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.System.MultiplePrompts[0].CacheControl.Type)
+
+		// 总数应 <= 4
+		assert.LessOrEqual(t, countCacheControls(req), 4)
+	})
+
+	t.Run("客户端已在 tools 设断点时不会重复注入", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "bash"},
+				{Name: "edit", CacheControl: &CacheControl{Type: "ephemeral"}},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Equal(t, "ephemeral", req.Tools[1].CacheControl.Type)
+		assert.Nil(t, req.Tools[0].CacheControl)
+	})
+
+	t.Run("满额消息断点场景仍优先保留 tools/system 锚点", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools:  []Tool{{Name: "bash"}, {Name: "edit"}},
+			System: &SystemPrompt{Prompt: lo.ToPtr("You are helpful")},
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{MultipleContent: []MessageContentBlock{
+						{Type: "text", Text: lo.ToPtr("m1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "text", Text: lo.ToPtr("m2"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "text", Text: lo.ToPtr("m3"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "text", Text: lo.ToPtr("m4"), CacheControl: &CacheControl{Type: "ephemeral"}},
+					}},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		require.NotNil(t, req.System)
+		require.Len(t, req.System.MultiplePrompts, 1)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.LessOrEqual(t, countCacheControls(req), 4)
+	})
+}
+
+// --- thinking 块安全处理 ---
+
+func TestEnsureCacheControl_ThinkingBlocks(t *testing.T) {
+	t.Run("Text 为 nil 的 text 块不可缓存", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{MultipleContent: []MessageContentBlock{
+						{Type: "text"},
+						{Type: "text", Text: lo.ToPtr("valid")},
+					}},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("空 text 块上的 cache_control 会被清理", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{MultipleContent: []MessageContentBlock{
+						{Type: "text", Text: lo.ToPtr(""), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "text", Text: lo.ToPtr("valid")},
+					}},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+	})
+
+	t.Run("thinking 块不会被注入 cache_control", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("question")},
+						},
+					},
+				},
+				{
+					Role: "assistant",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "thinking", Thinking: lo.ToPtr("let me think...")},
+							{Type: "text", Text: lo.ToPtr("answer")},
+						},
+					},
+				},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("follow up")},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// thinking 块绝不能有 cache_control
+		thinkingBlock := req.Messages[1].Content.MultipleContent[0]
+		assert.Equal(t, "thinking", thinkingBlock.Type)
+		assert.Nil(t, thinkingBlock.CacheControl)
+	})
+
+	t.Run("已有 cache_control 的 thinking 块会被清理", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "assistant",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "thinking", Thinking: lo.ToPtr("thought"), CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("reply")},
+						},
+					},
+				},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("msg1")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("resp")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("msg2")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// thinking 块上的 cache_control 应被清理
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+	})
+
+	t.Run("大量 thinking 块不影响 adaptive 密度计算", func(t *testing.T) {
+		blocks := make([]MessageContentBlock, 0, 70)
+		// 40 个 thinking 块 + 30 个 text 块
+		for range 40 {
+			blocks = append(blocks, MessageContentBlock{Type: "thinking", Thinking: lo.ToPtr("thought")})
+		}
+
+		for range 30 {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// thinking 块不计入可缓存密度，30 个 text 块 → desired = 2
+		// 所有 cache_control 应只在 text 块上
+		for _, block := range req.Messages[0].Content.MultipleContent {
+			if block.Type == "thinking" {
+				assert.Nil(t, block.CacheControl)
+			}
+		}
+	})
+
+	t.Run("redacted_thinking 块不会被注入 cache_control", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("question")},
+						},
+					},
+				},
+				{
+					Role: "assistant",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "thinking", Thinking: lo.ToPtr("let me think"), Signature: lo.ToPtr("sig")},
+							{Type: "redacted_thinking", Data: "encrypted-data"},
+							{Type: "text", Text: lo.ToPtr("answer")},
+						},
+					},
+				},
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("follow up")},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// thinking 和 redacted_thinking 块都不能有 cache_control
+		assert.Nil(t, req.Messages[1].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "thinking", req.Messages[1].Content.MultipleContent[0].Type)
+		assert.Nil(t, req.Messages[1].Content.MultipleContent[1].CacheControl)
+		assert.Equal(t, "redacted_thinking", req.Messages[1].Content.MultipleContent[1].Type)
+	})
+
+	t.Run("已有 cache_control 的 redacted_thinking 块会被清理", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "assistant",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "redacted_thinking", Data: "encrypted", CacheControl: &CacheControl{Type: "ephemeral"}},
+							{Type: "text", Text: lo.ToPtr("reply")},
+						},
+					},
+				},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("msg")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// redacted_thinking 块上的 cache_control 应被清理
+		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "redacted_thinking", req.Messages[0].Content.MultipleContent[0].Type)
+	})
+
+	t.Run("大量 redacted_thinking 块不影响 adaptive 密度计算", func(t *testing.T) {
+		blocks := make([]MessageContentBlock, 0, 70)
+		// 40 个 redacted_thinking 块 + 30 个 text 块
+		for range 40 {
+			blocks = append(blocks, MessageContentBlock{Type: "redacted_thinking", Data: "encrypted"})
+		}
+
+		for range 30 {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// redacted_thinking 块不计入可缓存密度，30 个 text 块 → desired = 2
+		for _, block := range req.Messages[0].Content.MultipleContent {
+			if block.Type == "redacted_thinking" {
+				assert.Nil(t, block.CacheControl)
+			}
+		}
+
+		assert.Equal(t, 2, countCacheControls(req))
+	})
+
+	t.Run("thinking 断点不会占用预算并阻断结构锚点补齐", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools:  []Tool{{Name: "bash"}, {Name: "edit"}},
+			System: &SystemPrompt{Prompt: lo.ToPtr("You are helpful")},
+			Messages: []MessageParam{
+				{
+					Role: "assistant",
+					Content: MessageContent{MultipleContent: []MessageContentBlock{
+						{Type: "thinking", Thinking: lo.ToPtr("t1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "thinking", Thinking: lo.ToPtr("t2"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "thinking", Thinking: lo.ToPtr("t3"), CacheControl: &CacheControl{Type: "ephemeral"}},
+						{Type: "thinking", Thinking: lo.ToPtr("t4"), CacheControl: &CacheControl{Type: "ephemeral"}},
+					}},
+				},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("u1")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("a1")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("u2")}},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		for _, block := range req.Messages[0].Content.MultipleContent {
+			if block.Type == "thinking" {
+				assert.Nil(t, block.CacheControl)
+			}
+		}
+
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		require.NotNil(t, req.System)
+		require.Len(t, req.System.MultiplePrompts, 1)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.LessOrEqual(t, countCacheControls(req), 4)
+	})
+}
+
+// --- 回归测试 ---
+
+func TestEnsureCacheControl_Regression(t *testing.T) {
+	t.Run("尾部消息全为 non-cacheable 时向前扫描注入 final 锚点", func(t *testing.T) {
+		req := &MessageRequest{
+			Messages: []MessageParam{
+				{
+					Role: "user",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "text", Text: lo.ToPtr("question")},
+						},
+					},
+				},
+				{
+					Role: "assistant",
+					Content: MessageContent{
+						MultipleContent: []MessageContentBlock{
+							{Type: "thinking", Thinking: lo.ToPtr("let me think")},
+						},
+					},
+				},
+			},
+		}
+
+		ensureCacheControl(req)
+
+		// thinking 块不应有 cache_control
+		assert.Nil(t, req.Messages[1].Content.MultipleContent[0].CacheControl)
+		// final 锚点应落在 msg[0] 的 "question" 上
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.Equal(t, "ephemeral", req.Messages[0].Content.MultipleContent[0].CacheControl.Type)
+		assert.Equal(t, 1, countCacheControls(req))
+	})
+
+	t.Run("断点总数不变量：任何场景下不超过 maxCacheControlBreakpoints", func(t *testing.T) {
+		// 构造压力场景：大量工具、多条系统提示、大量消息块
+		blocks := make([]MessageContentBlock, 0, 100)
+
+		for range 100 {
+			text := "chunk"
+			blocks = append(blocks, MessageContentBlock{Type: "text", Text: &text})
+		}
+
+		req := &MessageRequest{
+			Tools: []Tool{
+				{Name: "t1"},
+				{Name: "t2"},
+				{Name: "t3"},
+			},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "s1"},
+					{Type: "text", Text: "s2"},
+				},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{MultipleContent: blocks}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("response")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("follow up")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		assert.LessOrEqual(t, countCacheControls(req), maxCacheControlBreakpoints)
+	})
+
+	t.Run("多次调用 ensureCacheControl 结果幂等", func(t *testing.T) {
+		req := &MessageRequest{
+			Tools: []Tool{{Name: "bash"}, {Name: "edit"}},
+			System: &SystemPrompt{
+				MultiplePrompts: []SystemPromptPart{
+					{Type: "text", Text: "You are helpful."},
+				},
+			},
+			Messages: []MessageParam{
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("hello")}},
+				{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("hi")}},
+				{Role: "user", Content: MessageContent{Content: lo.ToPtr("question")}},
+			},
+		}
+
+		ensureCacheControl(req)
+		firstCount := countCacheControls(req)
+
+		ensureCacheControl(req)
+		secondCount := countCacheControls(req)
+
+		assert.Equal(t, firstCount, secondCount)
+		assert.LessOrEqual(t, secondCount, maxCacheControlBreakpoints)
 	})
 }
 
@@ -498,6 +977,6 @@ func TestEnsureCacheControl_OpenCodePluginScenario(t *testing.T) {
 		}
 
 		ensureCacheControl(req)
-		assert.Equal(t, 4, countCacheControls(req))
+		assert.Equal(t, 3, countCacheControls(req))
 	})
 }

--- a/llm/transformer/anthropic/integration_test.go
+++ b/llm/transformer/anthropic/integration_test.go
@@ -207,10 +207,6 @@ func TestTransformRequest_Integration(t *testing.T) {
 			requestFile: `anthropic-claude-code2.request.json`,
 		},
 		{
-			name:        "claude cache control",
-			requestFile: `anthropic-cache-control-inbound.request.json`,
-		},
-		{
 			name:        "claude thinking",
 			requestFile: `anthropic-thinking.request.json`,
 		},
@@ -265,11 +261,45 @@ func TestTransformRequest_Integration(t *testing.T) {
 			err = json.Unmarshal(outboundReq.Body, &gotReq)
 			require.NoError(t, err)
 
-			if !xtest.Equal(wantReq, gotReq) {
-				t.Errorf("wantReq != gotReq\n%s", cmp.Diff(wantReq, gotReq))
+			// 忽略 cache_control 差异：ensureCacheControl 会在 outbound 路径中自动注入断点，
+			// 可能导致 CacheControl 字段和 Content→MultipleContent 结构变化。
+			// 这些行为的正确性已在 ensure_cache_control_test.go 中覆盖。
+			if !xtest.Equal(wantReq, gotReq, ignoreCacheControlWithNormalize...) {
+				t.Errorf("wantReq != gotReq\n%s", cmp.Diff(wantReq, gotReq, ignoreCacheControlWithNormalize...))
 			}
 		})
 	}
+
+	// 单独测试 cache_control 超限的 fixture：该文件包含 6 个 cache_control 断点。
+	// outbound 阶段应自动裁剪，仅保留最近 4 个断点。
+	t.Run("cache control exceeds limit", func(t *testing.T) {
+		var wantReq MessageRequest
+
+		err := xtest.LoadTestData(t, "anthropic-cache-control-inbound.request.json", &wantReq)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		require.NoError(t, encoder.Encode(wantReq))
+
+		chatReq, err := inboundTransformer.TransformRequest(t.Context(), &httpclient.Request{
+			Headers: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			Body: buf.Bytes(),
+		})
+		require.NoError(t, err)
+
+		outboundReq, err := outboundTransformer.TransformRequest(t.Context(), chatReq)
+		require.NoError(t, err)
+
+		var gotReq MessageRequest
+		err = json.Unmarshal(outboundReq.Body, &gotReq)
+		require.NoError(t, err)
+		require.Equal(t, 4, countCacheControls(&gotReq))
+	})
 }
 
 func TestAnthropicTransformers_StreamingIntegration(t *testing.T) {

--- a/llm/transformer/anthropic/integration_test.go
+++ b/llm/transformer/anthropic/integration_test.go
@@ -257,7 +257,6 @@ func TestTransformRequest_Integration(t *testing.T) {
 			require.NoError(t, err)
 
 			var gotReq MessageRequest
-
 			err = json.Unmarshal(outboundReq.Body, &gotReq)
 			require.NoError(t, err)
 
@@ -271,7 +270,7 @@ func TestTransformRequest_Integration(t *testing.T) {
 	}
 
 	// 单独测试 cache_control 超限的 fixture：该文件包含 6 个 cache_control 断点。
-	// outbound 阶段应自动裁剪，仅保留最近 4 个断点。
+	// strict mode 下会重建为结构锚点 + 受预算约束的消息锚点（此场景为 3 个）。
 	t.Run("cache control exceeds limit", func(t *testing.T) {
 		var wantReq MessageRequest
 
@@ -296,9 +295,10 @@ func TestTransformRequest_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		var gotReq MessageRequest
+
 		err = json.Unmarshal(outboundReq.Body, &gotReq)
 		require.NoError(t, err)
-		require.Equal(t, 4, countCacheControls(&gotReq))
+		require.Equal(t, 3, countCacheControls(&gotReq))
 	})
 }
 

--- a/llm/transformer/anthropic/outbound.go
+++ b/llm/transformer/anthropic/outbound.go
@@ -164,6 +164,9 @@ func (t *OutboundTransformer) TransformRequest(
 	// Convert to Anthropic request format
 	anthropicReq := convertToAnthropicRequestWithConfig(llmReq, t.config)
 
+	// Apply cache_control breakpoint policy before serialization.
+	ensureCacheControl(anthropicReq)
+
 	// Determine endpoint based on platform
 	url, err := t.buildFullRequestURL(llmReq)
 	if err != nil {

--- a/llm/transformer/anthropic/outbound_test.go
+++ b/llm/transformer/anthropic/outbound_test.go
@@ -1012,9 +1012,9 @@ func TestOutboundTransformer_TransformRequest_WithTestData(t *testing.T) {
 				err = xtest.LoadTestData(t, tt.expectedFile, &expectedReq)
 				require.NoError(t, err)
 
-				// Verify the transformed request matches the expected request
-				if !xtest.Equal(expectedReq, gotReq) {
-					t.Fatalf("requests are not equal %s", cmp.Diff(expectedReq, gotReq))
+				// 忽略 cache_control 差异：ensureCacheControl 会在 outbound 路径中自动注入断点。
+				if !xtest.Equal(expectedReq, gotReq, ignoreCacheControlWithNormalize...) {
+					t.Fatalf("requests are not equal %s", cmp.Diff(expectedReq, gotReq, ignoreCacheControlWithNormalize...))
 				}
 			}
 		})
@@ -1192,10 +1192,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL enabled with Config",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://custom.api.com/v1",
+				Type:           PlatformDirect,
+				BaseURL:        "https://custom.api.com/v1",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
-				RawURL:  true,
+				RawURL:         true,
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1215,8 +1215,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL auto-enabled with # suffix",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://custom.api.com/v100#",
+				Type:           PlatformDirect,
+				BaseURL:        "https://custom.api.com/v100#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -1237,8 +1237,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with full path",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://custom.api.com/v1/messages#",
+				Type:           PlatformDirect,
+				BaseURL:        "https://custom.api.com/v1/messages#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -1259,10 +1259,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL false with standard URL",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://api.anthropic.com",
+				Type:           PlatformDirect,
+				BaseURL:        "https://api.anthropic.com",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
-				RawURL:  false,
+				RawURL:         false,
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1282,10 +1282,10 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL false with v1 already in URL",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://api.anthropic.com/v1",
+				Type:           PlatformDirect,
+				BaseURL:        "https://api.anthropic.com/v1",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
-				RawURL:  false,
+				RawURL:         false,
 			},
 			request: &llm.Request{
 				Model:     "claude-3-sonnet-20240229",
@@ -1305,8 +1305,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with custom endpoint without version",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://custom-endpoint.com/api/llm#",
+				Type:           PlatformDirect,
+				BaseURL:        "https://custom-endpoint.com/api/llm#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -1327,8 +1327,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with streaming enabled",
 			config: &Config{
-				Type:    PlatformDirect,
-				BaseURL: "https://custom.api.com/v1#",
+				Type:           PlatformDirect,
+				BaseURL:        "https://custom.api.com/v1#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -1350,8 +1350,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with DeepSeek platform",
 			config: &Config{
-				Type:    PlatformDeepSeek,
-				BaseURL: "https://api.deepseek.com/v1#",
+				Type:           PlatformDeepSeek,
+				BaseURL:        "https://api.deepseek.com/v1#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -1372,8 +1372,8 @@ func TestOutboundTransformer_RawURL(t *testing.T) {
 		{
 			name: "raw URL with Doubao platform",
 			config: &Config{
-				Type:    PlatformDoubao,
-				BaseURL: "https://ark.cn-beijing.volces.com/v20#",
+				Type:           PlatformDoubao,
+				BaseURL:        "https://ark.cn-beijing.volces.com/v20#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{

--- a/llm/transformer/anthropic/test_helpers_test.go
+++ b/llm/transformer/anthropic/test_helpers_test.go
@@ -14,8 +14,9 @@ var ignoreCacheControlOpts = []cmp.Option{
 }
 
 // ignoreCacheControlWithNormalize 在忽略 cache_control 的基础上，
-// 还将单个 text block 的 MultipleContent 归一化为 Content 字符串形式。
-// 仅在 ensureCacheControl 可能转换 Content→MultipleContent 的测试场景中使用。
+// 还将 ensureCacheControl 可能产生的结构变化归一化：
+// 1. 单个 text block 的 MultipleContent → Content 字符串形式（MessageContent 归一化）
+// 2. System.MultiplePrompts 单条文本 → System.Prompt 字符串形式（SystemPrompt 归一化）.
 var ignoreCacheControlWithNormalize = append(
 	ignoreCacheControlOpts,
 	cmp.Transformer("normalizeMessageContent", func(mc MessageContent) MessageContent {
@@ -24,5 +25,17 @@ var ignoreCacheControlWithNormalize = append(
 			return MessageContent{Content: mc.MultipleContent[0].Text}
 		}
 		return mc
+	}),
+	cmp.Transformer("normalizeSystemPrompt", func(sp *SystemPrompt) *SystemPrompt {
+		if sp == nil {
+			return nil
+		}
+		// ensureStructuralCacheControls 会把 System.Prompt 归一化为 MultiplePrompts，
+		// 这里反向还原：如果 MultiplePrompts 只有一条 text 且 Prompt 为空，还原回 Prompt 形式。
+		if sp.Prompt == nil && len(sp.MultiplePrompts) == 1 && sp.MultiplePrompts[0].Type == "text" {
+			text := sp.MultiplePrompts[0].Text
+			return &SystemPrompt{Prompt: &text}
+		}
+		return sp
 	}),
 )

--- a/llm/transformer/anthropic/test_helpers_test.go
+++ b/llm/transformer/anthropic/test_helpers_test.go
@@ -1,0 +1,28 @@
+package anthropic
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// ignoreCacheControlOpts 只忽略 cache_control 字段差异，保留结构严格对比。
+// ensureCacheControl 注入行为已在 ensure_cache_control_test.go 中专门覆盖。
+var ignoreCacheControlOpts = []cmp.Option{
+	cmpopts.IgnoreFields(Tool{}, "CacheControl"),
+	cmpopts.IgnoreFields(MessageContentBlock{}, "CacheControl"),
+	cmpopts.IgnoreFields(SystemPromptPart{}, "CacheControl"),
+}
+
+// ignoreCacheControlWithNormalize 在忽略 cache_control 的基础上，
+// 还将单个 text block 的 MultipleContent 归一化为 Content 字符串形式。
+// 仅在 ensureCacheControl 可能转换 Content→MultipleContent 的测试场景中使用。
+var ignoreCacheControlWithNormalize = append(
+	ignoreCacheControlOpts,
+	cmp.Transformer("normalizeMessageContent", func(mc MessageContent) MessageContent {
+		if mc.Content == nil && len(mc.MultipleContent) == 1 &&
+			mc.MultipleContent[0].Type == "text" && mc.MultipleContent[0].Text != nil {
+			return MessageContent{Content: mc.MultipleContent[0].Text}
+		}
+		return mc
+	}),
+)


### PR DESCRIPTION
## Summary

- **Anthropic cache_control mode**: 新增 `respect_client`（默认）和 `auto_optimize` 两种缓存控制策略，支持自动注入最优 cache_control 断点
- **Codex 版本升级**: `codexDefaultVersion` 从 0.21.0 升级到 0.98.0，修复第三方使用 0.21.0 无法调用 gpt-5.3-codex 的问题
- **UI 优化**: 缓存控制下拉框只显示短名称，描述根据选中值动态显示在下方

## Changes

### Anthropic cache_control
- 新增 `ensure_cache_control.go`：实现 `respect_client` / `auto_optimize` 两种模式
- `respect_client`：保留客户端标记，无标记时自动注入最优断点；超过 4 个断点报错
- `auto_optimize`：清空所有标记后重建最优断点（tool → system → user turn）
- 全链路贯通：GraphQL enum → ChannelSettings → Config → TransformRequest
- 534 行测试覆盖各种边界场景

### Codex
- `codexDefaultVersion`: 0.21.0 → 0.98.0
- 测试中硬编码版本号改为引用常量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cache-control handling for Anthropic prompts with adaptive injection, normalization, and enforced anchors.

* **Bug Fixes**
  * Enforces a four-breakpoint limit, trims excess breakpoints, avoids injecting into non-cacheable or inappropriate blocks, and removes TTLs where not applicable.

* **Tests**
  * Expanded unit and integration coverage for counting, injection, trimming, normalization, idempotency, comparison helpers, and content-structure assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->