### PR TITLE
fix(antigravity): repair broken OAuth authentication - remove API key fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /build
 RUN apk add --no-cache git ca-certificates tzdata
 
 COPY go.mod go.sum ./
+COPY llm/go.mod llm/go.sum llm/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOTOOLCHAIN=auto go mod download

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -276,6 +276,7 @@ const AuthenticatedProjectRequestsRequestIdRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof AuthenticatedIndexRoute
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/forgot-password': typeof authForgotPasswordRoute
   '/initialization': typeof authInitializationRoute
@@ -287,34 +288,33 @@ export interface FileRoutesByFullPath {
   '/500': typeof errors500Route
   '/503': typeof errors503Route
   '/permission': typeof AuthenticatedPermissionRoute
-  '/': typeof AuthenticatedIndexRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
   '/settings/profile': typeof AuthenticatedSettingsProfileRoute
-  '/api-keys': typeof AuthenticatedApiKeysIndexRoute
-  '/channels': typeof AuthenticatedChannelsIndexRoute
-  '/chats': typeof AuthenticatedChatsIndexRoute
-  '/data-storages': typeof AuthenticatedDataStoragesIndexRoute
-  '/help-center': typeof AuthenticatedHelpCenterIndexRoute
-  '/models': typeof AuthenticatedModelsIndexRoute
-  '/permission-demo': typeof AuthenticatedPermissionDemoIndexRoute
-  '/projects': typeof AuthenticatedProjectsIndexRoute
-  '/roles': typeof AuthenticatedRolesIndexRoute
+  '/api-keys/': typeof AuthenticatedApiKeysIndexRoute
+  '/channels/': typeof AuthenticatedChannelsIndexRoute
+  '/chats/': typeof AuthenticatedChatsIndexRoute
+  '/data-storages/': typeof AuthenticatedDataStoragesIndexRoute
+  '/help-center/': typeof AuthenticatedHelpCenterIndexRoute
+  '/models/': typeof AuthenticatedModelsIndexRoute
+  '/permission-demo/': typeof AuthenticatedPermissionDemoIndexRoute
+  '/projects/': typeof AuthenticatedProjectsIndexRoute
+  '/roles/': typeof AuthenticatedRolesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/system': typeof AuthenticatedSystemIndexRoute
-  '/users': typeof AuthenticatedUsersIndexRoute
+  '/system/': typeof AuthenticatedSystemIndexRoute
+  '/users/': typeof AuthenticatedUsersIndexRoute
   '/project/requests/$requestId': typeof AuthenticatedProjectRequestsRequestIdRoute
   '/project/threads/$threadId': typeof AuthenticatedProjectThreadsThreadIdRoute
   '/project/traces/$traceId': typeof AuthenticatedProjectTracesTraceIdRoute
-  '/project/api-keys': typeof AuthenticatedProjectApiKeysIndexRoute
-  '/project/playground': typeof AuthenticatedProjectPlaygroundIndexRoute
-  '/project/prompts': typeof AuthenticatedProjectPromptsIndexRoute
-  '/project/requests': typeof AuthenticatedProjectRequestsIndexRoute
-  '/project/roles': typeof AuthenticatedProjectRolesIndexRoute
-  '/project/threads': typeof AuthenticatedProjectThreadsIndexRoute
-  '/project/traces': typeof AuthenticatedProjectTracesIndexRoute
-  '/project/users': typeof AuthenticatedProjectUsersIndexRoute
+  '/project/api-keys/': typeof AuthenticatedProjectApiKeysIndexRoute
+  '/project/playground/': typeof AuthenticatedProjectPlaygroundIndexRoute
+  '/project/prompts/': typeof AuthenticatedProjectPromptsIndexRoute
+  '/project/requests/': typeof AuthenticatedProjectRequestsIndexRoute
+  '/project/roles/': typeof AuthenticatedProjectRolesIndexRoute
+  '/project/threads/': typeof AuthenticatedProjectThreadsIndexRoute
+  '/project/traces/': typeof AuthenticatedProjectTracesIndexRoute
+  '/project/users/': typeof AuthenticatedProjectUsersIndexRoute
 }
 export interface FileRoutesByTo {
   '/forgot-password': typeof authForgotPasswordRoute
@@ -402,6 +402,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/settings'
     | '/forgot-password'
     | '/initialization'
@@ -413,34 +414,33 @@ export interface FileRouteTypes {
     | '/500'
     | '/503'
     | '/permission'
-    | '/'
     | '/settings/appearance'
     | '/settings/display'
     | '/settings/notifications'
     | '/settings/profile'
-    | '/api-keys'
-    | '/channels'
-    | '/chats'
-    | '/data-storages'
-    | '/help-center'
-    | '/models'
-    | '/permission-demo'
-    | '/projects'
-    | '/roles'
+    | '/api-keys/'
+    | '/channels/'
+    | '/chats/'
+    | '/data-storages/'
+    | '/help-center/'
+    | '/models/'
+    | '/permission-demo/'
+    | '/projects/'
+    | '/roles/'
     | '/settings/'
-    | '/system'
-    | '/users'
+    | '/system/'
+    | '/users/'
     | '/project/requests/$requestId'
     | '/project/threads/$threadId'
     | '/project/traces/$traceId'
-    | '/project/api-keys'
-    | '/project/playground'
-    | '/project/prompts'
-    | '/project/requests'
-    | '/project/roles'
-    | '/project/threads'
-    | '/project/traces'
-    | '/project/users'
+    | '/project/api-keys/'
+    | '/project/playground/'
+    | '/project/prompts/'
+    | '/project/requests/'
+    | '/project/roles/'
+    | '/project/threads/'
+    | '/project/traces/'
+    | '/project/users/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/forgot-password'
@@ -543,7 +543,7 @@ declare module '@tanstack/react-router' {
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -634,14 +634,14 @@ declare module '@tanstack/react-router' {
     '/_authenticated/users/': {
       id: '/_authenticated/users/'
       path: '/users'
-      fullPath: '/users'
+      fullPath: '/users/'
       preLoaderRoute: typeof AuthenticatedUsersIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/system/': {
       id: '/_authenticated/system/'
       path: '/system'
-      fullPath: '/system'
+      fullPath: '/system/'
       preLoaderRoute: typeof AuthenticatedSystemIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
@@ -655,63 +655,63 @@ declare module '@tanstack/react-router' {
     '/_authenticated/roles/': {
       id: '/_authenticated/roles/'
       path: '/roles'
-      fullPath: '/roles'
+      fullPath: '/roles/'
       preLoaderRoute: typeof AuthenticatedRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/projects/': {
       id: '/_authenticated/projects/'
       path: '/projects'
-      fullPath: '/projects'
+      fullPath: '/projects/'
       preLoaderRoute: typeof AuthenticatedProjectsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/permission-demo/': {
       id: '/_authenticated/permission-demo/'
       path: '/permission-demo'
-      fullPath: '/permission-demo'
+      fullPath: '/permission-demo/'
       preLoaderRoute: typeof AuthenticatedPermissionDemoIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/models/': {
       id: '/_authenticated/models/'
       path: '/models'
-      fullPath: '/models'
+      fullPath: '/models/'
       preLoaderRoute: typeof AuthenticatedModelsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/help-center/': {
       id: '/_authenticated/help-center/'
       path: '/help-center'
-      fullPath: '/help-center'
+      fullPath: '/help-center/'
       preLoaderRoute: typeof AuthenticatedHelpCenterIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/data-storages/': {
       id: '/_authenticated/data-storages/'
       path: '/data-storages'
-      fullPath: '/data-storages'
+      fullPath: '/data-storages/'
       preLoaderRoute: typeof AuthenticatedDataStoragesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/chats/': {
       id: '/_authenticated/chats/'
       path: '/chats'
-      fullPath: '/chats'
+      fullPath: '/chats/'
       preLoaderRoute: typeof AuthenticatedChatsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/channels/': {
       id: '/_authenticated/channels/'
       path: '/channels'
-      fullPath: '/channels'
+      fullPath: '/channels/'
       preLoaderRoute: typeof AuthenticatedChannelsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/api-keys/': {
       id: '/_authenticated/api-keys/'
       path: '/api-keys'
-      fullPath: '/api-keys'
+      fullPath: '/api-keys/'
       preLoaderRoute: typeof AuthenticatedApiKeysIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
@@ -746,56 +746,56 @@ declare module '@tanstack/react-router' {
     '/_authenticated/project/users/': {
       id: '/_authenticated/project/users/'
       path: '/project/users'
-      fullPath: '/project/users'
+      fullPath: '/project/users/'
       preLoaderRoute: typeof AuthenticatedProjectUsersIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/traces/': {
       id: '/_authenticated/project/traces/'
       path: '/project/traces'
-      fullPath: '/project/traces'
+      fullPath: '/project/traces/'
       preLoaderRoute: typeof AuthenticatedProjectTracesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/threads/': {
       id: '/_authenticated/project/threads/'
       path: '/project/threads'
-      fullPath: '/project/threads'
+      fullPath: '/project/threads/'
       preLoaderRoute: typeof AuthenticatedProjectThreadsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/roles/': {
       id: '/_authenticated/project/roles/'
       path: '/project/roles'
-      fullPath: '/project/roles'
+      fullPath: '/project/roles/'
       preLoaderRoute: typeof AuthenticatedProjectRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/requests/': {
       id: '/_authenticated/project/requests/'
       path: '/project/requests'
-      fullPath: '/project/requests'
+      fullPath: '/project/requests/'
       preLoaderRoute: typeof AuthenticatedProjectRequestsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/prompts/': {
       id: '/_authenticated/project/prompts/'
       path: '/project/prompts'
-      fullPath: '/project/prompts'
+      fullPath: '/project/prompts/'
       preLoaderRoute: typeof AuthenticatedProjectPromptsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/playground/': {
       id: '/_authenticated/project/playground/'
       path: '/project/playground'
-      fullPath: '/project/playground'
+      fullPath: '/project/playground/'
       preLoaderRoute: typeof AuthenticatedProjectPlaygroundIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/api-keys/': {
       id: '/_authenticated/project/api-keys/'
       path: '/project/api-keys'
-      fullPath: '/project/api-keys'
+      fullPath: '/project/api-keys/'
       preLoaderRoute: typeof AuthenticatedProjectApiKeysIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }

--- a/internal/server/api/antigravity.go
+++ b/internal/server/api/antigravity.go
@@ -278,7 +278,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{antigravity.ClientMetadata},
 			},
 			Body: bodyBytes,
 		}
@@ -367,7 +367,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{antigravity.ClientMetadata},
 			},
 			Body: bodyBytes,
 		}

--- a/internal/server/api/antigravity.go
+++ b/internal/server/api/antigravity.go
@@ -259,7 +259,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 		url := fmt.Sprintf("%s/v1internal:loadCodeAssist", baseEndpoint)
 		reqBody := map[string]any{
 			"metadata": map[string]string{
-				"ideType":    "IDE_UNSPECIFIED",
+				"ideType":    "ANTIGRAVITY",
 				"platform":   "PLATFORM_UNSPECIFIED",
 				"pluginType": "GEMINI",
 			},
@@ -278,7 +278,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
 			},
 			Body: bodyBytes,
 		}
@@ -352,7 +352,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 		reqBody := map[string]any{
 			"tierId": tierID,
 			"metadata": map[string]string{
-				"ideType":    "IDE_UNSPECIFIED",
+				"ideType":    "ANTIGRAVITY",
 				"platform":   "PLATFORM_UNSPECIFIED",
 				"pluginType": "GEMINI",
 			},
@@ -367,7 +367,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 				"Content-Type":      []string{"application/json"},
 				"User-Agent":        []string{antigravity.UserAgent},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
-				"Client-Metadata":   []string{`{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
+				"Client-Metadata":   []string{`{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`},
 			},
 			Body: bodyBytes,
 		}

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -653,23 +653,36 @@ func isOAuthJSON(s string) bool {
 	return strings.HasPrefix(trimmed, "{") && strings.Contains(s, "access_token")
 }
 
+func extractProjectIDFromAntigravityCreds(apiKey string) string {
+	parts := strings.Split(apiKey, "|")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
+}
+
 func (svc *ChannelService) refreshOAuthToken(ctx context.Context, ch *ent.Channel, refreshed *oauth.OAuthCredentials) error {
 	if refreshed == nil {
 		return nil
 	}
 
-	credJSON, err := refreshed.ToJSON()
-	if err != nil {
-		return err
-	}
-
 	updated := ch.Credentials
 
-	// NOTE：必须是使用 APIKey 字段，不能使用 API Keys 字段
-	updated.APIKey = credJSON
+	if ch.Type == channel.TypeAntigravity {
+		projectID := extractProjectIDFromAntigravityCreds(ch.Credentials.APIKey)
+		updated.APIKey = fmt.Sprintf("%s|%s", refreshed.RefreshToken, projectID)
+	} else {
+		credJSON, err := refreshed.ToJSON()
+		if err != nil {
+			return err
+		}
+		// NOTE：必须是使用 APIKey 字段，不能使用 API Keys 字段
+		updated.APIKey = credJSON
+	}
+
 	updated.OAuth = refreshed
 
-	_, err = svc.entFromContext(ctx).Channel.UpdateOneID(ch.ID).SetCredentials(updated).Save(ctx)
+	_, err := svc.entFromContext(ctx).Channel.UpdateOneID(ch.ID).SetCredentials(updated).Save(ctx)
 
 	return err
 }

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -653,12 +653,12 @@ func isOAuthJSON(s string) bool {
 	return strings.HasPrefix(trimmed, "{") && strings.Contains(s, "access_token")
 }
 
-func extractProjectIDFromAntigravityCreds(apiKey string) string {
+func extractProjectIDFromAntigravityCreds(apiKey string) (string, error) {
 	parts := strings.Split(apiKey, "|")
 	if len(parts) >= 2 {
-		return parts[1]
+		return parts[1], nil
 	}
-	return ""
+	return "", errors.New("api key does not contain project ID (expected format: \"<refreshToken>|<projectID>\")")
 }
 
 func (svc *ChannelService) refreshOAuthToken(ctx context.Context, ch *ent.Channel, refreshed *oauth.OAuthCredentials) error {
@@ -669,7 +669,13 @@ func (svc *ChannelService) refreshOAuthToken(ctx context.Context, ch *ent.Channe
 	updated := ch.Credentials
 
 	if ch.Type == channel.TypeAntigravity {
-		projectID := extractProjectIDFromAntigravityCreds(ch.Credentials.APIKey)
+		projectID, err := extractProjectIDFromAntigravityCreds(ch.Credentials.APIKey)
+		if err != nil {
+			log.Warn(ctx, "failed to extract project ID from antigravity credentials",
+				log.Cause(err),
+				log.String("channel", ch.Name))
+			return fmt.Errorf("failed to extract project ID from antigravity credentials: %w", err)
+		}
 		updated.APIKey = fmt.Sprintf("%s|%s", refreshed.RefreshToken, projectID)
 	} else {
 		credJSON, err := refreshed.ToJSON()

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -680,7 +680,7 @@ func (svc *ChannelService) refreshOAuthToken(ctx context.Context, ch *ent.Channe
 	} else {
 		credJSON, err := refreshed.ToJSON()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to serialize refreshed credentials: %w", err)
 		}
 		// NOTE：必须是使用 APIKey 字段，不能使用 API Keys 字段
 		updated.APIKey = credJSON

--- a/llm/transformer/antigravity/constants.go
+++ b/llm/transformer/antigravity/constants.go
@@ -31,7 +31,7 @@ const (
 	ApiClient = "google-cloud-sdk vscode_cloudshelleditor/0.1"
 
 	// ClientMetadata used for Client-Metadata header.
-	ClientMetadata = `{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`
+	ClientMetadata = `{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}`
 
 	// DefaultProjectID is the fallback project ID (Cloud Code default).
 	DefaultProjectID = "rising-fact-p41fc"

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -210,31 +210,15 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 		headers.Set("Accept", "application/json")
 	}
 
-	// Auth
-	var auth *httpclient.AuthConfig
-
+	// Auth - OAuth only, no API key fallback
 	if t.tokenProvider != nil {
 		creds, err := t.tokenProvider.Get(ctx)
-		if err == nil {
-			headers.Set("Authorization", "Bearer "+creds.AccessToken)
-		} else {
-			slog.WarnContext(ctx, "failed to get oauth token, attempting fallback to api key", slog.Any("error", err))
-
-			if t.config.APIKey != "" {
-				auth = &httpclient.AuthConfig{
-					Type:      "api_key",
-					APIKey:    t.config.APIKey,
-					HeaderKey: "x-goog-api-key",
-				}
-			}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get OAuth token: %w", err)
 		}
-	} else if t.config.APIKey != "" {
-		// Fallback to API Key if no token provider (legacy/testing?)
-		auth = &httpclient.AuthConfig{
-			Type:      "api_key",
-			APIKey:    t.config.APIKey,
-			HeaderKey: "x-goog-api-key",
-		}
+		headers.Set("Authorization", "Bearer "+creds.AccessToken)
+	} else {
+		return nil, fmt.Errorf("no OAuth token provider configured")
 	}
 
 	// URL
@@ -245,7 +229,6 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 		URL:     url,
 		Headers: headers,
 		Body:    body,
-		Auth:    auth,
 	}
 
 	// Store the original model name in metadata for executor routing

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -211,12 +211,16 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 	}
 
 	// Auth - OAuth only, no API key fallback
+	var authConfig *httpclient.AuthConfig
 	if t.tokenProvider != nil {
 		creds, err := t.tokenProvider.Get(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get OAuth token: %w", err)
 		}
-		headers.Set("Authorization", "Bearer "+creds.AccessToken)
+		authConfig = &httpclient.AuthConfig{
+			Type:   httpclient.AuthTypeBearer,
+			APIKey: creds.AccessToken,
+		}
 	} else {
 		return nil, fmt.Errorf("no OAuth token provider configured")
 	}
@@ -229,6 +233,7 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 		URL:     url,
 		Headers: headers,
 		Body:    body,
+		Auth:    authConfig,
 	}
 
 	// Store the original model name in metadata for executor routing

--- a/llm/transformer/antigravity/transformer_test.go
+++ b/llm/transformer/antigravity/transformer_test.go
@@ -76,8 +76,10 @@ func TestTransformRequest_Antigravity(t *testing.T) {
 		assert.Equal(t, UserAgent, httpReq.Headers.Get("User-Agent"))
 		assert.Equal(t, ApiClient, httpReq.Headers.Get("X-Goog-Api-Client"))
 		assert.Equal(t, ClientMetadata, httpReq.Headers.Get("Client-Metadata"))
-		// Since we mocked the token response, we expect the mock access token
-		assert.Equal(t, "Bearer mock-access-token", httpReq.Headers.Get("Authorization"))
+		// Since we mocked the token response, we expect the mock access token in Auth config
+		require.NotNil(t, httpReq.Auth)
+		assert.Equal(t, httpclient.AuthTypeBearer, httpReq.Auth.Type)
+		assert.Equal(t, "mock-access-token", httpReq.Auth.APIKey)
 
 		// Check URL
 		assert.Equal(t, "https://api.antigravity.dev/v1internal:generateContent", httpReq.URL)
@@ -376,8 +378,10 @@ func TestNoAPIKeyAuthConfig(t *testing.T) {
 	httpReq, err := transformer.TransformRequest(context.Background(), req)
 	require.NoError(t, err)
 
-	// Verify Authorization header is set with Bearer token (OAuth)
-	assert.Equal(t, "Bearer mock-access-token", httpReq.Headers.Get("Authorization"))
+	// Verify Auth config is set with Bearer token (OAuth)
+	require.NotNil(t, httpReq.Auth)
+	assert.Equal(t, httpclient.AuthTypeBearer, httpReq.Auth.Type)
+	assert.Equal(t, "mock-access-token", httpReq.Auth.APIKey)
 
 	// Verify no X-Goog-Api-Key header is set
 	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"))
@@ -425,8 +429,10 @@ func TestOAuthOnlyHeaders(t *testing.T) {
 	httpReq, err := transformer.TransformRequest(context.Background(), req)
 	require.NoError(t, err)
 
-	// Verify OAuth headers are set correctly
-	assert.Equal(t, "Bearer oauth-access-token", httpReq.Headers.Get("Authorization"))
+	// Verify Auth config is set correctly with Bearer token
+	require.NotNil(t, httpReq.Auth)
+	assert.Equal(t, httpclient.AuthTypeBearer, httpReq.Auth.Type)
+	assert.Equal(t, "oauth-access-token", httpReq.Auth.APIKey)
 
 	// Verify X-Goog-Api-Key header is NOT present
 	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"), "X-Goog-Api-Key header should not be set when using OAuth")

--- a/llm/transformer/antigravity/transformer_test.go
+++ b/llm/transformer/antigravity/transformer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -27,9 +28,10 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestTransformRequest_Antigravity(t *testing.T) {
+	// Use OAuth credentials format: refreshToken|projectID
 	config := Config{
 		BaseURL: "https://api.antigravity.dev",
-		APIKey:  "secret-key",
+		APIKey:  "test-refresh-token|test-project-id",
 		Project: "my-project",
 	}
 
@@ -294,4 +296,144 @@ func TestTransformRequest_Antigravity(t *testing.T) {
 		assert.Equal(t, "OBJECT", parameters["type"]) // UPPERCASE, as Antigravity API expects
 		assert.NotNil(t, parameters["properties"])
 	})
+}
+
+// TestOAuthFailureNoFallback verifies that when OAuth token retrieval fails, an error is returned (not fallback to API key)
+func TestOAuthFailureNoFallback(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock HTTP Client that fails token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return nil, fmt.Errorf("token retrieval failed")
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	_, err = transformer.TransformRequest(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OAuth token")
+}
+
+// TestNoAPIKeyAuthConfig verifies that AuthConfig is never set to api_key type
+func TestNoAPIKeyAuthConfig(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock successful OAuth token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"access_token": "mock-access-token",
+						"token_type": "Bearer",
+						"expires_in": 3600
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify Authorization header is set with Bearer token (OAuth)
+	assert.Equal(t, "Bearer mock-access-token", httpReq.Headers.Get("Authorization"))
+
+	// Verify no X-Goog-Api-Key header is set
+	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"))
+}
+
+// TestOAuthOnlyHeaders verifies that X-Goog-Api-Key header is never sent
+func TestOAuthOnlyHeaders(t *testing.T) {
+	config := Config{
+		BaseURL: "https://api.antigravity.dev",
+		APIKey:  "test-refresh-token|test-project-id",
+		Project: "my-project",
+	}
+
+	// Mock successful OAuth token retrieval
+	mockRT := &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == TokenURL {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"access_token": "oauth-access-token",
+						"token_type": "Bearer",
+						"expires_in": 3600
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			}
+			return &http.Response{StatusCode: http.StatusNotFound}, nil
+		},
+	}
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: mockRT,
+	})
+
+	transformer, err := NewTransformer(config, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "claude-3-5-sonnet",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Test")}},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify OAuth headers are set correctly
+	assert.Equal(t, "Bearer oauth-access-token", httpReq.Headers.Get("Authorization"))
+
+	// Verify X-Goog-Api-Key header is NOT present
+	assert.Empty(t, httpReq.Headers.Get("X-Goog-Api-Key"), "X-Goog-Api-Key header should not be set when using OAuth")
+
+	// Verify other required headers are present
+	assert.Equal(t, "application/json", httpReq.Headers.Get("Content-Type"))
+	assert.Equal(t, UserAgent, httpReq.Headers.Get("User-Agent"))
+	assert.Equal(t, ApiClient, httpReq.Headers.Get("X-Goog-Api-Client"))
+	assert.Equal(t, ClientMetadata, httpReq.Headers.Get("Client-Metadata"))
 }


### PR DESCRIPTION
## Problem

Antigravity OAuth authentication was completely broken, manifesting as:

> \"Channel test failed: API keys are not supported by this API. Expected OAuth2 access token...\"

**Root cause: Two bugs working together:**

1. **API key fallback** (lines 221-238 in `transformer.go`) - Google now rejects all API key auth, making this fallback actively harmful
2. **Token refresh broke credential format** - The most critical bug. When OAuth tokens refreshed, `refreshToken|projectID` was converted to JSON, breaking all subsequent API calls

## Bug Origin

The credential format bug was introduced in commit `d5f3fd48` (Jan 29, 2026) when Antigravity was first added. The `refreshOAuthTokenFunc` was copied from Codex/Claude Code (which use JSON credentials) without adapting it for Antigravity's pipe-delimited format. This meant:
- Initial auth worked (correct format)
- First token refresh (~1 hour later) converted to JSON
- All subsequent calls failed

## Reference Implementation

Validated against **OpenCode Antigravity Auth Plugin (v1.5.0-1.5.1)** - uses OAuth-only with no API key fallback and `ideType: ANTIGRAVITY`.

## Changes

### 1. Preserve Pipe-Delimited Format on Token Refresh (f4aa9fc2) ⭐ Critical
**Files:** `internal/server/biz/channel_llm.go`, `llm/oauth/token_provider.go`

```go
// BEFORE: Always JSON (broken for Antigravity)
updated.APIKey = credJSON

// AFTER: Preserve pipe format for Antigravity
if ch.Type == channel.TypeAntigravity {
    projectID := extractProjectIDFromAntigravityCreds(ch.Credentials.APIKey)
    updated.APIKey = fmt.Sprintf("%s|%s", refreshed.RefreshToken, projectID)
} else {
    updated.APIKey = credJSON  // JSON for other providers
}
```

### 2. Remove API Key Fallback (534f5ea6)
**File:** `llm/transformer/antigravity/transformer.go`

- Removed API key fallback logic (Google rejects it entirely)
- OAuth failure now returns clear error instead of broken fallback

### 3. Update ideType to ANTIGRAVITY (d243c378)
**Files:** `llm/transformer/antigravity/constants.go`, `internal/server/api/antigravity.go`

- Changed from `IDE_UNSPECIFIED` to `ANTIGRAVITY`
- Aligns with OpenCode plugin v1.5.1 spec

### 4. Update Tests (8f1a19a0)
**File:** `llm/transformer/antigravity/transformer_test.go`

- Added `TestOAuthFailureNoFallback`, `TestNoAPIKeyAuthConfig`, `TestOAuthOnlyHeaders`
- Verifies no API key headers sent, proper OAuth-only behavior

## Verification

```bash
cd llm && go test ./transformer/antigravity/...
ok  	github.com/looplj/axonhub/llm/transformer/antigravity	0.269s
# 38/38 tests pass
```

✅ Token refresh preserves `refreshToken|projectID` format  
✅ No API key fallback logic remains  
✅ `X-Goog-Api-Key` header never sent  
✅ `ideType` is `ANTIGRAVITY`  

## Related Issues

- Closes #798 - Antigravity渠道无法使用 (Antigravity channel cannot be used)

## Breaking Changes

None. The API key fallback was already non-functional (Google rejects API keys). Existing OAuth channels continue to work.

## Related Commits

- `c4dcc62f` (Jan 19) - Auto OAuth refresh added for Codex/Claude Code (JSON format)
- `d5f3fd48` (Jan 29) - **Bug introduced:** Antigravity added with pipe format but using JSON refresh function
- `534f5ea6`, `d243c378`, `8f1a19a0`, `f4aa9fc2` - This PR: Fix OAuth-only auth and pipe format preservation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OAuth token refresh with clearer HTTP error context
  * Fixed Antigravity channel token refresh to preserve project context

* **Improvements**
  * Enforced OAuth-only authentication for Antigravity integrations (removed API-key fallback)
  * Standardized routing paths to use trailing slashes for consistent navigation
  * Ensured build reliability by adjusting backend module resolution

* **Tests**
  * Added tests covering OAuth success/failure and header/auth behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->