### PR TITLE
feat: add tool_choice, adaptive thinking and output_config support for Anthropic transformer

### DIFF
--- a/llm/transformer/anthropic/inbound.go
+++ b/llm/transformer/anthropic/inbound.go
@@ -80,6 +80,46 @@ func (t *InboundTransformer) TransformRequest(ctx context.Context, httpReq *http
 		}
 	}
 
+	// Validate thinking configuration
+	if anthropicReq.Thinking != nil {
+		switch anthropicReq.Thinking.Type {
+		case "enabled", "disabled", "adaptive":
+			// valid
+		default:
+			return nil, fmt.Errorf("%w: thinking.type must be one of: enabled, disabled, adaptive", transformer.ErrInvalidRequest)
+		}
+
+		if anthropicReq.Thinking.Type == "enabled" && anthropicReq.Thinking.BudgetTokens <= 0 {
+			return nil, fmt.Errorf("%w: budget_tokens is required and must be positive when thinking type is enabled", transformer.ErrInvalidRequest)
+		}
+	}
+
+	// Validate output_config effort value
+	if anthropicReq.OutputConfig != nil && anthropicReq.OutputConfig.Effort != "" {
+		switch anthropicReq.OutputConfig.Effort {
+		case "low", "medium", "high", "max":
+			// valid
+		default:
+			return nil, fmt.Errorf("%w: output_config.effort must be one of: low, medium, high, max", transformer.ErrInvalidRequest)
+		}
+	}
+
+	// Validate tool_choice
+	if anthropicReq.ToolChoice != nil {
+		switch anthropicReq.ToolChoice.Type {
+		case "auto", "none", "any", "tool":
+			// valid
+		default:
+			return nil, fmt.Errorf("%w: tool_choice.type must be one of: auto, none, any, tool", transformer.ErrInvalidRequest)
+		}
+
+		if anthropicReq.ToolChoice.Type == "tool" {
+			if anthropicReq.ToolChoice.Name == nil || *anthropicReq.ToolChoice.Name == "" {
+				return nil, fmt.Errorf("%w: tool_choice.name is required when type is tool", transformer.ErrInvalidRequest)
+			}
+		}
+	}
+
 	return convertToLLMRequest(&anthropicReq)
 }
 

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -307,13 +307,13 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 		case "adaptive":
 			// adaptive thinking 不需要 budget，但需要传递类型标记
 			// 使用 TransformerMetadata 保留 adaptive 类型信息
-			chatReq.TransformerMetadata["thinking_type"] = "adaptive"
+			chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType] = "adaptive"
 		}
 	}
 
 	// Convert output_config
 	if anthropicReq.OutputConfig != nil && anthropicReq.OutputConfig.Effort != "" {
-		chatReq.TransformerMetadata["output_config_effort"] = anthropicReq.OutputConfig.Effort
+		chatReq.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort] = anthropicReq.OutputConfig.Effort
 	}
 
 	return chatReq, nil

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -305,8 +305,7 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 			chatReq.ReasoningEffort = thinkingBudgetToReasoningEffort(anthropicReq.Thinking.BudgetTokens)
 			chatReq.ReasoningBudget = lo.ToPtr(anthropicReq.Thinking.BudgetTokens)
 		case "adaptive":
-			// adaptive thinking 不需要 budget，但需要传递类型标记
-			// 使用 TransformerMetadata 保留 adaptive 类型信息
+			// Adaptive thinking doesn't require a budget; preserve the type marker via TransformerMetadata.
 			chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType] = "adaptive"
 		}
 	}
@@ -331,7 +330,7 @@ func convertAnthropicToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
 			ToolChoice: new(src.Type),
 		}
 	case "any":
-		// Anthropic "any" 等价于 OpenAI "required"
+		// Anthropic "any" is equivalent to OpenAI "required"
 		required := "required"
 		return &llm.ToolChoice{
 			ToolChoice: &required,

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -293,13 +293,63 @@ func convertToLLMRequest(anthropicReq *MessageRequest) (*llm.Request, error) {
 		}
 	}
 
+	// Convert tool_choice
+	if anthropicReq.ToolChoice != nil {
+		chatReq.ToolChoice = convertAnthropicToolChoiceToLLM(anthropicReq.ToolChoice)
+	}
+
 	// Convert thinking configuration to reasoning effort and preserve budget
-	if anthropicReq.Thinking != nil && anthropicReq.Thinking.Type == "enabled" {
-		chatReq.ReasoningEffort = thinkingBudgetToReasoningEffort(anthropicReq.Thinking.BudgetTokens)
-		chatReq.ReasoningBudget = lo.ToPtr(anthropicReq.Thinking.BudgetTokens)
+	if anthropicReq.Thinking != nil {
+		switch anthropicReq.Thinking.Type {
+		case "enabled":
+			chatReq.ReasoningEffort = thinkingBudgetToReasoningEffort(anthropicReq.Thinking.BudgetTokens)
+			chatReq.ReasoningBudget = lo.ToPtr(anthropicReq.Thinking.BudgetTokens)
+		case "adaptive":
+			// adaptive thinking 不需要 budget，但需要传递类型标记
+			// 使用 TransformerMetadata 保留 adaptive 类型信息
+			chatReq.TransformerMetadata["thinking_type"] = "adaptive"
+		}
+	}
+
+	// Convert output_config
+	if anthropicReq.OutputConfig != nil && anthropicReq.OutputConfig.Effort != "" {
+		chatReq.TransformerMetadata["output_config_effort"] = anthropicReq.OutputConfig.Effort
 	}
 
 	return chatReq, nil
+}
+
+// convertAnthropicToolChoiceToLLM converts Anthropic ToolChoice to llm.ToolChoice.
+func convertAnthropicToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
+	if src == nil {
+		return nil
+	}
+
+	switch src.Type {
+	case "auto", "none":
+		return &llm.ToolChoice{
+			ToolChoice: &src.Type,
+		}
+	case "any":
+		// Anthropic "any" 等价于 OpenAI "required"
+		required := "required"
+		return &llm.ToolChoice{
+			ToolChoice: &required,
+		}
+	case "tool":
+		if src.Name != nil {
+			return &llm.ToolChoice{
+				NamedToolChoice: &llm.NamedToolChoice{
+					Type: "function",
+					Function: llm.ToolFunction{
+						Name: *src.Name,
+					},
+				},
+			}
+		}
+	}
+
+	return nil
 }
 
 func convertToAnthropicResponse(chatResp *llm.Response) *Message {

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -328,7 +328,7 @@ func convertAnthropicToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
 	switch src.Type {
 	case "auto", "none":
 		return &llm.ToolChoice{
-			ToolChoice: &src.Type,
+			ToolChoice: new(src.Type),
 		}
 	case "any":
 		// Anthropic "any" 等价于 OpenAI "required"

--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -327,13 +327,12 @@ func convertAnthropicToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
 	switch src.Type {
 	case "auto", "none":
 		return &llm.ToolChoice{
-			ToolChoice: new(src.Type),
+			ToolChoice: lo.ToPtr(src.Type),
 		}
 	case "any":
 		// Anthropic "any" is equivalent to OpenAI "required"
-		required := "required"
 		return &llm.ToolChoice{
-			ToolChoice: &required,
+			ToolChoice: lo.ToPtr("required"),
 		}
 	case "tool":
 		if src.Name != nil {

--- a/llm/transformer/anthropic/inbound_test.go
+++ b/llm/transformer/anthropic/inbound_test.go
@@ -1104,6 +1104,19 @@ func TestConvertToolChoiceFromAnthropic(t *testing.T) {
 			},
 		},
 		{
+			name: "anthropic none -> llm none",
+			input: &ToolChoice{
+				Type: "none",
+			},
+			validate: func(t *testing.T, got *llm.ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.NotNil(t, got.ToolChoice)
+				require.Equal(t, "none", *got.ToolChoice)
+				require.Nil(t, got.NamedToolChoice)
+			},
+		},
+		{
 			name: "anthropic any -> llm required",
 			input: &ToolChoice{
 				Type: "any",

--- a/llm/transformer/anthropic/inbound_test.go
+++ b/llm/transformer/anthropic/inbound_test.go
@@ -1084,6 +1084,63 @@ func TestConvertAnthropicToolToLLM(t *testing.T) {
 	}
 }
 
+func TestConvertToolChoiceFromAnthropic(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *ToolChoice
+		validate func(t *testing.T, got *llm.ToolChoice)
+	}{
+		{
+			name: "anthropic auto -> llm auto",
+			input: &ToolChoice{
+				Type: "auto",
+			},
+			validate: func(t *testing.T, got *llm.ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.NotNil(t, got.ToolChoice)
+				require.Equal(t, "auto", *got.ToolChoice)
+				require.Nil(t, got.NamedToolChoice)
+			},
+		},
+		{
+			name: "anthropic any -> llm required",
+			input: &ToolChoice{
+				Type: "any",
+			},
+			validate: func(t *testing.T, got *llm.ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.NotNil(t, got.ToolChoice)
+				require.Equal(t, "required", *got.ToolChoice)
+				require.Nil(t, got.NamedToolChoice)
+			},
+		},
+		{
+			name: "anthropic tool+name -> llm named tool choice",
+			input: &ToolChoice{
+				Type: "tool",
+				Name: lo.ToPtr("calculator"),
+			},
+			validate: func(t *testing.T, got *llm.ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.Nil(t, got.ToolChoice)
+				require.NotNil(t, got.NamedToolChoice)
+				require.Equal(t, "function", got.NamedToolChoice.Type)
+				require.Equal(t, "calculator", got.NamedToolChoice.Function.Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertAnthropicToolChoiceToLLM(tt.input)
+			tt.validate(t, got)
+		})
+	}
+}
+
 func TestInboundTransformer_WebSearchTool(t *testing.T) {
 	transformer := NewInboundTransformer()
 

--- a/llm/transformer/anthropic/inbound_test.go
+++ b/llm/transformer/anthropic/inbound_test.go
@@ -320,6 +320,82 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "thinking enabled without budget_tokens",
+			httpReq: &httpclient.Request{
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: []byte(`{
+					"model": "claude-sonnet-4-5-20250929",
+					"max_tokens": 16000,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"thinking": {"type": "enabled"}
+				}`),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid output_config effort value",
+			httpReq: &httpclient.Request{
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: []byte(`{
+					"model": "claude-sonnet-4-5-20250929",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"output_config": {"effort": "banana"}
+				}`),
+			},
+			expectError: true,
+		},
+		{
+			name: "tool_choice type tool without name",
+			httpReq: &httpclient.Request{
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: []byte(`{
+					"model": "claude-sonnet-4-5-20250929",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"tools": [{"name": "calculator", "description": "calc", "input_schema": {"type": "object"}}],
+					"tool_choice": {"type": "tool"}
+				}`),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid thinking type",
+			httpReq: &httpclient.Request{
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: []byte(`{
+					"model": "claude-sonnet-4-5-20250929",
+					"max_tokens": 16000,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"thinking": {"type": "banana"}
+				}`),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid tool_choice type",
+			httpReq: &httpclient.Request{
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: []byte(`{
+					"model": "claude-sonnet-4-5-20250929",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"tool_choice": {"type": "banana"}
+				}`),
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/llm/transformer/anthropic/model.go
+++ b/llm/transformer/anthropic/model.go
@@ -143,6 +143,12 @@ type SystemPromptPart struct {
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
 }
 
+// TransformerMetadataKeyThinkingType is the key for storing thinking type in TransformerMetadata.
+const TransformerMetadataKeyThinkingType = "thinking_type"
+
+// TransformerMetadataKeyOutputConfigEffort is the key for storing output config effort in TransformerMetadata.
+const TransformerMetadataKeyOutputConfigEffort = "output_config_effort"
+
 type Thinking struct {
 	Type         string `json:"type"          validate:"required,oneof=enabled disabled adaptive"`
 	BudgetTokens int64  `json:"budget_tokens,omitempty" validate:"required_if=Type enabled"`
@@ -154,7 +160,7 @@ type OutputConfig struct {
 	// Effort controls the overall effort level for the response.
 	// Any of "low", "medium", "high", "max".
 	// "max" is only supported by claude-opus-4-6.
-	Effort string `json:"effort,omitempty"`
+	Effort string `json:"effort,omitempty" validate:"omitempty,oneof=low medium high max"`
 }
 
 type ToolChoice struct {

--- a/llm/transformer/anthropic/model.go
+++ b/llm/transformer/anthropic/model.go
@@ -82,6 +82,9 @@ type MessageRequest struct {
 	// Thinking is an optional thinking configuration.
 	Thinking *Thinking `json:"thinking,omitempty"`
 
+	// OutputConfig is an optional output configuration.
+	OutputConfig *OutputConfig `json:"output_config,omitempty"`
+
 	// Tools is an optional array of tools.
 	Tools []Tool `json:"tools,omitempty"`
 	// ToolChoice is an optional tool choice configuration.
@@ -141,8 +144,17 @@ type SystemPromptPart struct {
 }
 
 type Thinking struct {
-	Type         string `json:"type"          validate:"required,oneof=enabled disabled"`
-	BudgetTokens int64  `json:"budget_tokens" validate:"required_if=Type enabled"`
+	Type         string `json:"type"          validate:"required,oneof=enabled disabled adaptive"`
+	BudgetTokens int64  `json:"budget_tokens,omitempty" validate:"required_if=Type enabled"`
+}
+
+// OutputConfig represents Anthropic output configuration.
+// See: https://platform.claude.com/docs/en/build-with-claude/effort
+type OutputConfig struct {
+	// Effort controls the overall effort level for the response.
+	// Any of "low", "medium", "high", "max".
+	// "max" is only supported by claude-opus-4-6.
+	Effort string `json:"effort,omitempty"`
 }
 
 type ToolChoice struct {

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -42,9 +42,13 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 	}
 
 	// Determine thinking config priority: adaptive > enabled > disabled
-	if v, ok := chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType].(string); ok && v == "adaptive" {
-		req.Thinking = &Thinking{Type: "adaptive"}
-	} else if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
+	if chatReq.TransformerMetadata != nil {
+		if v, ok := chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType].(string); ok && v == "adaptive" {
+			req.Thinking = &Thinking{Type: "adaptive"}
+		}
+	}
+
+	if req.Thinking == nil && (chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil) {
 		req.Thinking = buildThinking(chatReq, config)
 	}
 
@@ -162,7 +166,7 @@ func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
 	if src.NamedToolChoice != nil && src.NamedToolChoice.Function.Name != "" {
 		return &ToolChoice{
 			Type: "tool",
-			Name: new(src.NamedToolChoice.Function.Name),
+			Name: lo.ToPtr(src.NamedToolChoice.Function.Name),
 		}
 	}
 

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -19,6 +19,7 @@ func convertToAnthropicRequest(chatReq *llm.Request) *MessageRequest {
 func convertToAnthropicRequestWithConfig(chatReq *llm.Request, config *Config) *MessageRequest {
 	req := buildBaseRequest(chatReq, config)
 	req.Tools = convertToolsAnthropic(chatReq.Tools, config)
+	req.ToolChoice = convertToolChoiceToAnthropic(chatReq.ToolChoice)
 	req.Messages = convertMessages(chatReq)
 	req.StopSequences = convertStopSequences(chatReq.Stop)
 
@@ -40,8 +41,18 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 		req.Metadata = &AnthropicMetadata{UserID: chatReq.Metadata["user_id"]}
 	}
 
-	if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
+	// 确定 thinking 配置：adaptive > enabled > disabled
+	if chatReq.TransformerMetadata != nil && chatReq.TransformerMetadata["thinking_type"] == "adaptive" {
+		req.Thinking = &Thinking{Type: "adaptive"}
+	} else if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
 		req.Thinking = buildThinking(chatReq, config)
+	}
+
+	// 设置 output_config（通过 TransformerMetadata 传递）
+	if chatReq.TransformerMetadata != nil {
+		if effort, ok := chatReq.TransformerMetadata["output_config_effort"].(string); ok && effort != "" {
+			req.OutputConfig = &OutputConfig{Effort: effort}
+		}
 	}
 
 	return req
@@ -125,6 +136,37 @@ func convertToolsAnthropic(tools []llm.Tool, config *Config) []Tool {
 	}
 
 	return anthropicTools
+}
+
+// convertToolChoiceToAnthropic converts llm.ToolChoice to Anthropic ToolChoice.
+func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
+	if src == nil {
+		return nil
+	}
+
+	// 字符串形式的 tool_choice: "auto", "none", "any", "required"
+	if src.ToolChoice != nil {
+		choice := *src.ToolChoice
+
+		// OpenAI "required" 等价于 Anthropic "any"
+		if choice == "required" {
+			choice = "any"
+		}
+
+		return &ToolChoice{
+			Type: choice,
+		}
+	}
+
+	// 命名工具形式的 tool_choice: {type: "function", function: {name: "xxx"}}
+	if src.NamedToolChoice != nil {
+		return &ToolChoice{
+			Type: "tool",
+			Name: &src.NamedToolChoice.Function.Name,
+		}
+	}
+
+	return nil
 }
 
 // convertStopSequences converts stop sequences.

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -42,7 +42,7 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 	}
 
 	// 确定 thinking 配置：adaptive > enabled > disabled
-	if chatReq.TransformerMetadata != nil && chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType] == "adaptive" {
+	if v, ok := chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType].(string); ok && v == "adaptive" {
 		req.Thinking = &Thinking{Type: "adaptive"}
 	} else if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
 		req.Thinking = buildThinking(chatReq, config)
@@ -162,7 +162,7 @@ func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
 	if src.NamedToolChoice != nil && src.NamedToolChoice.Function.Name != "" {
 		return &ToolChoice{
 			Type: "tool",
-			Name: &src.NamedToolChoice.Function.Name,
+			Name: new(src.NamedToolChoice.Function.Name),
 		}
 	}
 

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -42,7 +42,7 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 	}
 
 	// 确定 thinking 配置：adaptive > enabled > disabled
-	if chatReq.TransformerMetadata != nil && chatReq.TransformerMetadata["thinking_type"] == "adaptive" {
+	if chatReq.TransformerMetadata != nil && chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType] == "adaptive" {
 		req.Thinking = &Thinking{Type: "adaptive"}
 	} else if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
 		req.Thinking = buildThinking(chatReq, config)
@@ -50,7 +50,7 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 
 	// 设置 output_config（通过 TransformerMetadata 传递）
 	if chatReq.TransformerMetadata != nil {
-		if effort, ok := chatReq.TransformerMetadata["output_config_effort"].(string); ok && effort != "" {
+		if effort, ok := chatReq.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort].(string); ok && effort != "" {
 			req.OutputConfig = &OutputConfig{Effort: effort}
 		}
 	}
@@ -159,7 +159,7 @@ func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
 	}
 
 	// 命名工具形式的 tool_choice: {type: "function", function: {name: "xxx"}}
-	if src.NamedToolChoice != nil {
+	if src.NamedToolChoice != nil && src.NamedToolChoice.Function.Name != "" {
 		return &ToolChoice{
 			Type: "tool",
 			Name: &src.NamedToolChoice.Function.Name,

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -41,14 +41,14 @@ func buildBaseRequest(chatReq *llm.Request, config *Config) *MessageRequest {
 		req.Metadata = &AnthropicMetadata{UserID: chatReq.Metadata["user_id"]}
 	}
 
-	// 确定 thinking 配置：adaptive > enabled > disabled
+	// Determine thinking config priority: adaptive > enabled > disabled
 	if v, ok := chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType].(string); ok && v == "adaptive" {
 		req.Thinking = &Thinking{Type: "adaptive"}
 	} else if chatReq.ReasoningEffort != "" || chatReq.ReasoningBudget != nil {
 		req.Thinking = buildThinking(chatReq, config)
 	}
 
-	// 设置 output_config（通过 TransformerMetadata 传递）
+	// Restore output_config from TransformerMetadata
 	if chatReq.TransformerMetadata != nil {
 		if effort, ok := chatReq.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort].(string); ok && effort != "" {
 			req.OutputConfig = &OutputConfig{Effort: effort}
@@ -144,11 +144,11 @@ func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
 		return nil
 	}
 
-	// 字符串形式的 tool_choice: "auto", "none", "any", "required"
+	// String-form tool_choice: "auto", "none", "any", "required"
 	if src.ToolChoice != nil {
 		choice := *src.ToolChoice
 
-		// OpenAI "required" 等价于 Anthropic "any"
+		// OpenAI "required" is equivalent to Anthropic "any"
 		if choice == "required" {
 			choice = "any"
 		}
@@ -158,7 +158,7 @@ func convertToolChoiceToAnthropic(src *llm.ToolChoice) *ToolChoice {
 		}
 	}
 
-	// 命名工具形式的 tool_choice: {type: "function", function: {name: "xxx"}}
+	// Named tool_choice: {type: "function", function: {name: "xxx"}}
 	if src.NamedToolChoice != nil && src.NamedToolChoice.Function.Name != "" {
 		return &ToolChoice{
 			Type: "tool",

--- a/llm/transformer/anthropic/outbound_convert_test.go
+++ b/llm/transformer/anthropic/outbound_convert_test.go
@@ -110,6 +110,21 @@ func TestConvertToolChoiceToAnthropic(t *testing.T) {
 				require.Nil(t, got)
 			},
 		},
+		{
+			name: "named function with empty name -> nil",
+			input: &llm.ToolChoice{
+				NamedToolChoice: &llm.NamedToolChoice{
+					Type: "function",
+					Function: llm.ToolFunction{
+						Name: "",
+					},
+				},
+			},
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.Nil(t, got)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/llm/transformer/anthropic/outbound_convert_test.go
+++ b/llm/transformer/anthropic/outbound_convert_test.go
@@ -42,6 +42,84 @@ func TestConvertToChatCompletionResponse(t *testing.T) {
 	require.Equal(t, int64(30), result.Usage.TotalTokens)
 }
 
+func TestConvertToolChoiceToAnthropic(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *llm.ToolChoice
+		validate func(t *testing.T, got *ToolChoice)
+	}{
+		{
+			name: "auto -> auto",
+			input: &llm.ToolChoice{
+				ToolChoice: lo.ToPtr("auto"),
+			},
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.Equal(t, "auto", got.Type)
+				require.Nil(t, got.Name)
+			},
+		},
+		{
+			name: "none -> none",
+			input: &llm.ToolChoice{
+				ToolChoice: lo.ToPtr("none"),
+			},
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.Equal(t, "none", got.Type)
+				require.Nil(t, got.Name)
+			},
+		},
+		{
+			name: "required -> any",
+			input: &llm.ToolChoice{
+				ToolChoice: lo.ToPtr("required"),
+			},
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.Equal(t, "any", got.Type)
+				require.Nil(t, got.Name)
+			},
+		},
+		{
+			name: "named function -> tool + name",
+			input: &llm.ToolChoice{
+				NamedToolChoice: &llm.NamedToolChoice{
+					Type: "function",
+					Function: llm.ToolFunction{
+						Name: "calculator",
+					},
+				},
+			},
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.NotNil(t, got)
+				require.Equal(t, "tool", got.Type)
+				require.NotNil(t, got.Name)
+				require.Equal(t, "calculator", *got.Name)
+			},
+		},
+		{
+			name:  "nil -> nil",
+			input: nil,
+			validate: func(t *testing.T, got *ToolChoice) {
+				t.Helper()
+				require.Nil(t, got)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToolChoiceToAnthropic(tt.input)
+			tt.validate(t, got)
+		})
+	}
+}
+
 func TestOutboundTransformer_ToolArgsRepair(t *testing.T) {
 	transformer, _ := NewOutboundTransformer("https://api.anthropic.com", "test-api-key")
 

--- a/llm/transformer/anthropic/outbound_test.go
+++ b/llm/transformer/anthropic/outbound_test.go
@@ -735,10 +735,12 @@ func TestOutboundTransformer_ToolUse(t *testing.T) {
 
 					err := json.Unmarshal(result.Body, &anthropicReq)
 					require.NoError(t, err)
-					// Note: Tool choice is not directly supported in current implementation
-					// but should not cause errors
 					require.NotNil(t, anthropicReq.Tools)
 					require.Len(t, anthropicReq.Tools, 1)
+					require.NotNil(t, anthropicReq.ToolChoice)
+					require.Equal(t, "tool", anthropicReq.ToolChoice.Type)
+					require.NotNil(t, anthropicReq.ToolChoice.Name)
+					require.Equal(t, "calculator", *anthropicReq.ToolChoice.Name)
 
 					// Verify beta header is NOT set for regular function tools
 					require.Empty(t, result.Headers.Get("Anthropic-Beta"))

--- a/llm/transformer/anthropic/thinking_test.go
+++ b/llm/transformer/anthropic/thinking_test.go
@@ -551,7 +551,7 @@ func TestThinking_AdaptiveOutbound(t *testing.T) {
 				ReasoningEffort: "high",
 				ReasoningBudget: lo.ToPtr(int64(30000)),
 				TransformerMetadata: map[string]any{
-					"thinking_type": "adaptive",
+					TransformerMetadataKeyThinkingType: "adaptive",
 				},
 			},
 			validate: func(t *testing.T, anthropicReq *MessageRequest) {
@@ -598,7 +598,7 @@ func TestThinking_AdaptiveInbound(t *testing.T) {
 			validate: func(t *testing.T, chatReq *llm.Request) {
 				t.Helper()
 				require.NotNil(t, chatReq.TransformerMetadata)
-				require.Equal(t, "adaptive", chatReq.TransformerMetadata["thinking_type"])
+				require.Equal(t, "adaptive", chatReq.TransformerMetadata[TransformerMetadataKeyThinkingType])
 				require.Empty(t, chatReq.ReasoningEffort)
 				require.Nil(t, chatReq.ReasoningBudget)
 			},
@@ -665,7 +665,7 @@ func TestOutputConfig_Outbound(t *testing.T) {
 					},
 				},
 				TransformerMetadata: map[string]any{
-					"output_config_effort": "max",
+					TransformerMetadataKeyOutputConfigEffort: "max",
 				},
 			},
 			validate: func(t *testing.T, anthropicReq *MessageRequest) {
@@ -723,7 +723,7 @@ func TestOutputConfig_Inbound(t *testing.T) {
 			validate: func(t *testing.T, chatReq *llm.Request) {
 				t.Helper()
 				require.NotNil(t, chatReq.TransformerMetadata)
-				require.Equal(t, "high", chatReq.TransformerMetadata["output_config_effort"])
+				require.Equal(t, "high", chatReq.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort])
 			},
 		},
 		{
@@ -741,7 +741,7 @@ func TestOutputConfig_Inbound(t *testing.T) {
 			validate: func(t *testing.T, chatReq *llm.Request) {
 				t.Helper()
 				require.NotNil(t, chatReq.TransformerMetadata)
-				_, ok := chatReq.TransformerMetadata["output_config_effort"]
+				_, ok := chatReq.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort]
 				require.False(t, ok)
 			},
 		},

--- a/llm/transformer/anthropic/thinking_test.go
+++ b/llm/transformer/anthropic/thinking_test.go
@@ -529,6 +529,233 @@ func TestThinkingBudgetToReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestThinking_AdaptiveOutbound(t *testing.T) {
+	tests := []struct {
+		name     string
+		chatReq  *llm.Request
+		validate func(t *testing.T, anthropicReq *MessageRequest)
+	}{
+		{
+			name: "metadata thinking_type=adaptive -> Thinking{Type: adaptive} and omit budget_tokens",
+			chatReq: &llm.Request{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: lo.ToPtr(int64(4096)),
+				Messages: []llm.Message{
+					{
+						Role: "user",
+						Content: llm.MessageContent{
+							Content: lo.ToPtr("Hello"),
+						},
+					},
+				},
+				ReasoningEffort: "high",
+				ReasoningBudget: lo.ToPtr(int64(30000)),
+				TransformerMetadata: map[string]any{
+					"thinking_type": "adaptive",
+				},
+			},
+			validate: func(t *testing.T, anthropicReq *MessageRequest) {
+				t.Helper()
+				require.NotNil(t, anthropicReq.Thinking)
+				require.Equal(t, "adaptive", anthropicReq.Thinking.Type)
+
+				thinkingJSON, err := json.Marshal(anthropicReq.Thinking)
+				require.NoError(t, err)
+				require.JSONEq(t, `{"type":"adaptive"}`, string(thinkingJSON))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			anthropicReq := convertToAnthropicRequest(tt.chatReq)
+			tt.validate(t, anthropicReq)
+		})
+	}
+}
+
+func TestThinking_AdaptiveInbound(t *testing.T) {
+	tests := []struct {
+		name         string
+		anthropicReq *MessageRequest
+		validate     func(t *testing.T, chatReq *llm.Request)
+	}{
+		{
+			name: "Thinking{Type: adaptive} -> TransformerMetadata thinking_type=adaptive",
+			anthropicReq: &MessageRequest{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: 4096,
+				Messages: []MessageParam{
+					{
+						Role: "user",
+						Content: MessageContent{
+							Content: lo.ToPtr("Hello"),
+						},
+					},
+				},
+				Thinking: &Thinking{Type: "adaptive"},
+			},
+			validate: func(t *testing.T, chatReq *llm.Request) {
+				t.Helper()
+				require.NotNil(t, chatReq.TransformerMetadata)
+				require.Equal(t, "adaptive", chatReq.TransformerMetadata["thinking_type"])
+				require.Empty(t, chatReq.ReasoningEffort)
+				require.Nil(t, chatReq.ReasoningBudget)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatReq, err := convertToLLMRequest(tt.anthropicReq)
+			require.NoError(t, err)
+			tt.validate(t, chatReq)
+		})
+	}
+}
+
+func TestThinking_AdaptiveJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		thinking Thinking
+		validate func(t *testing.T, data []byte)
+	}{
+		{
+			name: "adaptive marshal omits budget_tokens",
+			thinking: Thinking{
+				Type: "adaptive",
+			},
+			validate: func(t *testing.T, data []byte) {
+				t.Helper()
+				require.JSONEq(t, `{"type":"adaptive"}`, string(data))
+
+				var decoded Thinking
+				err := json.Unmarshal(data, &decoded)
+				require.NoError(t, err)
+				require.Equal(t, "adaptive", decoded.Type)
+				require.Equal(t, int64(0), decoded.BudgetTokens)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.thinking)
+			require.NoError(t, err)
+			tt.validate(t, data)
+		})
+	}
+}
+
+func TestOutputConfig_Outbound(t *testing.T) {
+	tests := []struct {
+		name     string
+		chatReq  *llm.Request
+		validate func(t *testing.T, anthropicReq *MessageRequest)
+	}{
+		{
+			name: "TransformerMetadata output_config_effort=max -> OutputConfig{Effort:max}",
+			chatReq: &llm.Request{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: lo.ToPtr(int64(4096)),
+				Messages: []llm.Message{
+					{
+						Role:    "user",
+						Content: llm.MessageContent{Content: lo.ToPtr("hello")},
+					},
+				},
+				TransformerMetadata: map[string]any{
+					"output_config_effort": "max",
+				},
+			},
+			validate: func(t *testing.T, anthropicReq *MessageRequest) {
+				t.Helper()
+				require.NotNil(t, anthropicReq.OutputConfig)
+				require.Equal(t, "max", anthropicReq.OutputConfig.Effort)
+			},
+		},
+		{
+			name: "without output_config metadata -> OutputConfig nil",
+			chatReq: &llm.Request{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: lo.ToPtr(int64(4096)),
+				Messages: []llm.Message{
+					{
+						Role:    "user",
+						Content: llm.MessageContent{Content: lo.ToPtr("hello")},
+					},
+				},
+			},
+			validate: func(t *testing.T, anthropicReq *MessageRequest) {
+				t.Helper()
+				require.Nil(t, anthropicReq.OutputConfig)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			anthropicReq := convertToAnthropicRequest(tt.chatReq)
+			tt.validate(t, anthropicReq)
+		})
+	}
+}
+
+func TestOutputConfig_Inbound(t *testing.T) {
+	tests := []struct {
+		name         string
+		anthropicReq *MessageRequest
+		validate     func(t *testing.T, chatReq *llm.Request)
+	}{
+		{
+			name: "OutputConfig effort=high -> TransformerMetadata output_config_effort=high",
+			anthropicReq: &MessageRequest{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: 4096,
+				Messages: []MessageParam{
+					{
+						Role:    "user",
+						Content: MessageContent{Content: lo.ToPtr("hello")},
+					},
+				},
+				OutputConfig: &OutputConfig{Effort: "high"},
+			},
+			validate: func(t *testing.T, chatReq *llm.Request) {
+				t.Helper()
+				require.NotNil(t, chatReq.TransformerMetadata)
+				require.Equal(t, "high", chatReq.TransformerMetadata["output_config_effort"])
+			},
+		},
+		{
+			name: "without output_config -> TransformerMetadata has no output_config_effort",
+			anthropicReq: &MessageRequest{
+				Model:     "claude-3-sonnet-20240229",
+				MaxTokens: 4096,
+				Messages: []MessageParam{
+					{
+						Role:    "user",
+						Content: MessageContent{Content: lo.ToPtr("hello")},
+					},
+				},
+			},
+			validate: func(t *testing.T, chatReq *llm.Request) {
+				t.Helper()
+				require.NotNil(t, chatReq.TransformerMetadata)
+				_, ok := chatReq.TransformerMetadata["output_config_effort"]
+				require.False(t, ok)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatReq, err := convertToLLMRequest(tt.anthropicReq)
+			require.NoError(t, err)
+			tt.validate(t, chatReq)
+		})
+	}
+}
+
 func TestInboundTransformer_RedactedThinkingInRequest(t *testing.T) {
 	const (
 		thinking     = "Let me analyze this step by step..."


### PR DESCRIPTION
## Summary

- Add bidirectional `tool_choice` conversion between Anthropic and LLM unified format (`auto`/`none`/`any↔required`/`tool+name`)
- Add `adaptive` thinking type support (Anthropic's new thinking mode without budget requirement)
- Add `output_config.effort` pass-through support (`low`/`medium`/`high`/`max`)

## Changes

| File | Change |
|------|--------|
| `model.go` | Add `OutputConfig` struct, extend `Thinking` validation to include `adaptive`, make `BudgetTokens` omitempty |
| `inbound_convert.go` | Add `convertAnthropicToolChoiceToLLM`, handle adaptive thinking and output_config in inbound |
| `outbound_convert.go` | Add `convertToolChoiceToAnthropic`, handle adaptive thinking priority and output_config in outbound |
| `*_test.go` | Full test coverage for all new features (inbound + outbound + JSON serialization) |

## Testing

- All existing tests pass
- `make test-backend-all` ✅
- `golangci-lint run` ✅ (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool choice configuration for controlling how models select or require tools, including named tools.
  * Adaptive thinking mode allowing flexible reasoning without enforcing token budgets.
  * Output configuration to specify model output effort levels (low/medium/high/max).

* **Tests**
  * Comprehensive tests for tool choice conversion/serialization.
  * Test suites validating adaptive thinking behavior and JSON handling.
  * Tests covering output configuration mapping inbound and outbound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->