### PR TITLE
fix(orchestrator): detect complete responses without terminal events for Codex + NanoGPT

### DIFF
--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -140,7 +140,8 @@ func (ts *InboundPersistentStream) Close() error {
 		if err == nil && meta.ID != "" && len(responseBody) > 0 {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
 			ts.state.StreamCompleted = true
-			ts.persistResponseChunks(ctx)
+			// Use _persistResponse directly to avoid re-aggregating chunks
+			ts._persistResponse(context.WithoutCancel(ctx), responseBody, meta)
 			return ts.stream.Close()
 		}
 	}
@@ -160,41 +161,48 @@ func (ts *InboundPersistentStream) persistResponseChunks(ctx context.Context) {
 		}
 	}()
 
-	// Update main request with aggregated response
 	// Use context without cancellation to ensure persistence even if client canceled
-	if ts.request != nil {
-		persistCtx := context.WithoutCancel(ctx)
+	persistCtx := context.WithoutCancel(ctx)
 
-		responseBody, meta, err := ts.transformer.AggregateStreamChunks(persistCtx, ts.responseChunks)
-		if err != nil {
-			log.Warn(persistCtx, "Failed to aggregate chunks for main request", log.Cause(err))
+	// Aggregate stream chunks first, then delegate to _persistResponse
+	responseBody, meta, err := ts.transformer.AggregateStreamChunks(persistCtx, ts.responseChunks)
+	if err != nil {
+		log.Warn(persistCtx, "Failed to aggregate chunks for main request", log.Cause(err))
+		dumper.DumpStreamEvents(persistCtx, ts.responseChunks, "response_chunks.json")
+	}
 
-			dumper.DumpStreamEvents(persistCtx, ts.responseChunks, "response_chunks.json")
+	ts._persistResponse(persistCtx, responseBody, meta)
+}
+
+// _persistResponse performs the actual persistence with pre-aggregated data.
+// This avoids redundant aggregation when the data is already available.
+func (ts *InboundPersistentStream) _persistResponse(ctx context.Context, responseBody []byte, meta llm.ResponseMeta) {
+	if ts.request == nil {
+		return
+	}
+
+	// Build latency metrics from performance record
+	var metrics *biz.LatencyMetrics
+
+	if ts.perf != nil {
+		firstTokenLatencyMs, requestLatencyMs, _ := ts.perf.Calculate()
+
+		metrics = &biz.LatencyMetrics{
+			LatencyMs: &requestLatencyMs,
 		}
-
-		// Build latency metrics from performance record
-		var metrics *biz.LatencyMetrics
-
-		if ts.perf != nil {
-			firstTokenLatencyMs, requestLatencyMs, _ := ts.perf.Calculate()
-
-			metrics = &biz.LatencyMetrics{
-				LatencyMs: &requestLatencyMs,
-			}
-			if ts.perf.Stream && ts.perf.FirstTokenTime != nil {
-				metrics.FirstTokenLatencyMs = &firstTokenLatencyMs
-			}
+		if ts.perf.Stream && ts.perf.FirstTokenTime != nil {
+			metrics.FirstTokenLatencyMs = &firstTokenLatencyMs
 		}
+	}
 
-		err = ts.requestService.UpdateRequestCompleted(persistCtx, ts.request.ID, meta.ID, responseBody, metrics)
-		if err != nil {
-			log.Warn(persistCtx, "Failed to update request status to completed", log.Cause(err))
-		}
+	err := ts.requestService.UpdateRequestCompleted(ctx, ts.request.ID, meta.ID, responseBody, metrics)
+	if err != nil {
+		log.Warn(ctx, "Failed to update request status to completed", log.Cause(err))
+	}
 
-		// Save all response chunks at once
-		if err := ts.requestService.SaveRequestChunks(persistCtx, ts.request.ID, ts.responseChunks); err != nil {
-			log.Warn(persistCtx, "Failed to save request chunks", log.Cause(err))
-		}
+	// Save all response chunks at once
+	if err := ts.requestService.SaveRequestChunks(ctx, ts.request.ID, ts.responseChunks); err != nil {
+		log.Warn(ctx, "Failed to save request chunks", log.Cause(err))
 	}
 }
 

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -112,8 +112,24 @@ func (ts *InboundPersistentStream) Close() error {
 		return ts.stream.Close()
 	}
 
-	// Check if context was canceled (client disconnected before [DONE])
-	if ctxErr != nil || streamErr != nil {
+	// If we haven't received a terminal event, check if the chunks we DO have form a complete response.
+	// This handles models that aggregate internally (like Codex) or upstream proxy hung connections
+	// where the provider sent the full JSON payload but failed to send [DONE] before dropping.
+	var responseBody []byte
+	var meta llm.ResponseMeta
+	var aggErr error
+
+	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted {
+		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.responseChunks)
+		if aggErr == nil && meta.ID != "" && len(responseBody) > 0 {
+			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
+			ts.state.StreamCompleted = true
+		}
+	}
+
+	// Check if context was canceled (client disconnected before [DONE]).
+	// Skip the error path if we determined the stream actually completed successfully above.
+	if (ctxErr != nil || streamErr != nil) && !ts.state.StreamCompleted {
 		// Use context without cancellation to ensure persistence even if client canceled
 		if ts.request != nil {
 			persistCtx := context.WithoutCancel(ctx)
@@ -132,24 +148,15 @@ func (ts *InboundPersistentStream) Close() error {
 		return ts.stream.Close()
 	}
 
-	// NEW: Check if we have a complete response even without terminal event
-	// This handles executors that aggregate streams internally (e.g., Codex)
-	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted {
-		// Try to aggregate and see if we have a valid complete response
-		responseBody, meta, err := ts.transformer.AggregateStreamChunks(ctx, ts.responseChunks)
-		if err == nil && meta.ID != "" && len(responseBody) > 0 {
-			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
-			ts.state.StreamCompleted = true
-			// Use _persistResponse directly to avoid re-aggregating chunks
-			ts._persistResponse(context.WithoutCancel(ctx), responseBody, meta)
-			return ts.stream.Close()
-		}
-	}
-
 	// Stream completed successfully - perform final persistence
 	log.Debug(ctx, "Stream completed successfully, performing final persistence")
 
-	ts.persistResponseChunks(ctx)
+	// We already aggregated the chunks above, so pass them directly to avoid double-aggregation
+	if len(responseBody) > 0 {
+		ts._persistResponse(context.WithoutCancel(ctx), responseBody, meta)
+	} else {
+		ts.persistResponseChunks(ctx)
+	}
 
 	return ts.stream.Close()
 }

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -132,6 +132,19 @@ func (ts *InboundPersistentStream) Close() error {
 		return ts.stream.Close()
 	}
 
+	// NEW: Check if we have a complete response even without terminal event
+	// This handles executors that aggregate streams internally (e.g., Codex)
+	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted {
+		// Try to aggregate and see if we have a valid complete response
+		responseBody, meta, err := ts.transformer.AggregateStreamChunks(ctx, ts.responseChunks)
+		if err == nil && meta.ID != "" && len(responseBody) > 0 {
+			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
+			ts.state.StreamCompleted = true
+			ts.persistResponseChunks(ctx)
+			return ts.stream.Close()
+		}
+	}
+
 	// Stream completed successfully - perform final persistence
 	log.Debug(ctx, "Stream completed successfully, performing final persistence")
 

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -106,7 +106,7 @@ func (ts *InboundPersistentStream) Close() error {
 	// the client disconnects immediately after receiving the last chunk.
 	if ts.state.StreamCompleted {
 		// Stream completed successfully - perform final persistence
-		log.Debug(ctx, "Stream completed successfully (received [DONE]), performing final persistence")
+		log.Debug(ctx, "Stream completed successfully (received terminal event), performing final persistence")
 		ts.persistResponseChunks(ctx)
 
 		return ts.stream.Close()

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -1,0 +1,274 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+// mockInboundTransformer is a mock transformer for testing.
+type mockInboundTransformer struct {
+	aggregateResponseBody []byte
+	aggregateMeta         llm.ResponseMeta
+	aggregateErr          error
+}
+
+func (m *mockInboundTransformer) APIFormat() llm.APIFormat {
+	return llm.APIFormatOpenAIChatCompletion
+}
+
+func (m *mockInboundTransformer) TransformRequest(ctx context.Context, request *httpclient.Request) (*llm.Request, error) {
+	return &llm.Request{}, nil
+}
+
+func (m *mockInboundTransformer) TransformResponse(ctx context.Context, response *llm.Response) (*httpclient.Response, error) {
+	return &httpclient.Response{}, nil
+}
+
+func (m *mockInboundTransformer) TransformStream(ctx context.Context, stream streams.Stream[*llm.Response]) (streams.Stream[*httpclient.StreamEvent], error) {
+	return nil, nil
+}
+
+func (m *mockInboundTransformer) TransformError(ctx context.Context, rawErr error) *httpclient.Error {
+	return nil
+}
+
+func (m *mockInboundTransformer) AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {
+	return m.aggregateResponseBody, m.aggregateMeta, m.aggregateErr
+}
+
+// mockStream is a simple mock stream for testing.
+type mockStream struct {
+	events     []*httpclient.StreamEvent
+	currentIdx int
+	closed     bool
+	err        error
+}
+
+func (m *mockStream) Next() bool {
+	if m.currentIdx >= len(m.events) {
+		return false
+	}
+	m.currentIdx++
+	return true
+}
+
+func (m *mockStream) Current() *httpclient.StreamEvent {
+	if m.currentIdx > len(m.events) {
+		return nil
+	}
+	return m.events[m.currentIdx-1]
+}
+
+func (m *mockStream) Err() error {
+	return m.err
+}
+
+func (m *mockStream) Close() error {
+	m.closed = true
+	return nil
+}
+
+// createTestRequestService creates a minimal request service for testing.
+func createTestRequestService(t *testing.T, client *ent.Client) *biz.RequestService {
+	t.Helper()
+
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		CacheConfig: xcache.Config{Mode: xcache.ModeMemory},
+		Ent:         client,
+	})
+
+	dataStorageService := &biz.DataStorageService{
+		AbstractService: &biz.AbstractService{},
+		SystemService:   systemService,
+		Cache:           xcache.NewFromConfig[ent.DataStorage](xcache.Config{Mode: xcache.ModeMemory}),
+	}
+
+	channelService := biz.NewChannelServiceForTest(client)
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+
+	return biz.NewRequestService(client, systemService, usageLogService, dataStorageService)
+}
+
+// TestInboundPersistentStream_Close_WithCompleteResponse tests the NEW behavior:
+// complete response without terminal event (e.g., Codex executor that aggregates internally)
+func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
+	// Setup
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+
+	// Create a complete response chunk with non-terminal event type
+	// This simulates Codex executor behavior where the response is complete but lacks terminal event
+	completeResponseChunk := &httpclient.StreamEvent{
+		Type: "chunk",
+		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
+	}
+
+	// Create mock stream with single complete response chunk (no [DONE] event)
+	mockStream := &mockStream{
+		events: []*httpclient.StreamEvent{completeResponseChunk},
+	}
+
+	// Create mock transformer that returns valid aggregated response
+	mockTransformer := &mockInboundTransformer{
+		aggregateResponseBody: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
+		aggregateMeta: llm.ResponseMeta{
+			ID: "chatcmpl-abc123",
+			Usage: &llm.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		},
+		aggregateErr: nil,
+	}
+
+	// Create real request service
+	requestService := createTestRequestService(t, client)
+
+	// Create test request and execution
+	testRequest := &ent.Request{
+		ID: 1,
+	}
+	testRequestExec := &ent.RequestExecution{
+		ID: 1,
+	}
+
+	// Create persistence state
+	state := &PersistenceState{
+		StreamCompleted: false,
+	}
+
+	// Create the InboundPersistentStream
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		testRequest,
+		testRequestExec,
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+
+	// Execute - Call Next() to process the chunk, then Close()
+	require.True(t, stream.Next(), "Expected Next() to return true")
+	event := stream.Current()
+	require.NotNil(t, event, "Expected current event to not be nil")
+
+	// Verify that StreamCompleted is still false (no terminal event yet)
+	assert.False(t, state.StreamCompleted, "StreamCompleted should be false before Close()")
+
+	// Call Close()
+	err := stream.Close()
+	require.NoError(t, err, "Close() should not return an error")
+
+	// Assert - Verify StreamCompleted is set to true
+	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after Close() with complete response")
+
+	// Verify stream is closed
+	assert.True(t, mockStream.closed, "Stream should be closed")
+}
+
+// TestInboundPersistentStream_Close_WithTerminalEvent tests the EXISTING behavior:
+// terminal event (e.g., [DONE] event from OpenAI)
+func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
+	// Setup
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+
+	// Create a regular response chunk
+	responseChunk := &httpclient.StreamEvent{
+		Type: "chunk",
+		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`),
+	}
+
+	// Create the [DONE] terminal event
+	doneEvent := &httpclient.StreamEvent{
+		Data: []byte("[DONE]"),
+	}
+
+	// Create mock stream with response chunk followed by [DONE] event
+	mockStream := &mockStream{
+		events: []*httpclient.StreamEvent{responseChunk, doneEvent},
+	}
+
+	// Create mock transformer
+	mockTransformer := &mockInboundTransformer{
+		aggregateResponseBody: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
+		aggregateMeta: llm.ResponseMeta{
+			ID: "chatcmpl-abc123",
+			Usage: &llm.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		},
+		aggregateErr: nil,
+	}
+
+	// Create real request service
+	requestService := createTestRequestService(t, client)
+
+	// Create test request and execution
+	testRequest := &ent.Request{
+		ID: 1,
+	}
+	testRequestExec := &ent.RequestExecution{
+		ID: 1,
+	}
+
+	// Create persistence state
+	state := &PersistenceState{
+		StreamCompleted: false,
+	}
+
+	// Create the InboundPersistentStream
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		testRequest,
+		testRequestExec,
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+
+	// Execute - Process all events
+	require.True(t, stream.Next(), "Expected Next() to return true for first chunk")
+	_ = stream.Current()
+
+	require.True(t, stream.Next(), "Expected Next() to return true for [DONE] event")
+	doneEvent = stream.Current()
+	require.NotNil(t, doneEvent, "Expected current event to not be nil")
+
+	// Verify that StreamCompleted is set to true by the [DONE] event
+	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after [DONE] event")
+
+	// Call Close()
+	err := stream.Close()
+	require.NoError(t, err, "Close() should not return an error")
+
+	// Assert - Verify StreamCompleted is still true
+	assert.True(t, state.StreamCompleted, "StreamCompleted should remain true after Close()")
+
+	// Verify stream is closed
+	assert.True(t, mockStream.closed, "Stream should be closed")
+}

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,7 +195,7 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 	ctx = ent.NewContext(ctx, client)
 
 	// Create a regular response chunk
-	responseChunk := &httpclient.StreamEvent{
+	regularResponseChunk := &httpclient.StreamEvent{
 		Type: "chunk",
 		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`),
 	}
@@ -206,7 +207,7 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 
 	// Create mock stream with response chunk followed by [DONE] event
 	mockStream := &mockStream{
-		events: []*httpclient.StreamEvent{responseChunk, doneEvent},
+		events: []*httpclient.StreamEvent{regularResponseChunk, doneEvent},
 	}
 
 	// Create mock transformer
@@ -256,8 +257,8 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 	_ = stream.Current()
 
 	require.True(t, stream.Next(), "Expected Next() to return true for [DONE] event")
-	doneEvent = stream.Current()
-	require.NotNil(t, doneEvent, "Expected current event to not be nil")
+	event := stream.Current()
+	require.NotNil(t, event, "Expected current event to not be nil")
 
 	// Verify that StreamCompleted is set to true by the [DONE] event
 	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after [DONE] event")
@@ -268,6 +269,80 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 
 	// Assert - Verify StreamCompleted is still true
 	assert.True(t, state.StreamCompleted, "StreamCompleted should remain true after Close()")
+
+	// Verify stream is closed
+	assert.True(t, mockStream.closed, "Stream should be closed")
+}
+
+// TestInboundPersistentStream_Close_WithAggregationError tests the error path:
+// aggregation fails but fallback behavior still works (persistResponseChunks called in final block)
+func TestInboundPersistentStream_Close_WithAggregationError(t *testing.T) {
+	// Setup
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+
+	// Create a regular response chunk
+	regularResponseChunk := &httpclient.StreamEvent{
+		Type: "chunk",
+		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`),
+	}
+
+	// Create mock stream with response chunk (no terminal event)
+	mockStream := &mockStream{
+		events: []*httpclient.StreamEvent{regularResponseChunk},
+	}
+
+	// Create mock transformer with aggregation error
+	mockTransformer := &mockInboundTransformer{
+		aggregateResponseBody: nil,
+		aggregateMeta:         llm.ResponseMeta{},
+		aggregateErr:          errors.New("aggregation failed"),
+	}
+
+	// Create real request service
+	requestService := createTestRequestService(t, client)
+
+	// Create test request and execution
+	testRequest := &ent.Request{
+		ID: 1,
+	}
+	testRequestExec := &ent.RequestExecution{
+		ID: 1,
+	}
+
+	// Create persistence state
+	state := &PersistenceState{
+		StreamCompleted: false,
+	}
+
+	// Create the InboundPersistentStream
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		testRequest,
+		testRequestExec,
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+
+	// Execute - Process the chunk
+	require.True(t, stream.Next(), "Expected Next() to return true for first chunk")
+	_ = stream.Current()
+
+	// Verify that StreamCompleted is still false (no terminal event yet)
+	assert.False(t, state.StreamCompleted, "StreamCompleted should be false before Close()")
+
+	// Call Close()
+	err := stream.Close()
+	require.NoError(t, err, "Close() should not return an error")
+
+	// Assert - Verify StreamCompleted is still false (no terminal event received)
+	assert.False(t, state.StreamCompleted, "StreamCompleted should remain false after Close() with aggregation error")
 
 	// Verify stream is closed
 	assert.True(t, mockStream.closed, "Stream should be closed")

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer"
 )
 
 // mockInboundTransformer is a mock transformer for testing.
@@ -101,29 +102,53 @@ func createTestRequestService(t *testing.T, client *ent.Client) *biz.RequestServ
 	return biz.NewRequestService(client, systemService, usageLogService, dataStorageService)
 }
 
-// TestInboundPersistentStream_Close_WithCompleteResponse tests the NEW behavior:
-// complete response without terminal event (e.g., Codex executor that aggregates internally)
-func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
-	// Setup
-	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
-	defer client.Close()
+// newInboundPersistentStreamHelper creates a configured InboundPersistentStream for testing.
+// It encapsulates common setup: ent.Client, context, RequestService, test request/execution, and persistence state.
+// The caller provides the mock stream and transformer to test specific behaviors.
+func newInboundPersistentStreamHelper(
+	t *testing.T,
+	mockStream streams.Stream[*httpclient.StreamEvent],
+	mockTransformer transformer.Inbound,
+) (*InboundPersistentStream, *ent.Client, context.Context, *PersistenceState) {
+	t.Helper()
 
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
 	ctx := context.Background()
 	ctx = ent.NewContext(ctx, client)
 
-	// Create a complete response chunk with non-terminal event type
-	// This simulates Codex executor behavior where the response is complete but lacks terminal event
+	requestService := createTestRequestService(t, client)
+
+	testRequest := &ent.Request{ID: 1}
+	testRequestExec := &ent.RequestExecution{ID: 1}
+
+	state := &PersistenceState{StreamCompleted: false}
+
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		testRequest,
+		testRequestExec,
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+
+	return stream, client, ctx, state
+}
+
+// TestInboundPersistentStream_Close_WithCompleteResponse tests the NEW behavior:
+// complete response without terminal event (e.g., Codex executor that aggregates internally)
+func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
 	completeResponseChunk := &httpclient.StreamEvent{
 		Type: "chunk",
 		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
 	}
 
-	// Create mock stream with single complete response chunk (no [DONE] event)
 	mockStream := &mockStream{
 		events: []*httpclient.StreamEvent{completeResponseChunk},
 	}
 
-	// Create mock transformer that returns valid aggregated response
 	mockTransformer := &mockInboundTransformer{
 		aggregateResponseBody: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
 		aggregateMeta: llm.ResponseMeta{
@@ -137,80 +162,38 @@ func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
 		aggregateErr: nil,
 	}
 
-	// Create real request service
-	requestService := createTestRequestService(t, client)
+	stream, client, _, state := newInboundPersistentStreamHelper(t, mockStream, mockTransformer)
+	defer client.Close()
 
-	// Create test request and execution
-	testRequest := &ent.Request{
-		ID: 1,
-	}
-	testRequestExec := &ent.RequestExecution{
-		ID: 1,
-	}
-
-	// Create persistence state
-	state := &PersistenceState{
-		StreamCompleted: false,
-	}
-
-	// Create the InboundPersistentStream
-	stream := NewInboundPersistentStream(
-		ctx,
-		mockStream,
-		testRequest,
-		testRequestExec,
-		requestService,
-		mockTransformer,
-		nil,
-		state,
-	)
-
-	// Execute - Call Next() to process the chunk, then Close()
 	require.True(t, stream.Next(), "Expected Next() to return true")
 	event := stream.Current()
 	require.NotNil(t, event, "Expected current event to not be nil")
 
-	// Verify that StreamCompleted is still false (no terminal event yet)
 	assert.False(t, state.StreamCompleted, "StreamCompleted should be false before Close()")
 
-	// Call Close()
 	err := stream.Close()
 	require.NoError(t, err, "Close() should not return an error")
 
-	// Assert - Verify StreamCompleted is set to true
 	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after Close() with complete response")
-
-	// Verify stream is closed
 	assert.True(t, mockStream.closed, "Stream should be closed")
 }
 
 // TestInboundPersistentStream_Close_WithTerminalEvent tests the EXISTING behavior:
 // terminal event (e.g., [DONE] event from OpenAI)
 func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
-	// Setup
-	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
-	defer client.Close()
-
-	ctx := context.Background()
-	ctx = ent.NewContext(ctx, client)
-
-	// Create a regular response chunk
 	regularResponseChunk := &httpclient.StreamEvent{
 		Type: "chunk",
 		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`),
 	}
 
-	// Create the [DONE] terminal event
 	doneEvent := &httpclient.StreamEvent{
 		Data: []byte("[DONE]"),
 	}
 
-	// Create mock stream with response chunk followed by [DONE] event
 	mockStream := &mockStream{
 		events: []*httpclient.StreamEvent{regularResponseChunk, doneEvent},
 	}
 
-	// Create mock transformer
 	mockTransformer := &mockInboundTransformer{
 		aggregateResponseBody: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
 		aggregateMeta: llm.ResponseMeta{
@@ -224,35 +207,9 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 		aggregateErr: nil,
 	}
 
-	// Create real request service
-	requestService := createTestRequestService(t, client)
+	stream, client, _, state := newInboundPersistentStreamHelper(t, mockStream, mockTransformer)
+	defer client.Close()
 
-	// Create test request and execution
-	testRequest := &ent.Request{
-		ID: 1,
-	}
-	testRequestExec := &ent.RequestExecution{
-		ID: 1,
-	}
-
-	// Create persistence state
-	state := &PersistenceState{
-		StreamCompleted: false,
-	}
-
-	// Create the InboundPersistentStream
-	stream := NewInboundPersistentStream(
-		ctx,
-		mockStream,
-		testRequest,
-		testRequestExec,
-		requestService,
-		mockTransformer,
-		nil,
-		state,
-	)
-
-	// Execute - Process all events
 	require.True(t, stream.Next(), "Expected Next() to return true for first chunk")
 	_ = stream.Current()
 
@@ -260,90 +217,44 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 	event := stream.Current()
 	require.NotNil(t, event, "Expected current event to not be nil")
 
-	// Verify that StreamCompleted is set to true by the [DONE] event
 	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after [DONE] event")
 
-	// Call Close()
 	err := stream.Close()
 	require.NoError(t, err, "Close() should not return an error")
 
-	// Assert - Verify StreamCompleted is still true
 	assert.True(t, state.StreamCompleted, "StreamCompleted should remain true after Close()")
-
-	// Verify stream is closed
 	assert.True(t, mockStream.closed, "Stream should be closed")
 }
 
 // TestInboundPersistentStream_Close_WithAggregationError tests the error path:
-// aggregation fails but fallback behavior still works (persistResponseChunks called in final block)
+// aggregation fails but fallback behavior still works (persistResponseChunks called in final block).
 func TestInboundPersistentStream_Close_WithAggregationError(t *testing.T) {
-	// Setup
-	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
-	defer client.Close()
-
-	ctx := context.Background()
-	ctx = ent.NewContext(ctx, client)
-
-	// Create a regular response chunk
 	regularResponseChunk := &httpclient.StreamEvent{
 		Type: "chunk",
 		Data: []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`),
 	}
 
-	// Create mock stream with response chunk (no terminal event)
 	mockStream := &mockStream{
 		events: []*httpclient.StreamEvent{regularResponseChunk},
 	}
 
-	// Create mock transformer with aggregation error
 	mockTransformer := &mockInboundTransformer{
 		aggregateResponseBody: nil,
 		aggregateMeta:         llm.ResponseMeta{},
 		aggregateErr:          errors.New("aggregation failed"),
 	}
 
-	// Create real request service
-	requestService := createTestRequestService(t, client)
+	stream, client, _, state := newInboundPersistentStreamHelper(t, mockStream, mockTransformer)
+	defer client.Close()
 
-	// Create test request and execution
-	testRequest := &ent.Request{
-		ID: 1,
-	}
-	testRequestExec := &ent.RequestExecution{
-		ID: 1,
-	}
-
-	// Create persistence state
-	state := &PersistenceState{
-		StreamCompleted: false,
-	}
-
-	// Create the InboundPersistentStream
-	stream := NewInboundPersistentStream(
-		ctx,
-		mockStream,
-		testRequest,
-		testRequestExec,
-		requestService,
-		mockTransformer,
-		nil,
-		state,
-	)
-
-	// Execute - Process the chunk
 	require.True(t, stream.Next(), "Expected Next() to return true for first chunk")
 	_ = stream.Current()
 
-	// Verify that StreamCompleted is still false (no terminal event yet)
 	assert.False(t, state.StreamCompleted, "StreamCompleted should be false before Close()")
 
-	// Call Close()
 	err := stream.Close()
 	require.NoError(t, err, "Close() should not return an error")
 
-	// Assert - Verify StreamCompleted is still false (no terminal event received)
 	assert.False(t, state.StreamCompleted, "StreamCompleted should remain false after Close() with aggregation error")
-
-	// Verify stream is closed
 	assert.True(t, mockStream.closed, "Stream should be closed")
 }


### PR DESCRIPTION
## Summary

Fixes an issue where **Codex models (e.g., openai/gpt-5.2-codex) on NanoGPT channels get stuck in "processing" status** even though responses complete successfully.

## Root Cause

Codex models force `Stream=true` but aggregate responses internally, returning complete JSON **without terminal stream events** (like `[DONE]` or `response.completed`). The `InboundPersistentStream` only marked completion when terminal events were detected, so `UpdateRequestCompleted()` was never called.

## Changes

### `internal/server/orchestrator/inbound.go`
- Added detection logic in `Close()` method (lines 135-146) to handle complete responses without terminal events
- Sets `StreamCompleted=true` when valid aggregated response is detected
- Ensures `UpdateRequestCompleted()` is called for Codex + NanoGPT

### `internal/server/orchestrator/inbound_test.go` (new file)
- Added test for complete response without terminal event
- Added test for terminal event handling (existing behavior)
- Added test for aggregation error path

## Test Results

```
✅ TestInboundPersistentStream_Close_WithCompleteResponse - PASS
✅ TestInboundPersistentStream_Close_WithTerminalEvent - PASS
✅ TestInboundPersistentStream_Close_WithAggregationError - PASS
✅ All existing orchestrator tests - PASS
```

## Docker Image

```bash
docker pull registry.kipp.nz/d2dyno/axonhub:60e3d
```

## Checklist

- [x] Code follows project conventions
- [x] Tests added and passing
- [x] Code reviewed (self-review + tool review)
- [x] Docker image built and pushed
- [x] No breaking changes

Fixes: Codex models stuck in processing on NanoGPT channel