### PR TITLE
feat(dashboard): add project-scoped dashboard with settings fallback

### DIFF
--- a/frontend/src/config/route-permission.ts
+++ b/frontend/src/config/route-permission.ts
@@ -72,6 +72,11 @@ export const routeConfigs: RouteGroup[] = [
     scopeLevel: 'any', // Project 路由组可以通过 system-level 或 project-level 权限访问
     routes: [
       {
+        path: '/project/dashboard',
+        requiredScopes: ['read_requests'],
+        mode: 'hidden',
+      },
+      {
         path: '/project/api-keys',
         requiredScopes: ['read_api_keys'],
         mode: 'hidden',

--- a/frontend/src/features/dashboard/components/daily-requests-stats.tsx
+++ b/frontend/src/features/dashboard/components/daily-requests-stats.tsx
@@ -7,11 +7,15 @@ import { formatNumber } from '@/utils/format-number';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGeneralSettings } from '../../system/data/system';
 import { useDailyRequestStats } from '../data/dashboard';
+import { useDashboardScope } from '../data/scope';
 
 export function DailyRequestStats() {
   const { t, i18n } = useTranslation();
+  const { projectScoped } = useDashboardScope();
   const { data: dailyStats, isLoading: isStatsLoading, error } = useDailyRequestStats();
-  const { data: generalSettings, isLoading: isSettingsLoading } = useGeneralSettings();
+  const { data: generalSettings, isLoading: isSettingsLoading } = useGeneralSettings({
+    gracefulFallback: projectScoped,
+  });
 
   const isLoading = isStatsLoading || isSettingsLoading;
 

--- a/frontend/src/features/dashboard/components/performance-chart.tsx
+++ b/frontend/src/features/dashboard/components/performance-chart.tsx
@@ -6,6 +6,7 @@ import { formatDuration } from '@/utils/format-duration';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useGeneralSettings } from '../../system/data/system';
+import { useDashboardScope } from '../data/scope';
 
 function groupBy<T>(array: T[], key: keyof T): Record<string, T[]> {
   return array.reduce((acc, item) => {
@@ -143,13 +144,15 @@ export function PerformanceChart({
   nameField,
 }: PerformanceChartProps) {
   const { t, i18n } = useTranslation();
-  const { data: generalSettings, isLoading: isSettingsLoading } = useGeneralSettings();
+  const { projectScoped } = useDashboardScope();
+  const { isLoading: isSettingsLoading } = useGeneralSettings({
+    gracefulFallback: projectScoped,
+  });
   const [activeSeries, setActiveSeries] = useState<string | null>(null);
   const [displayMode, setDisplayMode] = useState<PerformanceDisplayMode>('throughput');
 
   const isLoadingData = isLoading || isSettingsLoading;
 
-  const timezone = generalSettings?.timezone || 'UTC';
   const locale = i18n.language.startsWith('zh') ? 'zh-CN' : 'en-US';
 
   const memoizedSafeData = useMemo(() => data ?? [], [data]);

--- a/frontend/src/features/dashboard/data/dashboard.ts
+++ b/frontend/src/features/dashboard/data/dashboard.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@/gql/graphql';
+import { useDashboardScope } from './scope';
 
 // Schema definitions
 export const requestStatsSchema = z.object({
@@ -264,135 +265,235 @@ const TOKEN_STATS_AGGR_QUERY = `
   }
 `;
 
+function buildDashboardHeaders(scopeProjectID: string | null) {
+  return scopeProjectID ? { 'X-Project-ID': scopeProjectID } : undefined;
+}
+
 // Query hooks
 export function useDashboardStats() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['dashboardStats'],
+    queryKey: ['dashboardStats', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ dashboardOverview: DashboardStats }>(DASHBOARD_STATS_QUERY);
+      const data = await graphqlRequest<{ dashboardOverview: DashboardStats }>(
+        DASHBOARD_STATS_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return dashboardStatsSchema.parse(data.dashboardOverview);
     },
     refetchInterval: 30000, // Refetch every 30 seconds
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useRequestsByChannel() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['requestStatsByChannel'],
+    queryKey: ['requestStatsByChannel', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ requestStatsByChannel: RequestsByChannel[] }>(REQUESTS_BY_CHANNEL_QUERY);
+      const data = await graphqlRequest<{ requestStatsByChannel: RequestsByChannel[] }>(
+        REQUESTS_BY_CHANNEL_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.requestStatsByChannel.map((item) => requestsByChannelSchema.parse(item));
     },
     refetchInterval: 60000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useRequestsByModel() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['requestStatsByModel'],
+    queryKey: ['requestStatsByModel', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ requestStatsByModel: RequestsByModel[] }>(REQUESTS_BY_MODEL_QUERY);
+      const data = await graphqlRequest<{ requestStatsByModel: RequestsByModel[] }>(
+        REQUESTS_BY_MODEL_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.requestStatsByModel.map((item) => requestsByModelSchema.parse(item));
     },
     refetchInterval: 60000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useRequestsByAPIKey() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['requestStatsByAPIKey'],
+    queryKey: ['requestStatsByAPIKey', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ requestStatsByAPIKey: RequestsByAPIKey[] }>(REQUESTS_BY_API_KEY_QUERY);
+      const data = await graphqlRequest<{ requestStatsByAPIKey: RequestsByAPIKey[] }>(
+        REQUESTS_BY_API_KEY_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.requestStatsByAPIKey.map((item) => requestsByAPIKeySchema.parse(item));
     },
     refetchInterval: 60000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useTokensByAPIKey() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['tokenStatsByAPIKey'],
+    queryKey: ['tokenStatsByAPIKey', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ tokenStatsByAPIKey: TokensByAPIKey[] }>(TOKENS_BY_API_KEY_QUERY);
+      const data = await graphqlRequest<{ tokenStatsByAPIKey: TokensByAPIKey[] }>(
+        TOKENS_BY_API_KEY_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.tokenStatsByAPIKey.map((item) => tokensByAPIKeySchema.parse(item));
     },
     refetchInterval: 60000, // Auto-refresh every 60 seconds
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useDailyRequestStats() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['dailyRequestStats'],
+    queryKey: ['dailyRequestStats', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ dailyRequestStats: DailyRequestStats[] }>(DAILY_REQUEST_STATS_QUERY);
+      const data = await graphqlRequest<{ dailyRequestStats: DailyRequestStats[] }>(
+        DAILY_REQUEST_STATS_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.dailyRequestStats.map((item) => dailyRequestStatsSchema.parse(item));
     },
     refetchInterval: 300000, // Refetch every 5 minutes
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useHourlyRequestStats(date?: string) {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['hourlyRequestStats', date],
+    queryKey: ['hourlyRequestStats', date, scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ hourlyRequestStats: HourlyRequestStats[] }>(HOURLY_REQUEST_STATS_QUERY, { date });
+      const data = await graphqlRequest<{ hourlyRequestStats: HourlyRequestStats[] }>(
+        HOURLY_REQUEST_STATS_QUERY,
+        { date },
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.hourlyRequestStats.map((item) => hourlyRequestStatsSchema.parse(item));
     },
     refetchInterval: 300000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useTopProjects() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['topRequestsProjects'],
+    queryKey: ['topRequestsProjects', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ topRequestsProjects: TopProjects[] }>(TOP_PROJECTS_QUERY);
+      const data = await graphqlRequest<{ topRequestsProjects: TopProjects[] }>(
+        TOP_PROJECTS_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.topRequestsProjects.map((item) => topProjectsSchema.parse(item));
     },
     refetchInterval: 300000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useTokenStats() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['tokenStats'],
+    queryKey: ['tokenStats', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ tokenStats: TokenStats }>(TOKEN_STATS_AGGR_QUERY);
+      const data = await graphqlRequest<{ tokenStats: TokenStats }>(
+        TOKEN_STATS_AGGR_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return tokenStatsSchema.parse(data.tokenStats);
     },
     refetchInterval: 300000, // Refetch every 5 minutes
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useChannelSuccessRates() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['channelSuccessRates'],
+    queryKey: ['channelSuccessRates', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ channelSuccessRates: ChannelSuccessRate[] }>(CHANNEL_SUCCESS_RATES_QUERY);
+      const data = await graphqlRequest<{ channelSuccessRates: ChannelSuccessRate[] }>(
+        CHANNEL_SUCCESS_RATES_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.channelSuccessRates.map((item) => channelSuccessRateSchema.parse(item));
     },
     refetchInterval: 300000,
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useModelPerformanceStats() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['modelPerformanceStats'],
+    queryKey: ['modelPerformanceStats', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ modelPerformanceStats: ModelPerformanceStat[] }>(MODEL_PERFORMANCE_STATS_QUERY);
+      const data = await graphqlRequest<{ modelPerformanceStats: ModelPerformanceStat[] }>(
+        MODEL_PERFORMANCE_STATS_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.modelPerformanceStats.map((item) => modelPerformanceStatSchema.parse(item));
     },
     refetchInterval: 300000, // Refetch every 5 minutes
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useChannelPerformanceStats() {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['channelPerformanceStats'],
+    queryKey: ['channelPerformanceStats', scopeProjectID],
     queryFn: async () => {
-      const data = await graphqlRequest<{ channelPerformanceStats: ChannelPerformanceStat[] }>(CHANNEL_PERFORMANCE_STATS_QUERY);
+      const data = await graphqlRequest<{ channelPerformanceStats: ChannelPerformanceStat[] }>(
+        CHANNEL_PERFORMANCE_STATS_QUERY,
+        undefined,
+        buildDashboardHeaders(scopeProjectID)
+      );
       return data.channelPerformanceStats.map((item) => channelPerformanceStatSchema.parse(item));
     },
     refetchInterval: 300000, // Refetch every 5 minutes
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }

--- a/frontend/src/features/dashboard/data/fastest-performers.ts
+++ b/frontend/src/features/dashboard/data/fastest-performers.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@/gql/graphql';
+import { useDashboardScope } from './scope';
 
 // Refetch interval constant (30 seconds)
 const REFETCH_INTERVAL_MS = 30000;
@@ -63,34 +64,47 @@ const FASTEST_MODELS_QUERY = `
   }
 `;
 
+function buildDashboardHeaders(scopeProjectID: string | null) {
+  return scopeProjectID ? { 'X-Project-ID': scopeProjectID } : undefined;
+}
+
 // Query hooks
 export function useFastestChannels(timeWindow: string = 'day', limit: number = 5) {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['fastestChannels', timeWindow, limit],
+    queryKey: ['fastestChannels', timeWindow, limit, scopeProjectID],
     queryFn: async () => {
       const data = await graphqlRequest<{ fastestChannels: FastestChannel[] }>(
         FASTEST_CHANNELS_QUERY,
-        { input: { timeWindow, limit } }
+        { input: { timeWindow, limit } },
+        buildDashboardHeaders(scopeProjectID)
       );
       return data.fastestChannels.map((item) => fastestChannelSchema.parse(item));
     },
     refetchInterval: REFETCH_INTERVAL_MS,
     placeholderData: (previousData) => previousData, // Keep previous data while fetching to prevent flash
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
 
 export function useFastestModels(timeWindow: string = 'day', limit: number = 5) {
+  const { projectScoped, selectedProjectId } = useDashboardScope();
+  const scopeProjectID = projectScoped ? selectedProjectId : null;
+
   return useQuery({
-    queryKey: ['fastestModels', timeWindow, limit],
+    queryKey: ['fastestModels', timeWindow, limit, scopeProjectID],
     queryFn: async () => {
       const data = await graphqlRequest<{ fastestModels: FastestModel[] }>(
         FASTEST_MODELS_QUERY,
-        { input: { timeWindow, limit } }
+        { input: { timeWindow, limit } },
+        buildDashboardHeaders(scopeProjectID)
       );
       return data.fastestModels.map((item) => fastestModelSchema.parse(item));
     },
     refetchInterval: REFETCH_INTERVAL_MS,
     placeholderData: (previousData) => previousData, // Keep previous data while fetching to prevent flash
+    enabled: !projectScoped || !!scopeProjectID,
   });
 }
-

--- a/frontend/src/features/dashboard/data/scope.tsx
+++ b/frontend/src/features/dashboard/data/scope.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react';
+import { useSelectedProjectId } from '@/stores/projectStore';
+
+interface DashboardScopeContextValue {
+  projectScoped: boolean;
+}
+
+const DashboardScopeContext = createContext<DashboardScopeContextValue>({
+  projectScoped: false,
+});
+
+interface DashboardScopeProviderProps {
+  projectScoped: boolean;
+  children: React.ReactNode;
+}
+
+export function DashboardScopeProvider({ projectScoped, children }: DashboardScopeProviderProps) {
+  return <DashboardScopeContext.Provider value={{ projectScoped }}>{children}</DashboardScopeContext.Provider>;
+}
+
+export function useDashboardScope() {
+  const { projectScoped } = useContext(DashboardScopeContext);
+  const selectedProjectId = useSelectedProjectId();
+
+  const scopedHeaders = projectScoped && selectedProjectId ? { 'X-Project-ID': selectedProjectId } : undefined;
+
+  return {
+    projectScoped,
+    selectedProjectId,
+    scopedHeaders,
+  };
+}

--- a/frontend/src/features/dashboard/index.tsx
+++ b/frontend/src/features/dashboard/index.tsx
@@ -21,6 +21,7 @@ import { FastestModelsCard } from './components/fastest-models-card';
 import { ModelPerformanceStats } from './components/model-performance-stats';
 import { ChannelPerformanceStats } from './components/channel-performance-stats';
 import { useDashboardStats } from './data/dashboard';
+import { DashboardScopeProvider } from './data/scope';
 
 interface CollapsibleSectionProps {
   title: string;
@@ -85,7 +86,7 @@ function CollapsibleSection({ title, icon, children, storageKey, defaultOpen = f
   );
 }
 
-export default function DashboardPage() {
+function DashboardPageContent() {
   const { t } = useTranslation();
   const { isLoading, error } = useDashboardStats();
   const [modelTotalRequests, setModelTotalRequests] = useState(0);
@@ -257,5 +258,21 @@ export default function DashboardPage() {
         </div>
       </CollapsibleSection>
     </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <DashboardScopeProvider projectScoped={false}>
+      <DashboardPageContent />
+    </DashboardScopeProvider>
+  );
+}
+
+export function ProjectDashboardPage() {
+  return (
+    <DashboardScopeProvider projectScoped={true}>
+      <DashboardPageContent />
+    </DashboardScopeProvider>
   );
 }

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -42,7 +42,7 @@ export default function RequestDetailPage() {
   const [curlCommand, setCurlCommand] = useState('');
   const [isDownloadingVideo, setIsDownloadingVideo] = useState(false);
 
-  const { data: settings } = useGeneralSettings();
+  const { data: settings } = useGeneralSettings({ gracefulFallback: true });
   const { data: request, isLoading } = useRequest(requestId);
   const { data: executions } = useRequestExecutions(requestId, {
     first: 10,

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -24,7 +24,7 @@ export function useRequestsColumns(): ColumnDef<Request>[] {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'zh' ? zhCN : enUS;
   const permissions = useRequestPermissions();
-  const { data: settings } = useGeneralSettings();
+  const { data: settings } = useGeneralSettings({ gracefulFallback: true });
   const { navigateWithSearch } = usePaginationSearch({ defaultPageSize: 20 });
   const [displayMode, setDisplayMode] = useDisplayMode();
 

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -149,9 +149,18 @@ export interface SystemGeneralSettings {
   timezone: string;
 }
 
+export const DEFAULT_SYSTEM_GENERAL_SETTINGS: SystemGeneralSettings = {
+  currencyCode: 'USD',
+  timezone: 'UTC',
+};
+
 export interface UpdateSystemGeneralSettingsInput {
   currencyCode?: string;
   timezone?: string;
+}
+
+interface UseGeneralSettingsOptions {
+  gracefulFallback?: boolean;
 }
 
 export interface VideoStorageSettings {
@@ -689,20 +698,34 @@ export function useUpdateChannelSetting() {
   });
 }
 
-export function useGeneralSettings() {
+function shouldFallbackGeneralSettings(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /(default deny|deny rule|permission denied|read_settings)/i.test(error.message);
+}
+
+export function useGeneralSettings(options: UseGeneralSettingsOptions = {}) {
   const { handleError } = useErrorHandler();
+  const { gracefulFallback = false } = options;
 
   return useQuery({
-    queryKey: ['generalSettings'],
+    queryKey: ['generalSettings', gracefulFallback ? 'graceful' : 'strict'],
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ systemGeneralSettings: SystemGeneralSettings }>(SYSTEM_GENERAL_SETTINGS_QUERY);
         return data.systemGeneralSettings;
       } catch (error) {
+        if (gracefulFallback && shouldFallbackGeneralSettings(error)) {
+          return DEFAULT_SYSTEM_GENERAL_SETTINGS;
+        }
+
         handleError(error, i18n.t('common.errors.internalServerError'));
         throw error;
       }
     },
+    placeholderData: gracefulFallback ? DEFAULT_SYSTEM_GENERAL_SETTINGS : undefined,
   });
 }
 

--- a/frontend/src/features/threads/components/thread-detail-page.tsx
+++ b/frontend/src/features/threads/components/thread-detail-page.tsx
@@ -35,7 +35,7 @@ export default function ThreadDetailPage() {
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  const { data: settings } = useGeneralSettings();
+  const { data: settings } = useGeneralSettings({ gracefulFallback: true });
 
   const { pageSize, setCursors, paginationArgs, getSearchParams } = usePaginationSearch({
     defaultPageSize: 20,

--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -31,7 +31,7 @@ export default function TraceDetailPage() {
   const { getSearchParams } = usePaginationSearch({ defaultPageSize: 20 });
 
   const { data: trace, isLoading, refetch } = useTraceWithSegments(traceId);
-  const { data: settings } = useGeneralSettings();
+  const { data: settings } = useGeneralSettings({ gracefulFallback: true });
 
   // Parse rawRootSegment JSON once per trace
   // 仅解析 rawRootSegment（完整 JSON）

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -45,6 +45,7 @@ import { Route as AuthenticatedProjectRolesIndexRouteImport } from './routes/_au
 import { Route as AuthenticatedProjectRequestsIndexRouteImport } from './routes/_authenticated/project/requests/index'
 import { Route as AuthenticatedProjectPromptsIndexRouteImport } from './routes/_authenticated/project/prompts/index'
 import { Route as AuthenticatedProjectPlaygroundIndexRouteImport } from './routes/_authenticated/project/playground/index'
+import { Route as AuthenticatedProjectDashboardIndexRouteImport } from './routes/_authenticated/project/dashboard/index'
 import { Route as AuthenticatedProjectApiKeysIndexRouteImport } from './routes/_authenticated/project/api-keys/index'
 import { Route as AuthenticatedProjectTracesTraceIdRouteImport } from './routes/_authenticated/project/traces/$traceId'
 import { Route as AuthenticatedProjectThreadsThreadIdRouteImport } from './routes/_authenticated/project/threads/$threadId'
@@ -250,6 +251,12 @@ const AuthenticatedProjectPlaygroundIndexRoute =
     path: '/project/playground/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedProjectDashboardIndexRoute =
+  AuthenticatedProjectDashboardIndexRouteImport.update({
+    id: '/project/dashboard/',
+    path: '/project/dashboard/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedProjectApiKeysIndexRoute =
   AuthenticatedProjectApiKeysIndexRouteImport.update({
     id: '/project/api-keys/',
@@ -308,6 +315,7 @@ export interface FileRoutesByFullPath {
   '/project/threads/$threadId': typeof AuthenticatedProjectThreadsThreadIdRoute
   '/project/traces/$traceId': typeof AuthenticatedProjectTracesTraceIdRoute
   '/project/api-keys': typeof AuthenticatedProjectApiKeysIndexRoute
+  '/project/dashboard': typeof AuthenticatedProjectDashboardIndexRoute
   '/project/playground': typeof AuthenticatedProjectPlaygroundIndexRoute
   '/project/prompts': typeof AuthenticatedProjectPromptsIndexRoute
   '/project/requests': typeof AuthenticatedProjectRequestsIndexRoute
@@ -348,6 +356,7 @@ export interface FileRoutesByTo {
   '/project/threads/$threadId': typeof AuthenticatedProjectThreadsThreadIdRoute
   '/project/traces/$traceId': typeof AuthenticatedProjectTracesTraceIdRoute
   '/project/api-keys': typeof AuthenticatedProjectApiKeysIndexRoute
+  '/project/dashboard': typeof AuthenticatedProjectDashboardIndexRoute
   '/project/playground': typeof AuthenticatedProjectPlaygroundIndexRoute
   '/project/prompts': typeof AuthenticatedProjectPromptsIndexRoute
   '/project/requests': typeof AuthenticatedProjectRequestsIndexRoute
@@ -391,6 +400,7 @@ export interface FileRoutesById {
   '/_authenticated/project/threads/$threadId': typeof AuthenticatedProjectThreadsThreadIdRoute
   '/_authenticated/project/traces/$traceId': typeof AuthenticatedProjectTracesTraceIdRoute
   '/_authenticated/project/api-keys/': typeof AuthenticatedProjectApiKeysIndexRoute
+  '/_authenticated/project/dashboard/': typeof AuthenticatedProjectDashboardIndexRoute
   '/_authenticated/project/playground/': typeof AuthenticatedProjectPlaygroundIndexRoute
   '/_authenticated/project/prompts/': typeof AuthenticatedProjectPromptsIndexRoute
   '/_authenticated/project/requests/': typeof AuthenticatedProjectRequestsIndexRoute
@@ -434,6 +444,7 @@ export interface FileRouteTypes {
     | '/project/threads/$threadId'
     | '/project/traces/$traceId'
     | '/project/api-keys'
+    | '/project/dashboard'
     | '/project/playground'
     | '/project/prompts'
     | '/project/requests'
@@ -474,6 +485,7 @@ export interface FileRouteTypes {
     | '/project/threads/$threadId'
     | '/project/traces/$traceId'
     | '/project/api-keys'
+    | '/project/dashboard'
     | '/project/playground'
     | '/project/prompts'
     | '/project/requests'
@@ -516,6 +528,7 @@ export interface FileRouteTypes {
     | '/_authenticated/project/threads/$threadId'
     | '/_authenticated/project/traces/$traceId'
     | '/_authenticated/project/api-keys/'
+    | '/_authenticated/project/dashboard/'
     | '/_authenticated/project/playground/'
     | '/_authenticated/project/prompts/'
     | '/_authenticated/project/requests/'
@@ -792,6 +805,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectPlaygroundIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/project/dashboard/': {
+      id: '/_authenticated/project/dashboard/'
+      path: '/project/dashboard'
+      fullPath: '/project/dashboard'
+      preLoaderRoute: typeof AuthenticatedProjectDashboardIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/project/api-keys/': {
       id: '/_authenticated/project/api-keys/'
       path: '/project/api-keys'
@@ -865,6 +885,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedProjectThreadsThreadIdRoute: typeof AuthenticatedProjectThreadsThreadIdRoute
   AuthenticatedProjectTracesTraceIdRoute: typeof AuthenticatedProjectTracesTraceIdRoute
   AuthenticatedProjectApiKeysIndexRoute: typeof AuthenticatedProjectApiKeysIndexRoute
+  AuthenticatedProjectDashboardIndexRoute: typeof AuthenticatedProjectDashboardIndexRoute
   AuthenticatedProjectPlaygroundIndexRoute: typeof AuthenticatedProjectPlaygroundIndexRoute
   AuthenticatedProjectPromptsIndexRoute: typeof AuthenticatedProjectPromptsIndexRoute
   AuthenticatedProjectRequestsIndexRoute: typeof AuthenticatedProjectRequestsIndexRoute
@@ -896,6 +917,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedProjectTracesTraceIdRoute:
     AuthenticatedProjectTracesTraceIdRoute,
   AuthenticatedProjectApiKeysIndexRoute: AuthenticatedProjectApiKeysIndexRoute,
+  AuthenticatedProjectDashboardIndexRoute:
+    AuthenticatedProjectDashboardIndexRoute,
   AuthenticatedProjectPlaygroundIndexRoute:
     AuthenticatedProjectPlaygroundIndexRoute,
   AuthenticatedProjectPromptsIndexRoute: AuthenticatedProjectPromptsIndexRoute,

--- a/frontend/src/routes/_authenticated/project/dashboard/index.tsx
+++ b/frontend/src/routes/_authenticated/project/dashboard/index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { ProjectGuard } from '@/components/project-guard';
+import { RouteGuard } from '@/components/route-guard';
+import { ProjectDashboardPage } from '@/features/dashboard';
+
+function ProtectedProjectDashboard() {
+  return (
+    <ProjectGuard>
+      <RouteGuard requiredScopes={['read_requests']}>
+        <ProjectDashboardPage />
+      </RouteGuard>
+    </ProjectGuard>
+  );
+}
+
+export const Route = createFileRoute('/_authenticated/project/dashboard/')({
+  component: ProtectedProjectDashboard,
+});

--- a/frontend/src/sidebar.ts
+++ b/frontend/src/sidebar.ts
@@ -109,6 +109,11 @@ export function useSidebarData(): SidebarData {
       title: t('sidebar.groups.project'),
       items: [
         {
+          title: t('sidebar.items.dashboard'),
+          url: '/project/dashboard',
+          icon: IconLayoutDashboard,
+        } as NavLink,
+        {
           title: t('sidebar.items.apiKeys'),
           url: '/project/api-keys',
           icon: IconKey,

--- a/internal/server/gql/channel_performance_helpers.go
+++ b/internal/server/gql/channel_performance_helpers.go
@@ -9,6 +9,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/samber/lo"
 
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/channelprobe"
 	"github.com/looplj/axonhub/internal/log"
@@ -134,10 +136,12 @@ func (r *queryResolver) fetchChannelNames(ctx context.Context, channelIDs []int)
 		return channelNames
 	}
 
-	queriedChannels, err := r.client.Channel.Query().
-		Where(channel.IDIn(channelIDs...)).
-		Select(channel.FieldID, channel.FieldName).
-		All(ctx)
+	queriedChannels, err := authz.RunWithSystemBypass(ctx, "dashboard-channel-names", func(bypassCtx context.Context) ([]*ent.Channel, error) {
+		return r.client.Channel.Query().
+			Where(channel.IDIn(channelIDs...)).
+			Select(channel.FieldID, channel.FieldName).
+			All(bypassCtx)
+	})
 	if err != nil {
 		log.Error(ctx, "failed to query channel names for performance stats",
 			log.Any("channelIDs", channelIDs),
@@ -198,7 +202,13 @@ func buildChannelPerformanceResponse(
 	return response
 }
 
-func (r *queryResolver) buildChannelPerformanceStatsFromExecutions(ctx context.Context, startDateLocal time.Time, offsetSeconds int, daysCount int) ([]*ChannelPerformanceStat, error) {
+func (r *queryResolver) buildChannelPerformanceStatsFromExecutions(
+	ctx context.Context,
+	startDateLocal time.Time,
+	offsetSeconds int,
+	daysCount int,
+	projectID *int,
+) ([]*ChannelPerformanceStat, error) {
 	dbDriver := r.client.Driver()
 	sqlDB, ok := dbDriver.(*sql.Driver)
 	if !ok {
@@ -213,25 +223,44 @@ func (r *queryResolver) buildChannelPerformanceStatsFromExecutions(ctx context.C
 		placeholder = "$1"
 	}
 
+	projectIDPlaceholder := ""
+	if projectID != nil {
+		if useDollarPlaceholders {
+			projectIDPlaceholder = "$2"
+		} else {
+			projectIDPlaceholder = "?"
+		}
+	}
+
 	queryMode := qb.ThroughputModeRowNumber
 	if !useDollarPlaceholders {
 		queryMode = qb.ThroughputModeMaxID
 	}
 
-	query := qb.BuildDailyPerformanceStatsQuery(
+	query := qb.BuildDailyPerformanceStatsQueryWithProjectFilter(
 		dialectName,
 		r.systemService.TimeLocation(ctx).String(),
 		offsetSeconds,
 		qb.DailyThroughputByChannel,
 		placeholder,
 		queryMode,
+		projectIDPlaceholder,
 	)
 
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}
 
-	rows, err := sqlDB.DB().QueryContext(ctx, query, startDateLocal.UTC())
+	queryArgs := []any{startDateLocal.UTC()}
+	if projectID != nil {
+		if queryMode == qb.ThroughputModeMaxID {
+			queryArgs = append(queryArgs, *projectID, *projectID)
+		} else {
+			queryArgs = append(queryArgs, *projectID)
+		}
+	}
+
+	rows, err := sqlDB.DB().QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query channel performance stats from executions: %w", err)
 	}
@@ -315,22 +344,7 @@ func (r *queryResolver) buildChannelPerformanceStatsFromExecutions(ctx context.C
 		validChannelIDs = append(validChannelIDs, chID)
 	}
 
-	channelNames := make(map[int]string)
-	if len(validChannelIDs) > 0 {
-		queriedChannels, err := r.client.Channel.Query().
-			Where(channel.IDIn(validChannelIDs...)).
-			Select(channel.FieldID, channel.FieldName).
-			All(ctx)
-		if err != nil {
-			log.Error(ctx, "failed to query channel names for performance stats",
-				log.Any("channelIDs", validChannelIDs),
-				log.Cause(err))
-		} else {
-			for _, ch := range queriedChannels {
-				channelNames[ch.ID] = ch.Name
-			}
-		}
-	}
+	channelNames := r.fetchChannelNames(ctx, validChannelIDs)
 
 	response := make([]*ChannelPerformanceStat, 0)
 	for i := range daysCount {

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
 	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/channel"
@@ -30,11 +31,56 @@ import (
 	"github.com/samber/lo"
 )
 
+func (r *queryResolver) resolveDashboardContext(ctx context.Context) (context.Context, *int) {
+	projectID, hasProjectID := contexts.GetProjectID(ctx)
+	if hasProjectID {
+		return ctx, &projectID
+	}
+
+	return authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard), nil
+}
+
+func (r *queryResolver) ensureProjectDashboardAccess(ctx context.Context, projectID *int) error {
+	if projectID == nil {
+		return nil
+	}
+
+	_, err := r.client.Request.Query().
+		Where(request.IDLT(0)).
+		Count(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to authorize project dashboard access: %w", err)
+	}
+
+	return nil
+}
+
+func buildThroughputQueryArgs(mode qb.ThroughputQueryMode, since time.Time, projectID *int) []any {
+	sinceUTC := since.UTC()
+
+	if mode == qb.ThroughputModeMaxID {
+		if projectID != nil {
+			// Placeholder order in MAX_ID mode (SQLite/MySQL) is:
+			// outer since, outer project, subquery since, subquery project.
+			return []any{sinceUTC, *projectID, sinceUTC, *projectID}
+		}
+
+		// MAX_ID mode references the since timestamp in both outer and subquery WHERE clauses.
+		return []any{sinceUTC, sinceUTC}
+	}
+
+	if projectID != nil {
+		return []any{sinceUTC, *projectID}
+	}
+
+	return []any{sinceUTC}
+}
+
 // DashboardOverview is the resolver for the dashboardOverview field.
 // Note: This resolver provides high-level dashboard metrics.
 // For detailed request statistics, see RequestStats resolver documentation.
 func (r *queryResolver) DashboardOverview(ctx context.Context) (*DashboardOverview, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	// Initialize response with defaults to handle partial failures gracefully
 	stats := &DashboardOverview{
@@ -87,7 +133,7 @@ func (r *queryResolver) DashboardOverview(ctx context.Context) (*DashboardOvervi
 // For process tracking (e.g., failed requests), use request/request_execution tables.
 // For channel-level statistics, use request_execution table.
 func (r *queryResolver) RequestStats(ctx context.Context) (*RequestStats, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	// Initialize response with defaults to handle partial failures gracefully
 	stats := &RequestStats{
@@ -139,7 +185,7 @@ func (r *queryResolver) RequestStats(ctx context.Context) (*RequestStats, error)
 // Note: Uses usage_logs table for result-only statistics aggregated by channel.
 // For channel-level process tracking (e.g., success/failure rates), use request_execution table.
 func (r *queryResolver) RequestStatsByChannel(ctx context.Context) ([]*RequestStatsByChannel, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	// Use efficient aggregation query with JOIN to get channel details and filter out deleted channels
 	type channelStats struct {
@@ -191,7 +237,7 @@ func (r *queryResolver) RequestStatsByChannel(ctx context.Context) ([]*RequestSt
 // Note: Uses usage_logs table for result-only statistics aggregated by model.
 // This provides successful request counts per model.
 func (r *queryResolver) RequestStatsByModel(ctx context.Context) ([]*RequestStatsByModel, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	type modelStats struct {
 		ModelID string `json:"model_id"`
@@ -231,7 +277,7 @@ func (r *queryResolver) RequestStatsByModel(ctx context.Context) ([]*RequestStat
 // Note: Uses usage_logs table for result-only statistics aggregated by API key.
 // This provides successful request counts per API key.
 func (r *queryResolver) RequestStatsByAPIKey(ctx context.Context) ([]*RequestStatsByAPIKey, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	type apiKeyStats struct {
 		APIKeyID int `json:"api_key_id"`
@@ -268,10 +314,12 @@ func (r *queryResolver) RequestStatsByAPIKey(ctx context.Context) ([]*RequestSta
 		return item.APIKeyID
 	})
 
-	// Fetch API key details
-	apiKeys, err := r.client.APIKey.Query().
-		Where(apikey.IDIn(apiKeyIDs...)).
-		All(ctx)
+	// Fetch API key details with system bypass so dashboard visibility only depends on request access.
+	apiKeys, err := authz.RunWithSystemBypass(ctx, "dashboard-api-key-details", func(bypassCtx context.Context) ([]*ent.APIKey, error) {
+		return r.client.APIKey.Query().
+			Where(apikey.IDIn(apiKeyIDs...)).
+			All(bypassCtx)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API keys: %w", err)
 	}
@@ -301,7 +349,7 @@ func (r *queryResolver) RequestStatsByAPIKey(ctx context.Context) ([]*RequestSta
 // Note: Uses usage_logs table for token consumption statistics aggregated by API key.
 // This provides actual token usage (input, output, cached, reasoning) per API key.
 func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context) ([]*TokenStatsByAPIKey, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	type tokenStats struct {
 		APIKeyID        int   `json:"api_key_id"`
@@ -366,10 +414,12 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context) ([]*TokenStatsBy
 		return item.APIKeyID
 	})
 
-	// Fetch API key details
-	apiKeys, err := r.client.APIKey.Query().
-		Where(apikey.IDIn(apiKeyIDs...)).
-		All(ctx)
+	// Fetch API key details with system bypass so dashboard visibility only depends on request access.
+	apiKeys, err := authz.RunWithSystemBypass(ctx, "dashboard-api-key-details", func(bypassCtx context.Context) ([]*ent.APIKey, error) {
+		return r.client.APIKey.Query().
+			Where(apikey.IDIn(apiKeyIDs...)).
+			All(bypassCtx)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API keys: %w", err)
 	}
@@ -406,7 +456,7 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context) ([]*TokenStatsBy
 // Note: Uses usage_logs table for daily aggregated statistics (count, tokens, cost).
 // Provides result-only daily metrics for the last 30 days.
 func (r *queryResolver) DailyRequestStats(ctx context.Context) ([]*DailyRequestStats, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	daysCount := 30
 
@@ -503,7 +553,7 @@ func (r *queryResolver) DailyRequestStats(ctx context.Context) ([]*DailyRequestS
 // Note: Uses usage_logs table for project-level request statistics.
 // Provides result-only request counts per project.
 func (r *queryResolver) TopRequestsProjects(ctx context.Context) ([]*TopRequestsProjects, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	limitCount := 10
 
@@ -539,9 +589,11 @@ func (r *queryResolver) TopRequestsProjects(ctx context.Context) ([]*TopRequests
 		return item.ProjectID
 	})
 
-	projects, err := r.client.Project.Query().
-		Where(project.IDIn(projectIDs...)).
-		All(ctx)
+	projects, err := authz.RunWithSystemBypass(ctx, "dashboard-project-details", func(bypassCtx context.Context) ([]*ent.Project, error) {
+		return r.client.Project.Query().
+			Where(project.IDIn(projectIDs...)).
+			All(bypassCtx)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project details: %w", err)
 	}
@@ -571,7 +623,7 @@ func (r *queryResolver) TopRequestsProjects(ctx context.Context) ([]*TopRequests
 // Note: Uses usage_logs table for token consumption statistics (today, this week, this month).
 // Provides result-only token metrics aggregated by calendar periods.
 func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, _ = r.resolveDashboardContext(ctx)
 
 	// Initialize response with defaults to handle partial failures gracefully
 	stats := &TokenStats{
@@ -655,7 +707,10 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 // This provides success/failure rates per channel, suitable for monitoring channel health.
 // For result-only channel statistics, use RequestStatsByChannel instead.
 func (r *queryResolver) ChannelSuccessRates(ctx context.Context) ([]*ChannelSuccessRate, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, projectID := r.resolveDashboardContext(ctx)
+	if err := r.ensureProjectDashboardAccess(ctx, projectID); err != nil {
+		return nil, err
+	}
 
 	limitCount := 5
 
@@ -674,9 +729,14 @@ func (r *queryResolver) ChannelSuccessRates(ctx context.Context) ([]*ChannelSucc
 				requestexecution.FieldChannelID,
 				sql.As("SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END)", "success_count"),
 				sql.As("SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)", "failed_count"),
-			).
-				Where(sql.NotNull(requestexecution.FieldChannelID)).
-				GroupBy(requestexecution.FieldChannelID)
+			)
+
+			s.Where(sql.NotNull(s.C(requestexecution.FieldChannelID)))
+			if projectID != nil {
+				s.Where(sql.EQ(s.C(requestexecution.FieldProjectID), *projectID))
+			}
+
+			s.GroupBy(requestexecution.FieldChannelID)
 		}).
 		Scan(ctx, &results)
 	if err != nil {
@@ -724,11 +784,13 @@ func (r *queryResolver) ChannelSuccessRates(ctx context.Context) ([]*ChannelSucc
 		return item.ChannelID.ID
 	})
 
-	ctx = schematype.SkipSoftDelete(ctx)
+	channels, err := authz.RunWithSystemBypass(ctx, "dashboard-channel-details", func(bypassCtx context.Context) ([]*ent.Channel, error) {
+		bypassCtx = schematype.SkipSoftDelete(bypassCtx)
 
-	channels, err := r.client.Channel.Query().
-		Where(channel.IDIn(channelIDs...)).
-		All(ctx)
+		return r.client.Channel.Query().
+			Where(channel.IDIn(channelIDs...)).
+			All(bypassCtx)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get channel details: %w", err)
 	}
@@ -752,7 +814,10 @@ func (r *queryResolver) ChannelSuccessRates(ctx context.Context) ([]*ChannelSucc
 // Returns the fastest channels by throughput (tokens per second) based on completed request executions.
 // Groups by channel_id and calculates throughput from usage_log.completion_tokens and request_execution.metrics_latency_ms.
 func (r *queryResolver) FastestChannels(ctx context.Context, input FastestChannelsInput) ([]*FastestChannel, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, projectID := r.resolveDashboardContext(ctx)
+	if err := r.ensureProjectDashboardAccess(ctx, projectID); err != nil {
+		return nil, err
+	}
 
 	// Validate and set default limit
 	if input.Limit == nil || *input.Limit <= 0 {
@@ -811,11 +876,21 @@ func (r *queryResolver) FastestChannels(ctx context.Context, input FastestChanne
 	// Build query using shared helper function
 	// Fetch more items than needed to allow confidence-based filtering
 	sqlLimit := max(*input.Limit*4, 20)
-	query := qb.BuildThroughputQuery(
+	projectIDPlaceholder := ""
+	if projectID != nil {
+		if useDollarPlaceholders {
+			projectIDPlaceholder = "$2"
+		} else {
+			projectIDPlaceholder = "?"
+		}
+	}
+
+	query := qb.BuildThroughputQueryWithProjectFilter(
 		useDollarPlaceholders,
 		qb.ThroughputQueryByChannel,
 		sqlLimit,
 		queryMode,
+		projectIDPlaceholder,
 	)
 
 	// Use UTC for the time parameter to match the timezone of the created_at column.
@@ -823,14 +898,7 @@ func (r *queryResolver) FastestChannels(ctx context.Context, input FastestChanne
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}
-	// MaxID mode requires the timestamp twice (outer WHERE and subquery WHERE)
-	// ROW_NUMBER mode only needs it once (in the CTE)
-	var queryArgs []any
-	if queryMode == qb.ThroughputModeMaxID {
-		queryArgs = []any{since.UTC(), since.UTC()}
-	} else {
-		queryArgs = []any{since.UTC()}
-	}
+	queryArgs := buildThroughputQueryArgs(queryMode, since, projectID)
 
 	rows, err := sqlDB.DB().QueryContext(ctx, query, queryArgs...)
 	if err != nil {
@@ -892,7 +960,10 @@ func (r *queryResolver) FastestChannels(ctx context.Context, input FastestChanne
 // Returns the fastest models by throughput (tokens per second) based on completed request executions.
 // Groups by request.model_id (AxonHub model) and calculates throughput from usage_log.completion_tokens and request_execution.metrics_latency_ms.
 func (r *queryResolver) FastestModels(ctx context.Context, input FastestChannelsInput) ([]*FastestModel, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, projectID := r.resolveDashboardContext(ctx)
+	if err := r.ensureProjectDashboardAccess(ctx, projectID); err != nil {
+		return nil, err
+	}
 
 	// Validate and set default limit
 	if input.Limit == nil || *input.Limit <= 0 {
@@ -954,24 +1025,27 @@ func (r *queryResolver) FastestModels(ctx context.Context, input FastestChannels
 		sqlLimit = 20
 	}
 
-	query := qb.BuildThroughputQuery(
+	projectIDPlaceholder := ""
+	if projectID != nil {
+		if useDollarPlaceholders {
+			projectIDPlaceholder = "$2"
+		} else {
+			projectIDPlaceholder = "?"
+		}
+	}
+
+	query := qb.BuildThroughputQueryWithProjectFilter(
 		useDollarPlaceholders,
 		qb.ThroughputQueryByModel,
 		sqlLimit,
 		queryMode,
+		projectIDPlaceholder,
 	)
 
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}
-	// MaxID mode requires the timestamp twice (outer WHERE and subquery WHERE)
-	// ROW_NUMBER mode only needs it once (in the CTE)
-	var queryArgs []any
-	if queryMode == qb.ThroughputModeMaxID {
-		queryArgs = []any{since.UTC(), since.UTC()}
-	} else {
-		queryArgs = []any{since.UTC()}
-	}
+	queryArgs := buildThroughputQueryArgs(queryMode, since, projectID)
 
 	rows, err := sqlDB.DB().QueryContext(ctx, query, queryArgs...)
 	if err != nil {
@@ -1032,7 +1106,10 @@ func (r *queryResolver) FastestModels(ctx context.Context, input FastestChannels
 // Aggregates by date and model_id, calculating throughput (tokens per second).
 // Only includes successful (completed) requests with valid latency metrics.
 func (r *queryResolver) ModelPerformanceStats(ctx context.Context) ([]*ModelPerformanceStat, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, projectID := r.resolveDashboardContext(ctx)
+	if err := r.ensureProjectDashboardAccess(ctx, projectID); err != nil {
+		return nil, err
+	}
 
 	// Add 30-second timeout to prevent long-running queries
 	var cancel context.CancelFunc
@@ -1062,6 +1139,15 @@ func (r *queryResolver) ModelPerformanceStats(ctx context.Context) ([]*ModelPerf
 		placeholder = "$1"
 	}
 
+	projectIDPlaceholder := ""
+	if projectID != nil {
+		if useDollarPlaceholders {
+			projectIDPlaceholder = "$2"
+		} else {
+			projectIDPlaceholder = "?"
+		}
+	}
+
 	// Select throughput mode based on dialect: ROW_NUMBER for PostgreSQL, MaxID for older SQLite
 	queryMode := qb.ThroughputModeRowNumber
 	if !useDollarPlaceholders {
@@ -1069,20 +1155,30 @@ func (r *queryResolver) ModelPerformanceStats(ctx context.Context) ([]*ModelPerf
 	}
 
 	// Use shared query builder for daily performance stats
-	query := qb.BuildDailyPerformanceStatsQuery(
+	query := qb.BuildDailyPerformanceStatsQueryWithProjectFilter(
 		dialectName,
 		loc.String(),
 		offsetSeconds,
 		qb.DailyThroughputByModel,
 		placeholder,
 		queryMode,
+		projectIDPlaceholder,
 	)
 
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}
 
-	rows, err := sqlDB.DB().QueryContext(ctx, query, startDateUTC)
+	queryArgs := []any{startDateUTC}
+	if projectID != nil {
+		if queryMode == qb.ThroughputModeMaxID {
+			queryArgs = append(queryArgs, *projectID, *projectID)
+		} else {
+			queryArgs = append(queryArgs, *projectID)
+		}
+	}
+
+	rows, err := sqlDB.DB().QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query model performance stats: %w", err)
 	}
@@ -1179,7 +1275,10 @@ func (r *queryResolver) ModelPerformanceStats(ctx context.Context) ([]*ModelPerf
 
 // ChannelPerformanceStats is the resolver for the channelPerformanceStats field.
 func (r *queryResolver) ChannelPerformanceStats(ctx context.Context) ([]*ChannelPerformanceStat, error) {
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadDashboard)
+	ctx, projectID := r.resolveDashboardContext(ctx)
+	if err := r.ensureProjectDashboardAccess(ctx, projectID); err != nil {
+		return nil, err
+	}
 
 	var cancel context.CancelFunc
 
@@ -1195,13 +1294,17 @@ func (r *queryResolver) ChannelPerformanceStats(ctx context.Context) ([]*Channel
 	startTimestamp := startDateLocal.UTC().Unix()
 	_, offsetSeconds := nowLocal.Zone()
 
+	if projectID != nil {
+		return r.buildChannelPerformanceStatsFromExecutions(ctx, startDateLocal, offsetSeconds, daysCount, projectID)
+	}
+
 	probeResults, err := r.queryChannelProbeStats(ctx, startTimestamp, loc.String(), offsetSeconds)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(probeResults) == 0 {
-		return r.buildChannelPerformanceStatsFromExecutions(ctx, startDateLocal, offsetSeconds, daysCount)
+		return r.buildChannelPerformanceStatsFromExecutions(ctx, startDateLocal, offsetSeconds, daysCount, nil)
 	}
 
 	statsMap := aggregateProbeStats(probeResults)

--- a/internal/server/gql/dashboard.resolvers_test.go
+++ b/internal/server/gql/dashboard.resolvers_test.go
@@ -2,7 +2,9 @@ package gql
 
 import (
 	"testing"
+	"time"
 
+	"github.com/looplj/axonhub/internal/server/gql/qb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -327,5 +329,49 @@ func TestCalculateConfidenceAndSort_LargeDataset(t *testing.T) {
 			assert.True(t, got[i].score > got[i+1].score,
 				"items should be sorted by confidence score descending")
 		}
+	}
+}
+
+func TestBuildThroughputQueryArgs(t *testing.T) {
+	since := time.Date(2026, 1, 2, 15, 4, 5, 0, time.FixedZone("UTC+8", 8*60*60))
+	sinceUTC := since.UTC()
+	projectID := 42
+
+	tests := []struct {
+		name      string
+		mode      qb.ThroughputQueryMode
+		projectID *int
+		expected  []any
+	}{
+		{
+			name:      "row number without project",
+			mode:      qb.ThroughputModeRowNumber,
+			projectID: nil,
+			expected:  []any{sinceUTC},
+		},
+		{
+			name:      "row number with project",
+			mode:      qb.ThroughputModeRowNumber,
+			projectID: &projectID,
+			expected:  []any{sinceUTC, projectID},
+		},
+		{
+			name:      "max id without project",
+			mode:      qb.ThroughputModeMaxID,
+			projectID: nil,
+			expected:  []any{sinceUTC, sinceUTC},
+		},
+		{
+			name:      "max id with project",
+			mode:      qb.ThroughputModeMaxID,
+			projectID: &projectID,
+			expected:  []any{sinceUTC, projectID, sinceUTC, projectID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildThroughputQueryArgs(tt.mode, since, tt.projectID))
+		})
 	}
 }

--- a/internal/server/gql/qb/throughput.go
+++ b/internal/server/gql/qb/throughput.go
@@ -77,6 +77,18 @@ var AllowedQueryConfigs = map[ThroughputQueryType]QueryFragmentConfig{
 //
 // Returns: SQL query string with placeholders for the since timestamp
 func BuildThroughputQuery(useDollarPlaceholders bool, queryType ThroughputQueryType, limit int, mode ThroughputQueryMode) string {
+	return BuildThroughputQueryWithProjectFilter(useDollarPlaceholders, queryType, limit, mode, "")
+}
+
+// BuildThroughputQueryWithProjectFilter constructs a throughput query with an
+// optional project_id placeholder filter.
+func BuildThroughputQueryWithProjectFilter(
+	useDollarPlaceholders bool,
+	queryType ThroughputQueryType,
+	limit int,
+	mode ThroughputQueryMode,
+	projectIDPlaceholder string,
+) string {
 	// Validate that limit is positive to prevent malformed queries
 	if limit <= 0 {
 		limit = 20 // Default fallback
@@ -96,15 +108,20 @@ func BuildThroughputQuery(useDollarPlaceholders bool, queryType ThroughputQueryT
 	}
 
 	if mode == ThroughputModeMaxID {
-		return buildMaxIDQuery(placeholder, config, limit)
+		return buildMaxIDQuery(placeholder, config, limit, projectIDPlaceholder)
 	}
 
-	return buildRowNumberQuery(placeholder, config, limit)
+	return buildRowNumberQuery(placeholder, config, limit, projectIDPlaceholder)
 }
 
 // buildRowNumberQuery constructs a SQL query using ROW_NUMBER() window function.
 // This is the preferred approach for all modern database systems.
-func buildRowNumberQuery(placeholder string, config QueryFragmentConfig, limit int) string {
+func buildRowNumberQuery(placeholder string, config QueryFragmentConfig, limit int, projectIDPlaceholder string) string {
+	projectFilter := ""
+	if projectIDPlaceholder != "" {
+		projectFilter = " AND project_id = " + projectIDPlaceholder
+	}
+
 	return `
 WITH successful_execs AS (
     SELECT
@@ -115,7 +132,7 @@ WITH successful_execs AS (
         stream,
         ROW_NUMBER() OVER (PARTITION BY request_id ORDER BY created_at DESC) as rn
     FROM request_executions
-    WHERE status = 'completed' AND metrics_latency_ms > 0 AND created_at >= ` + placeholder + `
+    WHERE status = 'completed' AND metrics_latency_ms > 0 AND created_at >= ` + placeholder + projectFilter + `
 )
 SELECT
     ` + config.SelectColumns + `
@@ -147,7 +164,14 @@ LIMIT ` + fmt.Sprintf("%d", limit)
 
 // buildMaxIDQuery constructs a SQL query using MAX(id) subquery for SQLite compatibility.
 // This approach works on older SQLite versions that don't support window functions.
-func buildMaxIDQuery(placeholder string, config QueryFragmentConfig, limit int) string {
+func buildMaxIDQuery(placeholder string, config QueryFragmentConfig, limit int, projectIDPlaceholder string) string {
+	outerProjectFilter := ""
+	subqueryProjectFilter := ""
+	if projectIDPlaceholder != "" {
+		outerProjectFilter = "\n    AND se.project_id = " + projectIDPlaceholder
+		subqueryProjectFilter = "\n            AND re2.project_id = " + projectIDPlaceholder
+	}
+
 	// For MAX_ID mode, we need to adjust the query to not use the CTE pattern
 	// and instead use a correlated subquery to get the latest execution per request
 
@@ -177,6 +201,7 @@ JOIN usage_logs ul ON se.request_id = ul.request_id
 WHERE se.status = 'completed'
     AND se.metrics_latency_ms > 0
     AND se.created_at >= ` + placeholder + `
+    ` + outerProjectFilter + `
     AND se.id = (
         SELECT MAX(re2.id)
         FROM request_executions re2
@@ -184,6 +209,7 @@ WHERE se.status = 'completed'
             AND re2.status = 'completed'
             AND re2.metrics_latency_ms > 0
             AND re2.created_at >= ` + placeholder + `
+            ` + subqueryProjectFilter + `
     )
 GROUP BY ` + config.GroupBy + `
 ORDER BY throughput DESC

--- a/internal/server/gql/qb/throughput_daily.go
+++ b/internal/server/gql/qb/throughput_daily.go
@@ -233,6 +233,20 @@ func buildDailyMaxIDQuery(dateExpr string, config DailyQueryFragmentConfig, limi
 //
 // Returns: SQL query string ready for execution
 func BuildDailyPerformanceStatsQuery(dialect string, timezone string, offsetSeconds int, queryType DailyThroughputQueryType, placeholder string, mode ThroughputQueryMode) string {
+	return BuildDailyPerformanceStatsQueryWithProjectFilter(dialect, timezone, offsetSeconds, queryType, placeholder, mode, "")
+}
+
+// BuildDailyPerformanceStatsQueryWithProjectFilter constructs a SQL query for
+// daily performance statistics with an optional project_id placeholder filter.
+func BuildDailyPerformanceStatsQueryWithProjectFilter(
+	dialect string,
+	timezone string,
+	offsetSeconds int,
+	queryType DailyThroughputQueryType,
+	placeholder string,
+	mode ThroughputQueryMode,
+	projectIDPlaceholder string,
+) string {
 	config, ok := AllowedDailyQueryConfigs[queryType]
 	if !ok {
 		config = AllowedDailyQueryConfigs[DailyThroughputByModel]
@@ -248,14 +262,43 @@ func BuildDailyPerformanceStatsQuery(dialect string, timezone string, offsetSeco
 	}
 
 	if mode == ThroughputModeMaxID {
-		return buildDailyPerformanceStatsMaxIDQuery(dateExpr, config, queryType, placeholder, joinRequests, throughputSQL)
+		return buildDailyPerformanceStatsMaxIDQuery(
+			dateExpr,
+			config,
+			queryType,
+			placeholder,
+			joinRequests,
+			throughputSQL,
+			projectIDPlaceholder,
+		)
 	}
 
-	return buildDailyPerformanceStatsRowNumberQuery(dateExpr, config, queryType, placeholder, joinRequests, throughputSQL)
+	return buildDailyPerformanceStatsRowNumberQuery(
+		dateExpr,
+		config,
+		queryType,
+		placeholder,
+		joinRequests,
+		throughputSQL,
+		projectIDPlaceholder,
+	)
 }
 
 // buildDailyPerformanceStatsRowNumberQuery constructs the ROW_NUMBER() version of the daily performance stats query.
-func buildDailyPerformanceStatsRowNumberQuery(dateExpr string, config DailyQueryFragmentConfig, queryType DailyThroughputQueryType, placeholder string, joinRequests string, throughputSQL string) string {
+func buildDailyPerformanceStatsRowNumberQuery(
+	dateExpr string,
+	config DailyQueryFragmentConfig,
+	queryType DailyThroughputQueryType,
+	placeholder string,
+	joinRequests string,
+	throughputSQL string,
+	projectIDPlaceholder string,
+) string {
+	projectFilter := ""
+	if projectIDPlaceholder != "" {
+		projectFilter = "        AND se.project_id = " + projectIDPlaceholder + "\n"
+	}
+
 	return "WITH successful_execs AS (\n" +
 		"    SELECT\n" +
 		"        se.request_id,\n" +
@@ -270,6 +313,7 @@ func buildDailyPerformanceStatsRowNumberQuery(dateExpr string, config DailyQuery
 		"    WHERE se.status = 'completed'\n" +
 		"        AND se.metrics_latency_ms > 0\n" +
 		"        AND se.created_at >= " + placeholder + "\n" +
+		projectFilter +
 		"),\n" +
 		"daily AS (\n" +
 		"    SELECT\n" +
@@ -301,7 +345,22 @@ func buildDailyPerformanceStatsRowNumberQuery(dateExpr string, config DailyQuery
 }
 
 // buildDailyPerformanceStatsMaxIDQuery constructs the MAX(id) fallback version for older databases.
-func buildDailyPerformanceStatsMaxIDQuery(dateExpr string, config DailyQueryFragmentConfig, queryType DailyThroughputQueryType, placeholder string, joinRequests string, throughputSQL string) string {
+func buildDailyPerformanceStatsMaxIDQuery(
+	dateExpr string,
+	config DailyQueryFragmentConfig,
+	queryType DailyThroughputQueryType,
+	placeholder string,
+	joinRequests string,
+	throughputSQL string,
+	projectIDPlaceholder string,
+) string {
+	outerProjectFilter := ""
+	subqueryProjectFilter := ""
+	if projectIDPlaceholder != "" {
+		outerProjectFilter = "        AND se.project_id = " + projectIDPlaceholder + "\n"
+		subqueryProjectFilter = "                AND se2.project_id = " + projectIDPlaceholder + "\n"
+	}
+
 	return "WITH latest_execs AS (\n" +
 		"    SELECT\n" +
 		"        se.request_id,\n" +
@@ -315,12 +374,14 @@ func buildDailyPerformanceStatsMaxIDQuery(dateExpr string, config DailyQueryFrag
 		"    WHERE se.status = 'completed'\n" +
 		"        AND se.metrics_latency_ms > 0\n" +
 		"        AND se.created_at >= " + placeholder + "\n" +
+		outerProjectFilter +
 		"        AND se.id = (\n" +
 		"            SELECT MAX(se2.id)\n" +
 		"            FROM request_executions se2\n" +
 		"            WHERE se2.request_id = se.request_id\n" +
 		"                AND se2.status = 'completed'\n" +
 		"                AND se2.metrics_latency_ms > 0\n" +
+		subqueryProjectFilter +
 		"        )\n" +
 		"),\n" +
 		"daily AS (\n" +

--- a/internal/server/gql/qb/throughput_daily_test.go
+++ b/internal/server/gql/qb/throughput_daily_test.go
@@ -656,3 +656,39 @@ func TestBuildDailyPerformanceStatsQuery_ConditionalJoinRequests(t *testing.T) {
 	assert.NotContains(t, channelQuery, "JOIN requests r ON se.request_id = r.id", "channel query should not join requests")
 	assert.NotContains(t, channelQuery, "r.model_id", "channel query should not reference r.model_id")
 }
+
+func TestBuildDailyPerformanceStatsQueryWithProjectFilter(t *testing.T) {
+	rowNumberQuery := BuildDailyPerformanceStatsQueryWithProjectFilter(
+		"postgres",
+		"UTC",
+		0,
+		DailyThroughputByModel,
+		"$1",
+		ThroughputModeRowNumber,
+		"$2",
+	)
+	assert.Contains(t, rowNumberQuery, "AND se.project_id = $2")
+
+	maxIDQuery := BuildDailyPerformanceStatsQueryWithProjectFilter(
+		"sqlite",
+		"UTC",
+		0,
+		DailyThroughputByChannel,
+		"?",
+		ThroughputModeMaxID,
+		"?",
+	)
+	assert.Contains(t, maxIDQuery, "AND se.project_id = ?")
+	assert.Contains(t, maxIDQuery, "AND se2.project_id = ?")
+
+	queryWithoutProjectFilter := BuildDailyPerformanceStatsQueryWithProjectFilter(
+		"postgres",
+		"UTC",
+		0,
+		DailyThroughputByModel,
+		"$1",
+		ThroughputModeRowNumber,
+		"",
+	)
+	assert.NotContains(t, queryWithoutProjectFilter, "project_id =")
+}

--- a/internal/server/gql/qb/throughput_test.go
+++ b/internal/server/gql/qb/throughput_test.go
@@ -357,6 +357,36 @@ func TestBuildThroughputQuery_SQLStructure(t *testing.T) {
 	}
 }
 
+func TestBuildThroughputQueryWithProjectFilter(t *testing.T) {
+	rowNumberQuery := BuildThroughputQueryWithProjectFilter(
+		true,
+		ThroughputQueryByChannel,
+		10,
+		ThroughputModeRowNumber,
+		"$2",
+	)
+	assert.Contains(t, rowNumberQuery, "created_at >= $1 AND project_id = $2")
+
+	maxIDQuery := BuildThroughputQueryWithProjectFilter(
+		false,
+		ThroughputQueryByModel,
+		10,
+		ThroughputModeMaxID,
+		"?",
+	)
+	assert.Contains(t, maxIDQuery, "AND se.project_id = ?")
+	assert.Contains(t, maxIDQuery, "AND re2.project_id = ?")
+
+	queryWithoutProjectFilter := BuildThroughputQueryWithProjectFilter(
+		true,
+		ThroughputQueryByChannel,
+		10,
+		ThroughputModeRowNumber,
+		"",
+	)
+	assert.NotContains(t, queryWithoutProjectFilter, "project_id =")
+}
+
 // TestBuildProbeStatsQuery tests the BuildProbeStatsQuery function.
 func TestBuildProbeStatsQuery(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Closes #936

## Summary
- add a new project-scoped dashboard route at `/project/dashboard` and keep system dashboard `/` behavior unchanged
- introduce dashboard scope context in frontend, make dashboard query hooks project-aware (`X-Project-ID` + scoped query keys), and wire nav/route permissions
- add graceful fallback in `useGeneralSettings` (`USD`/`UTC`) and apply it to project request/trace/thread pages plus dashboard charts to avoid `read_settings` permission failures
- complete backend project-scoped dashboard handling (context resolution, project access guard, project-filtered fastest/model/channel stats, project-aware channel success rates, and execution-path fallback for channel performance)
- add regression tests for throughput query builders and resolver query-arg ordering (including MAX_ID mode with project placeholders)

## Validation
- `go test ./internal/server/gql/...`
- `go test ./...`
- `PATH=\"/Users/hao/.nvm/versions/node/v25.2.1/bin:$PATH\" pnpm eslint src/features/dashboard/data/dashboard.ts src/features/dashboard/data/fastest-performers.ts src/features/dashboard/components/performance-chart.tsx` (in `frontend/`)
- `PATH=\"/Users/hao/.nvm/versions/node/v25.2.1/bin:$PATH\" pnpm build` (in `frontend/`)
- `make build`
- `GOOS=linux GOARCH=amd64 make build-backend`

## Notes
- `frontend/src/routeTree.gen.ts` is regenerated during frontend build.
- full frontend repo lint currently has pre-existing baseline issues; changed files were linted and full build passed.