### PR TITLE
fix(antigravity): OAuth-only authentication - remove API key fallback

### DIFF
--- a/internal/server/api/antigravity.go
+++ b/internal/server/api/antigravity.go
@@ -259,7 +259,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 		url := fmt.Sprintf("%s/v1internal:loadCodeAssist", baseEndpoint)
 		reqBody := map[string]any{
 			"metadata": map[string]string{
-				"ideType":    "IDE_UNSPECIFIED",
+				"ideType":    "ANTIGRAVITY",
 				"platform":   "PLATFORM_UNSPECIFIED",
 				"pluginType": "GEMINI",
 			},
@@ -278,7 +278,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
 			},
 			Body: bodyBytes,
 		}
@@ -352,7 +352,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 		reqBody := map[string]any{
 			"tierId": tierID,
 			"metadata": map[string]string{
-				"ideType":    "IDE_UNSPECIFIED",
+				"ideType":    "ANTIGRAVITY",
 				"platform":   "PLATFORM_UNSPECIFIED",
 				"pluginType": "GEMINI",
 			},
@@ -367,7 +367,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
 			},
 			Body: bodyBytes,
 		}

--- a/llm/transformer/antigravity/constants.go
+++ b/llm/transformer/antigravity/constants.go
@@ -31,7 +31,7 @@ const (
 	ApiClient = "google-cloud-sdk vscode_cloudshelleditor/0.1"
 
 	// ClientMetadata used for Client-Metadata header.
-	ClientMetadata = `{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`
+	ClientMetadata = `{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`
 
 	// DefaultProjectID is the fallback project ID (Cloud Code default).
 	DefaultProjectID = "rising-fact-p41fc"

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -210,31 +210,15 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 		headers.Set("Accept", "application/json")
 	}
 
-	// Auth
-	var auth *httpclient.AuthConfig
-
+	// Auth - OAuth only, no API key fallback
 	if t.tokenProvider != nil {
 		creds, err := t.tokenProvider.Get(ctx)
-		if err == nil {
-			headers.Set("Authorization", "Bearer "+creds.AccessToken)
-		} else {
-			slog.WarnContext(ctx, "failed to get oauth token, attempting fallback to api key", slog.Any("error", err))
-
-			if t.config.APIKey != "" {
-				auth = &httpclient.AuthConfig{
-					Type:      "api_key",
-					APIKey:    t.config.APIKey,
-					HeaderKey: "x-goog-api-key",
-				}
-			}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get OAuth token: %w", err)
 		}
-	} else if t.config.APIKey != "" {
-		// Fallback to API Key if no token provider (legacy/testing?)
-		auth = &httpclient.AuthConfig{
-			Type:      "api_key",
-			APIKey:    t.config.APIKey,
-			HeaderKey: "x-goog-api-key",
-		}
+		headers.Set("Authorization", "Bearer "+creds.AccessToken)
+	} else {
+		return nil, fmt.Errorf("no OAuth token provider configured")
 	}
 
 	// URL
@@ -245,7 +229,6 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 		URL:     url,
 		Headers: headers,
 		Body:    body,
-		Auth:    auth,
 	}
 
 	// Store the original model name in metadata for executor routing

--- a/llm/transformer/antigravity/transformer_test.go
+++ b/llm/transformer/antigravity/transformer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -27,9 +28,10 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestTransformRequest_Antigravity(t *testing.T) {
+	// Use OAuth credentials format: refreshToken|projectID
 	config := Config{
 		BaseURL: "https://api.antigravity.dev",
-		APIKey:  "secret-key",
+		APIKey:  "test-refresh-token|test-project-id",
 		Project: "my-project",
 	}
 
@@ -294,4 +296,144 @@ func TestTransformRequest_Antigravity(t *testing.T) {
 		assert.Equal(t, "OBJECT", parameters["type"]) // UPPERCASE, as Antigravity API expects
 		assert.NotNil(t, parameters["properties"])
 	})
+}
+
+// TestOAuthFailureNoFallback verifies that when OAuth token retrieval fails, an error is returned (not fallback to API key)
+func TestOAuthFailureNoFallback(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock HTTP Client that fails token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return nil, fmt.Errorf("token retrieval failed")
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	_, err = transformer.TransformRequest(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OAuth token")
+}
+
+// TestNoAPIKeyAuthConfig verifies that AuthConfig is never set to api_key type
+func TestNoAPIKeyAuthConfig(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock successful OAuth token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"access_token": "mock-access-token",
+						"token_type": "Bearer",
+						"expires_in": 3600
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify Authorization header is set with Bearer token (OAuth)
+	assert.Equal(t, "Bearer mock-access-token", httpReq.Headers.Get("Authorization"))
+
+	// Verify no X-Goog-Api-Key header is set
+	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"))
+}
+
+// TestOAuthOnlyHeaders verifies that X-Goog-Api-Key header is never sent
+func TestOAuthOnlyHeaders(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock successful OAuth token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"access_token": "oauth-access-token",
+						"token_type": "Bearer",
+						"expires_in": 3600
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "claude-3-5-sonnet",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Test")}},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify OAuth headers are set correctly
+	assert.Equal(t, "Bearer oauth-access-token", httpReq.Headers.Get("Authorization"))
+
+	// Verify X-Goog-Api-Key header is NOT present
+	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"), "X-Goog-Api-Key header should not be set when using OAuth")
+
+	// Verify other required headers are present
+	assert.Equal(t, "application/json", httpReq.Headers.Get("Content-Type"))
+	assert.Equal(t, UserAgent, httpReq.Headers.Get("User-Agent"))
+	assert.Equal(t, ApiClient, httpReq.Headers.Get("X-Goog-Api-Client"))
+	assert.Equal(t, ClientMetadata, httpReq.Headers.Get("Client-Metadata"))
 }


### PR DESCRIPTION
## Summary
Google has deprecated API key authentication for Antigravity. This PR removes the API key fallback and ensures OAuth2 is used exclusively.

## Changes
- Remove API key fallback from transformer (OAuth-only auth)
- Update ideType from IDE_UNSPECIFIED to ANTIGRAVITY
- Add tests for OAuth-only authentication
- Update OAuth endpoints to use ANTIGRAVITY ideType

## Testing
- All tests pass: go test ./llm/transformer/antigravity/...
- Coverage: 73.5%
- New tests: TestOAuthFailureNoFallback, TestNoAPIKeyAuthConfig, TestOAuthOnlyHeaders

## Related
Fixes error: API keys are not supported by this API. Expected OAuth2 access token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by implementing OAuth-exclusive authentication, eliminating the legacy API key fallback mechanism and enforcing proper error handling for token retrieval failures.
  * Updated client metadata headers to accurately identify the IDE environment in API requests.

* **Tests**
  * Expanded test coverage to validate OAuth token retrieval, Bearer token usage in authorization headers, and proper header configuration for authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->