### PR TITLE
opt: strip cc billing header cch in inbound

### DIFF
--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/pipeline/cc"
 	"github.com/looplj/axonhub/llm/pipeline/stream"
 	"github.com/looplj/axonhub/llm/streams"
 	"github.com/looplj/axonhub/llm/transformer"
@@ -54,6 +55,7 @@ func NewChatCompletionOrchestrator(
 		QuotaService:    quotaService,
 		PromptProvider:  promptService,
 		Middlewares: []pipeline.Middleware{
+			cc.StripBillingHeaderCCH(),
 			stream.EnsureUsage(),
 		},
 		PipelineFactory:            pipeline.NewFactory(httpClient),

--- a/llm/pipeline/cc/billing_header.go
+++ b/llm/pipeline/cc/billing_header.go
@@ -1,0 +1,136 @@
+package cc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/pipeline"
+)
+
+const (
+	billingHeaderPrefix = "x-anthropic-billing-header:"
+	BillingCCHKey       = "claudecode_billing_cch"
+)
+
+// StripBillingHeaderCCH removes the random `cch=...;` suffix from Claude Code's
+// "x-anthropic-billing-header:" system message.
+//
+// It runs on unified llm.Request (OnInboundLlmRequest) so the transformation is applied
+// consistently regardless of provider/channel retries.
+//
+// The stripped cch value (if any) is saved into request.TransformerMetadata[BillingCCHKey]
+// for restoration by Claude Code outbound transformer when using official credentials.
+func StripBillingHeaderCCH() pipeline.Middleware {
+	return pipeline.OnLlmRequest("claudecode-strip-billing-cch", func(ctx context.Context, request *llm.Request) (*llm.Request, error) {
+		if request == nil || len(request.Messages) == 0 {
+			return request, nil
+		}
+
+		var capturedCCH string
+		changed := false
+
+		for i := range request.Messages {
+			msg := &request.Messages[i]
+			if msg.Role != "system" {
+				continue
+			}
+
+			if msg.Content.Content != nil {
+				newText, cch, didChange := stripBillingHeaderCCHFromText(*msg.Content.Content)
+				if didChange {
+					changed = true
+					*msg.Content.Content = newText
+					if capturedCCH == "" && cch != "" {
+						capturedCCH = cch
+					}
+				}
+			}
+
+			if len(msg.Content.MultipleContent) > 0 {
+				for j := range msg.Content.MultipleContent {
+					part := &msg.Content.MultipleContent[j]
+					if part.Type != "text" || part.Text == nil {
+						continue
+					}
+
+					newText, cch, didChange := stripBillingHeaderCCHFromText(*part.Text)
+					if didChange {
+						changed = true
+						*part.Text = newText
+						if capturedCCH == "" && cch != "" {
+							capturedCCH = cch
+						}
+					}
+				}
+			}
+		}
+
+		if !changed {
+			return request, nil
+		}
+
+		if capturedCCH != "" {
+			if request.TransformerMetadata == nil {
+				request.TransformerMetadata = make(map[string]any)
+			}
+			if _, exists := request.TransformerMetadata[BillingCCHKey]; !exists {
+				request.TransformerMetadata[BillingCCHKey] = capturedCCH
+			}
+		}
+
+		return request, nil
+	})
+}
+
+func stripBillingHeaderCCHFromText(text string) (string, string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return text, "", false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, billingHeaderPrefix) {
+		return text, "", false
+	}
+
+	rest := strings.TrimSpace(trimmed[len(billingHeaderPrefix):])
+	if rest == "" {
+		return text, "", false
+	}
+
+	originalHadTrailingSemi := strings.HasSuffix(strings.TrimSpace(rest), ";")
+
+	parts := strings.Split(rest, ";")
+	kept := make([]string, 0, len(parts))
+	var cch string
+
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		pl := strings.ToLower(p)
+		if strings.HasPrefix(pl, "cch=") {
+			if cch == "" {
+				cch = strings.TrimSpace(p[len("cch="):])
+			}
+			continue
+		}
+
+		kept = append(kept, p)
+	}
+
+	if cch == "" {
+		return text, "", false
+	}
+
+	out := billingHeaderPrefix + " " + strings.Join(kept, "; ")
+	if originalHadTrailingSemi || len(kept) > 0 {
+		out = strings.TrimSpace(out) + ";"
+	}
+
+	return out, cch, true
+}
+

--- a/llm/pipeline/cc/billing_header_test.go
+++ b/llm/pipeline/cc/billing_header_test.go
@@ -1,0 +1,72 @@
+package cc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestStripBillingHeaderCCH(t *testing.T) {
+	ctx := context.Background()
+	mw := StripBillingHeaderCCH()
+
+	t.Run("strips cch from system string content and captures it", func(t *testing.T) {
+		billingMsg := "x-anthropic-billing-header: cc_version=2.1.42.c31; cc_entrypoint=cli; cch=38a80;"
+
+		req := &llm.Request{
+			Model: "claude-sonnet-4-5",
+			Messages: []llm.Message{
+				{Role: "system", Content: llm.MessageContent{Content: &billingMsg}},
+				{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("hi")}},
+			},
+		}
+
+		out, err := mw.OnInboundLlmRequest(ctx, req)
+		require.NoError(t, err)
+
+		require.NotNil(t, out)
+		require.NotEmpty(t, out.Messages)
+		require.NotNil(t, out.Messages[0].Content.Content)
+
+		require.Contains(t, *out.Messages[0].Content.Content, "x-anthropic-billing-header:")
+		require.NotContains(t, *out.Messages[0].Content.Content, "cch=")
+
+		require.Equal(t, "x-anthropic-billing-header: cc_version=2.1.42.c31; cc_entrypoint=cli;", *out.Messages[0].Content.Content)
+
+		require.NotNil(t, out.TransformerMetadata)
+		require.Equal(t, "38a80", out.TransformerMetadata[BillingCCHKey])
+	})
+
+	t.Run("strips cch from system multiple content part", func(t *testing.T) {
+		billingMsg := "x-anthropic-billing-header: cc_version=2.1.42.c31; cc_entrypoint=cli; cch=abcde;"
+
+		req := &llm.Request{
+			Model: "claude-sonnet-4-5",
+			Messages: []llm.Message{
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						MultipleContent: []llm.MessageContentPart{
+							{Type: "text", Text: &billingMsg},
+						},
+					},
+				},
+				{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("hi")}},
+			},
+		}
+
+		out, err := mw.OnInboundLlmRequest(ctx, req)
+		require.NoError(t, err)
+
+		require.NotNil(t, out.Messages[0].Content.MultipleContent[0].Text)
+		require.Contains(t, *out.Messages[0].Content.MultipleContent[0].Text, "x-anthropic-billing-header:")
+		require.NotContains(t, *out.Messages[0].Content.MultipleContent[0].Text, "cch=")
+
+		require.NotNil(t, out.TransformerMetadata)
+		require.Equal(t, "abcde", out.TransformerMetadata[BillingCCHKey])
+	})
+}

--- a/llm/transformer/anthropic/claudecode/outbound.go
+++ b/llm/transformer/anthropic/claudecode/outbound.go
@@ -120,11 +120,11 @@ func (t *ClaudeCodeTransformer) TransformRequest(
 	// Apply structured transformations before serialization
 	reqCopy = *disableThinkingIfToolChoiceForcedStructured(&reqCopy)
 	reqCopy = *injectClaudeCodeSystemMessageStructured(&reqCopy)
-	if !t.isOfficial {
-		reqCopy = *removeBillingSystemMessages(&reqCopy)
+	if t.isOfficial {
+		reqCopy = *ensureBillingSystemMessageCCH(&reqCopy)
 	}
 	reqCopy = *injectFakeUserIDStructured(&reqCopy)
-	if isClaudeOAuthToken(apiKey) && !keepClientUA {
+	if t.isOfficial && !keepClientUA {
 		reqCopy = *applyClaudeToolPrefixStructured(&reqCopy, toolPrefix)
 	}
 
@@ -169,7 +169,7 @@ func (t *ClaudeCodeTransformer) TransformRequest(
 		httpReq.Metadata = make(map[string]string)
 	}
 
-	if isClaudeOAuthToken(apiKey) && !keepClientUA {
+	if t.isOfficial && !keepClientUA {
 		httpReq.Metadata["strip_tool_prefix"] = "true"
 	}
 

--- a/llm/transformer/anthropic/claudecode/outbound_test.go
+++ b/llm/transformer/anthropic/claudecode/outbound_test.go
@@ -108,7 +108,10 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 
 	t.Run("applies tool prefix for OAuth tokens from non-CLI clients", func(t *testing.T) {
 
-		transformer, err := NewOutboundTransformer(Params{TokenProvider: newMockTokenProvider("sk-ant-oat01-test-oauth-token")})
+		transformer, err := NewOutboundTransformer(Params{
+			TokenProvider: newMockTokenProvider("sk-ant-oat01-test-oauth-token"),
+			IsOfficial:    true,
+		})
 		require.NoError(t, err)
 
 		req := &llm.Request{
@@ -185,7 +188,7 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 		assert.True(t, isValidUserID(userID))
 	})
 
-	t.Run("removes billing system messages when not official", func(t *testing.T) {
+	t.Run("does not add billing cch when not official", func(t *testing.T) {
 
 		transformer, err := NewOutboundTransformer(Params{
 			TokenProvider: newMockTokenProvider("test-api-key"),
@@ -193,7 +196,7 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		billingMsg := "x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli; cch=e478e;"
+		billingMsg := "x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli;"
 		req := &llm.Request{
 			Model: "claude-sonnet-4-5",
 			Messages: []llm.Message{
@@ -206,17 +209,18 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 		httpReq, err := transformer.TransformRequest(ctx, req)
 		require.NoError(t, err)
 
-		// The billing system message should be removed
+		// The billing system message should not contain cch (it's stripped by pipeline middleware).
 		system := gjson.GetBytes(httpReq.Body, "system")
 		require.True(t, system.Exists())
 
-		// Should only contain the injected Claude Code system message, not the billing header
 		for _, item := range system.Array() {
-			assert.NotContains(t, item.Get("text").String(), "x-anthropic-billing-header")
+			if strings.Contains(item.Get("text").String(), "x-anthropic-billing-header") {
+				assert.NotContains(t, item.Get("text").String(), "cch=")
+			}
 		}
 	})
 
-	t.Run("preserves billing system messages when official", func(t *testing.T) {
+	t.Run("restores billing cch when official and stripped", func(t *testing.T) {
 
 		transformer, err := NewOutboundTransformer(Params{
 			TokenProvider: newMockTokenProvider("test-api-key"),
@@ -224,7 +228,7 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		billingMsg := "x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli; cch=e478e;"
+		billingMsg := "x-anthropic-billing-header: cc_version=2.1.42.c31; cc_entrypoint=cli;"
 		req := &llm.Request{
 			Model: "claude-sonnet-4-5",
 			Messages: []llm.Message{
@@ -232,22 +236,26 @@ func TestClaudeCodeTransformer_TransformRequest(t *testing.T) {
 				{Role: "user", Content: llm.MessageContent{Content: strPtr("Hello")}},
 			},
 			MaxTokens: int64Ptr(1024),
+			TransformerMetadata: map[string]any{
+				"claudecode_billing_cch": "38a80",
+			},
 		}
 
 		httpReq, err := transformer.TransformRequest(ctx, req)
 		require.NoError(t, err)
 
-		// The billing system message should be preserved
+		// The billing system message should include the restored cch.
 		system := gjson.GetBytes(httpReq.Body, "system")
 		require.True(t, system.Exists())
 
-		foundBilling := false
+		foundCCH := false
 		for _, item := range system.Array() {
-			if strings.Contains(item.Get("text").String(), "x-anthropic-billing-header") {
-				foundBilling = true
+			if strings.Contains(item.Get("text").String(), "x-anthropic-billing-header") &&
+				strings.Contains(item.Get("text").String(), "cch=38a80;") {
+				foundCCH = true
 			}
 		}
-		assert.True(t, foundBilling, "billing system message should be preserved for official channels")
+		assert.True(t, foundCCH, "billing system message should restore cch for official channels")
 	})
 
 	t.Run("disables thinking when tool_choice forces tool use", func(t *testing.T) {

--- a/llm/transformer/anthropic/claudecode/utils.go
+++ b/llm/transformer/anthropic/claudecode/utils.go
@@ -14,6 +14,8 @@ import (
 	"github.com/looplj/axonhub/llm"
 )
 
+const claudeCodeBillingCCHMetadataKey = "claudecode_billing_cch"
+
 // userIDPattern matches Claude Code format: user_[64-hex]_account__session_[uuid-v4].
 var userIDPattern = regexp.MustCompile(`^user_[a-fA-F0-9]{64}_account__session_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
@@ -70,11 +72,6 @@ func extractAndRemoveBetas(body []byte) ([]string, []byte) {
 	body, _ = sjson.DeleteBytes(body, "betas")
 
 	return betas, body
-}
-
-// isClaudeOAuthToken checks if the API key is a Claude OAuth token.
-func isClaudeOAuthToken(apiKey string) bool {
-	return strings.Contains(apiKey, "sk-ant-oat")
 }
 
 // disableThinkingIfToolChoiceForcedStructured clears ReasoningEffort when tool_choice forces tool use.
@@ -220,6 +217,91 @@ func removeBillingSystemMessages(llmReq *llm.Request) *llm.Request {
 	llmReq.Messages = filtered
 
 	return llmReq
+}
+
+func ensureBillingSystemMessageCCH(llmReq *llm.Request) *llm.Request {
+	if llmReq == nil || len(llmReq.Messages) == 0 {
+		return llmReq
+	}
+
+	cch := ""
+	if llmReq.TransformerMetadata != nil {
+		if v, ok := llmReq.TransformerMetadata[claudeCodeBillingCCHMetadataKey]; ok {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				cch = strings.TrimSpace(s)
+			}
+		}
+	}
+	if cch == "" {
+		return llmReq
+	}
+
+	for i := range llmReq.Messages {
+		msg := &llmReq.Messages[i]
+		if msg.Role != "system" {
+			continue
+		}
+
+		if msg.Content.Content != nil {
+			updated, changed := ensureBillingHeaderCCHInText(*msg.Content.Content, cch)
+			if changed {
+				*msg.Content.Content = updated
+			}
+		}
+
+		if len(msg.Content.MultipleContent) > 0 {
+			for j := range msg.Content.MultipleContent {
+				part := &msg.Content.MultipleContent[j]
+				if part.Type != "text" || part.Text == nil {
+					continue
+				}
+
+				updated, changed := ensureBillingHeaderCCHInText(*part.Text, cch)
+				if changed {
+					*part.Text = updated
+				}
+			}
+		}
+	}
+
+	return llmReq
+}
+
+func ensureBillingHeaderCCHInText(text string, cch string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return text, false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, billingHeaderPrefix) {
+		return text, false
+	}
+
+	rest := strings.TrimSpace(trimmed[len(billingHeaderPrefix):])
+	if rest == "" {
+		return text, false
+	}
+
+	parts := strings.Split(rest, ";")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		if strings.HasPrefix(strings.ToLower(p), "cch=") {
+			return text, false
+		}
+	}
+
+	out := strings.TrimSpace(trimmed)
+	if !strings.HasSuffix(out, ";") {
+		out += ";"
+	}
+	out += " cch=" + strings.TrimSpace(cch) + ";"
+
+	return out, true
 }
 
 // injectClaudeCodeSystemMessageStructured prepends the Claude Code system message.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced billing metadata handling in the LLM pipeline for improved request processing.

* **Refactor**
  * Simplified channel authentication logic by centralizing control through configuration flags instead of token-based decisions.

* **Tests**
  * Added unit tests for billing metadata extraction and request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->