### PR TITLE
fix(dashboard): remove overflow-hidden to fix card clipping on hover

### DIFF
--- a/frontend/src/features/dashboard/index.tsx
+++ b/frontend/src/features/dashboard/index.tsx
@@ -75,7 +75,7 @@ function CollapsibleSection({ title, icon, children, storageKey, defaultOpen = f
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3, ease: 'easeInOut' }}
-            className='overflow-hidden'
+            className='overflow-visible'
           >
             <div className='space-y-4'>{children}</div>
           </motion.div>


### PR DESCRIPTION
## Problem

When hovering over a card inside a collapsible category on the dashboard, the card enlarges by 2% (scale 1.02). However, cards positioned at the top-left of a category have their left and top edges clipped/hidden underneath the category boundaries, while bottom/right edges render correctly.

Before:

<img width="538" height="768" alt="Screenshot from 2026-02-21 14-01-26" src="https://github.com/user-attachments/assets/384f4e92-904e-48ff-bea4-45adf1aa4cd4" />


After:

<img width="538" height="768" alt="Screenshot from 2026-02-21 14-01-52" src="https://github.com/user-attachments/assets/e3ca8e7b-313e-417f-880f-9e08467a3898" />


This was tested on a 1650x1175 screen resolution where the issue was most visible.

### Root Cause

The collapsible container in `frontend/src/features/dashboard/index.tsx` had `overflow-hidden` on the motion.div that animates the expand/collapse. This CSS property clipped any content that extended beyond the container boundaries, including the scaled card hover effect.

## Solution

Changed `overflow-hidden` to `overflow-visible` on the collapsible container (line 78). This allows cards to extend beyond container boundaries when scaled on hover without being clipped.

### Changed Files

- `frontend/src/features/dashboard/index.tsx:78` - Changed `className='overflow-hidden'` to `className='overflow-visible'`

### Verification

- ✅ Cards in top-left position no longer have clipped left/top edges
- ✅ Cards in all positions render correctly on hover
- ✅ Collapsible expand/collapse animations still work smoothly
- ✅ No visual regressions in dashboard layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced collapsible section animations to display content more visibly during expand and collapse interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->