### PR TITLE
fix: handle embedding responses for stats display

### DIFF
--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -27,13 +27,7 @@ export function calculateTokensPerSecond(request: Request): string {
     (usageLog.completionReasoningTokens || 0) +
     (usageLog.completionAudioTokens || 0);
 
-  // For embeddings or other requests with no completion tokens,
-  // fall back to total tokens
-  const tokens = completionTokens > 0
-    ? completionTokens
-    : (usageLog.totalTokens || 0);
-
-  if (tokens === 0) {
+  if (completionTokens === 0) {
     return '-';
   }
 
@@ -52,7 +46,7 @@ export function calculateTokensPerSecond(request: Request): string {
   }
 
   const latencySeconds = effectiveLatencyMs / 1000;
-  const tokensPerSecond = tokens / latencySeconds;
+  const tokensPerSecond = completionTokens / latencySeconds;
 
   return `${Math.round(tokensPerSecond)} tok/s`;
 }

--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -27,7 +27,13 @@ export function calculateTokensPerSecond(request: Request): string {
     (usageLog.completionReasoningTokens || 0) +
     (usageLog.completionAudioTokens || 0);
 
-  if (completionTokens === 0) {
+  // For embeddings or other requests with no completion tokens,
+  // fall back to total tokens
+  const tokens = completionTokens > 0
+    ? completionTokens
+    : (usageLog.totalTokens || 0);
+
+  if (tokens === 0) {
     return '-';
   }
 
@@ -46,7 +52,7 @@ export function calculateTokensPerSecond(request: Request): string {
   }
 
   const latencySeconds = effectiveLatencyMs / 1000;
-  const tokensPerSecond = completionTokens / latencySeconds;
+  const tokensPerSecond = tokens / latencySeconds;
 
   return `${Math.round(tokensPerSecond)} tok/s`;
 }

--- a/internal/server/orchestrator/request_test.go
+++ b/internal/server/orchestrator/request_test.go
@@ -1,0 +1,338 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+func TestPersistRequestMiddleware_OnOutboundLlmResponse_NilRequest(t *testing.T) {
+	state := &PersistenceState{
+		Request: nil,
+	}
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	ctx := context.Background()
+	resp := &llm.Response{ID: "resp-1"}
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, resp)
+
+	require.NoError(t, err)
+	require.Equal(t, resp, result)
+}
+
+func TestPersistRequestMiddleware_OnOutboundLlmResponse_NilResponse(t *testing.T) {
+	state := &PersistenceState{
+		Request: &ent.Request{ID: 1},
+	}
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	ctx := context.Background()
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, nil)
+
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestPersistRequestMiddleware_Name(t *testing.T) {
+	middleware := &persistRequestMiddleware{}
+	require.Equal(t, "persist-request", middleware.Name())
+}
+
+func TestPersistRequestMiddleware_UsageExtraction_EmbeddingResponse(t *testing.T) {
+	t.Parallel()
+	
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+	ctx = ent.NewContext(ctx, client)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Test Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"text-embedding-3-small"}).
+		SetDefaultTestModel("text-embedding-3-small").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = openai.NewOutboundTransformer(ch.BaseURL, "test-key")
+	require.NoError(t, err)
+
+	state := &PersistenceState{
+		Request: &ent.Request{
+			ID:         1,
+			ProjectID:  1,
+			APIKeyID:   1,
+			Source:     "test",
+			Format:     "openai",
+			ModelID:    "text-embedding-3-small",
+		},
+		RequestExec: &ent.RequestExecution{
+			ID:        1,
+			ChannelID: ch.ID,
+			ModelID:   "text-embedding-3-small",
+		},
+	}
+
+	channelService := biz.NewChannelServiceForTest(client)
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		Ent: client,
+	})
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+
+	state.UsageLogService = usageLogService
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	llmResp := &llm.Response{
+		ID: "resp-1",
+		Embedding: &llm.EmbeddingResponse{
+			Usage: &llm.EmbeddingUsage{
+				PromptTokens: 100,
+				TotalTokens:  100,
+			},
+		},
+	}
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, llmResp)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, llmResp.ID, result.ID)
+	require.NotNil(t, result.Embedding)
+	require.Equal(t, int64(100), result.Embedding.Usage.PromptTokens)
+}
+
+func TestPersistRequestMiddleware_UsageExtraction_ChatResponse(t *testing.T) {
+	t.Parallel()
+	
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+	ctx = ent.NewContext(ctx, client)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Test Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = openai.NewOutboundTransformer(ch.BaseURL, "test-key")
+	require.NoError(t, err)
+
+	state := &PersistenceState{
+		Request: &ent.Request{
+			ID:         1,
+			ProjectID:  1,
+			APIKeyID:   1,
+			Source:     "test",
+			Format:     "openai",
+			ModelID:    "gpt-4",
+		},
+		RequestExec: &ent.RequestExecution{
+			ID:        1,
+			ChannelID: ch.ID,
+			ModelID:   "gpt-4",
+		},
+	}
+
+	channelService := biz.NewChannelServiceForTest(client)
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		Ent: client,
+	})
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+
+	state.UsageLogService = usageLogService
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	llmResp := &llm.Response{
+		ID: "resp-2",
+		Usage: &llm.Usage{
+			PromptTokens:     50,
+			CompletionTokens: 150,
+			TotalTokens:      200,
+		},
+	}
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, llmResp)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, llmResp.ID, result.ID)
+	require.NotNil(t, result.Usage)
+	require.Equal(t, int64(50), result.Usage.PromptTokens)
+	require.Equal(t, int64(150), result.Usage.CompletionTokens)
+	require.Equal(t, int64(200), result.Usage.TotalTokens)
+}
+
+func TestPersistRequestMiddleware_UsageExtraction_NilUsage(t *testing.T) {
+	t.Parallel()
+	
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+	ctx = ent.NewContext(ctx, client)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Test Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = openai.NewOutboundTransformer(ch.BaseURL, "test-key")
+	require.NoError(t, err)
+
+	state := &PersistenceState{
+		Request: &ent.Request{
+			ID:         1,
+			ProjectID:  1,
+			APIKeyID:   1,
+			Source:     "test",
+			Format:     "openai",
+			ModelID:    "gpt-4",
+		},
+		RequestExec: &ent.RequestExecution{
+			ID:        1,
+			ChannelID: ch.ID,
+			ModelID:   "gpt-4",
+		},
+	}
+
+	channelService := biz.NewChannelServiceForTest(client)
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		Ent: client,
+	})
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+
+	state.UsageLogService = usageLogService
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	llmResp := &llm.Response{
+		ID:   "resp-3",
+		Usage: nil,
+	}
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, llmResp)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, llmResp.ID, result.ID)
+}
+
+func TestPersistRequestMiddleware_UsageExtraction_EmbeddingWithNilUsage(t *testing.T) {
+	t.Parallel()
+	
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+	ctx = ent.NewContext(ctx, client)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Test Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"text-embedding-3-small"}).
+		SetDefaultTestModel("text-embedding-3-small").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = openai.NewOutboundTransformer(ch.BaseURL, "test-key")
+	require.NoError(t, err)
+
+	state := &PersistenceState{
+		Request: &ent.Request{
+			ID:         1,
+			ProjectID:  1,
+			APIKeyID:   1,
+			Source:     "test",
+			Format:     "openai",
+			ModelID:    "text-embedding-3-small",
+		},
+		RequestExec: &ent.RequestExecution{
+			ID:        1,
+			ChannelID: ch.ID,
+			ModelID:   "text-embedding-3-small",
+		},
+	}
+
+	channelService := biz.NewChannelServiceForTest(client)
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		Ent: client,
+	})
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+
+	state.UsageLogService = usageLogService
+
+	middleware := &persistRequestMiddleware{
+		inbound: &PersistentInboundTransformer{
+			state: state,
+		},
+	}
+
+	llmResp := &llm.Response{
+		ID: "resp-4",
+		Embedding: &llm.EmbeddingResponse{
+			Usage: nil,
+		},
+	}
+
+	result, err := middleware.OnOutboundLlmResponse(ctx, llmResp)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, llmResp.ID, result.ID)
+}

--- a/llm/transformer/nanogpt/outbound.go
+++ b/llm/transformer/nanogpt/outbound.go
@@ -86,6 +86,11 @@ func (t *OutboundTransformer) TransformResponse(
 		return nil, fmt.Errorf("response body is empty")
 	}
 
+	// Route to embedded OpenAI transformer for embedding responses
+	if httpResp.Request != nil && httpResp.Request.APIFormat == string(llm.APIFormatOpenAIEmbedding) {
+		return t.Outbound.TransformResponse(ctx, httpResp)
+	}
+
 	var nanoResp Response
 
 	err := json.Unmarshal(httpResp.Body, &nanoResp)


### PR DESCRIPTION
## Summary

- Fix embedding response handling to properly track and display usage statistics
- Delegate NanoGPT embedding responses to OpenAI transformer for correct parsing
- Add unit tests for embedding usage extraction and routing logic

Before this change:

<img width="589" height="237" alt="Screenshot from 2026-02-12 23-00-43" src="https://github.com/user-attachments/assets/03fca3d5-0937-4a26-88ed-c538b1b276c2" />

After:

<img width="589" height="199" alt="Screenshot from 2026-02-12 23-03-07" src="https://github.com/user-attachments/assets/6a770e44-cc28-4850-b540-4c685fa83558" />

## Changes

### Backend
- `internal/server/orchestrator/request.go`: Handle embedding usage for stats display by converting `EmbeddingUsage` to standard `Usage` format
- `llm/transformer/nanogpt/outbound.go`: Route embedding responses to embedded OpenAI transformer

### Tests
- `internal/server/orchestrator/request_test.go`: Add tests for embedding usage extraction
- `llm/transformer/nanogpt/outbound_test.go`: Add tests for embedding response routing

## Details

This fix ensures that:
1. Embedding requests properly track token usage for stats display
2. NanoGPT correctly delegates embedding response transformation to the embedded OpenAI transformer
3. Both embedding and chat response paths are properly tested

## Related Commits

- `85543890` fix(orchestrator): handle embedding usage for stats display
- `11ec85e2` fix(nanogpt): delegate embedding responses to OpenAI transformer
- `d6dc17d1` fix(frontend): calculate token/s for embeddings using totalTokens (reverted)
- `13302f98` Revert "fix(frontend): calculate token/s for embeddings using totalTokens"
- `301af855` test: add unit tests for embedding response handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of embedding model responses to correctly track token usage and propagate response data.

* **Tests**
  * Added comprehensive test coverage for embedding and chat response processing, including edge cases for nil usage and various response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->