### PR TITLE
Fix: Preserve chunks with both ReasoningSignature and content / 修复：保留同时包含 ReasoningSignature 和内容的块

### DIFF
--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -150,10 +150,11 @@ func (t *InboundTransformer) TransformStreamChunk(
 	}, nil
 }
 
-// isReasoningSignatureEvent checks if the response contains ReasoningSignature.
+// isReasoningSignatureEvent checks if the response contains ONLY ReasoningSignature.
 // This is a help func to adapt the Anthropic thinking signature to OpenAI format.
 // In the real world, the signature will use a separate event, so if the response contains
-// ReasoningSignature, it means the event is for signature_delta, we should ignore it.
+// ONLY ReasoningSignature (without any other content), it means the event is for signature_delta,
+// we should ignore it.
 func isReasoningSignatureEvent(resp *llm.Response) bool {
 	if len(resp.Choices) != 1 {
 		return false
@@ -165,11 +166,19 @@ func isReasoningSignatureEvent(resp *llm.Response) bool {
 	}
 
 	// Check if ReasoningSignature is set
-	if delta.ReasoningSignature != nil && *delta.ReasoningSignature != "" {
-		return true
+	if delta.ReasoningSignature == nil || *delta.ReasoningSignature == "" {
+		return false
 	}
 
-	return false
+	// If ReasoningSignature is set, check if there's any other content
+	// If there is other content, this is NOT a pure signature event and should NOT be skipped
+	hasContent := delta.Content.Content != nil || len(delta.Content.MultipleContent) > 0
+	hasReasoningContent := delta.ReasoningContent != nil && *delta.ReasoningContent != ""
+	hasToolCalls := len(delta.ToolCalls) > 0
+	hasRefusal := delta.Refusal != ""
+
+	// Only skip if ONLY ReasoningSignature is present (pure signature event)
+	return !hasContent && !hasReasoningContent && !hasToolCalls && !hasRefusal
 }
 
 func (t *InboundTransformer) AggregateStreamChunks(

--- a/llm/transformer/openai/reasoning_fix_test.go
+++ b/llm/transformer/openai/reasoning_fix_test.go
@@ -1,0 +1,84 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsReasoningSignatureEvent_Fix(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *llm.Response
+		wantSkip bool // true means isReasoningSignatureEvent returns true (skip this chunk)
+	}{
+		{
+			name: "Anthropic Pure Signature (Should Skip)",
+			response: &llm.Response{
+				Choices: []llm.Choice{
+					{
+						Delta: &llm.Message{
+							ReasoningSignature: lo.ToPtr("signature_123"),
+							// No content
+						},
+					},
+				},
+			},
+			wantSkip: true,
+		},
+		{
+			name: "Gemini Mixed Chunk - Signature + Content (Should Keep)",
+			response: &llm.Response{
+				Choices: []llm.Choice{
+					{
+						Delta: &llm.Message{
+							ReasoningSignature: lo.ToPtr("signature_gemini"),
+							Content: llm.MessageContent{
+								Content: lo.ToPtr("Thinking done. Hello!"),
+							},
+						},
+					},
+				},
+			},
+			wantSkip: false, // Fix: Before valid check this was true (skipped)
+		},
+		{
+			name: "Gemini Mixed Chunk - Signature + Reasoning (Should Keep)",
+			response: &llm.Response{
+				Choices: []llm.Choice{
+					{
+						Delta: &llm.Message{
+							ReasoningSignature: lo.ToPtr("signature_gemini"),
+							ReasoningContent:   lo.ToPtr("I am thinking..."),
+						},
+					},
+				},
+			},
+			wantSkip: false, // Fix: Before valid check this was true (skipped)
+		},
+		{
+			name: "Standard Content (Should Keep)",
+			response: &llm.Response{
+				Choices: []llm.Choice{
+					{
+						Delta: &llm.Message{
+							Content: llm.MessageContent{
+								Content: lo.ToPtr("Just content"),
+							},
+						},
+					},
+				},
+			},
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isReasoningSignatureEvent(tt.response)
+			assert.Equal(t, tt.wantSkip, got, "isReasoningSignatureEvent mismatch")
+		})
+	}
+}


### PR DESCRIPTION
## Problem / 问题

When using Gemini models with thinking capabilities, the main request's response body is incorrectly saved as empty values because all chunks containing `ReasoningSignature` are being filtered out, even when they contain actual content.

当使用具有思维能力的 Gemini 模型时，主请求的响应体被错误地保存为空值，因为所有包含 `ReasoningSignature` 的块都被过滤掉了，即使它们包含实际内容。

## Root Cause / 根本原因

The `isReasoningSignatureEvent` function in `llm/transformer/openai/inbound.go` was skipping **all** chunks that have a `ReasoningSignature` field, regardless of whether they also contain actual content like text, reasoning content, or tool calls.

`llm/transformer/openai/inbound.go` 中的 `isReasoningSignatureEvent` 函数跳过了**所有**具有 `ReasoningSignature` 字段的块，无论它们是否还包含文本、推理内容或工具调用等实际内容。

### Before (Incorrect Behavior) / 修改前（错误行为）
```go
func isReasoningSignatureEvent(resp *llm.Response) bool {
    // ...
    // ❌ Returns true for ANY chunk with ReasoningSignature
    if delta.ReasoningSignature != nil && *delta.ReasoningSignature != "" {
        return true
    }
    return false
}
```

This caused:
1. Gemini thinking chunks (with both signature + content) to be skipped
2. All chunks filtered out by `streams.NoNil`
3. Empty `responseChunks` array
4. Empty response body saved to database
5. Gemini 3 Tool Calls would be dropped if signature is attached to the same chunk as per documentation.
---
导致结果：
1. Gemini 思考块（同时包含签名+内容）被跳过
2. 所有块都被 `streams.NoNil` 过滤掉
3. `responseChunks` 数组为空
4. 保存到数据库的响应体为空
5. Gemini 3 Tool Calls would be dropped if signature is attached to the same chunk as per documentation.

### After (Correct Behavior) / 修改后（正确行为）
```go
func isReasoningSignatureEvent(resp *llm.Response) bool {
    // ...
    if delta.ReasoningSignature == nil || *delta.ReasoningSignature == "" {
        return false
    }

    // ✅ Check if there's any other content besides the signature
    hasContent := delta.Content.Content != nil || len(delta.Content.MultipleContent) > 0
    hasReasoningContent := delta.ReasoningContent != nil && *delta.ReasoningContent != ""
    hasToolCalls := len(delta.ToolCalls) > 0
    hasRefusal := delta.Refusal != ""

    // ✅ Only skip if ONLY ReasoningSignature is present (pure signature event)
    return !hasContent && !hasReasoningContent && !hasToolCalls && !hasRefusal
}
```

Now the function correctly:
1. Preserves chunks with signature + content (Gemini thinking)
2. Still skips pure signature events (Anthropic signature_delta)
3. Allows proper aggregation of all content

现在该函数正确地：
1. 保留包含签名+内容的块（Gemini 思考）
2. 仍然跳过纯签名事件（Anthropic signature_delta）
3. 允许正确聚合所有内容

## Changes / 变更

**Modified Files / 修改的文件:**

1. `llm/transformer/openai/inbound.go`
   - Modified `isReasoningSignatureEvent` function (lines 153-182)
   - Updated function documentation to clarify "ONLY" behavior
   - Added checks for other delta fields: `Content`, `ReasoningContent`, `ToolCalls`, `Refusal`
   - Changed logic to only skip chunks with **exclusively** `ReasoningSignature`

2. `llm/transformer/openai/reasoning_fix_test.go` (new file)
   - Added comprehensive unit tests for `isReasoningSignatureEvent`
   - Covers 4 test cases: Anthropic pure signature, Gemini mixed chunks, standard content


1. `llm/transformer/openai/inbound.go`
   - 修改了 `isReasoningSignatureEvent` 函数（第 153-182 行）
   - 更新了函数文档以阐明 "ONLY"（仅）的行为
   - 添加了对其他 delta 字段的检查：`Content`, `ReasoningContent`, `ToolCalls`, `Refusal`
   - 更改逻辑为仅跳过 **独占** 包含 `ReasoningSignature` 的块

2. `llm/transformer/openai/reasoning_fix_test.go`（新文件）
   - 为 `isReasoningSignatureEvent` 添加了全面的单元测试
   - 覆盖 4 个测试用例：Anthropic 纯签名、Gemini 混合块、标准内容

## Testing / 测试

### Manual Testing / 手动测试
1. Configure a Gemini 2.5 Pro channel
2. Send a chat completion request that triggers thinking (complex reasoning task)
3. Verify in the web UI that:
   - Request status: `completed` ✅
   - Response body: Contains full OpenAI-formatted response with `reasoning_content` ✅
   - Execution record: Contains full Gemini response ✅
   - Usage: Correctly shows `promptTokens` + `thoughtsTokenCount` + `completionTokens` ✅

---

1. 配置 Gemini 2.5 Pro 渠道
2. 发送触发思考的聊天完成请求（复杂的推理任务）
3. 在 Web UI 中验证：
   - 请求状态：`completed` ✅
   - 响应体：包含完整的 OpenAI 格式响应与 `reasoning_content` ✅
   - 执行记录：包含完整的 Gemini 响应 ✅
   - 用量：正确显示 `promptTokens` + `thoughtsTokenCount` + `completionTokens` ✅

### Verification Points / 验证点
- [x] Gemini requests with thinking content now store full response body / 带有思考内容的 Gemini 请求现在存储完整的响应体
- [x] Gemini requests without thinking still work correctly / 不带思考的 Gemini 请求仍然正常工作
- [x] Anthropic signature_delta events are still properly filtered (unit test) / Anthropic signature_delta 事件仍然被正确过滤（单元测试）
- [x] OpenAI models (no reasoning signature) are unaffected / OpenAI 模型（无推理签名）不受影响
- [x] Streaming to clients still works correctly (real-time output) / 客户端流式传输仍然正常工作（实时输出）

### Regression Testing / 回归测试

All existing transformer tests pass, confirming no regression:
所有现有的 transformer 测试通过，确认没有回归：

```bash
$ go test ./llm/transformer/openai/ ./llm/transformer/anthropic/ ./llm/transformer/gemini/

ok   github.com/looplj/axonhub/llm/transformer/anthropic  0.183s
ok   github.com/looplj/axonhub/llm/transformer/gemini     0.384s
ok   github.com/looplj/axonhub/llm/transformer/openai     0.821s  (excluding unrelated FakeExecutor tests)
```

Key test results / 关键测试结果:
- `TestIsReasoningSignatureEvent_Fix`: ✅ All 4 cases pass / 全部 4 个用例通过
  - Anthropic Pure Signature (Should Skip) ✅
  - Gemini Mixed Chunk - Signature + Content (Should Keep) ✅
  - Gemini Mixed Chunk - Signature + Reasoning (Should Keep) ✅
  - Standard Content (Should Keep) ✅
- `TestAggregateStreamChunks`: ✅ All cases pass / 全部用例通过
- Anthropic transformer tests: ✅ All pass / 全部通过
- Gemini transformer tests: ✅ All pass / 全部通过

**Note / 注意**: Anthropic behavior is verified via unit test (`isReasoningSignatureEvent` correctly returns `true` for pure signature events). End-to-end manual testing with real Anthropic API was not performed. Reviewer may want to verify with actual Anthropic extended thinking requests if concerned.

**注意**：Anthropic 行为通过单元测试验证（`isReasoningSignatureEvent` 对纯签名事件正确返回 `true`）。未使用真实 Anthropic API 进行端到端手动测试。如有顾虑，审阅者可使用实际的 Anthropic extended thinking 请求进行验证。

### Test Case Example / 测试用例示例

#### Reproduction Analysis / 复现分析

I have successfully reproduced the data loss scenario:
我已成功复现数据丢失场景：

- **Observation / 观察**: The streaming output continues, but the **first sentence/content part is missing**. / 流式输出继续，但**第一句话/内容部分丢失**。
- **Cause / 原因**: Gemini often bundles the `ReasoningSignature` and the first `Content` part in the **same chunk**. / Gemini 经常在**同一个块**中捆绑 `ReasoningSignature` 和第一个 `Content` 部分。
- **Effect / 影响**: The buggy code drops this first chunk entirely. The user/system receives the stream starting from the second chunk, resulting in silent data loss at the beginning of the message. / 有缺陷的代码完全丢弃了这第一个块。用户/系统从第二个块开始接收流，导致消息开头的静默数据丢失。

**Note / 注意**: This bug depends on how the upstream provider (Gemini) or network stack chunks the response, making it difficult to reproduce consistently in live environments. If `{signature}` and `{content}` arrive in separate chunks, the bug is hidden. If `{signature, content}` arrive in the same merged chunk, the bug triggers.

由于此 Bug 取决于上游提供商 (Gemini) 或网络栈如何对响应进行分块，因此很难在实时环境中一致地复现。如果 `{signature}` 和 `{content}` 分在不同的块中到达，Bug 就会被隐藏。如果 `{signature, content}` 在同一个合并块中到达，Bug 就会触发。

#### Unit Test / 单元测试

Given this is a race condition/chunking behavior, I added a deterministic **unit test** to prove the logic handles all cases correctly.
鉴于这是一种竞争条件/分块行为，我添加了一个确定性的 **单元测试** 来证明该逻辑能正确处理所有情况。

**Test file / 测试文件**: `llm/transformer/openai/reasoning_fix_test.go`

```bash
go test -v ./llm/transformer/openai/ -run TestIsReasoningSignatureEvent_Fix
```

**Test cases covered / 测试用例覆盖**:
1. **Anthropic Pure Signature**: Should skip (Original intent) / 应跳过（原始意图）
2. **Gemini Mixed Chunk (Signature + Content)**: Should keep (The Fix) / 应保留（修复）
3. **Gemini Mixed Chunk (Signature + Reasoning)**: Should keep (The Fix) / 应保留（修复）
4. **Standard Content**: Should keep / 应保留

#### Manual Test Request / 手动测试请求

```bash
curl -X POST http://localhost:8090/v1/chat/completions \
  -H "Authorization: Bearer xxx" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemini-2.5-pro",
    "messages": [{"role": "user", "content": "晚上好"}],
    "stream": true
  }'
```

**Expected Result (in database) / 期望结果（在数据库中）**:
- Request response body should contain complete OpenAI format with all fields populated / 请求响应体应包含填充了所有字段的完整 OpenAI 格式
- Should include `reasoning_content` field if Gemini produced thinking tokens / 如果 Gemini 产生了思考令牌，应包含 `reasoning_content` 字段
- Usage should match Gemini's reported usage / 用量应与 Gemini 报告的用量匹配

## Breaking Changes / 破坏性变更

None. This fix only corrects incorrect behavior - it does not change the API contract or introduce new features.
无。此修复仅纠正了不正确的行为 - 它不会更改 API 契约或引入新功能。

## Backward Compatibility / 向后兼容性

✅ Fully backward compatible:
- Existing behavior for pure signature events (Anthropic) is preserved
- Gemini requests now work correctly (previously broken)
- OpenAI and other providers are unaffected
- Stream output to clients remains unchanged

✅ 完全向后兼容：
- 纯签名事件（Anthropic）的现有行为得以保留
- Gemini 请求现在可以正常工作（以前已损坏）
- OpenAI 和其他提供商不受影响
- 客户端的流输出保持不变

## Related Issues / 相关 Issue

Fixes #817

## Checklist / 检查清单

- [x] Code follows project style guidelines / 代码遵循项目风格指南
- [x] Comments updated to reflect new behavior / 注释已更新以反映新行为
- [x] Manual testing completed successfully / 手动测试成功完成
- [x] Unit tests added/updated (if applicable) / 单元测试已添加/更新（如适用）
- [x] Regression tests pass / 回归测试通过
- [x] No breaking changes introduced / 未引入破坏性变更
- [x] Documentation (function comments) updated / 文档（函数注释）已更新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined response event filtering logic to only skip signature-only events, ensuring events with additional content are preserved.

* **Tests**
  * Added comprehensive test coverage for response event filtering across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->