### PR TITLE
fix: auto-refresh pagination limit

### DIFF
--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -105,7 +105,7 @@ export function RequestsTable({
     localStorage.setItem('requests-table-column-visibility', JSON.stringify(columnVisibility));
   }, [columnVisibility]);
 
-  const displayedData = useAnimatedList(data, autoRefresh);
+  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 
   // Sync filters with the server state
   const handleColumnFiltersChange = (updater: any) => {

--- a/frontend/src/features/threads/components/threads-table.tsx
+++ b/frontend/src/features/threads/components/threads-table.tsx
@@ -76,7 +76,7 @@ export function ThreadsTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefresh);
+  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/features/traces/components/traces-table.tsx
+++ b/frontend/src/features/traces/components/traces-table.tsx
@@ -77,7 +77,7 @@ export function TracesTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefresh);
+  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -79,10 +79,7 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
         if (nextItem) {
           setDisplayedData((prev) => {
             const newData = [nextItem, ...prev];
-            if (newData.length > pageSize) {
-              return newData.slice(0, pageSize);
-            }
-            return newData;
+            return newData.slice(0, pageSize);
           });
         }
       }

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -5,7 +5,7 @@ const MAX_ITEMS = 50;
 const parsedInterval = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL, 10);
 const ANIMATION_INTERVAL = !isNaN(parsedInterval) && parsedInterval > 0 ? parsedInterval : 500;
 
-export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean) {
+export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean, pageSize: number = MAX_ITEMS) {
   const [displayedData, setDisplayedData] = useState<T[]>(data);
   const queueRef = useRef<T[]>([]);
   const prevDataLengthRef = useRef<number>(data.length);
@@ -79,8 +79,8 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
         if (nextItem) {
           setDisplayedData((prev) => {
             const newData = [nextItem, ...prev];
-            if (newData.length > MAX_ITEMS) {
-              return newData.slice(0, MAX_ITEMS);
+            if (newData.length > pageSize) {
+              return newData.slice(0, pageSize);
             }
             return newData;
           });


### PR DESCRIPTION
## Summary

Fixes bug where the /requests, /threads, and /traces pages load more rows than the selected rows per page limit when auto-refresh is ON.

## Root Cause

The useAnimatedList hook had a hardcoded MAX_ITEMS = 50 constant that was used to cap displayed data during auto-refresh animations, completely ignoring the actual pageSize setting (e.g., 20).

## Changes

- Modified useAnimatedList hook to accept pageSize as a third parameter (with MAX_ITEMS as default for backward compatibility)
- Updated requests-table.tsx, threads-table.tsx, and traces-table.tsx to pass pageSize to the hook
- Removed redundant nullish coalescing in the hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Table lists (requests, threads, traces) now respect page size for animated updates and truncation, so visible items consistently match your selected pagination size during live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->