### PR TITLE
fix: token statistics card responsive layout overflow on mobile

### DIFF
--- a/frontend/src/features/dashboard/components/token-stats-card.tsx
+++ b/frontend/src/features/dashboard/components/token-stats-card.tsx
@@ -22,21 +22,21 @@ export function TokenStatsCard() {
           <Skeleton className='h-4 w-4' />
         </CardHeader>
         <CardContent>
-          <div className='flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-2'>
-            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
-              <Skeleton className='h-4 w-[40px] mb-0.5' />
+          <div className='flex items-end justify-between gap-2 sm:flex-col sm:gap-2 xl:flex-row xl:items-end xl:justify-between'>
+            <div className='text-center w-full sm:min-w-0 sm:flex sm:items-center sm:justify-between xl:block xl:flex-1 xl:text-center'>
+              <Skeleton className='h-4 w-[40px] sm:mb-0 xl:mb-1' />
               <Skeleton className='h-6 w-[60px]' />
             </div>
-            <div className='bg-border h-px w-full shrink-0 sm:hidden'></div>
-            <div className='bg-border h-8 w-px shrink-0 hidden sm:block'></div>
-            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
-              <Skeleton className='h-4 w-[40px] mb-0.5' />
+            <div className='bg-border h-8 w-px shrink-0 sm:hidden xl:block'></div>
+            <div className='bg-border h-px w-full shrink-0 hidden sm:block xl:hidden'></div>
+            <div className='text-center w-full sm:min-w-0 sm:flex sm:items-center sm:justify-between xl:block xl:flex-1 xl:text-center'>
+              <Skeleton className='h-4 w-[40px] sm:mb-0 xl:mb-1' />
               <Skeleton className='h-6 w-[60px]' />
             </div>
-            <div className='bg-border h-px w-full shrink-0 sm:hidden'></div>
-            <div className='bg-border h-8 w-px shrink-0 hidden sm:block'></div>
-            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
-              <Skeleton className='h-4 w-[40px] mb-0.5' />
+            <div className='bg-border h-8 w-px shrink-0 sm:hidden xl:block'></div>
+            <div className='bg-border h-px w-full shrink-0 hidden sm:block xl:hidden'></div>
+            <div className='text-center w-full sm:min-w-0 sm:flex sm:items-center sm:justify-between xl:block xl:flex-1 xl:text-center'>
+              <Skeleton className='h-4 w-[40px] sm:mb-0 xl:mb-1' />
               <Skeleton className='h-6 w-[60px]' />
             </div>
           </div>
@@ -117,21 +117,21 @@ export function TokenStatsCard() {
         </div>
       </CardHeader>
       <CardContent>
-        <div className='flex flex-col gap-2 xl:flex-row xl:items-end xl:justify-between xl:gap-2'>
-          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
-            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.input')}</div>
+        <div className='flex items-end justify-between gap-2 sm:flex-col sm:gap-2 xl:flex-row xl:items-end xl:justify-between'>
+          <div className='text-center min-w-0 sm:flex sm:items-center sm:justify-between sm:w-full xl:block xl:text-center xl:flex-1'>
+            <div className='text-muted-foreground text-xs sm:mb-0 xl:mb-1'>{t('dashboard.stats.input')}</div>
             <div className='font-mono text-lg font-bold'>{formatNumber(tokens.input)}</div>
           </div>
-          <div className='bg-border h-px w-full shrink-0 xl:hidden'></div>
-          <div className='bg-border h-8 w-px shrink-0 hidden xl:block'></div>
-          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
-            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.output')}</div>
+          <div className='bg-border h-8 w-px shrink-0 sm:hidden xl:block'></div>
+          <div className='bg-border h-px w-full shrink-0 hidden sm:block xl:hidden'></div>
+          <div className='text-center min-w-0 sm:flex sm:items-center sm:justify-between sm:w-full xl:block xl:text-center xl:flex-1'>
+            <div className='text-muted-foreground text-xs sm:mb-0 xl:mb-1'>{t('dashboard.stats.output')}</div>
             <div className='font-mono text-lg font-bold'>{formatNumber(tokens.output)}</div>
           </div>
-          <div className='bg-border h-px w-full shrink-0 xl:hidden'></div>
-          <div className='bg-border h-8 w-px shrink-0 hidden xl:block'></div>
-          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
-            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.cached')}</div>
+          <div className='bg-border h-8 w-px shrink-0 sm:hidden xl:block'></div>
+          <div className='bg-border h-px w-full shrink-0 hidden sm:block xl:hidden'></div>
+          <div className='text-center min-w-0 sm:flex sm:items-center sm:justify-between sm:w-full xl:block xl:text-center xl:flex-1'>
+            <div className='text-muted-foreground text-xs sm:mb-0 xl:mb-1'>{t('dashboard.stats.cached')}</div>
             <div className='text-muted-foreground font-mono text-lg font-bold'>{formatNumber(tokens.cached)}</div>
           </div>
         </div>

--- a/frontend/src/features/dashboard/components/token-stats-card.tsx
+++ b/frontend/src/features/dashboard/components/token-stats-card.tsx
@@ -16,15 +16,29 @@ export function TokenStatsCard() {
 
   if (isLoading) {
     return (
-      <Card>
+      <Card className='min-w-0'>
         <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
           <Skeleton className='h-4 w-[120px]' />
           <Skeleton className='h-4 w-4' />
         </CardHeader>
         <CardContent>
-          <div className='space-y-2'>
-            <Skeleton className='h-8 w-[80px]' />
-            <Skeleton className='mt-1 h-4 w-[140px]' />
+          <div className='flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-2'>
+            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
+              <Skeleton className='h-4 w-[40px] mb-0.5' />
+              <Skeleton className='h-6 w-[60px]' />
+            </div>
+            <div className='bg-border h-px w-full shrink-0 sm:hidden'></div>
+            <div className='bg-border h-8 w-px shrink-0 hidden sm:block'></div>
+            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
+              <Skeleton className='h-4 w-[40px] mb-0.5' />
+              <Skeleton className='h-6 w-[60px]' />
+            </div>
+            <div className='bg-border h-px w-full shrink-0 sm:hidden'></div>
+            <div className='bg-border h-8 w-px shrink-0 hidden sm:block'></div>
+            <div className='flex flex-col items-center text-center w-full sm:min-w-0 sm:flex-1'>
+              <Skeleton className='h-4 w-[40px] mb-0.5' />
+              <Skeleton className='h-6 w-[60px]' />
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -33,16 +47,15 @@ export function TokenStatsCard() {
 
   if (error) {
     return (
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <div className='flex items-center gap-2'>
-            <div className='bg-primary/10 text-primary dark:bg-primary/20 rounded-lg p-1.5'>
+      <Card className='hover-card min-w-0'>
+        <CardHeader className='flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-2 sm:space-y-0 pb-2'>
+          <div className='flex items-center gap-2 min-w-0'>
+            <div className='bg-primary/10 text-primary dark:bg-primary/20 rounded-lg p-1.5 shrink-0'>
               <BarChart4 className='h-4 w-4' />
             </div>
-            <CardTitle className='text-sm font-medium'>{t('dashboard.cards.tokenStats')}</CardTitle>
+            <CardTitle className='text-sm font-medium truncate'>{t('dashboard.cards.tokenStats')}</CardTitle>
           </div>
-          <div className='flex items-center gap-1'>
-            {/* <span className='text-xs text-muted-foreground'>{t('dashboard.stats.this')}</span> */}
+          <div className='flex items-center gap-1 shrink-0'>
             <span className='bg-primary/10 text-primary dark:bg-primary/20 rounded-md px-2 py-1 text-xs'>{t('dashboard.stats.month')}</span>
           </div>
         </CardHeader>
@@ -78,15 +91,15 @@ export function TokenStatsCard() {
   const tokens = getTokens(timeRange);
 
   return (
-    <Card className='hover-card'>
-      <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+    <Card className='hover-card min-w-0'>
+      <CardHeader className='flex flex-wrap items-start sm:items-center justify-between gap-2 pb-2'>
         <div className='flex items-center gap-2'>
-          <div className='bg-primary/10 text-primary dark:bg-primary/20 rounded-lg p-1.5'>
+          <div className='bg-primary/10 text-primary dark:bg-primary/20 rounded-lg p-1.5 shrink-0'>
             <BarChart4 className='h-4 w-4' />
           </div>
-          <CardTitle className='text-sm font-medium'>{t('dashboard.cards.tokenStats')}</CardTitle>
+          <CardTitle className='text-sm font-medium whitespace-normal leading-tight'>{t('dashboard.cards.tokenStats')}</CardTitle>
         </div>
-        <div className='flex items-center gap-1'>
+        <div className='flex items-center gap-1 shrink-0'>
           {/* <span className='text-xs text-muted-foreground'>{t('dashboard.stats.this')}</span> */}
           <Tabs value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
             <TabsList className='h-6 p-0.5'>
@@ -104,19 +117,21 @@ export function TokenStatsCard() {
         </div>
       </CardHeader>
       <CardContent>
-        <div className='flex items-end justify-between'>
-          <div className='text-center'>
-            <div className='text-muted-foreground mb-1 text-xs'>{t('dashboard.stats.input')}</div>
+        <div className='flex flex-col gap-2 xl:flex-row xl:items-end xl:justify-between xl:gap-2'>
+          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
+            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.input')}</div>
             <div className='font-mono text-lg font-bold'>{formatNumber(tokens.input)}</div>
           </div>
-          <div className='bg-border h-8 w-px'></div>
-          <div className='text-center'>
-            <div className='text-muted-foreground mb-1 text-xs'>{t('dashboard.stats.output')}</div>
+          <div className='bg-border h-px w-full shrink-0 xl:hidden'></div>
+          <div className='bg-border h-8 w-px shrink-0 hidden xl:block'></div>
+          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
+            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.output')}</div>
             <div className='font-mono text-lg font-bold'>{formatNumber(tokens.output)}</div>
           </div>
-          <div className='bg-border h-8 w-px'></div>
-          <div className='text-center'>
-            <div className='text-muted-foreground mb-1 text-xs'>{t('dashboard.stats.cached')}</div>
+          <div className='bg-border h-px w-full shrink-0 xl:hidden'></div>
+          <div className='bg-border h-8 w-px shrink-0 hidden xl:block'></div>
+          <div className='flex items-center justify-between w-full xl:min-w-0 xl:flex-1 xl:block xl:text-center'>
+            <div className='text-muted-foreground text-xs xl:mb-1'>{t('dashboard.stats.cached')}</div>
             <div className='text-muted-foreground font-mono text-lg font-bold'>{formatNumber(tokens.cached)}</div>
           </div>
         </div>

--- a/frontend/src/features/dashboard/index.tsx
+++ b/frontend/src/features/dashboard/index.tsx
@@ -39,8 +39,8 @@ export default function DashboardPage() {
               <Skeleton className='h-[180px]' />
             </div>
             <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-7'>
-              <Skeleton className='col-span-4 h-[300px]' />
-              <Skeleton className='col-span-3 h-[300px]' />
+              <Skeleton className='col-span-1 h-[300px] lg:col-span-4' />
+              <Skeleton className='col-span-1 h-[300px] lg:col-span-3' />
             </div>
           </div>
         </Tabs>
@@ -70,7 +70,7 @@ export default function DashboardPage() {
             <TodayRequestsCard />
           </div>
           <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-7'>
-            <Card className='hover-card col-span-4'>
+            <Card className='hover-card col-span-1 lg:col-span-4'>
               <CardHeader>
                 <CardTitle>{t('dashboard.charts.dailyRequestOverview')}</CardTitle>
               </CardHeader>
@@ -78,7 +78,7 @@ export default function DashboardPage() {
                 <DailyRequestStats />
               </CardContent>
             </Card>
-            <Card className='hover-card col-span-3'>
+            <Card className='hover-card col-span-1 lg:col-span-3'>
               <CardHeader>
                 <CardTitle>{t('dashboard.charts.channelSuccessRate')}</CardTitle>
                 <CardDescription>{t('dashboard.charts.channelSuccessRateDescription')}</CardDescription>


### PR DESCRIPTION
## Summary | 概述

**English:**
Fixes responsive layout overflow issues in the Token Statistics card and Channel Success Rate card on the dashboard, ensuring proper display on mobile and tablet devices.

**中文:**
修复仪表盘中 Token Statistics 卡片和 Channel Success Rate 卡片的响应式布局溢出问题，确保在移动端和平板设备上正确显示。

---

## Changes | 修改内容

### Token Statistics Card (`token-stats-card.tsx`)
- **Mobile (< 768px)**: Keep horizontal layout for better mobile experience
- **Tablet (768px - 1280px)**: Use stacked layout (label left, value right)
- **Desktop (≥ 1280px)**: Return to horizontal three-column layout
- Added `min-w-0` to prevent flexbox overflow
- Updated loading skeleton to match new responsive layout
- Added `truncate` and `whitespace-normal` to prevent text truncation

### Channel Success Rate Card (`dashboard/index.tsx`)
- Changed static `col-span` to responsive breakpoints
- Mobile: `col-span-1` (full width)
- Desktop (lg+): `col-span-3` for proper grid layout

---

## Screenshots | 截图

### Before | 修改前
<img width="411" height="268" alt="Screenshot from 2026-02-08 19-28-16" src="https://github.com/user-attachments/assets/edc66ddd-25b5-4c80-8edf-7cb6f2eb09e7" />
<img width="335" height="603" alt="Screenshot from 2026-02-08 20-31-45" src="https://github.com/user-attachments/assets/28baa36b-5cc4-4213-911b-b32d73bf89f0" />
<details>
<summary>Click to expand</summary>

| Screen Size | Before |
|-------------|--------|
| Mobile (< 768px) | Content overflow, cards split incorrectly |
| Tablet (768-1280px) | Misaligned layout |
| Desktop (≥ 1280px) | Normal |

</details>

### After | 修改后

<img width="397" height="282" alt="Screenshot from 2026-02-08 20-39-49" src="https://github.com/user-attachments/assets/05e38bad-0f37-4bc9-87e8-4b08a1fddb7e" />
<img width="334" height="562" alt="Screenshot from 2026-02-08 20-46-56" src="https://github.com/user-attachments/assets/39742e90-1925-4b94-a432-3cdea7aa0774" />
<details>
<summary>Click to expand</summary>

| Screen Size | After |
|-------------|-------|
| Mobile (< 768px) | Full width, horizontal layout |
| Tablet (768-1280px) | Stacked label-value layout |
| Desktop (≥ 1280px) | Three-column horizontal layout |

</details>


---

## Testing | 测试

- ✅ ESLint passes
- ✅ Build completes successfully
- ✅ Manual testing on mobile/tablet/desktop breakpoints

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] Breaking changes (none)

---

## Related | 相关

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Dashboard token statistics now display better on different screen sizes
  * Improved layout spacing and alignment across mobile, tablet, and desktop views
  * Enhanced visual clarity of loading and error states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->