### PR TITLE
feat(claudecode): add IsOfficial param to strip billing header for non-OAuth channels

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -309,6 +309,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel) (*Channel
 			transformer, err := claudecode.NewOutboundTransformer(claudecode.Params{
 				TokenProvider: tokens,
 				BaseURL:       c.BaseURL,
+				IsOfficial:    true,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create claudecode outbound transformer: %w", err)
@@ -330,6 +331,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel) (*Channel
 		transformer, err := claudecode.NewOutboundTransformer(claudecode.Params{
 			TokenProvider: tokens,
 			BaseURL:       c.BaseURL,
+			IsOfficial:    false,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create claudecode outbound transformer: %w", err)


### PR DESCRIPTION
## Summary

Add an `IsOfficial` parameter to the Claude Code Transformer. When `IsOfficial` is `false` (non-OAuth / API key channels), system messages prefixed with `x-anthropic-billing-header:` are automatically removed before forwarding the request to the upstream API.

## Motivation

The Claude Code CLI injects system messages like:
```
x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli; cch=e478e;
```
These billing metadata messages are only meaningful for official OAuth channels. For non-OAuth (API key) channels, they should be stripped to avoid leaking client information and unnecessary token consumption.

## Changes

### `llm/transformer/anthropic/claudecode/outbound.go`
- Added `IsOfficial` field to `Params` struct
- Added `isOfficial` field to `ClaudeCodeTransformer` struct
- In `TransformRequest`, call `removeBillingSystemMessages()` when `isOfficial == false`

### `llm/transformer/anthropic/claudecode/utils.go`
- Added `billingHeaderPrefix` constant (`x-anthropic-billing-header:`)
- Added `removeBillingSystemMessages()` function that filters out system messages matching the billing header prefix

### `internal/server/biz/channel_llm.go`
- OAuth path: set `IsOfficial: true`
- Non-OAuth (API key) path: set `IsOfficial: false`

### `llm/transformer/anthropic/claudecode/outbound_test.go`
- Added test: `removes billing system messages when not official`
- Added test: `preserves billing system messages when official`

## Testing

All existing and new tests pass:
```
PASS: removes_billing_system_messages_when_not_official
PASS: preserves_billing_system_messages_when_official
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of billing headers in Claude Code API requests when using non-official credentials.

* **Tests**
  * Added test coverage for billing header management based on credential type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->