### PR TITLE
fix: correct development guide link and add NanoGPT provider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Here are some screenshots of AxonHub in action:
 | **ZAI**                | ✅ Done    | -                            | Image Generation |
 | **AWS Bedrock**        | 🔄 Testing | Claude on AWS                | OpenAI, Anthropic, Gemini |
 | **Google Cloud**       | 🔄 Testing | Claude on GCP                | OpenAI, Anthropic, Gemini |
+| **NanoGPT**            | ✅ Done    | Various models, Image Gen    | OpenAI, Anthropic, Gemini, Image Generation |
 
 ---
 
@@ -462,7 +463,7 @@ For detailed SDK usage examples and code samples, please refer to the API docume
 
 ## 🛠️ Development Guide
 
-For detailed development instructions, architecture design, and contribution guidelines, please see [docs/en/guides/development.md](docs/en/guides/development.md).
+For detailed development instructions, architecture design, and contribution guidelines, please see [docs/en/development/development.md](docs/en/development/development.md).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,7 @@
 | **ZAI**                | ✅ 已完成   | -                            | Image Generation |
 | **AWS Bedrock**        | 🔄 测试中  | Claude on AWS                | OpenAI, Anthropic, Gemini |
 | **Google Cloud**       | 🔄 测试中  | Claude on GCP                | OpenAI, Anthropic, Gemini |
+| **NanoGPT**            | ✅ 已完成  | 多种模型、图像生成             | OpenAI, Anthropic, Gemini, Image Generation |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -440,7 +440,7 @@ AxonHub 提供灵活的模型管理系统，支持通过模型关联将抽象模
 
 ## 🛠️ 开发指南
 
-详细的开发说明、架构设计和贡献指南，请查看 [docs/zh/guides/development.md](docs/zh/guides/development.md)。
+详细的开发说明、架构设计和贡献指南，请查看 [docs/zh/development/development.md](docs/zh/development/development.md)。
 
 ---
 


### PR DESCRIPTION
Corrects invalid development guide link path and adds NanoGPT to supported providers table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NanoGPT to the list of supported providers with its available models/APIs — users can now select NanoGPT where providers are listed.

* **Documentation**
  * Updated Development Guide links in the English and Chinese READMEs to point to the new documentation location — ensures guides open correctly for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->