### PR TITLE
fix(ui): ensure active tabs use white text on orange background in Claude dark theme

### DIFF
--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -21,7 +21,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot='tabs-trigger'
       className={cn(
-        "data-[state=active]:bg-primary focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground data-[state=active]:text-primary-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground dark:data-[state=active]:text-primary-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -21,7 +21,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot='tabs-trigger'
       className={cn(
-        "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-primary focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground data-[state=active]:text-primary-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Fix text visibility issue on the Claude (dark) theme for toggle buttons and tabs. When active, the text color was hard to see against the active orange background because it was using light gray text instead of white.

## Problem

In the Claude dark theme, active tabs were displaying with light gray text () on an orange background (), creating poor contrast and making the text difficult to read.

## Solution

Added the Tailwind CSS variant  to the  component. This ensures that in dark mode, when a tab is active, it uses white text () instead of gray ().

## Changes

- Modified: 
- Added:  class variant

## Visual Changes

### Before:
<img width="188" height="101" alt="Screenshot From 2026-02-21 15-20-39" src="https://github.com/user-attachments/assets/ad910d45-dc55-4038-933d-47c2d9ed5aa5" />


### After:
<img width="188" height="101" alt="Screenshot From 2026-02-21 15-21-04" src="https://github.com/user-attachments/assets/dd0bdca2-95d9-4f04-ad8b-b2b86d859bf6" />


## Affected Components

This fix applies to all tab components using :
- API Keys page tabs (All, User, Service Account)
- Dashboard Token Stats tabs (thisMonth, thisWeek, thisDay)
- Dashboard Performance Chart toggle (throughput, ttft)
- Dashboard Fastest Performers tabs (month, week, day)
- System Settings tabs (general, brand, retry, storage, backup, about)
- Channel Type tabs

## Testing

- [ ] Verified active tabs display white text on orange background
- [ ] Verified inactive tabs still use appropriate muted text color
- [ ] No regressions in other themes or components

## Related Issues

Fixes text visibility issue on toggle buttons like radix-trigger-thisDay and radix-trigger-ttft when active in Claude dark theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated active tab styling in dark mode with improved text color contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->