### PR TITLE
Fix AutoSyncModelPattern not being saved in channel updates

### DIFF
--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -537,12 +537,10 @@ func (svc *ChannelService) UpdateChannel(ctx context.Context, id int, input *ent
 		mut.ClearRemark()
 	}
 
-	if input.AutoSyncModelPattern != nil {
-		mut.SetAutoSyncModelPattern(*input.AutoSyncModelPattern)
-	}
-
 	if input.ClearAutoSyncModelPattern {
 		mut.ClearAutoSyncModelPattern()
+	} else if input.AutoSyncModelPattern != nil {
+		mut.SetAutoSyncModelPattern(*input.AutoSyncModelPattern)
 	}
 
 	if input.ClearErrorMessage {

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -537,6 +537,14 @@ func (svc *ChannelService) UpdateChannel(ctx context.Context, id int, input *ent
 		mut.ClearRemark()
 	}
 
+	if input.AutoSyncModelPattern != nil {
+		mut.SetAutoSyncModelPattern(*input.AutoSyncModelPattern)
+	}
+
+	if input.ClearAutoSyncModelPattern {
+		mut.ClearAutoSyncModelPattern()
+	}
+
 	if input.ClearErrorMessage {
 		mut.ClearErrorMessage()
 	}


### PR DESCRIPTION
The AutoSyncModelPattern field wasn't being handled during channel updates, which is why model filter rules weren't persisting. Added the set/clear logic to match how other optional fields are handled in UpdateChannel. Fixes #916.