### PR TITLE
refactor: cleanup llm package deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/looplj/axonhub
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/go-openapi/inflect v0.21.4 // indirect

--- a/llm/internal/pkg/xjson/constants.go
+++ b/llm/internal/pkg/xjson/constants.go
@@ -1,0 +1,7 @@
+package xjson
+
+var (
+	EmptyJSON      = []byte("{}")
+	NullJSON       = []byte("null")
+	EmptyArrayJSON = []byte("[]")
+)

--- a/llm/internal/pkg/xjson/json.go
+++ b/llm/internal/pkg/xjson/json.go
@@ -1,0 +1,43 @@
+package xjson
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func MustMarshalString(v any) string {
+	return string(MustMarshal(v))
+}
+
+func MustMarshal(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func MustTo[T any](v []byte) T {
+	t, err := To[T](v)
+	if err != nil {
+		panic(err)
+	}
+
+	return t
+}
+
+func To[T any](v []byte) (T, error) {
+	var t T
+
+	err := json.Unmarshal(v, &t)
+	if err != nil {
+		return t, err
+	}
+
+	return t, nil
+}
+
+func IsNull(v json.RawMessage) bool {
+	return len(v) == 0 || bytes.Equal(v, NullJSON)
+}

--- a/llm/internal/pkg/xjson/safe.go
+++ b/llm/internal/pkg/xjson/safe.go
@@ -1,0 +1,30 @@
+package xjson
+
+import (
+	"encoding/json"
+
+	"github.com/kaptinlin/jsonrepair"
+)
+
+// SafeJSONRawMessage tries to convert a string into a valid JSON RawMessage.
+// Strategy:
+// 1) If empty or only whitespace, return {}.
+// 2) If valid JSON, use it directly.
+// 3) Try jsonrepair; if repaired is valid JSON, use it.
+// 4) Fallback to {}.
+func SafeJSONRawMessage(s string) json.RawMessage {
+	if len(s) == 0 {
+		return json.RawMessage("{}")
+	}
+
+	if json.Valid([]byte(s)) {
+		return json.RawMessage(s)
+	}
+
+	repaired, err := jsonrepair.JSONRepair(s)
+	if err == nil && json.Valid([]byte(repaired)) {
+		return json.RawMessage(repaired)
+	}
+
+	return json.RawMessage("{}")
+}

--- a/llm/internal/pkg/xjson/schema.go
+++ b/llm/internal/pkg/xjson/schema.go
@@ -1,0 +1,139 @@
+package xjson
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/samber/lo"
+)
+
+func Transform(rawSchema json.RawMessage, transform func(*jsonschema.Schema)) (json.RawMessage, error) {
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(rawSchema, &schema); err != nil {
+		return nil, err
+	}
+
+	transformSchemaRecursive(&schema, transform)
+
+	return json.Marshal(&schema)
+}
+
+func transformSchemaRecursive(schema *jsonschema.Schema, transform func(*jsonschema.Schema)) {
+	if schema == nil {
+		return
+	}
+
+	transform(schema)
+
+	// Recursively transform sub-schema fields
+	lo.ForEach([]*jsonschema.Schema{
+		schema.Items,
+		schema.AdditionalItems,
+		schema.Contains,
+		schema.Not,
+		schema.If,
+		schema.Then,
+		schema.Else,
+		schema.PropertyNames,
+		schema.UnevaluatedProperties,
+		schema.UnevaluatedItems,
+		schema.ContentSchema,
+	}, func(subSchema *jsonschema.Schema, _ int) {
+		transformSchemaRecursive(subSchema, transform)
+	})
+
+	// Transform schema slices
+	schemaSlices := [][]*jsonschema.Schema{
+		schema.PrefixItems,
+		schema.ItemsArray,
+		schema.AllOf,
+		schema.AnyOf,
+		schema.OneOf,
+	}
+	lo.ForEach(schemaSlices, func(schemas []*jsonschema.Schema, _ int) {
+		lo.ForEach(schemas, func(subSchema *jsonschema.Schema, _ int) {
+			transformSchemaRecursive(subSchema, transform)
+		})
+	})
+
+	// Transform schema maps
+	schemaMaps := []map[string]*jsonschema.Schema{
+		schema.Defs,
+		schema.Definitions,
+		schema.DependentSchemas,
+		schema.Properties,
+		schema.PatternProperties,
+		schema.DependencySchemas,
+	}
+	lo.ForEach(schemaMaps, func(schemaMap map[string]*jsonschema.Schema, _ int) {
+		lo.ForEach(lo.Values(schemaMap), func(subSchema *jsonschema.Schema, _ int) {
+			transformSchemaRecursive(subSchema, transform)
+		})
+	})
+}
+
+func CleanSchema(rawSchema json.RawMessage, fields ...string) (json.RawMessage, error) {
+	return Transform(rawSchema, func(schema *jsonschema.Schema) {
+		clearFieldsFromSchema(schema, fields...)
+	})
+}
+
+// clearFieldsFromSchema clears specified fields from a single schema.
+func clearFieldsFromSchema(schema *jsonschema.Schema, fields ...string) {
+	schemaValue := reflect.ValueOf(schema).Elem()
+	schemaType := reflect.TypeFor[jsonschema.Schema]()
+
+	for _, fieldName := range fields {
+		// Handle special cases for JSON field names that don't match Go struct field names
+		switch fieldName {
+		case "$schema":
+			schema.Schema = ""
+		case "$id":
+			schema.ID = ""
+		case "$ref":
+			schema.Ref = ""
+		case "$comment":
+			schema.Comment = ""
+		case "$defs":
+			schema.Defs = nil
+		case "$anchor":
+			schema.Anchor = ""
+		case "$dynamicAnchor":
+			schema.DynamicAnchor = ""
+		case "$dynamicRef":
+			schema.DynamicRef = ""
+		case "$vocabulary":
+			schema.Vocabulary = nil
+		case "additionalProperties":
+			schema.AdditionalProperties = nil
+		case "definitions":
+			schema.Definitions = nil
+		case "dependentSchemas":
+			schema.DependentSchemas = nil
+		case "dependentRequired":
+			schema.DependentRequired = nil
+		case "patternProperties":
+			schema.PatternProperties = nil
+		case "propertyNames":
+			schema.PropertyNames = nil
+		case "unevaluatedProperties":
+			schema.UnevaluatedProperties = nil
+		case "unevaluatedItems":
+			schema.UnevaluatedItems = nil
+		case "contentSchema":
+			schema.ContentSchema = nil
+		case "extra":
+			schema.Extra = nil
+		default:
+			// Try to find and clear the field by name
+			if _, found := schemaType.FieldByName(fieldName); found {
+				fieldValue := schemaValue.FieldByName(fieldName)
+				if fieldValue.CanSet() {
+					// Set to zero value based on field type
+					fieldValue.Set(reflect.Zero(fieldValue.Type()))
+				}
+			}
+		}
+	}
+}

--- a/llm/internal/pkg/xmap/misc.go
+++ b/llm/internal/pkg/xmap/misc.go
@@ -1,0 +1,137 @@
+package xmap
+
+import (
+	"github.com/samber/lo"
+)
+
+// GetStringPtr extracts a *string value from a map[string]any.
+func GetStringPtr(m map[string]any, key string) *string {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case string:
+			return lo.ToPtr(vv)
+		case *string:
+			return vv
+		default:
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// GetInt64Ptr extracts a *int64 value from a map[string]any.
+func GetInt64Ptr(m map[string]any, key string) *int64 {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case int64:
+			return lo.ToPtr(vv)
+		case *int64:
+			return vv
+		default:
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// GetBoolPtr extracts a *bool value from a map[string]any.
+func GetBoolPtr(m map[string]any, key string) *bool {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case bool:
+			return lo.ToPtr(vv)
+		case *bool:
+			return vv
+		default:
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// GetStringSlice extracts a []string value from a map[string]any.
+func GetStringSlice(m map[string]any, key string) []string {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		if slice, ok := v.([]string); ok {
+			return slice
+		}
+	}
+
+	return nil
+}
+
+func GetSlice[T any](m map[string]any, key string) []T {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case []T:
+			return vv
+		case []*T:
+			return lo.FromSlicePtr(vv)
+		default:
+			return []T{}
+		}
+	}
+
+	return nil
+}
+
+func GetSlicePtr[T any](m map[string]any, key string) []*T {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case []*T:
+			return vv
+		case []T:
+			return lo.ToSlicePtr(vv)
+		default:
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func GetPtr[T any](m map[string]any, key string) *T {
+	if m == nil {
+		return nil
+	}
+
+	if v, ok := m[key]; ok {
+		switch vv := v.(type) {
+		case T:
+			return lo.ToPtr(vv)
+		case *T:
+			return vv
+		default:
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/llm/internal/pkg/xtest/cmp.go
+++ b/llm/internal/pkg/xtest/cmp.go
@@ -1,0 +1,101 @@
+package xtest
+
+import (
+	"encoding/json"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+)
+
+// Custom comparator for json.RawMessage that compares semantic equality.
+func jsonRawMessageComparer(x, y json.RawMessage) bool {
+	if len(x) == 0 && len(y) == 0 {
+		return true
+	}
+
+	if len(x) == 0 || len(y) == 0 {
+		return false
+	}
+
+	var xVal, yVal any
+	if err := json.Unmarshal(x, &xVal); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(y, &yVal); err != nil {
+		return false
+	}
+
+	return cmp.Equal(xVal, yVal)
+}
+
+func nilString(x *string) string {
+	if x == nil {
+		return ""
+	}
+
+	return *x
+}
+
+func nilInt(x *int) int {
+	if x == nil {
+		return 0
+	}
+
+	return *x
+}
+
+// Equal provides semantic equality comparison with custom transformers and comparers.
+func Equal(a, b any, opts ...cmp.Option) bool {
+	allOpts := append(opts,
+		NilCompletionTokensDetails,
+		NilPromptTokensDetails,
+		ToolCallsTransformer,
+		cmpopts.IgnoreFields(llm.Request{}, "TransformOptions"),
+		cmp.Transformer("", nilString),
+		cmp.Transformer("", nilInt),
+		cmp.Comparer(jsonRawMessageComparer))
+
+	return cmp.Equal(a, b, allOpts...)
+}
+
+// NilPromptTokensDetails transformer for handling nil PromptTokensDetails.
+var NilPromptTokensDetails = cmp.Transformer("nilPromptTokensDetails", func(x *llm.PromptTokensDetails) llm.PromptTokensDetails {
+	if x == nil {
+		return llm.PromptTokensDetails{}
+	}
+	return *x
+})
+
+// NilCompletionTokensDetails transformer for handling nil CompletionTokensDetails.
+var NilCompletionTokensDetails = cmp.Transformer("nilCompletionTokensDetails", func(x *llm.CompletionTokensDetails) llm.CompletionTokensDetails {
+	if x == nil {
+		return llm.CompletionTokensDetails{}
+	}
+	return *x
+})
+
+// ToolCallsTransformer transformer for handling tool call comparisons.
+var ToolCallsTransformer = cmp.Transformer("toolCall", func(x llm.ToolCall) llm.ToolCall {
+	var args any
+	if x.Function.Arguments != "" {
+		err := json.Unmarshal([]byte(x.Function.Arguments), &args)
+		if err != nil {
+			args = x.Function.Arguments
+		}
+	}
+	rawArgs := xjson.MustMarshalString(args)
+	return llm.ToolCall{
+		ID:   x.ID,
+		Type: x.Type,
+		Function: llm.FunctionCall{
+			Name:      x.Function.Name,
+			Arguments: rawArgs,
+		},
+		Index:        x.Index,
+		CacheControl: x.CacheControl,
+	}
+})

--- a/llm/internal/pkg/xtest/stream.go
+++ b/llm/internal/pkg/xtest/stream.go
@@ -1,0 +1,128 @@
+package xtest
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// LoadStreamChunks loads stream chunks from a JSONL file in testdata directory.
+func LoadStreamChunks(t *testing.T, filename string) ([]*httpclient.StreamEvent, error) {
+	t.Helper()
+
+	//nolint:gosec
+	file, err := os.Open("testdata/" + filename)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	var (
+		chunks []*httpclient.StreamEvent
+		idx    int
+	)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Parse the line as a temporary struct to handle the Data field correctly
+		var temp struct {
+			LastEventID string `json:"LastEventID"`
+			Type        string `json:"Type"`
+			Data        string `json:"Data"` // Data is a JSON string in the test file
+		}
+
+		err := json.Unmarshal([]byte(line), &temp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal stream chunk at line: %d %s %w", idx, line, err)
+		}
+
+		// Create the StreamEvent with Data as []byte
+		streamEvent := &httpclient.StreamEvent{
+			LastEventID: temp.LastEventID,
+			Type:        temp.Type,
+			Data:        []byte(temp.Data), // Convert string to []byte
+		}
+
+		chunks = append(chunks, streamEvent)
+		idx++
+	}
+
+	return chunks, scanner.Err()
+}
+
+// LoadTestData loads test data from a JSON file in testdata directory.
+func LoadTestData(t *testing.T, filename string, v any) error {
+	t.Helper()
+
+	//nolint:gosec
+	file, err := os.Open("testdata/" + filename)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	decoder := json.NewDecoder(file)
+
+	return decoder.Decode(v)
+}
+
+func LoadLlmResponses(t *testing.T, filename string) ([]*llm.Response, error) {
+	t.Helper()
+
+	expectedData, err := LoadStreamChunks(t, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var expectedResponses []*llm.Response
+
+	for idx, line := range expectedData {
+		if line != nil {
+			// Check if this is a DONE event
+			if bytes.Contains(line.Data, []byte(`[DONE]`)) {
+				// This is a DONE event, add the DoneResponse
+				expectedResponses = append(expectedResponses, llm.DoneResponse)
+			} else {
+				// Parse the Data field as llm.Response
+				var resp llm.Response
+
+				err = json.Unmarshal(line.Data, &resp)
+				if err != nil {
+					return nil, fmt.Errorf("failed to unmarshal response at index %d: %s %w", idx, string(line.Data), err)
+				}
+
+				require.NoError(t, err)
+
+				expectedResponses = append(expectedResponses, &resp)
+			}
+		}
+	}
+
+	return expectedResponses, nil
+}

--- a/llm/internal/pkg/xurl/dataurl.go
+++ b/llm/internal/pkg/xurl/dataurl.go
@@ -1,0 +1,108 @@
+// Package xurl provides utilities for URL parsing and manipulation.
+package xurl
+
+import "strings"
+
+// DataURL represents a parsed data URL with its components.
+type DataURL struct {
+	// MediaType is the MIME type (e.g., "image/png", "text/plain").
+	MediaType string
+	// Data is the base64-encoded or raw data portion.
+	Data string
+	// IsBase64 indicates whether the data is base64-encoded.
+	IsBase64 bool
+}
+
+// ParseDataURL parses a data URL and returns its components.
+// Returns nil if the URL is not a valid data URL.
+//
+// Data URL format: data:[<mediatype>][;base64],<data>
+// Examples:
+//   - data:image/png;base64,iVBORw0KGgo...
+//   - data:text/plain,Hello%20World
+func ParseDataURL(url string) *DataURL {
+	if !strings.HasPrefix(url, "data:") {
+		return nil
+	}
+
+	// Split into header and data parts
+	parts := strings.SplitN(url, ",", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+
+	header := parts[0]
+	data := parts[1]
+
+	// Parse header: data:[<mediatype>][;base64]
+	headerParts := strings.Split(header, ";")
+	if len(headerParts) == 0 {
+		return nil
+	}
+
+	mediaType := strings.TrimPrefix(headerParts[0], "data:")
+	if mediaType == "" {
+		mediaType = "text/plain" // Default media type per RFC 2397
+	}
+
+	isBase64 := false
+
+	for _, part := range headerParts[1:] {
+		if strings.TrimSpace(part) == "base64" {
+			isBase64 = true
+			break
+		}
+	}
+
+	return &DataURL{
+		MediaType: mediaType,
+		Data:      data,
+		IsBase64:  isBase64,
+	}
+}
+
+// IsDataURL checks if the given URL is a data URL.
+func IsDataURL(url string) bool {
+	return strings.HasPrefix(url, "data:")
+}
+
+// ExtractBase64FromDataURL extracts the base64 data from a data URL.
+// If the URL is not a data URL, returns the original URL unchanged.
+func ExtractBase64FromDataURL(url string) string {
+	if !strings.HasPrefix(url, "data:") {
+		return url
+	}
+
+	parts := strings.SplitN(url, ",", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+
+	return url
+}
+
+// ExtractMediaTypeFromDataURL extracts the media type from a data URL.
+// Returns empty string if the URL is not a valid data URL.
+func ExtractMediaTypeFromDataURL(url string) string {
+	parsed := ParseDataURL(url)
+	if parsed == nil {
+		return ""
+	}
+
+	return parsed.MediaType
+}
+
+// BuildDataURL constructs a data URL from media type and data.
+// If isBase64 is true, adds ";base64" to the URL.
+// If mediaType is empty, uses "text/plain" as default per RFC 2397.
+func BuildDataURL(mediaType string, data string, isBase64 bool) string {
+	if mediaType == "" {
+		mediaType = "text/plain"
+	}
+
+	if isBase64 {
+		return "data:" + mediaType + ";base64," + data
+	}
+
+	return "data:" + mediaType + "," + data
+}

--- a/llm/internal/pkg/xurl/dataurl_test.go
+++ b/llm/internal/pkg/xurl/dataurl_test.go
@@ -1,0 +1,427 @@
+package xurl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDataURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		mediaType string
+		data      string
+		isBase64  bool
+		expected  string
+	}{
+		{
+			name:      "PDF with base64",
+			mediaType: "application/pdf",
+			data:      "JVBERi0xLjQK",
+			isBase64:  true,
+			expected:  "data:application/pdf;base64,JVBERi0xLjQK",
+		},
+		{
+			name:      "PNG image with base64",
+			mediaType: "image/png",
+			data:      "iVBORw0KGgo",
+			isBase64:  true,
+			expected:  "data:image/png;base64,iVBORw0KGgo",
+		},
+		{
+			name:      "Plain text without base64",
+			mediaType: "text/plain",
+			data:      "Hello%20World",
+			isBase64:  false,
+			expected:  "data:text/plain,Hello%20World",
+		},
+		{
+			name:      "Empty media type defaults to text/plain",
+			mediaType: "",
+			data:      "test",
+			isBase64:  false,
+			expected:  "data:text/plain,test",
+		},
+		{
+			name:      "Word document with base64",
+			mediaType: "application/msword",
+			data:      "0M8R4KGx",
+			isBase64:  true,
+			expected:  "data:application/msword;base64,0M8R4KGx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildDataURL(tt.mediaType, tt.data, tt.isBase64)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseDataURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected *DataURL
+	}{
+		{
+			name: "valid base64 image png",
+			url:  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+			expected: &DataURL{
+				MediaType: "image/png",
+				Data:      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid base64 image jpeg",
+			url:  "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD",
+			expected: &DataURL{
+				MediaType: "image/jpeg",
+				Data:      "/9j/4AAQSkZJRgABAQAAAQABAAD",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid base64 image webp",
+			url:  "data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=",
+			expected: &DataURL{
+				MediaType: "image/webp",
+				Data:      "UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid base64 image gif",
+			url:  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+			expected: &DataURL{
+				MediaType: "image/gif",
+				Data:      "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid plain text without base64",
+			url:  "data:text/plain,Hello%20World",
+			expected: &DataURL{
+				MediaType: "text/plain",
+				Data:      "Hello%20World",
+				IsBase64:  false,
+			},
+		},
+		{
+			name: "valid text with charset and base64",
+			url:  "data:text/plain;charset=utf-8;base64,SGVsbG8gV29ybGQ=",
+			expected: &DataURL{
+				MediaType: "text/plain",
+				Data:      "SGVsbG8gV29ybGQ=",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid html content",
+			url:  "data:text/html;base64,PGh0bWw+PC9odG1sPg==",
+			expected: &DataURL{
+				MediaType: "text/html",
+				Data:      "PGh0bWw+PC9odG1sPg==",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid json content",
+			url:  "data:application/json;base64,eyJrZXkiOiJ2YWx1ZSJ9",
+			expected: &DataURL{
+				MediaType: "application/json",
+				Data:      "eyJrZXkiOiJ2YWx1ZSJ9",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid pdf content",
+			url:  "data:application/pdf;base64,JVBERi0xLjQK",
+			expected: &DataURL{
+				MediaType: "application/pdf",
+				Data:      "JVBERi0xLjQK",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "valid audio content",
+			url:  "data:audio/mp3;base64,//uQxAAAAAANIAAAAAExBTUUzLjEwMFVVVVVVVVVVVVVV",
+			expected: &DataURL{
+				MediaType: "audio/mp3",
+				Data:      "//uQxAAAAAANIAAAAAExBTUUzLjEwMFVVVVVVVVVVVVVV",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "default media type when empty",
+			url:  "data:;base64,SGVsbG8=",
+			expected: &DataURL{
+				MediaType: "text/plain",
+				Data:      "SGVsbG8=",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "data with comma in content",
+			url:  "data:text/plain,Hello,World",
+			expected: &DataURL{
+				MediaType: "text/plain",
+				Data:      "Hello,World",
+				IsBase64:  false,
+			},
+		},
+		{
+			name:     "not a data URL - http",
+			url:      "http://example.com/image.png",
+			expected: nil,
+		},
+		{
+			name:     "not a data URL - https",
+			url:      "https://example.com/image.png",
+			expected: nil,
+		},
+		{
+			name:     "not a data URL - file",
+			url:      "file:///path/to/file.png",
+			expected: nil,
+		},
+		{
+			name:     "empty string",
+			url:      "",
+			expected: nil,
+		},
+		{
+			name:     "data URL without comma",
+			url:      "data:image/png;base64",
+			expected: nil,
+		},
+		{
+			name: "data URL with empty data",
+			url:  "data:image/png;base64,",
+			expected: &DataURL{
+				MediaType: "image/png",
+				Data:      "",
+				IsBase64:  true,
+			},
+		},
+		{
+			name: "data URL with multiple semicolons",
+			url:  "data:image/svg+xml;charset=utf-8;base64,PHN2Zz48L3N2Zz4=",
+			expected: &DataURL{
+				MediaType: "image/svg+xml",
+				Data:      "PHN2Zz48L3N2Zz4=",
+				IsBase64:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseDataURL(tt.url)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expected.MediaType, result.MediaType)
+				assert.Equal(t, tt.expected.Data, result.Data)
+				assert.Equal(t, tt.expected.IsBase64, result.IsBase64)
+			}
+		})
+	}
+}
+
+func TestIsDataURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "valid data URL",
+			url:      "data:image/png;base64,iVBORw0KGgo=",
+			expected: true,
+		},
+		{
+			name:     "data URL with text",
+			url:      "data:text/plain,Hello",
+			expected: true,
+		},
+		{
+			name:     "http URL",
+			url:      "http://example.com",
+			expected: false,
+		},
+		{
+			name:     "https URL",
+			url:      "https://example.com",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			url:      "",
+			expected: false,
+		},
+		{
+			name:     "data prefix only",
+			url:      "data:",
+			expected: true,
+		},
+		{
+			name:     "DATA uppercase",
+			url:      "DATA:image/png;base64,abc",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDataURL(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractBase64FromDataURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "valid data URL with base64",
+			url:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+			expected: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+		},
+		{
+			name:     "valid data URL with plain text",
+			url:      "data:text/plain,Hello%20World",
+			expected: "Hello%20World",
+		},
+		{
+			name:     "http URL returns unchanged",
+			url:      "http://example.com/image.png",
+			expected: "http://example.com/image.png",
+		},
+		{
+			name:     "https URL returns unchanged",
+			url:      "https://example.com/image.png",
+			expected: "https://example.com/image.png",
+		},
+		{
+			name:     "empty string returns unchanged",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "data URL without comma returns unchanged",
+			url:      "data:image/png;base64",
+			expected: "data:image/png;base64",
+		},
+		{
+			name:     "data URL with empty data",
+			url:      "data:image/png;base64,",
+			expected: "",
+		},
+		{
+			name:     "data URL with comma in data",
+			url:      "data:text/plain,Hello,World",
+			expected: "Hello,World",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractBase64FromDataURL(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractMediaTypeFromDataURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "image/png",
+			url:      "data:image/png;base64,iVBORw0KGgo=",
+			expected: "image/png",
+		},
+		{
+			name:     "image/jpeg",
+			url:      "data:image/jpeg;base64,/9j/4AAQ=",
+			expected: "image/jpeg",
+		},
+		{
+			name:     "image/webp",
+			url:      "data:image/webp;base64,UklGRh4=",
+			expected: "image/webp",
+		},
+		{
+			name:     "image/gif",
+			url:      "data:image/gif;base64,R0lGODlh=",
+			expected: "image/gif",
+		},
+		{
+			name:     "image/svg+xml",
+			url:      "data:image/svg+xml;base64,PHN2Zz4=",
+			expected: "image/svg+xml",
+		},
+		{
+			name:     "text/plain",
+			url:      "data:text/plain,Hello",
+			expected: "text/plain",
+		},
+		{
+			name:     "text/html",
+			url:      "data:text/html;base64,PGh0bWw+",
+			expected: "text/html",
+		},
+		{
+			name:     "application/json",
+			url:      "data:application/json;base64,e30=",
+			expected: "application/json",
+		},
+		{
+			name:     "application/pdf",
+			url:      "data:application/pdf;base64,JVBERi0=",
+			expected: "application/pdf",
+		},
+		{
+			name:     "audio/mp3",
+			url:      "data:audio/mp3;base64,//uQxAA=",
+			expected: "audio/mp3",
+		},
+		{
+			name:     "default media type when empty",
+			url:      "data:;base64,SGVsbG8=",
+			expected: "text/plain",
+		},
+		{
+			name:     "http URL returns empty",
+			url:      "http://example.com",
+			expected: "",
+		},
+		{
+			name:     "empty string returns empty",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "invalid data URL returns empty",
+			url:      "data:image/png;base64",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractMediaTypeFromDataURL(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/llm/pipeline/non_streaming.go
+++ b/llm/pipeline/non_streaming.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
@@ -21,7 +21,7 @@ func (p *pipeline) notStream(
 		// Apply error response middlewares
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		if httpErr, ok := xerrors.As[*httpclient.Error](err); ok {
+		if httpErr, ok := errors.AsType[*httpclient.Error](err); ok {
 			return nil, p.Outbound.TransformError(ctx, httpErr)
 		}
 

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
@@ -23,7 +23,7 @@ func (p *pipeline) stream(
 		// Apply error response middlewares
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		if httpErr, ok := xerrors.As[*httpclient.Error](err); ok {
+		if httpErr, ok := errors.AsType[*httpclient.Error](err); ok {
 			return nil, p.Outbound.TransformError(ctx, httpErr)
 		}
 

--- a/llm/pipeline/streaming_integration_test.go
+++ b/llm/pipeline/streaming_integration_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"

--- a/llm/transformer/aisdk/convert_stream_data_test.go
+++ b/llm/transformer/aisdk/convert_stream_data_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/aisdk/datastream.go
+++ b/llm/transformer/aisdk/datastream.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	transformer "github.com/looplj/axonhub/llm/transformer"
@@ -183,7 +182,7 @@ func (t *DataStreamTransformer) TransformError(ctx context.Context, rawErr error
 		}
 	}
 
-	if httpErr, ok := xerrors.As[*httpclient.Error](rawErr); ok {
+	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
 		return httpErr
 	}
 
@@ -196,7 +195,7 @@ func (t *DataStreamTransformer) TransformError(ctx context.Context, rawErr error
 		}
 	}
 
-	if llmErr, ok := xerrors.As[*llm.ResponseError](rawErr); ok {
+	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		return &httpclient.Error{
 			StatusCode: llmErr.StatusCode,
 			Status:     http.StatusText(llmErr.StatusCode),

--- a/llm/transformer/aisdk/text.go
+++ b/llm/transformer/aisdk/text.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
@@ -195,7 +194,7 @@ func (t *TextTransformer) TransformError(ctx context.Context, rawErr error) *htt
 		}
 	}
 
-	if httpErr, ok := xerrors.As[*httpclient.Error](rawErr); ok {
+	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
 		return httpErr
 	}
 
@@ -208,7 +207,7 @@ func (t *TextTransformer) TransformError(ctx context.Context, rawErr error) *htt
 		}
 	}
 
-	if llmErr, ok := xerrors.As[*llm.ResponseError](rawErr); ok {
+	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		return &httpclient.Error{
 			StatusCode: llmErr.StatusCode,
 			Status:     http.StatusText(llmErr.StatusCode),

--- a/llm/transformer/anthropic/aggregator_test.go
+++ b/llm/transformer/anthropic/aggregator_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestAggregateStreamChunks(t *testing.T) {

--- a/llm/transformer/anthropic/claudecode/outbound_test.go
+++ b/llm/transformer/anthropic/claudecode/outbound_test.go
@@ -574,4 +574,3 @@ func (m *mockHTTPStream) Err() error {
 func (m *mockHTTPStream) Close() error {
 	return nil
 }
-

--- a/llm/transformer/anthropic/inbound.go
+++ b/llm/transformer/anthropic/inbound.go
@@ -8,10 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	transformer "github.com/looplj/axonhub/llm/transformer"
 )
 
@@ -135,7 +134,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if llmErr, ok := xerrors.As[*llm.ResponseError](rawErr); ok {
+	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		return &httpclient.Error{
 			StatusCode: llmErr.StatusCode,
 			Status:     http.StatusText(llmErr.StatusCode),
@@ -150,7 +149,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if httpErr, ok := xerrors.As[*httpclient.Error](rawErr); ok {
+	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
 		return httpErr
 	}
 

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 )
 
 func convertImageSourceToLLMImageURLPart(source *ImageSource, cacheControl *CacheControl) (llm.MessageContentPart, bool) {

--- a/llm/transformer/anthropic/inbound_integration_test.go
+++ b/llm/transformer/anthropic/inbound_integration_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestInboundTransformer_TransformRequest_WithTestData(t *testing.T) {

--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/dumper"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
@@ -46,8 +45,6 @@ type anthropicInboundStream struct {
 	stopReason                *string
 	// Tool call tracking
 	toolCalls map[int]*llm.ToolCall // Track tool calls by index
-
-	sourceEvents []*llm.Response
 
 	lastEventType string
 }
@@ -92,10 +89,6 @@ func (s *anthropicInboundStream) Next() bool {
 	chunk := s.source.Current()
 	if chunk == nil {
 		return s.Next() // Try next chunk
-	}
-
-	if dumper.Enabled() {
-		s.sourceEvents = append(s.sourceEvents, chunk)
 	}
 
 	// Handle [DONE] marker
@@ -605,9 +598,5 @@ func (s *anthropicInboundStream) Err() error {
 }
 
 func (s *anthropicInboundStream) Close() error {
-	if dumper.Enabled() {
-		dumper.DumpObject(s.ctx, s.sourceEvents, "anthropic-inbound-stream")
-	}
-
 	return s.source.Close()
 }

--- a/llm/transformer/anthropic/inbound_stream_test.go
+++ b/llm/transformer/anthropic/inbound_stream_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/anthropic/integration_test.go
+++ b/llm/transformer/anthropic/integration_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestAnthropicTransformers_Integration(t *testing.T) {

--- a/llm/transformer/anthropic/outbound.go
+++ b/llm/transformer/anthropic/outbound.go
@@ -10,11 +10,11 @@ import (
 	// Import bedrock package to register its decoder.
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	_ "github.com/looplj/axonhub/llm/bedrock"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/vertex"
 )

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -3,9 +3,9 @@ package anthropic
 import (
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 

--- a/llm/transformer/anthropic/outbound_integration_test.go
+++ b/llm/transformer/anthropic/outbound_integration_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestOutboundTransformer_TransformResponse_WithTestData(t *testing.T) {

--- a/llm/transformer/anthropic/outbound_stream_delta_test.go
+++ b/llm/transformer/anthropic/outbound_stream_delta_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/anthropic/outbound_stream_test.go
+++ b/llm/transformer/anthropic/outbound_stream_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/anthropic/outbound_test.go
+++ b/llm/transformer/anthropic/outbound_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestOutboundTransformer_TransformRequest(t *testing.T) {

--- a/llm/transformer/anthropic/usage_test.go
+++ b/llm/transformer/anthropic/usage_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func Test_convertUsage(t *testing.T) {

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/oauth"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 )
 
 func extractTextFromContent(content *Content) string {

--- a/llm/transformer/gemini/inbound.go
+++ b/llm/transformer/gemini/inbound.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/transformer"
 )
 

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -7,10 +7,10 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xmap"
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	geminioai "github.com/looplj/axonhub/llm/transformer/gemini/openai"
 )
 

--- a/llm/transformer/gemini/inbound_convert_test.go
+++ b/llm/transformer/gemini/inbound_convert_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	geminioai "github.com/looplj/axonhub/llm/transformer/gemini/openai"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )

--- a/llm/transformer/gemini/inbound_stream_test.go
+++ b/llm/transformer/gemini/inbound_stream_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/gemini/integraion_test.go
+++ b/llm/transformer/gemini/integraion_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestGeminiTransformers_Integration(t *testing.T) {

--- a/llm/transformer/gemini/openai/outbound.go
+++ b/llm/transformer/gemini/openai/outbound.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/looplj/axonhub/internal/log"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	geminioai "github.com/looplj/axonhub/llm/transformer/gemini/openai"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )

--- a/llm/transformer/gemini/outbound_convert_test.go
+++ b/llm/transformer/gemini/outbound_convert_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 

--- a/llm/transformer/openai/aggregator_test.go
+++ b/llm/transformer/openai/aggregator_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestAggregateStreamChunks(t *testing.T) {

--- a/llm/transformer/openai/embedding_test.go
+++ b/llm/transformer/openai/embedding_test.go
@@ -267,8 +267,8 @@ func TestEmbeddingInboundTransformer_TransformRequest(t *testing.T) {
 func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 	t.Run("valid request with /v1 suffix", func(t *testing.T) {
 		config := &Config{
-			PlatformType: PlatformOpenAI,
-			BaseURL:      "https://api.openai.com/v1",
+			PlatformType:   PlatformOpenAI,
+			BaseURL:        "https://api.openai.com/v1",
 			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
@@ -296,8 +296,8 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 
 	t.Run("nil llm request", func(t *testing.T) {
 		config := &Config{
-			PlatformType: PlatformOpenAI,
-			BaseURL:      "https://api.openai.com/v1",
+			PlatformType:   PlatformOpenAI,
+			BaseURL:        "https://api.openai.com/v1",
 			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
@@ -310,8 +310,8 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 
 	t.Run("missing embedding request", func(t *testing.T) {
 		config := &Config{
-			PlatformType: PlatformOpenAI,
-			BaseURL:      "https://api.openai.com/v1",
+			PlatformType:   PlatformOpenAI,
+			BaseURL:        "https://api.openai.com/v1",
 			APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 		}
 		transformer, err := NewOutboundTransformerWithConfig(config)
@@ -330,8 +330,8 @@ func TestEmbeddingOutboundTransformer_TransformRequest(t *testing.T) {
 
 func TestEmbeddingOutboundTransformer_TransformResponse(t *testing.T) {
 	config := &Config{
-		PlatformType: PlatformOpenAI,
-		BaseURL:      "https://api.openai.com/v1",
+		PlatformType:   PlatformOpenAI,
+		BaseURL:        "https://api.openai.com/v1",
 		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -566,8 +566,8 @@ func TestEmbeddingTransformers_APIFormat(t *testing.T) {
 	require.Equal(t, llm.APIFormatOpenAIEmbedding, inbound.APIFormat())
 
 	config := &Config{
-		PlatformType: PlatformOpenAI,
-		BaseURL:      "https://api.openai.com/v1",
+		PlatformType:   PlatformOpenAI,
+		BaseURL:        "https://api.openai.com/v1",
 		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	outbound, err := NewOutboundTransformerWithConfig(config)
@@ -577,8 +577,8 @@ func TestEmbeddingTransformers_APIFormat(t *testing.T) {
 
 func TestEmbeddingOutboundTransformer_TransformError(t *testing.T) {
 	config := &Config{
-		PlatformType: PlatformOpenAI,
-		BaseURL:      "https://api.openai.com/v1",
+		PlatformType:   PlatformOpenAI,
+		BaseURL:        "https://api.openai.com/v1",
 		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 	}
 	transformer, err := NewOutboundTransformerWithConfig(config)
@@ -666,8 +666,8 @@ func TestEmbeddingOutboundTransformer_URLBuilding(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			config := &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      tc.baseURL,
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        tc.baseURL,
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			}
 			transformer, err := NewOutboundTransformerWithConfig(config)
@@ -698,8 +698,8 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 		{
 			name: "raw URL enabled for embedding",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom.api.com/v100#",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom.api.com/v100#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -716,8 +716,8 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 		{
 			name: "raw URL auto-enabled with # suffix for embedding",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://custom.api.com/v20#",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://custom.api.com/v20#",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
 			},
 			request: &llm.Request{
@@ -734,10 +734,10 @@ func TestOutboundTransformer_RawURL_Embedding(t *testing.T) {
 		{
 			name: "raw URL false for embedding",
 			config: &Config{
-				PlatformType: PlatformOpenAI,
-				BaseURL:      "https://api.openai.com",
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://api.openai.com",
 				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
-				RawURL:       false,
+				RawURL:         false,
 			},
 			request: &llm.Request{
 				RequestType: llm.RequestTypeEmbedding,

--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -8,10 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/streams"
 	transformer "github.com/looplj/axonhub/llm/transformer"
 )
@@ -206,7 +205,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if httpErr, ok := xerrors.As[*httpclient.Error](rawErr); ok {
+	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
 		return httpErr
 	}
 
@@ -219,7 +218,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if llmErr, ok := xerrors.As[*llm.ResponseError](rawErr); ok {
+	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		return &httpclient.Error{
 			StatusCode: llmErr.StatusCode,
 			Status:     http.StatusText(llmErr.StatusCode),

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -29,13 +29,13 @@ type streamAggregator struct {
 
 // aggregatedItem holds the accumulated state for an output item.
 type aggregatedItem struct {
-	ID        string
-	Type      string
-	Status    string
-	Role      string
-	CallID    string
-	Name      string
-	Arguments *strings.Builder
+	ID               string
+	Type             string
+	Status           string
+	Role             string
+	CallID           string
+	Name             string
+	Arguments        *strings.Builder
 	EncryptedContent *string
 
 	// For message type
@@ -319,10 +319,10 @@ func (a *streamAggregator) buildResponse() *Response {
 				}
 
 				output = append(output, Item{
-					ID:      item.ID,
-					Type:    item.Type,
-					Status:  lo.ToPtr(item.Status),
-					Summary: summary,
+					ID:               item.ID,
+					Type:             item.Type,
+					Status:           lo.ToPtr(item.Status),
+					Summary:          summary,
 					EncryptedContent: item.EncryptedContent,
 				})
 

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestAggregateStreamChunks(t *testing.T) {

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -11,12 +11,11 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xerrors"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xmap"
-	"github.com/looplj/axonhub/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
@@ -116,7 +115,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if llmErr, ok := xerrors.As[*llm.ResponseError](rawErr); ok {
+	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		errResp := ResponseError{
 			Error: ResponseErrorDetail{
 				Message: llmErr.Detail.Message,
@@ -132,7 +131,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if httpErr, ok := xerrors.As[*httpclient.Error](rawErr); ok {
+	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
 		return httpErr
 	}
 

--- a/llm/transformer/openai/responses/inbound_integration_test.go
+++ b/llm/transformer/openai/responses/inbound_integration_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestInboundTransformer_TransformRequest_WithTestData(t *testing.T) {

--- a/llm/transformer/openai/responses/inbound_stream.go
+++ b/llm/transformer/openai/responses/inbound_stream.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/dumper"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
@@ -72,9 +71,6 @@ type responsesInboundStream struct {
 	eventQueue []*httpclient.StreamEvent
 	queueIndex int
 	err        error
-
-	// For dumping
-	sourceEvents []*llm.Response
 }
 
 func (s *responsesInboundStream) enqueueEvent(ev *StreamEvent) error {
@@ -122,10 +118,6 @@ func (s *responsesInboundStream) Next() bool {
 	chunk := s.source.Current()
 	if chunk == nil {
 		return s.Next() // Try next chunk
-	}
-
-	if dumper.Enabled() {
-		s.sourceEvents = append(s.sourceEvents, chunk)
 	}
 
 	// Handle [DONE] marker
@@ -718,10 +710,6 @@ func (s *responsesInboundStream) Err() error {
 }
 
 func (s *responsesInboundStream) Close() error {
-	if dumper.Enabled() {
-		dumper.DumpObject(s.ctx, s.sourceEvents, "responses-inbound-stream")
-	}
-
 	return s.source.Close()
 }
 

--- a/llm/transformer/openai/responses/inbound_stream_test.go
+++ b/llm/transformer/openai/responses/inbound_stream_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/openai/responses/integration_test.go
+++ b/llm/transformer/openai/responses/integration_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestTransformRequest_Integration(t *testing.T) {

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/transformer"
 )
 

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 

--- a/llm/transformer/openai/responses/outbound_integration_test.go
+++ b/llm/transformer/openai/responses/outbound_integration_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 )
 
 func TestOutboundTransformer_TransformResponse_Integration(t *testing.T) {

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
 

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 

--- a/llm/transformer/openrouter/model_test.go
+++ b/llm/transformer/openrouter/model_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/looplj/axonhub/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/transformer/openrouter"
 )
 

--- a/llm/transformer/zai/outbound.go
+++ b/llm/transformer/zai/outbound.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/looplj/axonhub/internal/tracing"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // Config holds all configuration for the Zai outbound transformer.
@@ -127,8 +127,8 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 
 	if zaiReq.RequestID == "" {
-		traceID, _ := tracing.GetTraceID(ctx)
-		zaiReq.RequestID = traceID
+		sessionID, _ := shared.GetSessionID(ctx)
+		zaiReq.RequestID = sessionID
 	}
 
 	// zai only support auto tool choice.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized internal packages and updated the Go toolchain version.
  * Added internal helpers for JSON, data-URL handling, and type-safe map access.
  * Standardized error type handling across transformers.
  * Removed an internal runtime dumper to eliminate unnecessary side-effects.

* **Tests**
  * Added robust tests and test utilities for streaming data and data-URL parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->