### PR TITLE
fix:  block/sensitive headers canonical form 

### DIFF
--- a/llm/httpclient/utils.go
+++ b/llm/httpclient/utils.go
@@ -87,7 +87,7 @@ var blockedHeaders = map[string]bool{
 	"Connection":        true,
 	"X-Channel-Id":      true,
 	"X-Project-Id":      true,
-	"X-Real-IP":         true,
+	"X-Real-Ip":         true,
 	"X-Forwarded-For":   true,
 	"X-Forwarded-Proto": true,
 	"X-Forwarded-Host":  true,
@@ -118,7 +118,7 @@ var sensitiveHeaders = map[string]bool{
 	"Cookie":              true,
 	"Set-Cookie":          true,
 	"Proxy-Authorization": true,
-	"WWW-Authenticate":    true,
+	"Www-Authenticate":    true,
 }
 
 var mergeWithAppendHeaders = map[string]bool{}

--- a/llm/httpclient/utils_test.go
+++ b/llm/httpclient/utils_test.go
@@ -297,9 +297,8 @@ func TestMaskSensitiveHeaders_MasksAllHardcodedHeaders(t *testing.T) {
 	got := MaskSensitiveHeaders(headers)
 
 	for k := range sensitiveHeaders {
-		canonical := http.CanonicalHeaderKey(k)
-		require.Equal(t, []string{"******"}, got.Values(canonical),
-			"sensitiveHeaders %q (canonical: %q) should be masked", k, canonical)
+		require.Equal(t, []string{"******"}, got.Values(k),
+			"sensitiveHeaders %q should be masked", k)
 	}
 	require.Equal(t, []string{"visible"}, got.Values("X-Custom"))
 }

--- a/llm/httpclient/utils_test.go
+++ b/llm/httpclient/utils_test.go
@@ -237,6 +237,73 @@ func TestMergeHTTPHeaders(t *testing.T) {
 	}
 }
 
+// TestHeaderMaps_CanonicalForm verifies every key in the three header maps
+// matches Go's http.CanonicalHeaderKey form. A mismatch causes silent lookup
+// failures when iterating http.Header (which always uses canonical keys).
+func TestHeaderMaps_CanonicalForm(t *testing.T) {
+	for name, m := range map[string]map[string]bool{
+		"blockedHeaders":    blockedHeaders,
+		"sensitiveHeaders":  sensitiveHeaders,
+		"libManagedHeaders": libManagedHeaders,
+	} {
+		for k := range m {
+			canonical := http.CanonicalHeaderKey(k)
+			require.Equal(t, canonical, k, "%s key %q should be canonical form %q", name, k, canonical)
+		}
+	}
+}
+
+// TestMergeHTTPHeaders_BlocksAllHardcodedHeaders builds an http.Header via
+// Set() (auto-canonicalized, matching real HTTP server behavior) for every
+// header in blockedHeaders, sensitiveHeaders and libManagedHeaders, then
+// verifies none of them appear in the merge result.
+func TestMergeHTTPHeaders_BlocksAllHardcodedHeaders(t *testing.T) {
+	src := make(http.Header)
+	for k := range blockedHeaders {
+		src.Set(k, "blocked-val")
+	}
+	for k := range sensitiveHeaders {
+		src.Set(k, "sensitive-val")
+	}
+	for k := range libManagedHeaders {
+		src.Set(k, "lib-val")
+	}
+	src.Set("X-Custom", "keep-me")
+
+	dest := make(http.Header)
+	got := MergeHTTPHeaders(dest, src)
+
+	for k := range blockedHeaders {
+		require.Empty(t, got.Values(k), "blockedHeaders %q should not be merged", k)
+	}
+	for k := range sensitiveHeaders {
+		require.Empty(t, got.Values(k), "sensitiveHeaders %q should not be merged", k)
+	}
+	for k := range libManagedHeaders {
+		require.Empty(t, got.Values(k), "libManagedHeaders %q should not be merged", k)
+	}
+	require.Equal(t, "keep-me", got.Get("X-Custom"), "non-blocked header should be merged")
+}
+
+// TestMaskSensitiveHeaders_MasksAllHardcodedHeaders verifies every header in
+// sensitiveHeaders is masked to "******" by MaskSensitiveHeaders.
+func TestMaskSensitiveHeaders_MasksAllHardcodedHeaders(t *testing.T) {
+	headers := make(http.Header)
+	for k := range sensitiveHeaders {
+		headers.Set(k, "secret-value")
+	}
+	headers.Set("X-Custom", "visible")
+
+	got := MaskSensitiveHeaders(headers)
+
+	for k := range sensitiveHeaders {
+		canonical := http.CanonicalHeaderKey(k)
+		require.Equal(t, []string{"******"}, got.Values(canonical),
+			"sensitiveHeaders %q (canonical: %q) should be masked", k, canonical)
+	}
+	require.Equal(t, []string{"visible"}, got.Values("X-Custom"))
+}
+
 func TestRegisterAppendHeaders(t *testing.T) {
 	RegisterMergeWithAppendHeaders("X-New-Append")
 


### PR DESCRIPTION
## 问题

Go 的 `http.Header` 在存储 key 时使用 canonical form（连字符后首字母大写，同段其余字母小写），例如：
- `X-Real-IP` → `X-Real-Ip`
- `WWW-Authenticate` → `Www-Authenticate`

`MergeHTTPHeaders` 遍历 `http.Header` 时拿到的 key 是 canonical form，然后直接做 map 查找 `blockedHeaders[k]`。但 `blockedHeaders` 和 `sensitiveHeaders` 中有两个 key 不是 canonical form：

| Map | 原始 key | Canonical form | 匹配结果 |
|---|---|---|---|
| `blockedHeaders` | `X-Real-IP` | `X-Real-Ip` | 查找失败，头被透传 |
| `sensitiveHeaders` | `WWW-Authenticate` | `Www-Authenticate` | 查找失败，头未脱敏 |

这导致客户端的 `X-Real-IP` 头（通常由反向代理设置，包含客户端真实 IP）被原样转发到上游 AI 提供商。

## 修复

将两个 map key 改为 canonical form：
- `blockedHeaders`: `"X-Real-IP"` → `"X-Real-Ip"`
- `sensitiveHeaders`: `"WWW-Authenticate"` → `"Www-Authenticate"`

## 测试

新增三个回归测试：
- `TestHeaderMaps_CanonicalForm` — 遍历三个 map 的所有 key，断言每个都等于 `http.CanonicalHeaderKey(k)`，防止未来新增 key 出现同样问题
- `TestMergeHTTPHeaders_BlocksAllHardcodedHeaders` — 用 `http.Header.Set()` 构造请求头（模拟 Go HTTP Server 的 canonical 化行为），验证所有 blocked/sensitive/libManaged 头在合并时被阻止
- `TestMaskSensitiveHeaders_MasksAllHardcodedHeaders` — 验证所有 sensitive 头被正确脱敏为 `"******"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved HTTP header consistency and canonical formatting to strengthen standards compliance and reliability.

* **Tests**
  * Added tests validating header formatting, enforcement of blocked headers during merges, and masking of sensitive header values to protect exposed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->