### PR TITLE
兼容 OpenAI 入站 extra_fields.extra_content 的 thought_signature 解析，并修复签名base64不正确导致的genai报错问题

### DIFF
--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -326,6 +326,19 @@ func getGeminiToolCallThoughtSignature(toolCall llm.ToolCall) *string {
 	return lo.ToPtr(normalized)
 }
 
+func getGeminiToolCallThoughtSignatureWithPrefix(toolCall llm.ToolCall) *string {
+	if toolCall.TransformerMetadata == nil {
+		return nil
+	}
+
+	raw, ok := toolCall.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature].(string)
+	if !ok || raw == "" {
+		return nil
+	}
+
+	return shared.NormalizeGeminiThoughtSignature(raw)
+}
+
 func setGeminiToolCallThoughtSignature(toolCall *llm.ToolCall, signature string) {
 	if toolCall == nil || signature == "" {
 		return
@@ -335,7 +348,12 @@ func setGeminiToolCallThoughtSignature(toolCall *llm.ToolCall, signature string)
 		toolCall.TransformerMetadata = map[string]any{}
 	}
 
-	toolCall.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature] = signature
+	normalized := shared.NormalizeGeminiThoughtSignature(signature)
+	if normalized == nil {
+		return
+	}
+
+	toolCall.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature] = *normalized
 }
 
 func reasoningEffortToThinkingBudget(effort string) int64 {

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func extractTextFromContent(content *Content) string {
@@ -303,6 +304,38 @@ var defaultGeminiReasoningEffortMapping = map[string]int64{
 	"low":    1024,
 	"medium": 8192,
 	"high":   32768,
+}
+
+const transformerMetadataKeyGoogleThoughtSignature = shared.TransformerMetadataKeyGoogleThoughtSignature
+
+func getGeminiToolCallThoughtSignature(toolCall llm.ToolCall) *string {
+	if toolCall.TransformerMetadata == nil {
+		return nil
+	}
+
+	raw, ok := toolCall.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature].(string)
+	if !ok || raw == "" {
+		return nil
+	}
+
+	normalized := shared.StripGeminiThoughtSignaturePrefix(raw)
+	if normalized == "" {
+		return nil
+	}
+
+	return lo.ToPtr(normalized)
+}
+
+func setGeminiToolCallThoughtSignature(toolCall *llm.ToolCall, signature string) {
+	if toolCall == nil || signature == "" {
+		return
+	}
+
+	if toolCall.TransformerMetadata == nil {
+		toolCall.TransformerMetadata = map[string]any{}
+	}
+
+	toolCall.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature] = signature
 }
 
 func reasoningEffortToThinkingBudget(effort string) int64 {

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -543,7 +543,7 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 					Args: args,
 				},
 			}
-			if signature := getGeminiToolCallThoughtSignature(toolCall); signature != nil {
+			if signature := getGeminiToolCallThoughtSignatureWithPrefix(toolCall); signature != nil {
 				part.ThoughtSignature = *signature
 				hasToolCallThoughtSignature = true
 			}
@@ -556,9 +556,13 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 			}
 		}
 
-		msgThoughtSignature := shared.DecodeGeminiThoughtSignature(msg.ReasoningSignature)
+		var msgThoughtSignature *string
+		if shared.IsGeminiThoughtSignature(msg.ReasoningSignature) {
+			msgThoughtSignature = msg.ReasoningSignature
+		}
+
 		if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil && !hasToolCallThoughtSignature {
-			msgThoughtSignature = lo.ToPtr("context_engineering_is_the_way_to_go")
+			msgThoughtSignature = shared.NormalizeGeminiThoughtSignature("context_engineering_is_the_way_to_go")
 		}
 
 		if msgThoughtSignature != nil && lastPart != nil {

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -561,10 +561,6 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 			msgThoughtSignature = msg.ReasoningSignature
 		}
 
-		if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil && !hasToolCallThoughtSignature {
-			msgThoughtSignature = shared.NormalizeGeminiThoughtSignature("context_engineering_is_the_way_to_go")
-		}
-
 		if msgThoughtSignature != nil && lastPart != nil {
 			if firstFunctionCallPart != nil && !hasToolCallThoughtSignature {
 				firstFunctionCallPart.ThoughtSignature = *msgThoughtSignature

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
 	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	geminioai "github.com/looplj/axonhub/llm/transformer/gemini/openai"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // convertGeminiToLLMRequest converts Gemini GenerateContentRequest to unified Request.
@@ -298,8 +299,8 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 	)
 
 	for _, part := range content.Parts {
-		if msg.ReasoningSignature == nil && part.ThoughtSignature != "" {
-			msg.ReasoningSignature = lo.ToPtr(part.ThoughtSignature)
+		if msg.ReasoningSignature == nil {
+			msg.ReasoningSignature = shared.NormalizeGeminiThoughtSignature(part.ThoughtSignature)
 		}
 
 		switch {
@@ -368,6 +369,7 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 					Arguments: string(argsJSON),
 				},
 			}
+			setGeminiToolCallThoughtSignature(&tc, part.ThoughtSignature)
 
 			toolCalls = append(toolCalls, tc)
 
@@ -526,6 +528,8 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 			}
 		}
 
+		hasToolCallThoughtSignature := false
+
 		for _, toolCall := range msg.ToolCalls {
 			var args map[string]any
 			if toolCall.Function.Arguments != "" {
@@ -539,6 +543,10 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 					Args: args,
 				},
 			}
+			if signature := getGeminiToolCallThoughtSignature(toolCall); signature != nil {
+				part.ThoughtSignature = *signature
+				hasToolCallThoughtSignature = true
+			}
 
 			parts = append(parts, part)
 
@@ -548,13 +556,13 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 			}
 		}
 
-		msgThoughtSignature := msg.ReasoningSignature
-		if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil {
+		msgThoughtSignature := shared.DecodeGeminiThoughtSignature(msg.ReasoningSignature)
+		if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil && !hasToolCallThoughtSignature {
 			msgThoughtSignature = lo.ToPtr("context_engineering_is_the_way_to_go")
 		}
 
 		if msgThoughtSignature != nil && lastPart != nil {
-			if firstFunctionCallPart != nil {
+			if firstFunctionCallPart != nil && !hasToolCallThoughtSignature {
 				firstFunctionCallPart.ThoughtSignature = *msgThoughtSignature
 			} else {
 				lastPart.ThoughtSignature = *msgThoughtSignature

--- a/llm/transformer/gemini/inbound_convert_test.go
+++ b/llm/transformer/gemini/inbound_convert_test.go
@@ -953,12 +953,16 @@ func TestConvertGeminiContentToLLMMessage_ThoughtSignature(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, result)
 				require.NotNil(t, result.ReasoningSignature)
-				require.Equal(t, "signature_A", *result.ReasoningSignature)
+				require.True(t, shared.IsGeminiThoughtSignature(result.ReasoningSignature))
+				decoded := shared.DecodeGeminiThoughtSignature(result.ReasoningSignature)
+				require.NotNil(t, decoded)
+				require.Equal(t, "signature_A", *decoded)
 				require.Len(t, result.ToolCalls, 1)
 				tc := result.ToolCalls[0]
 				require.Equal(t, "call_001", tc.ID)
 				require.Equal(t, "check_flight", tc.Function.Name)
-				require.Nil(t, tc.TransformerMetadata)
+				require.NotNil(t, tc.TransformerMetadata)
+				require.Equal(t, "signature_A", tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
 			},
 		},
 		{
@@ -986,20 +990,56 @@ func TestConvertGeminiContentToLLMMessage_ThoughtSignature(t *testing.T) {
 			validate: func(t *testing.T, result *llm.Message) {
 				t.Helper()
 				require.NotNil(t, result.ReasoningSignature)
-				require.False(t, shared.IsGeminiThoughtSignature(result.ReasoningSignature))
-				require.NotNil(t, result.ReasoningSignature)
-				require.Equal(t, "signature_parallel", *result.ReasoningSignature)
+				require.True(t, shared.IsGeminiThoughtSignature(result.ReasoningSignature))
+				decoded := shared.DecodeGeminiThoughtSignature(result.ReasoningSignature)
+				require.NotNil(t, decoded)
+				require.Equal(t, "signature_parallel", *decoded)
 				require.Len(t, result.ToolCalls, 2)
 
 				// First call should have signature
 				tc1 := result.ToolCalls[0]
 				require.Equal(t, "call_paris", tc1.ID)
-				require.Nil(t, tc1.TransformerMetadata)
+				require.NotNil(t, tc1.TransformerMetadata)
+				require.Equal(t, "signature_parallel", tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
 
 				// Second call should not have signature
 				tc2 := result.ToolCalls[1]
 				require.Equal(t, "call_london", tc2.ID)
 				require.Nil(t, tc2.TransformerMetadata)
+			},
+		},
+		{
+			name: "function call with already prefixed thought signature",
+			input: &Content{
+				Role: "model",
+				Parts: []*Part{
+					{
+						FunctionCall: &FunctionCall{
+							ID:   "call_003",
+							Name: "check_weather",
+							Args: map[string]any{"city": "Tokyo"},
+						},
+						ThoughtSignature: shared.GeminiThoughtSignaturePrefix + "signature_prefixed",
+					},
+				},
+			},
+			validate: func(t *testing.T, result *llm.Message) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.NotNil(t, result.ReasoningSignature)
+				require.True(t, shared.IsGeminiThoughtSignature(result.ReasoningSignature))
+				require.Equal(t, shared.GeminiThoughtSignaturePrefix+"signature_prefixed", *result.ReasoningSignature)
+				decoded := shared.DecodeGeminiThoughtSignature(result.ReasoningSignature)
+				require.NotNil(t, decoded)
+				require.Equal(t, "signature_prefixed", *decoded)
+				require.Len(t, result.ToolCalls, 1)
+				require.Equal(t, "call_003", result.ToolCalls[0].ID)
+				require.NotNil(t, result.ToolCalls[0].TransformerMetadata)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_prefixed",
+					result.ToolCalls[0].TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 			},
 		},
 		{
@@ -1043,12 +1083,39 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 		validate func(t *testing.T, result *Candidate)
 	}{
 		{
+			name: "tool call with prefixed thought signature",
+			input: &llm.Choice{
+				Index: 0,
+				Message: &llm.Message{
+					Role:               "assistant",
+					ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("signature_prefixed")),
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_001",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "check_flight",
+								Arguments: `{"flight":"AA100"}`,
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *Candidate) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.NotNil(t, result.Content)
+				require.Len(t, result.Content.Parts, 1)
+				require.Equal(t, "signature_prefixed", result.Content.Parts[0].ThoughtSignature)
+			},
+		},
+		{
 			name: "tool call with thought signature",
 			input: &llm.Choice{
 				Index: 0,
 				Message: &llm.Message{
 					Role:               "assistant",
-					ReasoningSignature: lo.ToPtr("signature_A"),
+					ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("signature_A")),
 					ToolCalls: []llm.ToolCall{
 						{
 							ID:   "call_001",
@@ -1077,7 +1144,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				Index: 0,
 				Message: &llm.Message{
 					Role:               "assistant",
-					ReasoningSignature: lo.ToPtr("signature_A"),
+					ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("signature_A")),
 					ToolCalls: []llm.ToolCall{
 						{
 							ID:   "call_001",
@@ -1108,6 +1175,69 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 
 				require.Equal(t, "book_taxi", result.Content.Parts[1].FunctionCall.Name)
 				require.Empty(t, result.Content.Parts[1].ThoughtSignature)
+			},
+		},
+		{
+			name: "multiple tool calls with per-tool thought signature metadata",
+			input: &llm.Choice{
+				Index: 0,
+				Message: &llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_001",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "check_flight",
+								Arguments: `{"flight":"AA100"}`,
+							},
+						},
+						{
+							ID:   "call_002",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "book_taxi",
+								Arguments: `{"time":"10 AM"}`,
+							},
+							TransformerMetadata: map[string]any{
+								transformerMetadataKeyGoogleThoughtSignature: "signature_tool_2",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *Candidate) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.Len(t, result.Content.Parts, 2)
+				require.Empty(t, result.Content.Parts[0].ThoughtSignature)
+				require.Equal(t, "signature_tool_2", result.Content.Parts[1].ThoughtSignature)
+			},
+		},
+		{
+			name: "tool call with non-gemini reasoning signature uses default signature",
+			input: &llm.Choice{
+				Index: 0,
+				Message: &llm.Message{
+					Role:               "assistant",
+					ReasoningSignature: lo.ToPtr(shared.OpenAIEncryptedContentPrefix + "encrypted_data"),
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_001",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"location":"NYC"}`,
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *Candidate) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.Len(t, result.Content.Parts, 1)
+				require.Equal(t, "context_engineering_is_the_way_to_go", result.Content.Parts[0].ThoughtSignature)
 			},
 		},
 		{

--- a/llm/transformer/gemini/inbound_convert_test.go
+++ b/llm/transformer/gemini/inbound_convert_test.go
@@ -1223,7 +1223,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 			},
 		},
 		{
-			name: "tool call with non-gemini reasoning signature uses default signature",
+			name: "tool call with non-gemini reasoning signature keeps thought signature empty",
 			input: &llm.Choice{
 				Index: 0,
 				Message: &llm.Message{
@@ -1245,11 +1245,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 1)
-				require.Equal(
-					t,
-					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
-					result.Content.Parts[0].ThoughtSignature,
-				)
+				require.Empty(t, result.Content.Parts[0].ThoughtSignature)
 			},
 		},
 		{
@@ -1275,15 +1271,11 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 1)
 				require.NotNil(t, result.Content.Parts[0].FunctionCall)
-				require.Equal(
-					t,
-					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
-					result.Content.Parts[0].ThoughtSignature,
-				)
+				require.Empty(t, result.Content.Parts[0].ThoughtSignature)
 			},
 		},
 		{
-			name: "parallel tool calls without signature - only first gets default",
+			name: "parallel tool calls without signature keep thought signatures empty",
 			input: &llm.Choice{
 				Index: 0,
 				Message: &llm.Message{
@@ -1312,11 +1304,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 2)
-				require.Equal(
-					t,
-					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
-					result.Content.Parts[0].ThoughtSignature,
-				)
+				require.Empty(t, result.Content.Parts[0].ThoughtSignature)
 				require.Empty(t, result.Content.Parts[1].ThoughtSignature)
 			},
 		},

--- a/llm/transformer/gemini/inbound_convert_test.go
+++ b/llm/transformer/gemini/inbound_convert_test.go
@@ -962,7 +962,11 @@ func TestConvertGeminiContentToLLMMessage_ThoughtSignature(t *testing.T) {
 				require.Equal(t, "call_001", tc.ID)
 				require.Equal(t, "check_flight", tc.Function.Name)
 				require.NotNil(t, tc.TransformerMetadata)
-				require.Equal(t, "signature_A", tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_A",
+					tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 			},
 		},
 		{
@@ -1000,7 +1004,11 @@ func TestConvertGeminiContentToLLMMessage_ThoughtSignature(t *testing.T) {
 				tc1 := result.ToolCalls[0]
 				require.Equal(t, "call_paris", tc1.ID)
 				require.NotNil(t, tc1.TransformerMetadata)
-				require.Equal(t, "signature_parallel", tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_parallel",
+					tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 
 				// Second call should not have signature
 				tc2 := result.ToolCalls[1]
@@ -1106,7 +1114,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.NotNil(t, result)
 				require.NotNil(t, result.Content)
 				require.Len(t, result.Content.Parts, 1)
-				require.Equal(t, "signature_prefixed", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(t, shared.GeminiThoughtSignaturePrefix+"signature_prefixed", result.Content.Parts[0].ThoughtSignature)
 			},
 		},
 		{
@@ -1135,7 +1143,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.Len(t, result.Content.Parts, 1)
 				require.NotNil(t, result.Content.Parts[0].FunctionCall)
 				require.Equal(t, "check_flight", result.Content.Parts[0].FunctionCall.Name)
-				require.Equal(t, "signature_A", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(t, shared.GeminiThoughtSignaturePrefix+"signature_A", result.Content.Parts[0].ThoughtSignature)
 			},
 		},
 		{
@@ -1171,7 +1179,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.Len(t, result.Content.Parts, 2)
 
 				require.Equal(t, "check_flight", result.Content.Parts[0].FunctionCall.Name)
-				require.Equal(t, "signature_A", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(t, shared.GeminiThoughtSignaturePrefix+"signature_A", result.Content.Parts[0].ThoughtSignature)
 
 				require.Equal(t, "book_taxi", result.Content.Parts[1].FunctionCall.Name)
 				require.Empty(t, result.Content.Parts[1].ThoughtSignature)
@@ -1211,7 +1219,7 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 2)
 				require.Empty(t, result.Content.Parts[0].ThoughtSignature)
-				require.Equal(t, "signature_tool_2", result.Content.Parts[1].ThoughtSignature)
+				require.Equal(t, shared.GeminiThoughtSignaturePrefix+"signature_tool_2", result.Content.Parts[1].ThoughtSignature)
 			},
 		},
 		{
@@ -1237,7 +1245,11 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 1)
-				require.Equal(t, "context_engineering_is_the_way_to_go", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
+					result.Content.Parts[0].ThoughtSignature,
+				)
 			},
 		},
 		{
@@ -1263,7 +1275,11 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 1)
 				require.NotNil(t, result.Content.Parts[0].FunctionCall)
-				require.Equal(t, "context_engineering_is_the_way_to_go", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
+					result.Content.Parts[0].ThoughtSignature,
+				)
 			},
 		},
 		{
@@ -1296,7 +1312,11 @@ func TestConvertLLMChoiceToGeminiCandidate_ThoughtSignature(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, result)
 				require.Len(t, result.Content.Parts, 2)
-				require.Equal(t, "context_engineering_is_the_way_to_go", result.Content.Parts[0].ThoughtSignature)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"context_engineering_is_the_way_to_go",
+					result.Content.Parts[0].ThoughtSignature,
+				)
 				require.Empty(t, result.Content.Parts[1].ThoughtSignature)
 			},
 		},

--- a/llm/transformer/gemini/openai/outbound.go
+++ b/llm/transformer/gemini/openai/outbound.go
@@ -15,6 +15,7 @@ import (
 	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // Config holds all configuration for the Gemini OpenAI outbound transformer.
@@ -329,6 +330,7 @@ func (t *OutboundTransformer) TransformRequest(
 
 	// Convert llm.Request to openai.Request
 	oaiReq := openai.RequestFromLLM(&req)
+	fillGeminiThoughtSignatureForGeminiOpenAIRequest(&req, oaiReq)
 
 	geminiReq := Request{Request: *oaiReq}
 	if extraBody != nil {
@@ -362,6 +364,74 @@ func (t *OutboundTransformer) TransformRequest(
 		Body:    body,
 		Auth:    auth,
 	}, nil
+}
+
+func fillGeminiThoughtSignatureForGeminiOpenAIRequest(src *llm.Request, dst *openai.Request) {
+	if src == nil || dst == nil {
+		return
+	}
+
+	for i := range src.Messages {
+		if i >= len(dst.Messages) {
+			break
+		}
+
+		srcMsg := src.Messages[i]
+		if len(srcMsg.ToolCalls) == 0 || len(dst.Messages[i].ToolCalls) == 0 {
+			continue
+		}
+
+		dstToolCallIndexByID := make(map[string]int, len(dst.Messages[i].ToolCalls))
+		for j := range dst.Messages[i].ToolCalls {
+			if dst.Messages[i].ToolCalls[j].ID != "" {
+				dstToolCallIndexByID[dst.Messages[i].ToolCalls[j].ID] = j
+			}
+		}
+
+		hasToolCallThoughtSignature := false
+		for j := range srcMsg.ToolCalls {
+			raw, ok := srcMsg.ToolCalls[j].TransformerMetadata[openai.TransformerMetadataKeyGoogleThoughtSignature].(string)
+			if !ok || raw == "" {
+				continue
+			}
+
+			dstToolCallIndex := -1
+			if srcMsg.ToolCalls[j].ID != "" {
+				if idx, exists := dstToolCallIndexByID[srcMsg.ToolCalls[j].ID]; exists {
+					dstToolCallIndex = idx
+				}
+			}
+
+			if dstToolCallIndex == -1 && j < len(dst.Messages[i].ToolCalls) {
+				dstToolCallIndex = j
+			}
+
+			if dstToolCallIndex == -1 {
+				continue
+			}
+
+			ensureGoogleThoughtSignatureExtraContent(&dst.Messages[i].ToolCalls[dstToolCallIndex]).ThoughtSignature = shared.StripGeminiThoughtSignaturePrefix(raw)
+			hasToolCallThoughtSignature = true
+		}
+
+		if hasToolCallThoughtSignature || !shared.IsGeminiThoughtSignature(srcMsg.ReasoningSignature) {
+			continue
+		}
+
+		ensureGoogleThoughtSignatureExtraContent(&dst.Messages[i].ToolCalls[0]).ThoughtSignature = shared.StripGeminiThoughtSignaturePrefix(*srcMsg.ReasoningSignature)
+	}
+}
+
+func ensureGoogleThoughtSignatureExtraContent(tc *openai.ToolCall) *openai.ToolCallGoogleExtraContent {
+	if tc.ExtraContent == nil {
+		tc.ExtraContent = &openai.ToolCallExtraContent{}
+	}
+
+	if tc.ExtraContent.Google == nil {
+		tc.ExtraContent.Google = &openai.ToolCallGoogleExtraContent{}
+	}
+
+	return tc.ExtraContent.Google
 }
 
 func (t *OutboundTransformer) TransformError(ctx context.Context, rawErr *httpclient.Error) *llm.ResponseError {

--- a/llm/transformer/gemini/openai/outbound_test.go
+++ b/llm/transformer/gemini/openai/outbound_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	oaitransformer "github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func TestNewOutboundTransformer(t *testing.T) {
@@ -551,6 +553,221 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOutboundTransformer_TransformRequest_StripsPrefixedThoughtSignatureForGemini(t *testing.T) {
+	transformerInterface, err := NewOutboundTransformer("https://generativelanguage.googleapis.com", "test-api-key")
+	require.NoError(t, err)
+	transformer := transformerInterface.(*OutboundTransformer)
+
+	httpReq, err := transformer.TransformRequest(t.Context(), &llm.Request{
+		Model: "gemini-3-pro",
+		Messages: []llm.Message{
+			{
+				Role:               "assistant",
+				ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("base64_signature")),
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "get_weather",
+							Arguments: `{"city":"Shanghai"}`,
+						},
+						Index: 0,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, httpReq)
+
+	var geminiReq Request
+	require.NoError(t, json.Unmarshal(httpReq.Body, &geminiReq))
+	require.Len(t, geminiReq.Messages, 1)
+	require.Len(t, geminiReq.Messages[0].ToolCalls, 1)
+	require.NotNil(t, geminiReq.Messages[0].ToolCalls[0].ExtraContent)
+	require.NotNil(t, geminiReq.Messages[0].ToolCalls[0].ExtraContent.Google)
+	require.Equal(
+		t,
+		"base64_signature",
+		geminiReq.Messages[0].ToolCalls[0].ExtraContent.Google.ThoughtSignature,
+	)
+}
+
+func TestOutboundTransformer_TransformRequest_KeepToolCallSignaturePosition(t *testing.T) {
+	transformerInterface, err := NewOutboundTransformer("https://generativelanguage.googleapis.com", "test-api-key")
+	require.NoError(t, err)
+	transformer := transformerInterface.(*OutboundTransformer)
+
+	httpReq, err := transformer.TransformRequest(t.Context(), &llm.Request{
+		Model: "gemini-3-pro",
+		Messages: []llm.Message{
+			{
+				Role:               "assistant",
+				ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("sig_from_second")),
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "tool_a",
+							Arguments: "{}",
+						},
+						Index: 0,
+					},
+					{
+						ID:   "call_2",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "tool_b",
+							Arguments: "{}",
+						},
+						Index: 1,
+						TransformerMetadata: map[string]any{
+							oaitransformer.TransformerMetadataKeyGoogleThoughtSignature: "sig_from_second",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, httpReq)
+
+	var geminiReq Request
+	require.NoError(t, json.Unmarshal(httpReq.Body, &geminiReq))
+	require.Len(t, geminiReq.Messages, 1)
+	require.Len(t, geminiReq.Messages[0].ToolCalls, 2)
+	require.Nil(t, geminiReq.Messages[0].ToolCalls[0].ExtraContent)
+	require.NotNil(t, geminiReq.Messages[0].ToolCalls[1].ExtraContent)
+	require.NotNil(t, geminiReq.Messages[0].ToolCalls[1].ExtraContent.Google)
+	require.Equal(t, "sig_from_second", geminiReq.Messages[0].ToolCalls[1].ExtraContent.Google.ThoughtSignature)
+}
+
+func TestFillGeminiThoughtSignatureForGeminiOpenAIRequest_FallbackByToolCallID(t *testing.T) {
+	src := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "tool_a",
+							Arguments: "{}",
+						},
+						Index: 0,
+					},
+					{
+						ID:   "call_2",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "tool_b",
+							Arguments: "{}",
+						},
+						Index: 1,
+						TransformerMetadata: map[string]any{
+							oaitransformer.TransformerMetadataKeyGoogleThoughtSignature: "sig_call_2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &oaitransformer.Request{
+		Messages: []oaitransformer.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []oaitransformer.ToolCall{
+					{
+						ID:   "call_2",
+						Type: "function",
+						Function: oaitransformer.FunctionCall{
+							Name:      "tool_b",
+							Arguments: "{}",
+						},
+						Index: 0,
+					},
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: oaitransformer.FunctionCall{
+							Name:      "tool_a",
+							Arguments: "{}",
+						},
+						Index: 1,
+					},
+				},
+			},
+		},
+	}
+
+	fillGeminiThoughtSignatureForGeminiOpenAIRequest(src, dst)
+
+	require.Len(t, dst.Messages, 1)
+	require.Len(t, dst.Messages[0].ToolCalls, 2)
+	require.NotNil(t, dst.Messages[0].ToolCalls[0].ExtraContent)
+	require.NotNil(t, dst.Messages[0].ToolCalls[0].ExtraContent.Google)
+	require.Equal(t, "sig_call_2", dst.Messages[0].ToolCalls[0].ExtraContent.Google.ThoughtSignature)
+	require.Nil(t, dst.Messages[0].ToolCalls[1].ExtraContent)
+}
+
+func TestFillGeminiThoughtSignatureForGeminiOpenAIRequest_StripsPrefixedMetadataSignature(t *testing.T) {
+	prefixed := shared.EncodeGeminiThoughtSignature(lo.ToPtr("sig_prefixed"))
+	require.NotNil(t, prefixed)
+
+	src := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "tool_a",
+							Arguments: "{}",
+						},
+						Index: 0,
+						TransformerMetadata: map[string]any{
+							oaitransformer.TransformerMetadataKeyGoogleThoughtSignature: *prefixed,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &oaitransformer.Request{
+		Messages: []oaitransformer.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []oaitransformer.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: oaitransformer.FunctionCall{
+							Name:      "tool_a",
+							Arguments: "{}",
+						},
+						Index: 0,
+					},
+				},
+			},
+		},
+	}
+
+	fillGeminiThoughtSignatureForGeminiOpenAIRequest(src, dst)
+
+	require.Len(t, dst.Messages, 1)
+	require.Len(t, dst.Messages[0].ToolCalls, 1)
+	require.NotNil(t, dst.Messages[0].ToolCalls[0].ExtraContent)
+	require.NotNil(t, dst.Messages[0].ToolCalls[0].ExtraContent.Google)
+	require.Equal(t, "sig_prefixed", dst.Messages[0].ToolCalls[0].ExtraContent.Google.ThoughtSignature)
 }
 
 func TestTransformRequestWithExtraBody(t *testing.T) {

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -382,6 +382,8 @@ func convertLLMMessageToGeminiContent(msg *llm.Message) *Content {
 	//         Gemini 3 Pro will have the signature on the last part if the model generates a thought.
 	//         Gemini 2.5 won't have a signature in any part.
 
+	hasToolCallThoughtSignature := false
+
 	// Add tool calls
 	for _, toolCall := range msg.ToolCalls {
 		var args map[string]any
@@ -395,6 +397,10 @@ func convertLLMMessageToGeminiContent(msg *llm.Message) *Content {
 				Name: toolCall.Function.Name,
 				Args: args,
 			},
+		}
+		if signature := getGeminiToolCallThoughtSignature(toolCall); signature != nil {
+			part.ThoughtSignature = *signature
+			hasToolCallThoughtSignature = true
 		}
 
 		parts = append(parts, part)
@@ -411,12 +417,12 @@ func convertLLMMessageToGeminiContent(msg *llm.Message) *Content {
 	// We try the best to support this fields to keep this fields in the chat conversions, so we use the ReasoningSignature to hold the field,
 	// And this field will be preserved during claude code trace, will not degrade the gemini model performance.
 	msgThoughtSignature := shared.DecodeGeminiThoughtSignature(msg.ReasoningSignature)
-	if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil {
+	if len(msg.ToolCalls) > 0 && msgThoughtSignature == nil && !hasToolCallThoughtSignature {
 		msgThoughtSignature = lo.ToPtr("context_engineering_is_the_way_to_go")
 	}
 
 	if msgThoughtSignature != nil && lastPart != nil {
-		if firstFunctionCallPart != nil {
+		if firstFunctionCallPart != nil && !hasToolCallThoughtSignature {
 			firstFunctionCallPart.ThoughtSignature = *msgThoughtSignature
 		} else {
 			lastPart.ThoughtSignature = *msgThoughtSignature
@@ -577,8 +583,8 @@ func convertGeminiCandidateToLLMChoiceWithState(candidate *Candidate, isStream b
 		)
 
 		for _, part := range candidate.Content.Parts {
-			if msg.ReasoningSignature == nil && part.ThoughtSignature != "" {
-				msg.ReasoningSignature = shared.EncodeGeminiThoughtSignature(&part.ThoughtSignature)
+			if msg.ReasoningSignature == nil {
+				msg.ReasoningSignature = shared.NormalizeGeminiThoughtSignature(part.ThoughtSignature)
 			}
 
 			switch {
@@ -627,6 +633,8 @@ func convertGeminiCandidateToLLMChoiceWithState(candidate *Candidate, isStream b
 				if tc.ID == "" {
 					tc.ID = uuid.NewString()
 				}
+
+				setGeminiToolCallThoughtSignature(&tc, part.ThoughtSignature)
 
 				toolCalls = append(toolCalls, tc)
 				nextToolCallIndex++

--- a/llm/transformer/gemini/outbound_convert_test.go
+++ b/llm/transformer/gemini/outbound_convert_test.go
@@ -1593,7 +1593,11 @@ func TestConvertGeminiToLLMResponse_ThoughtSignature(t *testing.T) {
 				require.Equal(t, "call_001", tc.ID)
 				require.Equal(t, "check_flight", tc.Function.Name)
 				require.NotNil(t, tc.TransformerMetadata)
-				require.Equal(t, "signature_A", tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_A",
+					tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 			},
 		},
 		{
@@ -1642,7 +1646,11 @@ func TestConvertGeminiToLLMResponse_ThoughtSignature(t *testing.T) {
 				tc1 := result.Choices[0].Message.ToolCalls[0]
 				require.Equal(t, "call_paris", tc1.ID)
 				require.NotNil(t, tc1.TransformerMetadata)
-				require.Equal(t, "signature_parallel", tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_parallel",
+					tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 
 				// Second call should not have signature
 				tc2 := result.Choices[0].Message.ToolCalls[1]

--- a/llm/transformer/gemini/outbound_convert_test.go
+++ b/llm/transformer/gemini/outbound_convert_test.go
@@ -1592,7 +1592,8 @@ func TestConvertGeminiToLLMResponse_ThoughtSignature(t *testing.T) {
 				tc := result.Choices[0].Message.ToolCalls[0]
 				require.Equal(t, "call_001", tc.ID)
 				require.Equal(t, "check_flight", tc.Function.Name)
-				require.Nil(t, tc.TransformerMetadata)
+				require.NotNil(t, tc.TransformerMetadata)
+				require.Equal(t, "signature_A", tc.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
 			},
 		},
 		{
@@ -1640,12 +1641,59 @@ func TestConvertGeminiToLLMResponse_ThoughtSignature(t *testing.T) {
 				// First call should have signature
 				tc1 := result.Choices[0].Message.ToolCalls[0]
 				require.Equal(t, "call_paris", tc1.ID)
-				require.Nil(t, tc1.TransformerMetadata)
+				require.NotNil(t, tc1.TransformerMetadata)
+				require.Equal(t, "signature_parallel", tc1.TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature])
 
 				// Second call should not have signature
 				tc2 := result.Choices[0].Message.ToolCalls[1]
 				require.Equal(t, "call_london", tc2.ID)
 				require.Nil(t, tc2.TransformerMetadata)
+			},
+		},
+		{
+			name: "function call with already prefixed thought signature",
+			input: &GenerateContentResponse{
+				ResponseID:   "resp_prefixed_sig",
+				ModelVersion: "gemini-3-pro",
+				Candidates: []*Candidate{
+					{
+						Index: 0,
+						Content: &Content{
+							Role: "model",
+							Parts: []*Part{
+								{
+									FunctionCall: &FunctionCall{
+										ID:   "call_prefixed",
+										Name: "check_weather",
+										Args: map[string]any{"city": "Tokyo"},
+									},
+									ThoughtSignature: shared.GeminiThoughtSignaturePrefix + "signature_prefixed",
+								},
+							},
+						},
+						FinishReason: "STOP",
+					},
+				},
+			},
+			validate: func(t *testing.T, result *llm.Response) {
+				t.Helper()
+				require.NotNil(t, result.Choices[0].Message)
+				require.NotNil(t, result.Choices[0].Message.ReasoningSignature)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_prefixed",
+					*result.Choices[0].Message.ReasoningSignature,
+				)
+				decoded := shared.DecodeGeminiThoughtSignature(result.Choices[0].Message.ReasoningSignature)
+				require.NotNil(t, decoded)
+				require.Equal(t, "signature_prefixed", *decoded)
+				require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+				require.NotNil(t, result.Choices[0].Message.ToolCalls[0].TransformerMetadata)
+				require.Equal(
+					t,
+					shared.GeminiThoughtSignaturePrefix+"signature_prefixed",
+					result.Choices[0].Message.ToolCalls[0].TransformerMetadata[transformerMetadataKeyGoogleThoughtSignature],
+				)
 			},
 		},
 		{
@@ -1760,9 +1808,44 @@ func TestConvertLLMMessageToGeminiContent_ThoughtSignature(t *testing.T) {
 			},
 		},
 		{
-			name: "tool call without signature",
+			name: "multiple tool calls with per-tool thought signature metadata",
 			input: &llm.Message{
 				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_001",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "check_flight",
+							Arguments: `{"flight":"AA100"}`,
+						},
+					},
+					{
+						ID:   "call_002",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "book_taxi",
+							Arguments: `{"time":"10 AM"}`,
+						},
+						TransformerMetadata: map[string]any{
+							transformerMetadataKeyGoogleThoughtSignature: "signature_tool_2",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *Content) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.Len(t, result.Parts, 2)
+				require.Empty(t, result.Parts[0].ThoughtSignature)
+				require.Equal(t, "signature_tool_2", result.Parts[1].ThoughtSignature)
+			},
+		},
+		{
+			name: "tool call with non-gemini signature uses default signature",
+			input: &llm.Message{
+				Role:               "assistant",
+				ReasoningSignature: lo.ToPtr(shared.OpenAIEncryptedContentPrefix + "encrypted_data"),
 				ToolCalls: []llm.ToolCall{
 					{
 						ID:   "call_001",

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -19,10 +19,15 @@ func (tc ToolCall) ToLLMToolCall() llm.ToolCall {
 		Index: tc.Index,
 	}
 
-	if tc.ExtraContent != nil &&
-		tc.ExtraContent.Google != nil &&
-		tc.ExtraContent.Google.ThoughtSignature != "" {
-		thoughtSignature := tc.ExtraContent.Google.ThoughtSignature
+	extraContent := tc.ExtraContent
+	if extraContent == nil && tc.ExtraFields != nil {
+		extraContent = tc.ExtraFields.ExtraContent
+	}
+
+	if extraContent != nil &&
+		extraContent.Google != nil &&
+		extraContent.Google.ThoughtSignature != "" {
+		thoughtSignature := extraContent.Google.ThoughtSignature
 		normalized := shared.NormalizeGeminiThoughtSignature(thoughtSignature)
 		if normalized != nil {
 			thoughtSignature = *normalized

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -4,11 +4,12 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // ToLLMToolCall converts OpenAI ToolCall to unified llm.ToolCall.
 func (tc ToolCall) ToLLMToolCall() llm.ToolCall {
-	return llm.ToolCall{
+	toolCall := llm.ToolCall{
 		ID:   tc.ID,
 		Type: tc.Type,
 		Function: llm.FunctionCall{
@@ -17,6 +18,16 @@ func (tc ToolCall) ToLLMToolCall() llm.ToolCall {
 		},
 		Index: tc.Index,
 	}
+
+	if tc.ExtraContent != nil &&
+		tc.ExtraContent.Google != nil &&
+		tc.ExtraContent.Google.ThoughtSignature != "" {
+		toolCall.TransformerMetadata = map[string]any{
+			TransformerMetadataKeyGoogleThoughtSignature: tc.ExtraContent.Google.ThoughtSignature,
+		}
+	}
+
+	return toolCall
 }
 
 // ToLLMRequest converts OpenAI Request to unified llm.Request.
@@ -120,6 +131,15 @@ func (m Message) ToLLMMessage() llm.Message {
 		msg.ToolCalls = lo.Map(m.ToolCalls, func(tc ToolCall, _ int) llm.ToolCall {
 			return tc.ToLLMToolCall()
 		})
+
+		firstThoughtSignature := lo.FindOrElse(msg.ToolCalls, llm.ToolCall{}, func(tc llm.ToolCall) bool {
+			raw, ok := tc.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string)
+			return ok && raw != ""
+		})
+
+		if raw, ok := firstThoughtSignature.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string); ok {
+			msg.ReasoningSignature = shared.NormalizeGeminiThoughtSignature(raw)
+		}
 	}
 
 	// Convert Annotations

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -22,8 +22,14 @@ func (tc ToolCall) ToLLMToolCall() llm.ToolCall {
 	if tc.ExtraContent != nil &&
 		tc.ExtraContent.Google != nil &&
 		tc.ExtraContent.Google.ThoughtSignature != "" {
+		thoughtSignature := tc.ExtraContent.Google.ThoughtSignature
+		normalized := shared.NormalizeGeminiThoughtSignature(thoughtSignature)
+		if normalized != nil {
+			thoughtSignature = *normalized
+		}
+
 		toolCall.TransformerMetadata = map[string]any{
-			TransformerMetadataKeyGoogleThoughtSignature: tc.ExtraContent.Google.ThoughtSignature,
+			TransformerMetadataKeyGoogleThoughtSignature: thoughtSignature,
 		}
 	}
 

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -923,6 +923,32 @@ func TestMessage_ToLLMMessage_WithAlreadyPrefixedGeminiThoughtSignature(t *testi
 	require.Equal(t, "base64_signature", *decoded)
 }
 
+func TestToolCall_ToLLMToolCall_NormalizesGeminiThoughtSignature(t *testing.T) {
+	tc := ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "get_weather",
+			Arguments: `{"city":"Shanghai"}`,
+		},
+		Index: 0,
+		ExtraContent: &ToolCallExtraContent{
+			Google: &ToolCallGoogleExtraContent{
+				ThoughtSignature: "base64_signature",
+			},
+		},
+	}
+
+	got := tc.ToLLMToolCall()
+
+	require.NotNil(t, got.TransformerMetadata)
+	require.Equal(
+		t,
+		shared.GeminiThoughtSignaturePrefix+"base64_signature",
+		got.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature],
+	)
+}
+
 func TestMessageFromLLM_WithGeminiThoughtSignatureDoesNotInjectToolCallExtraContent(t *testing.T) {
 	msg := llm.Message{
 		Role:               "assistant",
@@ -984,4 +1010,52 @@ func TestInboundTransformer_TransformResponse_WithGeminiToolCallThoughtSignature
 	require.NotNil(t, oaiResp.Choices[0].Message)
 	require.Len(t, oaiResp.Choices[0].Message.ToolCalls, 1)
 	require.Nil(t, oaiResp.Choices[0].Message.ToolCalls[0].ExtraContent)
+}
+
+func TestInboundTransformer_TransformResponse_WithGeminiPrefixedToolCallMetadata(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	resp, err := transformer.TransformResponse(t.Context(), &llm.Response{
+		ID:      "chatcmpl-1",
+		Object:  "chat.completion",
+		Created: 123,
+		Model:   "gemini-3-pro",
+		Choices: []llm.Choice{
+			{
+				Index: 0,
+				Message: &llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"Shanghai"}`,
+							},
+							Index: 0,
+							TransformerMetadata: map[string]any{
+								TransformerMetadataKeyGoogleThoughtSignature: shared.GeminiThoughtSignaturePrefix + "base64_signature",
+							},
+						},
+					},
+				},
+				FinishReason: lo.ToPtr("tool_calls"),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var oaiResp Response
+	require.NoError(t, json.Unmarshal(resp.Body, &oaiResp))
+	require.Len(t, oaiResp.Choices, 1)
+	require.NotNil(t, oaiResp.Choices[0].Message)
+	require.Len(t, oaiResp.Choices[0].Message.ToolCalls, 1)
+	require.NotNil(t, oaiResp.Choices[0].Message.ToolCalls[0].ExtraContent)
+	require.NotNil(t, oaiResp.Choices[0].Message.ToolCalls[0].ExtraContent.Google)
+	require.Equal(
+		t,
+		shared.GeminiThoughtSignaturePrefix+"base64_signature",
+		oaiResp.Choices[0].Message.ToolCalls[0].ExtraContent.Google.ThoughtSignature,
+	)
 }

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func TestInboundTransformer_TransformRequest(t *testing.T) {
@@ -473,6 +475,73 @@ func TestInboundTransformer_TransformStreamChunk(t *testing.T) {
 	}
 }
 
+func TestInboundTransformer_TransformStream_SkipsPureReasoningSignatureChunk(t *testing.T) {
+	transformer := NewInboundTransformer()
+	signature := shared.GeminiThoughtSignaturePrefix + "stream_signature"
+
+	stream, err := transformer.TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion.chunk",
+			Created: 1677652288,
+			Model:   "gemini-3-pro",
+			Choices: []llm.Choice{
+				{
+					Index: 0,
+					Delta: &llm.Message{
+						ReasoningSignature: &signature,
+					},
+				},
+			},
+		},
+		{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion.chunk",
+			Created: 1677652289,
+			Model:   "gemini-3-pro",
+			Choices: []llm.Choice{
+				{
+					Index: 0,
+					Delta: &llm.Message{
+						Role: "assistant",
+						ToolCalls: []llm.ToolCall{
+							{
+								ID:   "call_1",
+								Type: "function",
+								Function: llm.FunctionCall{
+									Name:      "get_weather",
+									Arguments: `{"city":"Shanghai"}`,
+								},
+								Index: 0,
+							},
+						},
+					},
+					FinishReason: lo.ToPtr("tool_calls"),
+				},
+			},
+		},
+		{
+			Object: "[DONE]",
+		},
+	}))
+	require.NoError(t, err)
+
+	var events []*httpclient.StreamEvent
+	for stream.Next() {
+		events = append(events, stream.Current())
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 2)
+
+	var chunkResp Response
+	require.NoError(t, json.Unmarshal(events[0].Data, &chunkResp))
+	require.Len(t, chunkResp.Choices, 1)
+	require.NotNil(t, chunkResp.Choices[0].Delta)
+	require.Len(t, chunkResp.Choices[0].Delta.ToolCalls, 1)
+	require.Nil(t, chunkResp.Choices[0].Delta.ToolCalls[0].ExtraContent)
+	require.Equal(t, "[DONE]", string(events[1].Data))
+}
+
 func TestInboundTransformer_TransformResponse(t *testing.T) {
 	transformer := NewInboundTransformer()
 
@@ -791,4 +860,128 @@ func TestInboundTransformer_TransformResponse_WithCitations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMessage_ToLLMMessage_WithGeminiThoughtSignature(t *testing.T) {
+	msg := Message{
+		Role: "assistant",
+		ToolCalls: []ToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city":"Shanghai"}`,
+				},
+				Index: 0,
+				ExtraContent: &ToolCallExtraContent{
+					Google: &ToolCallGoogleExtraContent{
+						ThoughtSignature: "base64_signature",
+					},
+				},
+			},
+		},
+	}
+
+	got := msg.ToLLMMessage()
+
+	require.Len(t, got.ToolCalls, 1)
+	require.NotNil(t, got.ReasoningSignature)
+	require.True(t, shared.IsGeminiThoughtSignature(got.ReasoningSignature))
+	decoded := shared.DecodeGeminiThoughtSignature(got.ReasoningSignature)
+	require.NotNil(t, decoded)
+	require.Equal(t, "base64_signature", *decoded)
+}
+
+func TestMessage_ToLLMMessage_WithAlreadyPrefixedGeminiThoughtSignature(t *testing.T) {
+	msg := Message{
+		Role: "assistant",
+		ToolCalls: []ToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city":"Shanghai"}`,
+				},
+				Index: 0,
+				ExtraContent: &ToolCallExtraContent{
+					Google: &ToolCallGoogleExtraContent{
+						ThoughtSignature: shared.GeminiThoughtSignaturePrefix + "base64_signature",
+					},
+				},
+			},
+		},
+	}
+
+	got := msg.ToLLMMessage()
+
+	require.NotNil(t, got.ReasoningSignature)
+	require.Equal(t, shared.GeminiThoughtSignaturePrefix+"base64_signature", *got.ReasoningSignature)
+	decoded := shared.DecodeGeminiThoughtSignature(got.ReasoningSignature)
+	require.NotNil(t, decoded)
+	require.Equal(t, "base64_signature", *decoded)
+}
+
+func TestMessageFromLLM_WithGeminiThoughtSignatureDoesNotInjectToolCallExtraContent(t *testing.T) {
+	msg := llm.Message{
+		Role:               "assistant",
+		ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("base64_signature")),
+		ToolCalls: []llm.ToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: llm.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city":"Shanghai"}`,
+				},
+				Index: 0,
+			},
+		},
+	}
+
+	got := MessageFromLLM(msg)
+
+	require.Len(t, got.ToolCalls, 1)
+	require.Nil(t, got.ToolCalls[0].ExtraContent)
+}
+
+func TestInboundTransformer_TransformResponse_WithGeminiToolCallThoughtSignatureDoesNotInjectExtraContent(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	resp, err := transformer.TransformResponse(t.Context(), &llm.Response{
+		ID:      "chatcmpl-1",
+		Object:  "chat.completion",
+		Created: 123,
+		Model:   "gemini-3-pro",
+		Choices: []llm.Choice{
+			{
+				Index: 0,
+				Message: &llm.Message{
+					Role:               "assistant",
+					ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("base64_signature")),
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"Shanghai"}`,
+							},
+							Index: 0,
+						},
+					},
+				},
+				FinishReason: lo.ToPtr("tool_calls"),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var oaiResp Response
+	require.NoError(t, json.Unmarshal(resp.Body, &oaiResp))
+	require.Len(t, oaiResp.Choices, 1)
+	require.NotNil(t, oaiResp.Choices[0].Message)
+	require.Len(t, oaiResp.Choices[0].Message.ToolCalls, 1)
+	require.Nil(t, oaiResp.Choices[0].Message.ToolCalls[0].ExtraContent)
 }

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -949,6 +949,87 @@ func TestToolCall_ToLLMToolCall_NormalizesGeminiThoughtSignature(t *testing.T) {
 	)
 }
 
+func TestToolCall_ToLLMToolCall_NormalizesGeminiThoughtSignatureFromExtraFields(t *testing.T) {
+	tc := ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "get_weather",
+			Arguments: `{"city":"Shanghai"}`,
+		},
+		Index: 0,
+		ExtraFields: &ToolCallExtraFields{
+			ExtraContent: &ToolCallExtraContent{
+				Google: &ToolCallGoogleExtraContent{
+					ThoughtSignature: "base64_signature",
+				},
+			},
+		},
+	}
+
+	got := tc.ToLLMToolCall()
+
+	require.NotNil(t, got.TransformerMetadata)
+	require.Equal(
+		t,
+		shared.GeminiThoughtSignaturePrefix+"base64_signature",
+		got.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature],
+	)
+}
+
+func TestInboundTransformer_TransformRequest_WithToolCallExtraFieldsThoughtSignature(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	req := &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "/v1/chat/completions",
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: []byte(`{
+			"model":"gemini-2.5-flash",
+			"messages":[
+				{
+					"role":"assistant",
+					"tool_calls":[
+						{
+							"id":"call_1",
+							"type":"function",
+							"index":0,
+							"function":{"name":"game-art_generate_image","arguments":"{}"},
+							"extra_fields":{
+								"extra_content":{
+									"google":{"thought_signature":"raw_signature_from_extra_fields"}
+								}
+							}
+						}
+					]
+				}
+			]
+		}`),
+	}
+
+	got, err := transformer.TransformRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Messages, 1)
+	require.Len(t, got.Messages[0].ToolCalls, 1)
+	require.NotNil(t, got.Messages[0].ReasoningSignature)
+	require.Equal(
+		t,
+		shared.GeminiThoughtSignaturePrefix+"raw_signature_from_extra_fields",
+		*got.Messages[0].ReasoningSignature,
+	)
+
+	metadataSignature, ok := got.Messages[0].ToolCalls[0].TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		shared.GeminiThoughtSignaturePrefix+"raw_signature_from_extra_fields",
+		metadataSignature,
+	)
+}
+
 func TestMessageFromLLM_WithGeminiThoughtSignatureDoesNotInjectToolCallExtraContent(t *testing.T) {
 	msg := llm.Message{
 		Role:               "assistant",

--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -347,6 +347,11 @@ type ToolCallExtraContent struct {
 	Google *ToolCallGoogleExtraContent `json:"google,omitempty"`
 }
 
+// ToolCallExtraFields represents wrapped extension fields used by some providers.
+type ToolCallExtraFields struct {
+	ExtraContent *ToolCallExtraContent `json:"extra_content,omitempty"`
+}
+
 // ToolCallGoogleExtraContent represents Google-specific extension fields for tool calls.
 type ToolCallGoogleExtraContent struct {
 	ThoughtSignature string `json:"thought_signature,omitempty"`
@@ -360,6 +365,8 @@ type ToolCall struct {
 	Index    int          `json:"index"`
 	// ExtraContent carries provider-specific extension fields, such as Gemini OpenAI thought signature.
 	ExtraContent *ToolCallExtraContent `json:"extra_content,omitempty"`
+	// ExtraFields is a compatibility wrapper for payloads that nest extra_content under extra_fields.
+	ExtraFields *ToolCallExtraFields `json:"extra_fields,omitempty"`
 }
 
 // ToolFunction represents a tool function reference.

--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // TransformerMetadataKeyCitations is the key used to store citations in TransformerMetadata.
 const TransformerMetadataKeyCitations = "citations"
+
+// TransformerMetadataKeyGoogleThoughtSignature 用于在 ToolCall TransformerMetadata 中保存 Gemini thought signature。
+const TransformerMetadataKeyGoogleThoughtSignature = shared.TransformerMetadataKeyGoogleThoughtSignature
 
 // Request represents an OpenAI chat completion request.
 // This is a clean OpenAI-specific model without helper fields.
@@ -338,12 +342,24 @@ type FunctionCall struct {
 	Arguments string `json:"arguments"`
 }
 
+// ToolCallExtraContent represents provider-specific extension fields for tool calls.
+type ToolCallExtraContent struct {
+	Google *ToolCallGoogleExtraContent `json:"google,omitempty"`
+}
+
+// ToolCallGoogleExtraContent represents Google-specific extension fields for tool calls.
+type ToolCallGoogleExtraContent struct {
+	ThoughtSignature string `json:"thought_signature,omitempty"`
+}
+
 // ToolCall represents a tool call in the response.
 type ToolCall struct {
 	ID       string       `json:"id,omitempty"`
 	Type     string       `json:"type,omitempty"`
 	Function FunctionCall `json:"function"`
 	Index    int          `json:"index"`
+	// ExtraContent carries provider-specific extension fields, such as Gemini OpenAI thought signature.
+	ExtraContent *ToolCallExtraContent `json:"extra_content,omitempty"`
 }
 
 // ToolFunction represents a tool function reference.

--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -160,6 +160,11 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	// Convert to OpenAI Request format (this strips helper fields)
 	oaiReq := RequestFromLLM(llmReq)
+	//nolint:exhaustive // Checked.
+	switch t.config.PlatformType {
+	case PlatformOpenAI, PlatformAzure:
+		stripUnsupportedToolCallExtraContentForOpenAI(oaiReq)
+	}
 
 	body, err := json.Marshal(oaiReq)
 	if err != nil {
@@ -278,6 +283,49 @@ func (t *OutboundTransformer) TransformStreamChunk(
 	}
 
 	return t.TransformResponse(ctx, httpResp)
+}
+
+func stripUnsupportedToolCallExtraContentForOpenAI(req *Request) {
+	if req == nil {
+		return
+	}
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].ToolCalls {
+			extraContent := req.Messages[i].ToolCalls[j].ExtraContent
+			if extraContent == nil || extraContent.Google == nil {
+				continue
+			}
+
+			if extraContent.Google.ThoughtSignature == "" {
+				continue
+			}
+
+			extraContent.Google.ThoughtSignature = ""
+
+			// 仅在对象已空时才清理，避免误删其他扩展字段。
+			if isJSONEmptyObject(extraContent.Google) {
+				extraContent.Google = nil
+			}
+
+			if isJSONEmptyObject(extraContent) {
+				req.Messages[i].ToolCalls[j].ExtraContent = nil
+			}
+		}
+	}
+}
+
+func isJSONEmptyObject(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(raw, []byte("{}")) || bytes.Equal(raw, []byte("null"))
 }
 
 // buildFullRequestURL constructs the appropriate URL based on the platform.

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -192,7 +192,7 @@ func ToolFromLLM(t llm.Tool) Tool {
 
 // ToolCallFromLLM creates OpenAI ToolCall from unified llm.ToolCall.
 func ToolCallFromLLM(tc llm.ToolCall) ToolCall {
-	return ToolCall{
+	toolCall := ToolCall{
 		ID:   tc.ID,
 		Type: tc.Type,
 		Function: FunctionCall{
@@ -201,6 +201,16 @@ func ToolCallFromLLM(tc llm.ToolCall) ToolCall {
 		},
 		Index: tc.Index,
 	}
+
+	if raw, ok := tc.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string); ok && raw != "" {
+		toolCall.ExtraContent = &ToolCallExtraContent{
+			Google: &ToolCallGoogleExtraContent{
+				ThoughtSignature: raw,
+			},
+		}
+	}
+
+	return toolCall
 }
 
 // ToLLMResponse converts OpenAI Response to unified llm.Response.

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func TestRequestFromLLM(t *testing.T) {
@@ -337,4 +338,94 @@ func TestResponse_ToLLMResponse_WithCitations(t *testing.T) {
 			tt.validate(t, result)
 		})
 	}
+}
+
+func TestRequestFromLLM_KeepsGoogleThoughtSignatureInRequestModel(t *testing.T) {
+	req := RequestFromLLM(&llm.Request{
+		Model: "gemini-3-pro",
+		Messages: []llm.Message{
+			{
+				Role:               "assistant",
+				ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("sig_from_reasoning")),
+				ToolCalls: []llm.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "get_weather",
+							Arguments: `{"city":"Shanghai"}`,
+						},
+						Index: 0,
+						TransformerMetadata: map[string]any{
+							TransformerMetadataKeyGoogleThoughtSignature: "sig_from_metadata",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 1)
+	require.Len(t, req.Messages[0].ToolCalls, 1)
+	require.NotNil(t, req.Messages[0].ToolCalls[0].ExtraContent)
+	require.NotNil(t, req.Messages[0].ToolCalls[0].ExtraContent.Google)
+	require.Equal(t, "sig_from_metadata", req.Messages[0].ToolCalls[0].ExtraContent.Google.ThoughtSignature)
+}
+
+func TestMessageFromLLM_DoesNotOverrideFirstToolCallWhenMetadataExists(t *testing.T) {
+	msg := MessageFromLLM(llm.Message{
+		Role:               "assistant",
+		ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("sig_from_second_tool_call")),
+		ToolCalls: []llm.ToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: llm.FunctionCall{
+					Name:      "tool_a",
+					Arguments: "{}",
+				},
+				Index: 0,
+			},
+			{
+				ID:   "call_2",
+				Type: "function",
+				Function: llm.FunctionCall{
+					Name:      "tool_b",
+					Arguments: "{}",
+				},
+				Index: 1,
+				TransformerMetadata: map[string]any{
+					TransformerMetadataKeyGoogleThoughtSignature: "sig_from_second_tool_call",
+				},
+			},
+		},
+	})
+
+	require.Len(t, msg.ToolCalls, 2)
+	require.Nil(t, msg.ToolCalls[0].ExtraContent)
+	require.NotNil(t, msg.ToolCalls[1].ExtraContent)
+	require.NotNil(t, msg.ToolCalls[1].ExtraContent.Google)
+	require.Equal(t, "sig_from_second_tool_call", msg.ToolCalls[1].ExtraContent.Google.ThoughtSignature)
+}
+
+func TestMessageFromLLM_GeminiReasoningSignatureDoesNotInjectThoughtSignature(t *testing.T) {
+	msg := MessageFromLLM(llm.Message{
+		Role:               "assistant",
+		ReasoningSignature: shared.EncodeGeminiThoughtSignature(lo.ToPtr("gemini_signature")),
+		ToolCalls: []llm.ToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: llm.FunctionCall{
+					Name:      "tool_a",
+					Arguments: "{}",
+				},
+				Index: 0,
+			},
+		},
+	})
+
+	require.Len(t, msg.ToolCalls, 1)
+	require.Nil(t, msg.ToolCalls[0].ExtraContent)
 }

--- a/llm/transformer/openai/outbound_test.go
+++ b/llm/transformer/openai/outbound_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func TestOutboundTransformer_TransformRequest(t *testing.T) {
@@ -187,6 +188,117 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOutboundTransformer_TransformRequest_StripsUnsupportedToolCallExtraContentForOpenAI(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "openai platform",
+			config: &Config{
+				PlatformType:   PlatformOpenAI,
+				BaseURL:        "https://api.openai.com/v1",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+			},
+		},
+		{
+			name: "azure platform",
+			config: &Config{
+				PlatformType:   PlatformAzure,
+				BaseURL:        "https://example.openai.azure.com",
+				APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+				APIVersion:     DefaultAzureAPIVersion,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformerInterface, err := NewOutboundTransformerWithConfig(tt.config)
+			if err != nil {
+				t.Fatalf("Failed to create transformer: %v", err)
+			}
+
+			transformer := transformerInterface.(*OutboundTransformer)
+
+			httpReq, err := transformer.TransformRequest(t.Context(), &llm.Request{
+				Model: "gpt-4o-mini",
+				Messages: []llm.Message{
+					{
+						Role: "assistant",
+						ToolCalls: []llm.ToolCall{
+							{
+								ID:   "call_1",
+								Type: "function",
+								Function: llm.FunctionCall{
+									Name:      "get_weather",
+									Arguments: `{"city":"Shanghai"}`,
+								},
+								Index: 0,
+								TransformerMetadata: map[string]any{
+									TransformerMetadataKeyGoogleThoughtSignature: "sig_from_metadata",
+								},
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("TransformRequest() unexpected error = %v", err)
+			}
+
+			var oaiReq Request
+			if err := json.Unmarshal(httpReq.Body, &oaiReq); err != nil {
+				t.Fatalf("failed to unmarshal request body: %v", err)
+			}
+
+			if !assert.Len(t, oaiReq.Messages, 1) || !assert.Len(t, oaiReq.Messages[0].ToolCalls, 1) {
+				return
+			}
+
+			assert.Nil(t, oaiReq.Messages[0].ToolCalls[0].ExtraContent)
+		})
+	}
+}
+
+func TestStripUnsupportedToolCallExtraContentForOpenAI_OnlyStripsThoughtSignature(t *testing.T) {
+	req := &Request{
+		Messages: []Message{
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{
+					{
+						ID: "call_1",
+						ExtraContent: &ToolCallExtraContent{
+							Google: &ToolCallGoogleExtraContent{
+								ThoughtSignature: "",
+							},
+						},
+					},
+					{
+						ID: "call_2",
+						ExtraContent: &ToolCallExtraContent{
+							Google: &ToolCallGoogleExtraContent{
+								ThoughtSignature: "sig_to_strip",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stripUnsupportedToolCallExtraContentForOpenAI(req)
+
+	if !assert.NotNil(t, req.Messages[0].ToolCalls[0].ExtraContent) {
+		return
+	}
+
+	assert.NotNil(t, req.Messages[0].ToolCalls[0].ExtraContent.Google)
+	assert.Equal(t, "", req.Messages[0].ToolCalls[0].ExtraContent.Google.ThoughtSignature)
+	assert.Nil(t, req.Messages[0].ToolCalls[1].ExtraContent)
 }
 
 func TestOutboundTransformer_TransformError(t *testing.T) {
@@ -579,6 +691,65 @@ func TestNewOutboundTransformer(t *testing.T) {
 			_, err := NewOutboundTransformer(tt.baseURL, tt.apiKey)
 			tt.assertErr(t, err)
 		})
+	}
+}
+
+func TestOutboundTransformer_TransformResponse_WithGeminiToolCallThoughtSignature(t *testing.T) {
+	transformerInterface, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	if err != nil {
+		t.Fatalf("Failed to create transformer: %v", err)
+	}
+
+	transformer := transformerInterface.(*OutboundTransformer)
+
+	httpResp := &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Body: mustMarshal(Response{
+			ID:      "chatcmpl-1",
+			Object:  "chat.completion",
+			Created: 123,
+			Model:   "gemini-3-pro",
+			Choices: []Choice{
+				{
+					Index: 0,
+					Message: &Message{
+						Role: "assistant",
+						ToolCalls: []ToolCall{
+							{
+								ID:   "call_1",
+								Type: "function",
+								Function: FunctionCall{
+									Name:      "get_weather",
+									Arguments: `{"city":"Shanghai"}`,
+								},
+								Index: 0,
+								ExtraContent: &ToolCallExtraContent{
+									Google: &ToolCallGoogleExtraContent{
+										ThoughtSignature: "base64_signature",
+									},
+								},
+							},
+						},
+					},
+					FinishReason: lo.ToPtr("tool_calls"),
+				},
+			},
+		}),
+	}
+
+	result, err := transformer.TransformResponse(t.Context(), httpResp)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	if !assert.Len(t, result.Choices, 1) || !assert.NotNil(t, result.Choices[0].Message) {
+		return
+	}
+
+	assert.NotNil(t, result.Choices[0].Message.ReasoningSignature)
+	assert.True(t, shared.IsGeminiThoughtSignature(result.Choices[0].Message.ReasoningSignature))
+	decoded := shared.DecodeGeminiThoughtSignature(result.Choices[0].Message.ReasoningSignature)
+	assert.NotNil(t, decoded)
+	if decoded != nil {
+		assert.Equal(t, "base64_signature", *decoded)
 	}
 }
 

--- a/llm/transformer/shared/gemini.go
+++ b/llm/transformer/shared/gemini.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"encoding/base64"
 	"strings"
 )
 
@@ -13,22 +12,45 @@ const TransformerMetadataKeyGoogleThoughtSignature = "google_thought_signature"
 // This signature allows AxonHub to "wrap" and preserve these reasoning blocks in the internal
 // message structure. This ensures that when switching between different providers (e.g., Gemini -> OpenAI -> Gemini),
 // the original reasoning context is maintained and can be restored, preventing model performance degradation.
-var GeminiThoughtSignaturePrefix = base64.StdEncoding.EncodeToString([]byte("<GEMINI_THOUGHT_SIGNATURE>"))
+//
+// NOTE: This prefix MUST NOT end with "=".
+// If the prefix contains base64 padding "=", concatenating "prefix + raw_signature" may produce an invalid whole base64 string.
+// Plaintext marker before base64: "GEMINI_THOUGHT_SIGNATURE_V1".
+var GeminiThoughtSignaturePrefix = "R0VNSU5JX1RIT1VHSFRfU0lHTkFUVVJFX1Yx"
+
+var legacyGeminiThoughtSignaturePrefix = "PEdFTUlOSV9USE9VR0hUX1NJR05BVFVSRT4="
+
+func geminiThoughtSignaturePrefixLength(signature string) int {
+	if strings.HasPrefix(signature, GeminiThoughtSignaturePrefix) {
+		return len(GeminiThoughtSignaturePrefix)
+	}
+
+	if strings.HasPrefix(signature, legacyGeminiThoughtSignaturePrefix) {
+		return len(legacyGeminiThoughtSignaturePrefix)
+	}
+
+	return 0
+}
 
 func IsGeminiThoughtSignature(signature *string) bool {
 	if signature == nil {
 		return false
 	}
 
-	return strings.HasPrefix(*signature, GeminiThoughtSignaturePrefix)
+	return geminiThoughtSignaturePrefixLength(*signature) > 0
 }
 
 func DecodeGeminiThoughtSignature(signature *string) *string {
-	if !IsGeminiThoughtSignature(signature) {
+	if signature == nil {
 		return nil
 	}
 
-	decoded := (*signature)[len(GeminiThoughtSignaturePrefix):]
+	prefixLength := geminiThoughtSignaturePrefixLength(*signature)
+	if prefixLength == 0 {
+		return nil
+	}
+
+	decoded := (*signature)[prefixLength:]
 
 	return &decoded
 }
@@ -49,8 +71,8 @@ func NormalizeGeminiThoughtSignature(signature string) *string {
 		return nil
 	}
 
-	if IsGeminiThoughtSignature(&signature) {
-		return &signature
+	if decoded := DecodeGeminiThoughtSignature(&signature); decoded != nil {
+		return EncodeGeminiThoughtSignature(decoded)
 	}
 
 	return EncodeGeminiThoughtSignature(&signature)

--- a/llm/transformer/shared/gemini.go
+++ b/llm/transformer/shared/gemini.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// TransformerMetadataKeyGoogleThoughtSignature 用于在 ToolCall TransformerMetadata 中保存 Gemini thought signature。
+const TransformerMetadataKeyGoogleThoughtSignature = "google_thought_signature"
+
 // GeminiThoughtSignaturePrefix is the prefix used for Gemini thought/reasoning signatures.
 // In models like Gemini 2.0, reasoning process is a first-class citizen.
 // This signature allows AxonHub to "wrap" and preserve these reasoning blocks in the internal
@@ -38,4 +41,31 @@ func EncodeGeminiThoughtSignature(signature *string) *string {
 	encoded := GeminiThoughtSignaturePrefix + *signature
 
 	return &encoded
+}
+
+// NormalizeGeminiThoughtSignature normalizes Gemini thought signatures into internal encoded format.
+func NormalizeGeminiThoughtSignature(signature string) *string {
+	if signature == "" {
+		return nil
+	}
+
+	if IsGeminiThoughtSignature(&signature) {
+		return &signature
+	}
+
+	return EncodeGeminiThoughtSignature(&signature)
+}
+
+// StripGeminiThoughtSignaturePrefix removes internal prefix from Gemini thought signatures.
+func StripGeminiThoughtSignaturePrefix(signature string) string {
+	if !IsGeminiThoughtSignature(&signature) {
+		return signature
+	}
+
+	decoded := DecodeGeminiThoughtSignature(&signature)
+	if decoded == nil {
+		return signature
+	}
+
+	return *decoded
 }

--- a/llm/transformer/shared/gemini_test.go
+++ b/llm/transformer/shared/gemini_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,11 @@ func TestIsGeminiThoughtSignature(t *testing.T) {
 		{
 			name:      "valid signature",
 			signature: stringPtr(GeminiThoughtSignaturePrefix + "some-signature"),
+			expected:  true,
+		},
+		{
+			name:      "valid legacy signature",
+			signature: stringPtr(legacyGeminiThoughtSignaturePrefix + "some-signature"),
 			expected:  true,
 		},
 		{
@@ -66,6 +72,11 @@ func TestDecodeGeminiThoughtSignature(t *testing.T) {
 		{
 			name:      "valid signature",
 			signature: stringPtr(GeminiThoughtSignaturePrefix + "some-signature"),
+			expected:  stringPtr("some-signature"),
+		},
+		{
+			name:      "valid legacy signature",
+			signature: stringPtr(legacyGeminiThoughtSignaturePrefix + "some-signature"),
 			expected:  stringPtr("some-signature"),
 		},
 		{
@@ -146,6 +157,11 @@ func TestNormalizeGeminiThoughtSignature(t *testing.T) {
 			expected:  stringPtr(GeminiThoughtSignaturePrefix + "normalized"),
 		},
 		{
+			name:      "already legacy prefixed signature should normalize to new prefix",
+			signature: legacyGeminiThoughtSignaturePrefix + "normalized",
+			expected:  stringPtr(GeminiThoughtSignaturePrefix + "normalized"),
+		},
+		{
 			name:      "plain signature",
 			signature: "normalized",
 			expected:  stringPtr(GeminiThoughtSignaturePrefix + "normalized"),
@@ -174,6 +190,11 @@ func TestStripGeminiThoughtSignaturePrefix(t *testing.T) {
 		{
 			name:      "prefixed signature",
 			signature: GeminiThoughtSignaturePrefix + "stripped",
+			expected:  "stripped",
+		},
+		{
+			name:      "legacy prefixed signature",
+			signature: legacyGeminiThoughtSignaturePrefix + "stripped",
 			expected:  "stripped",
 		},
 		{
@@ -208,4 +229,17 @@ func TestGeminiEncodeDecodeRoundTrip(t *testing.T) {
 	decoded := DecodeGeminiThoughtSignature(encoded)
 	require.NotNil(t, decoded)
 	require.Equal(t, *original, *decoded)
+}
+
+func TestGeminiThoughtSignatureWholeValueCanDecodeAsBase64(t *testing.T) {
+	signature := stringPtr("YWJjZA==")
+
+	encoded := EncodeGeminiThoughtSignature(signature)
+	require.NotNil(t, encoded)
+	_, err := base64.StdEncoding.DecodeString(*encoded)
+	require.NoError(t, err)
+
+	legacy := legacyGeminiThoughtSignaturePrefix + *signature
+	_, err = base64.StdEncoding.DecodeString(legacy)
+	require.Error(t, err)
 }

--- a/llm/transformer/shared/gemini_test.go
+++ b/llm/transformer/shared/gemini_test.go
@@ -129,6 +129,73 @@ func TestEncodeGeminiThoughtSignature(t *testing.T) {
 	}
 }
 
+func TestNormalizeGeminiThoughtSignature(t *testing.T) {
+	tests := []struct {
+		name      string
+		signature string
+		expected  *string
+	}{
+		{
+			name:      "empty signature",
+			signature: "",
+			expected:  nil,
+		},
+		{
+			name:      "already prefixed signature",
+			signature: GeminiThoughtSignaturePrefix + "normalized",
+			expected:  stringPtr(GeminiThoughtSignaturePrefix + "normalized"),
+		},
+		{
+			name:      "plain signature",
+			signature: "normalized",
+			expected:  stringPtr(GeminiThoughtSignaturePrefix + "normalized"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeGeminiThoughtSignature(tt.signature)
+			if tt.expected == nil {
+				require.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				require.Equal(t, *tt.expected, *result)
+			}
+		})
+	}
+}
+
+func TestStripGeminiThoughtSignaturePrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		signature string
+		expected  string
+	}{
+		{
+			name:      "prefixed signature",
+			signature: GeminiThoughtSignaturePrefix + "stripped",
+			expected:  "stripped",
+		},
+		{
+			name:      "plain signature",
+			signature: "plain",
+			expected:  "plain",
+		},
+		{
+			name:      "prefix only",
+			signature: GeminiThoughtSignaturePrefix,
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripGeminiThoughtSignaturePrefix(tt.signature)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGeminiEncodeDecodeRoundTrip(t *testing.T) {
 	original := stringPtr("some-random-signature-data")
 


### PR DESCRIPTION
原有的base64签名，后面补齐了一个=，再拼接思考签名后，在genai的go sdk中会报错（因为会对base64进行decode）

另外，在openai格式调用gemini格式时，思考签名会被直接缺失抛弃