### PR TITLE
fix(frontend): correct tokens per second calculation for cache hits

### DIFF
--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -41,9 +41,9 @@ export function calculateTokensPerSecond(request: Request): string {
     }
   }
 
-  // For cache hits (TTFT == Latency), use minimum 1ms to calculate T/s based on total time
+  // For cache hits (TTFT == Latency), use minimum 100ms to calculate T/s based on total time
   if (effectiveLatencyMs <= 0) {
-    effectiveLatencyMs = 1; // Minimum 1ms to show T/s for cache hits
+    effectiveLatencyMs = 100; // Minimum 100ms to show sane T/s for cache hits
   }
 
   const latencySeconds = effectiveLatencyMs / 1000;

--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -5,6 +5,11 @@ import { Request } from '../data/schema';
 
 export type DisplayMode = 'latency' | 'tokensPerSecond';
 
+// Minimum latency value (in milliseconds) used for tokens/second calculations
+// when a cache hit occurs (effective latency is zero or negative).
+// This ensures we display a reasonable tokens/second value instead of infinity.
+const MINIMUM_LATENCY_MS_FOR_CACHE_HITS = 100;
+
 const VALID_DISPLAY_MODES: DisplayMode[] = ['latency', 'tokensPerSecond'];
 
 /**
@@ -41,9 +46,10 @@ export function calculateTokensPerSecond(request: Request): string {
     }
   }
 
-  // For cache hits (TTFT == Latency), use minimum 100ms to calculate T/s based on total time
+  // For cache hits (TTFT == Latency), effective latency becomes 0 or negative.
+  // Use a fixed minimum to avoid division by zero and show reasonable tokens/second.
   if (effectiveLatencyMs <= 0) {
-    effectiveLatencyMs = 100; // Minimum 100ms to show sane T/s for cache hits
+    effectiveLatencyMs = MINIMUM_LATENCY_MS_FOR_CACHE_HITS;
   }
 
   const latencySeconds = effectiveLatencyMs / 1000;

--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -41,8 +41,9 @@ export function calculateTokensPerSecond(request: Request): string {
     }
   }
 
+  // For cache hits (TTFT == Latency), use minimum 1ms to calculate T/s based on total time
   if (effectiveLatencyMs <= 0) {
-    return '-';
+    effectiveLatencyMs = 1; // Minimum 1ms to show T/s for cache hits
   }
 
   const latencySeconds = effectiveLatencyMs / 1000;

--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -36,7 +36,7 @@ export function calculateTokensPerSecond(request: Request): string {
   // For non-streaming: use full latency
   let effectiveLatencyMs = request.metricsLatencyMs;
   if (request.stream && request.metricsFirstTokenLatencyMs != null) {
-    if (request.metricsFirstTokenLatencyMs < request.metricsLatencyMs) {
+    if (request.metricsFirstTokenLatencyMs <= request.metricsLatencyMs) {
       effectiveLatencyMs = request.metricsLatencyMs - request.metricsFirstTokenLatencyMs;
     }
   }


### PR DESCRIPTION
## Summary

This PR fixes the tokens per second (T/s) calculation for cache hit scenarios in the request metrics display.

## Problem

When a request results in a cache hit, the Time To First Token (TTFT) equals the total latency. This caused the effective latency calculation to be 0 or negative, resulting in either:
- A dash (`-`) being displayed instead of T/s
- Unrealistically high T/s values (millions of tokens/sec) when using a 1ms minimum

## Changes

1. **Fixed comparison operator**: Changed `<` to `<=` to properly handle the cache hit case where TTFT equals total latency

2. **Added minimum latency fallback**: Instead of showing `-` for cache hits, we now calculate T/s using a minimum latency value

3. **Increased minimum to 100ms**: Changed from 1ms to 100ms to show more realistic T/s values for cache hits (e.g., 1000 tokens now shows ~10,000 tok/s instead of 1,000,000 tok/s)

## Files Changed

- `frontend/src/features/requests/utils/tokens-per-second.ts`