### PR TITLE
feat(dashboard): add all-time token statistics

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -137,6 +137,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.trace.extra_trace_body_fields", []string{})
 	v.SetDefault("server.trace.claude_code_trace_enabled", false)
 	v.SetDefault("server.trace.codex_trace_enabled", false)
+
+	// Dashboard defaults
+	v.SetDefault("server.dashboard.all_time_token_stats_soft_ttl", "1h")
+	v.SetDefault("server.dashboard.all_time_token_stats_hard_ttl", "24h")
+
 	v.SetDefault("server.debug", false)
 
 	// CORS defaults

--- a/frontend/src/features/dashboard/components/token-stats-card.tsx
+++ b/frontend/src/features/dashboard/components/token-stats-card.tsx
@@ -1,13 +1,29 @@
 import { useState } from 'react';
 import { BarChart4 } from 'lucide-react';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { formatNumber } from '@/utils/format-number';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useTokenStats } from '../data/dashboard';
 
 type TimeRange = 'allTime' | 'thisMonth' | 'thisWeek' | 'thisDay';
+
+function formatLastUpdated(timestamp: string | null): string {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
 
 export function TokenStatsCard() {
   const { t } = useTranslation();
@@ -106,7 +122,7 @@ export function TokenStatsCard() {
           </div>
           <CardTitle className='text-sm font-medium whitespace-normal leading-tight'>{t('dashboard.cards.tokenStats')}</CardTitle>
         </div>
-        <div className='flex items-center gap-1 shrink-0'>
+        <div className='flex items-center gap-2 shrink-0'>
           {/* <span className='text-xs text-muted-foreground'>{t('dashboard.stats.this')}</span> */}
           <Tabs value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
             <TabsList className='h-6 p-0.5'>
@@ -124,6 +140,36 @@ export function TokenStatsCard() {
               </TabsTrigger>
             </TabsList>
           </Tabs>
+          <div className='hidden sm:block w-6 h-6'>
+            {timeRange === 'allTime' && stats?.lastUpdated && (
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button className='text-muted-foreground hover:text-foreground transition-colors w-6 h-6 flex items-center justify-center'>
+                      <IconInfoCircle className='h-4 w-4' />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <span>Updated: {formatLastUpdated(stats.lastUpdated)}</span>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+          <div className='sm:hidden w-11 h-11'>
+            {timeRange === 'allTime' && stats?.lastUpdated && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button className='text-muted-foreground hover:text-foreground transition-colors w-11 h-11 flex items-center justify-center'>
+                    <IconInfoCircle className='h-5 w-5' />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent className='w-fit'>
+                  <span className='text-sm'>Updated: {formatLastUpdated(stats.lastUpdated)}</span>
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
         </div>
       </CardHeader>
       <CardContent>

--- a/frontend/src/features/dashboard/components/token-stats-card.tsx
+++ b/frontend/src/features/dashboard/components/token-stats-card.tsx
@@ -12,10 +12,10 @@ import { useTokenStats } from '../data/dashboard';
 
 type TimeRange = 'allTime' | 'thisMonth' | 'thisWeek' | 'thisDay';
 
-function formatLastUpdated(timestamp: string | null): string {
+function formatLastUpdated(timestamp: string | null, locale: string): string {
   if (!timestamp) return '';
   const date = new Date(timestamp);
-  return date.toLocaleString('en-US', {
+  return date.toLocaleString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -25,8 +25,52 @@ function formatLastUpdated(timestamp: string | null): string {
   });
 }
 
+interface LastUpdatedInfoProps {
+  lastUpdated: string | null;
+  locale: string;
+  t: (key: string, options?: Record<string, string>) => string;
+}
+
+function LastUpdatedInfo({ lastUpdated, locale, t }: LastUpdatedInfoProps) {
+  if (!lastUpdated) return null;
+
+  const formattedTime = formatLastUpdated(lastUpdated, locale);
+  const label = t('dashboard.stats.updated', { time: formattedTime });
+
+  return (
+    <>
+      <div className='hidden sm:block w-6 h-6'>
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button className='text-muted-foreground hover:text-foreground transition-colors w-6 h-6 flex items-center justify-center'>
+                <IconInfoCircle className='h-4 w-4' />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span>{label}</span>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className='sm:hidden w-11 h-11'>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button className='text-muted-foreground hover:text-foreground transition-colors w-11 h-11 flex items-center justify-center'>
+              <IconInfoCircle className='h-5 w-5' />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className='w-fit'>
+            <span className='text-sm'>{label}</span>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </>
+  );
+}
+
 export function TokenStatsCard() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { data: stats, isLoading, error } = useTokenStats();
   const [timeRange, setTimeRange] = useState<TimeRange>('thisDay');
 
@@ -140,36 +184,13 @@ export function TokenStatsCard() {
               </TabsTrigger>
             </TabsList>
           </Tabs>
-          <div className='hidden sm:block w-6 h-6'>
-            {timeRange === 'allTime' && stats?.lastUpdated && (
-              <TooltipProvider delayDuration={0}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button className='text-muted-foreground hover:text-foreground transition-colors w-6 h-6 flex items-center justify-center'>
-                      <IconInfoCircle className='h-4 w-4' />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <span>Updated: {formatLastUpdated(stats.lastUpdated)}</span>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-          </div>
-          <div className='sm:hidden w-11 h-11'>
-            {timeRange === 'allTime' && stats?.lastUpdated && (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button className='text-muted-foreground hover:text-foreground transition-colors w-11 h-11 flex items-center justify-center'>
-                    <IconInfoCircle className='h-5 w-5' />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className='w-fit'>
-                  <span className='text-sm'>Updated: {formatLastUpdated(stats.lastUpdated)}</span>
-                </PopoverContent>
-              </Popover>
-            )}
-          </div>
+          {timeRange === 'allTime' && (
+            <LastUpdatedInfo
+              lastUpdated={stats?.lastUpdated ?? null}
+              locale={i18n.language}
+              t={t}
+            />
+          )}
         </div>
       </CardHeader>
       <CardContent>

--- a/frontend/src/features/dashboard/components/token-stats-card.tsx
+++ b/frontend/src/features/dashboard/components/token-stats-card.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTokenStats } from '../data/dashboard';
 
-type TimeRange = 'thisMonth' | 'thisWeek' | 'thisDay';
+type TimeRange = 'allTime' | 'thisMonth' | 'thisWeek' | 'thisDay';
 
 export function TokenStatsCard() {
   const { t } = useTranslation();
@@ -67,6 +67,13 @@ export function TokenStatsCard() {
   }
 
   const getTokens = (range: TimeRange) => {
+    if (range === 'allTime') {
+      return {
+        input: stats?.totalInputTokensAllTime || 0,
+        output: stats?.totalOutputTokensAllTime || 0,
+        cached: stats?.totalCachedTokensAllTime || 0,
+      };
+    }
     if (range === 'thisDay') {
       return {
         input: stats?.totalInputTokensToday || 0,
@@ -103,6 +110,9 @@ export function TokenStatsCard() {
           {/* <span className='text-xs text-muted-foreground'>{t('dashboard.stats.this')}</span> */}
           <Tabs value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
             <TabsList className='h-6 p-0.5'>
+              <TabsTrigger value='allTime' className='h-5 px-2 text-[10px]'>
+                {t('dashboard.stats.all')}
+              </TabsTrigger>
               <TabsTrigger value='thisMonth' className='h-5 px-2 text-[10px]'>
                 {t('dashboard.stats.month')}
               </TabsTrigger>

--- a/frontend/src/features/dashboard/data/dashboard.ts
+++ b/frontend/src/features/dashboard/data/dashboard.ts
@@ -112,6 +112,9 @@ export const tokenStatsSchema = z.object({
   totalInputTokensThisMonth: z.number(),
   totalOutputTokensThisMonth: z.number(),
   totalCachedTokensThisMonth: z.number(),
+  totalInputTokensAllTime: z.number(),
+  totalOutputTokensAllTime: z.number(),
+  totalCachedTokensAllTime: z.number(),
 });
 
 export type TokenStats = z.infer<typeof tokenStatsSchema>;
@@ -260,6 +263,9 @@ const TOKEN_STATS_AGGR_QUERY = `
       totalInputTokensThisMonth
       totalOutputTokensThisMonth
       totalCachedTokensThisMonth
+      totalInputTokensAllTime
+      totalOutputTokensAllTime
+      totalCachedTokensAllTime
     }
   }
 `;

--- a/frontend/src/features/dashboard/data/dashboard.ts
+++ b/frontend/src/features/dashboard/data/dashboard.ts
@@ -115,6 +115,7 @@ export const tokenStatsSchema = z.object({
   totalInputTokensAllTime: z.number(),
   totalOutputTokensAllTime: z.number(),
   totalCachedTokensAllTime: z.number(),
+  lastUpdated: z.string().nullable(),
 });
 
 export type TokenStats = z.infer<typeof tokenStatsSchema>;
@@ -266,6 +267,7 @@ const TOKEN_STATS_AGGR_QUERY = `
       totalInputTokensAllTime
       totalOutputTokensAllTime
       totalCachedTokensAllTime
+      lastUpdated
     }
   }
 `;

--- a/frontend/src/locales/en/dashboard.json
+++ b/frontend/src/locales/en/dashboard.json
@@ -66,5 +66,6 @@
   "dashboard.cards.fastestPerformers.noData": "No data available",
   "dashboard.cards.fastestPerformers.description": "Fastest {{type}} by tokens/second · {{count}} requests across top performers",
   "dashboard.cards.fastestPerformers.channelType": "channels",
-  "dashboard.cards.fastestPerformers.modelType": "models"
+  "dashboard.cards.fastestPerformers.modelType": "models",
+  "dashboard.stats.updated": "Updated: {{time}}"
 }

--- a/frontend/src/locales/en/dashboard.json
+++ b/frontend/src/locales/en/dashboard.json
@@ -42,6 +42,7 @@
   "dashboard.stats.month": "MO",
   "dashboard.stats.week": "WK",
   "dashboard.stats.day": "Day",
+  "dashboard.stats.all": "All",
   "dashboard.stats.failedRequests": "Failed requests",
   "dashboard.stats.requests": "Requests",
   "dashboard.stats.inputTokens": "Input Tokens",

--- a/frontend/src/locales/zh-CN/dashboard.json
+++ b/frontend/src/locales/zh-CN/dashboard.json
@@ -42,6 +42,7 @@
   "dashboard.stats.month": "月",
   "dashboard.stats.week": "周",
   "dashboard.stats.day": "日",
+  "dashboard.stats.all": "全部",
   "dashboard.stats.failedRequests": "失败请求",
   "dashboard.stats.requests": "请求",
   "dashboard.stats.inputTokens": "输入Token",

--- a/frontend/src/locales/zh-CN/dashboard.json
+++ b/frontend/src/locales/zh-CN/dashboard.json
@@ -66,5 +66,6 @@
   "dashboard.cards.fastestPerformers.noData": "暂无数据",
   "dashboard.cards.fastestPerformers.description": "最快的{{type}} by tokens/second · {{count}} 次请求",
   "dashboard.cards.fastestPerformers.channelType": "通道",
-  "dashboard.cards.fastestPerformers.modelType": "模型"
+  "dashboard.cards.fastestPerformers.modelType": "模型",
+  "dashboard.stats.updated": "更新时间: {{time}}"
 }

--- a/internal/server/biz/usage_log.go
+++ b/internal/server/biz/usage_log.go
@@ -20,6 +20,10 @@ type UsageLogService struct {
 
 	SystemService  *SystemService
 	ChannelService *ChannelService
+
+	// OnUsageLogCreated is called after a usage log is successfully created.
+	// Used to invalidate caches that depend on usage log data.
+	OnUsageLogCreated func()
 }
 
 func (s *UsageLogService) computeUsageCost(ctx context.Context, channelID int, modelID string, usage *llm.Usage) ([]objects.CostItem, *float64, string) {
@@ -161,6 +165,10 @@ func (s *UsageLogService) CreateUsageLog(ctx context.Context, params CreateUsage
 			log.String("model_id", params.ActualModelID),
 			log.Int64("total_tokens", params.Usage.TotalTokens),
 		)
+	}
+
+	if s.OnUsageLogCreated != nil {
+		s.OnUsageLogCreated()
 	}
 
 	return usageLog, nil

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -19,10 +19,24 @@ type Config struct {
 	// LLMRequestTimeout is the maximum duration for processing a request to LLM.
 	LLMRequestTimeout time.Duration `conf:"llm_request_timeout" yaml:"llm_request_timeout" json:"llm_request_timeout"`
 
-	Trace tracing.Config `conf:"trace" yaml:"trace" json:"trace"`
+	Trace     tracing.Config `conf:"trace" yaml:"trace" json:"trace"`
+	Dashboard Dashboard      `conf:"dashboard" yaml:"dashboard" json:"dashboard"`
 
 	Debug bool `conf:"debug" yaml:"debug" json:"debug"`
 	CORS  CORS `conf:"cors" yaml:"cors" json:"cors"`
+}
+
+// Dashboard holds configuration for the dashboard cache settings.
+type Dashboard struct {
+	// AllTimeTokenStatsSoftTTL is the duration after which cached all-time token stats
+	// are considered stale and will be refreshed asynchronously (stale-while-revalidate).
+	// Default: 1 hour
+	AllTimeTokenStatsSoftTTL time.Duration `conf:"all_time_token_stats_soft_ttl" yaml:"all_time_token_stats_soft_ttl" json:"all_time_token_stats_soft_ttl"`
+
+	// AllTimeTokenStatsHardTTL is the maximum duration for which cached all-time token stats
+	// are considered valid. After this, synchronous refresh is required.
+	// Default: 24 hours
+	AllTimeTokenStatsHardTTL time.Duration `conf:"all_time_token_stats_hard_ttl" yaml:"all_time_token_stats_hard_ttl" json:"all_time_token_stats_hard_ttl"`
 }
 
 type CORS struct {

--- a/internal/server/gql/dashboard.graphql
+++ b/internal/server/gql/dashboard.graphql
@@ -64,6 +64,10 @@ type TokenStats {
   totalInputTokensThisMonth: Int!
   totalOutputTokensThisMonth: Int!
   totalCachedTokensThisMonth: Int!
+
+  totalInputTokensAllTime: Int!
+  totalOutputTokensAllTime: Int!
+  totalCachedTokensAllTime: Int!
 }
 
 type TopRequestsProjects {

--- a/internal/server/gql/dashboard.graphql
+++ b/internal/server/gql/dashboard.graphql
@@ -68,6 +68,7 @@ type TokenStats {
   totalInputTokensAllTime: Int!
   totalOutputTokensAllTime: Int!
   totalCachedTokensAllTime: Int!
+  lastUpdated: Time
 }
 
 type TopRequestsProjects {

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -658,7 +658,8 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 	allTimeCacheMu.RUnlock()
 
 	// Helper function to refresh cache data
-	refreshCache := func(ctx context.Context) (*TokenStats, error) {
+	// Returns the stats, the cache timestamp, and any error
+	refreshCache := func(ctx context.Context) (*TokenStats, time.Time, error) {
 		// Use singleflight to prevent concurrent refresh attempts
 		result, err, _ := allTimeRefreshGroup.Do("allTimeTokenStats", func() (interface{}, error) {
 			// Query all usage_logs records without time filter
@@ -690,42 +691,49 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 				TotalCachedTokensAllTime: allTimeRecords[0].CachedTokens,
 			}
 
+			cacheTime := time.Now().UTC()
+
 			allTimeCacheMu.Lock()
 			allTimeCache = newStats
-			allTimeCacheTime = time.Now().UTC()
+			allTimeCacheTime = cacheTime
 			allTimeCacheMu.Unlock()
 
-			return newStats, nil
+			return &cacheResult{
+				stats: newStats,
+				time:  cacheTime,
+			}, nil
 		})
 
 		if err != nil {
-			return nil, err
+			return nil, time.Time{}, err
 		}
-		newStats, ok := result.(*TokenStats)
+		cacheRes, ok := result.(*cacheResult)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type from singleflight: %T", result)
+			return nil, time.Time{}, fmt.Errorf("unexpected type from singleflight: %T", result)
 		}
-		return newStats, nil
+		return cacheRes.stats, cacheRes.time, nil
 	}
 
 	// Stale-while-revalidate logic
 	if cacheExists && cacheAge < hardTTL {
 		// Cache is valid (within hard TTL)
+		// Capture all cache data under a single read lock to prevent race conditions
 		allTimeCacheMu.RLock()
-		stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
-		stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
-		stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
+		cachedStats := allTimeCache
 		lastUpdated := allTimeCacheTime
 		allTimeCacheMu.RUnlock()
 
-		// Set LastUpdated from cache timestamp
+		// Safe to access cachedStats here since we have a local copy
+		stats.TotalInputTokensAllTime = cachedStats.TotalInputTokensAllTime
+		stats.TotalOutputTokensAllTime = cachedStats.TotalOutputTokensAllTime
+		stats.TotalCachedTokensAllTime = cachedStats.TotalCachedTokensAllTime
 		stats.LastUpdated = &lastUpdated
 
 		// If cache is stale (exceeded soft TTL), trigger async refresh
 		if cacheAge >= softTTL {
 			go func() {
 				bgCtx := context.Background()
-				if _, err := refreshCache(bgCtx); err != nil {
+				if _, _, err := refreshCache(bgCtx); err != nil {
 					log.Error(bgCtx, "async all-time token stats cache refresh failed",
 						log.Cause(err),
 						log.Duration("cache_age", cacheAge),
@@ -737,7 +745,7 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 		}
 	} else {
 		// Cache is invalid or expired (exceeded hard TTL) - compute synchronously
-		newStats, err := refreshCache(ctx)
+		newStats, newCacheTime, err := refreshCache(ctx)
 		if err != nil || newStats == nil {
 			log.Error(ctx, "synchronous all-time token stats aggregation failed - cache exceeded hard TTL",
 				log.Cause(err),
@@ -759,10 +767,7 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 			stats.TotalInputTokensAllTime = newStats.TotalInputTokensAllTime
 			stats.TotalOutputTokensAllTime = newStats.TotalOutputTokensAllTime
 			stats.TotalCachedTokensAllTime = newStats.TotalCachedTokensAllTime
-			allTimeCacheMu.RLock()
-			lastUpdated := allTimeCacheTime
-			allTimeCacheMu.RUnlock()
-			stats.LastUpdated = &lastUpdated
+			stats.LastUpdated = &newCacheTime
 		}
 	}
 
@@ -1341,6 +1346,12 @@ var (
 	hardTTL             = 24 * time.Hour
 	allTimeRefreshGroup singleflight.Group
 )
+
+// cacheResult holds the result of a cache refresh operation.
+type cacheResult struct {
+	stats *TokenStats
+	time  time.Time
+}
 
 // SetTokenStatsCacheTTL sets the cache TTL values for all-time token stats.
 // Call this during server initialization to override defaults.

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -701,7 +701,11 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 		if err != nil {
 			return nil, err
 		}
-		return result.(*TokenStats), nil
+		newStats, ok := result.(*TokenStats)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type from singleflight: %T", result)
+		}
+		return newStats, nil
 	}
 
 	// Stale-while-revalidate logic

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -14,6 +14,7 @@ import (
 
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/apikey"
@@ -29,13 +30,8 @@ import (
 	"github.com/looplj/axonhub/internal/scopes"
 	"github.com/looplj/axonhub/internal/server/gql/qb"
 	"github.com/samber/lo"
-)
-
-var (
-	allTimeCache     *TokenStats
-	allTimeCacheMu   sync.RWMutex
-	allTimeCacheTime time.Time
-	cacheTTL         = 24 * time.Hour
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/singleflight"
 )
 
 // DashboardOverview is the resolver for the dashboardOverview field.
@@ -655,53 +651,114 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 	stats.TotalOutputTokensThisMonth = output
 	stats.TotalCachedTokensThisMonth = cached
 
-	// Get all-time token stats with caching
+	// Get all-time token stats with stale-while-revalidate caching
 	allTimeCacheMu.RLock()
-	cacheValid := allTimeCache != nil && time.Since(allTimeCacheTime) < cacheTTL
+	cacheAge := time.Since(allTimeCacheTime)
+	cacheExists := allTimeCache != nil
 	allTimeCacheMu.RUnlock()
 
-	if cacheValid {
-		stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
-		stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
-		stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
-	} else {
-		// Query all usage_logs records without time filter
-		type allTimeTokenSums struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
-			CachedTokens int `json:"cached_tokens"`
-		}
+	// Helper function to refresh cache data
+	refreshCache := func(ctx context.Context) (*TokenStats, error) {
+		// Use singleflight to prevent concurrent refresh attempts
+		result, err, _ := allTimeRefreshGroup.Do("allTimeTokenStats", func() (interface{}, error) {
+			// Query all usage_logs records without time filter
+			type allTimeTokenSums struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+				CachedTokens int `json:"cached_tokens"`
+			}
 
-		var allTimeRecords []allTimeTokenSums
+			var allTimeRecords []allTimeTokenSums
 
-		err := r.client.UsageLog.Query().
-			Modify(func(s *sql.Selector) {
-				s.Select(
-					sql.As(sql.Sum(usagelog.FieldPromptTokens), "input_tokens"),
-					sql.As(sql.Sum(usagelog.FieldCompletionTokens), "output_tokens"),
-					sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),
-				)
-			}).
-			Scan(ctx, &allTimeRecords)
+			err := r.client.UsageLog.Query().
+				Modify(func(s *sql.Selector) {
+					s.Select(
+						sql.As(sql.Sum(usagelog.FieldPromptTokens), "input_tokens"),
+						sql.As(sql.Sum(usagelog.FieldCompletionTokens), "output_tokens"),
+						sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),
+					)
+				}).
+				Scan(ctx, &allTimeRecords)
 
-		if err != nil || len(allTimeRecords) == 0 {
-			log.Warn(ctx, "failed to aggregate all-time token stats", log.Cause(err))
-			stats.TotalInputTokensAllTime = 0
-			stats.TotalOutputTokensAllTime = 0
-			stats.TotalCachedTokensAllTime = 0
-		} else {
-			allTimeCacheMu.Lock()
-			allTimeCache = &TokenStats{
+			if err != nil || len(allTimeRecords) == 0 {
+				return nil, err
+			}
+
+			newStats := &TokenStats{
 				TotalInputTokensAllTime:  allTimeRecords[0].InputTokens,
 				TotalOutputTokensAllTime: allTimeRecords[0].OutputTokens,
 				TotalCachedTokensAllTime: allTimeRecords[0].CachedTokens,
 			}
-			allTimeCacheTime = time.Now()
+
+			allTimeCacheMu.Lock()
+			allTimeCache = newStats
+			allTimeCacheTime = time.Now().UTC()
 			allTimeCacheMu.Unlock()
 
-			stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
-			stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
-			stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
+			return newStats, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		return result.(*TokenStats), nil
+	}
+
+	// Stale-while-revalidate logic
+	if cacheExists && cacheAge < hardTTL {
+		// Cache is valid (within hard TTL)
+		allTimeCacheMu.RLock()
+		stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
+		stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
+		stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
+		lastUpdated := allTimeCacheTime
+		allTimeCacheMu.RUnlock()
+
+		// Set LastUpdated from cache timestamp
+		stats.LastUpdated = &lastUpdated
+
+		// If cache is stale (exceeded soft TTL), trigger async refresh
+		if cacheAge >= softTTL {
+			go func() {
+				bgCtx := context.Background()
+				if _, err := refreshCache(bgCtx); err != nil {
+					log.Error(bgCtx, "async all-time token stats cache refresh failed",
+						log.Cause(err),
+						log.Duration("cache_age", cacheAge),
+						log.Duration("soft_ttl", softTTL),
+						log.Duration("hard_ttl", hardTTL),
+					)
+				}
+			}()
+		}
+	} else {
+		// Cache is invalid or expired (exceeded hard TTL) - compute synchronously
+		newStats, err := refreshCache(ctx)
+		if err != nil || newStats == nil {
+			log.Error(ctx, "synchronous all-time token stats aggregation failed - cache exceeded hard TTL",
+				log.Cause(err),
+				log.Bool("cache_exists", cacheExists),
+				log.Duration("cache_age", cacheAge),
+				log.Duration("hard_ttl", hardTTL),
+			)
+			graphql.AddError(ctx, &gqlerror.Error{
+				Path:    graphql.GetPath(ctx),
+				Message: "Failed to aggregate all-time token statistics",
+				Extensions: map[string]interface{}{
+					"code": "TOKEN_STATS_ALL_TIME_AGG_FAILED",
+				},
+			})
+			stats.TotalInputTokensAllTime = 0
+			stats.TotalOutputTokensAllTime = 0
+			stats.TotalCachedTokensAllTime = 0
+		} else {
+			stats.TotalInputTokensAllTime = newStats.TotalInputTokensAllTime
+			stats.TotalOutputTokensAllTime = newStats.TotalOutputTokensAllTime
+			stats.TotalCachedTokensAllTime = newStats.TotalCachedTokensAllTime
+			allTimeCacheMu.RLock()
+			lastUpdated := allTimeCacheTime
+			allTimeCacheMu.RUnlock()
+			stats.LastUpdated = &lastUpdated
 		}
 	}
 
@@ -1271,3 +1328,39 @@ func (r *queryResolver) ChannelPerformanceStats(ctx context.Context) ([]*Channel
 
 	return buildChannelPerformanceResponse(statsMap, channelNames, startDateLocal, daysCount), nil
 }
+
+var (
+	allTimeCache        *TokenStats
+	allTimeCacheTime    time.Time
+	allTimeCacheMu      sync.RWMutex
+	softTTL             = 1 * time.Hour
+	hardTTL             = 24 * time.Hour
+	allTimeRefreshGroup singleflight.Group
+)
+
+// SetTokenStatsCacheTTL sets the cache TTL values for all-time token stats.
+// Call this during server initialization to override defaults.
+func SetTokenStatsCacheTTL(soft, hard time.Duration) {
+	allTimeCacheMu.Lock()
+	defer allTimeCacheMu.Unlock()
+	softTTL = soft
+	hardTTL = hard
+}
+
+// InvalidateAllTimeTokenStatsCache clears the all-time token stats cache.
+// This should be called when new usage logs are created to ensure fresh data.
+func InvalidateAllTimeTokenStatsCache() {
+	allTimeCacheMu.Lock()
+	allTimeCache = nil
+	allTimeCacheTime = time.Time{}
+	allTimeCacheMu.Unlock()
+}
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
+/*
+ */

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"entgo.io/ent/dialect"
@@ -28,6 +29,13 @@ import (
 	"github.com/looplj/axonhub/internal/scopes"
 	"github.com/looplj/axonhub/internal/server/gql/qb"
 	"github.com/samber/lo"
+)
+
+var (
+	allTimeCache     *TokenStats
+	allTimeCacheMu   sync.RWMutex
+	allTimeCacheTime time.Time
+	cacheTTL         = 24 * time.Hour
 )
 
 // DashboardOverview is the resolver for the dashboardOverview field.
@@ -646,6 +654,56 @@ func (r *queryResolver) TokenStats(ctx context.Context) (*TokenStats, error) {
 	stats.TotalInputTokensThisMonth = input
 	stats.TotalOutputTokensThisMonth = output
 	stats.TotalCachedTokensThisMonth = cached
+
+	// Get all-time token stats with caching
+	allTimeCacheMu.RLock()
+	cacheValid := allTimeCache != nil && time.Since(allTimeCacheTime) < cacheTTL
+	allTimeCacheMu.RUnlock()
+
+	if cacheValid {
+		stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
+		stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
+		stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
+	} else {
+		// Query all usage_logs records without time filter
+		type allTimeTokenSums struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+			CachedTokens int `json:"cached_tokens"`
+		}
+
+		var allTimeRecords []allTimeTokenSums
+
+		err := r.client.UsageLog.Query().
+			Modify(func(s *sql.Selector) {
+				s.Select(
+					sql.As(sql.Sum(usagelog.FieldPromptTokens), "input_tokens"),
+					sql.As(sql.Sum(usagelog.FieldCompletionTokens), "output_tokens"),
+					sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),
+				)
+			}).
+			Scan(ctx, &allTimeRecords)
+
+		if err != nil || len(allTimeRecords) == 0 {
+			log.Warn(ctx, "failed to aggregate all-time token stats", log.Cause(err))
+			stats.TotalInputTokensAllTime = 0
+			stats.TotalOutputTokensAllTime = 0
+			stats.TotalCachedTokensAllTime = 0
+		} else {
+			allTimeCacheMu.Lock()
+			allTimeCache = &TokenStats{
+				TotalInputTokensAllTime:  allTimeRecords[0].InputTokens,
+				TotalOutputTokensAllTime: allTimeRecords[0].OutputTokens,
+				TotalCachedTokensAllTime: allTimeRecords[0].CachedTokens,
+			}
+			allTimeCacheTime = time.Now()
+			allTimeCacheMu.Unlock()
+
+			stats.TotalInputTokensAllTime = allTimeCache.TotalInputTokensAllTime
+			stats.TotalOutputTokensAllTime = allTimeCache.TotalOutputTokensAllTime
+			stats.TotalCachedTokensAllTime = allTimeCache.TotalCachedTokensAllTime
+		}
+	}
 
 	return stats, nil
 }

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1348,12 +1348,15 @@ type ComplexityRoot struct {
 	}
 
 	TokenStats struct {
+		TotalCachedTokensAllTime   func(childComplexity int) int
 		TotalCachedTokensThisMonth func(childComplexity int) int
 		TotalCachedTokensThisWeek  func(childComplexity int) int
 		TotalCachedTokensToday     func(childComplexity int) int
+		TotalInputTokensAllTime    func(childComplexity int) int
 		TotalInputTokensThisMonth  func(childComplexity int) int
 		TotalInputTokensThisWeek   func(childComplexity int) int
 		TotalInputTokensToday      func(childComplexity int) int
+		TotalOutputTokensAllTime   func(childComplexity int) int
 		TotalOutputTokensThisMonth func(childComplexity int) int
 		TotalOutputTokensThisWeek  func(childComplexity int) int
 		TotalOutputTokensToday     func(childComplexity int) int
@@ -7340,6 +7343,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TieredPricing.Tiers(childComplexity), true
 
+	case "TokenStats.totalCachedTokensAllTime":
+		if e.complexity.TokenStats.TotalCachedTokensAllTime == nil {
+			break
+		}
+
+		return e.complexity.TokenStats.TotalCachedTokensAllTime(childComplexity), true
 	case "TokenStats.totalCachedTokensThisMonth":
 		if e.complexity.TokenStats.TotalCachedTokensThisMonth == nil {
 			break
@@ -7358,6 +7367,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TokenStats.TotalCachedTokensToday(childComplexity), true
+	case "TokenStats.totalInputTokensAllTime":
+		if e.complexity.TokenStats.TotalInputTokensAllTime == nil {
+			break
+		}
+
+		return e.complexity.TokenStats.TotalInputTokensAllTime(childComplexity), true
 	case "TokenStats.totalInputTokensThisMonth":
 		if e.complexity.TokenStats.TotalInputTokensThisMonth == nil {
 			break
@@ -7376,6 +7391,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TokenStats.TotalInputTokensToday(childComplexity), true
+	case "TokenStats.totalOutputTokensAllTime":
+		if e.complexity.TokenStats.TotalOutputTokensAllTime == nil {
+			break
+		}
+
+		return e.complexity.TokenStats.TotalOutputTokensAllTime(childComplexity), true
 	case "TokenStats.totalOutputTokensThisMonth":
 		if e.complexity.TokenStats.TotalOutputTokensThisMonth == nil {
 			break
@@ -31449,6 +31470,12 @@ func (ec *executionContext) fieldContext_Query_tokenStats(_ context.Context, fie
 				return ec.fieldContext_TokenStats_totalOutputTokensThisMonth(ctx, field)
 			case "totalCachedTokensThisMonth":
 				return ec.fieldContext_TokenStats_totalCachedTokensThisMonth(ctx, field)
+			case "totalInputTokensAllTime":
+				return ec.fieldContext_TokenStats_totalInputTokensAllTime(ctx, field)
+			case "totalOutputTokensAllTime":
+				return ec.fieldContext_TokenStats_totalOutputTokensAllTime(ctx, field)
+			case "totalCachedTokensAllTime":
+				return ec.fieldContext_TokenStats_totalCachedTokensAllTime(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TokenStats", field.Name)
 		},
@@ -39719,6 +39746,93 @@ func (ec *executionContext) _TokenStats_totalCachedTokensThisMonth(ctx context.C
 }
 
 func (ec *executionContext) fieldContext_TokenStats_totalCachedTokensThisMonth(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TokenStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenStats_totalInputTokensAllTime(ctx context.Context, field graphql.CollectedField, obj *TokenStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TokenStats_totalInputTokensAllTime,
+		func(ctx context.Context) (any, error) {
+			return obj.TotalInputTokensAllTime, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TokenStats_totalInputTokensAllTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TokenStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenStats_totalOutputTokensAllTime(ctx context.Context, field graphql.CollectedField, obj *TokenStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TokenStats_totalOutputTokensAllTime,
+		func(ctx context.Context) (any, error) {
+			return obj.TotalOutputTokensAllTime, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TokenStats_totalOutputTokensAllTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TokenStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenStats_totalCachedTokensAllTime(ctx context.Context, field graphql.CollectedField, obj *TokenStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TokenStats_totalCachedTokensAllTime,
+		func(ctx context.Context) (any, error) {
+			return obj.TotalCachedTokensAllTime, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TokenStats_totalCachedTokensAllTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TokenStats",
 		Field:      field,
@@ -80304,6 +80418,21 @@ func (ec *executionContext) _TokenStats(ctx context.Context, sel ast.SelectionSe
 			}
 		case "totalCachedTokensThisMonth":
 			out.Values[i] = ec._TokenStats_totalCachedTokensThisMonth(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalInputTokensAllTime":
+			out.Values[i] = ec._TokenStats_totalInputTokensAllTime(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalOutputTokensAllTime":
+			out.Values[i] = ec._TokenStats_totalOutputTokensAllTime(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCachedTokensAllTime":
+			out.Values[i] = ec._TokenStats_totalCachedTokensAllTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1348,6 +1348,7 @@ type ComplexityRoot struct {
 	}
 
 	TokenStats struct {
+		LastUpdated                func(childComplexity int) int
 		TotalCachedTokensAllTime   func(childComplexity int) int
 		TotalCachedTokensThisMonth func(childComplexity int) int
 		TotalCachedTokensThisWeek  func(childComplexity int) int
@@ -7343,6 +7344,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TieredPricing.Tiers(childComplexity), true
 
+	case "TokenStats.lastUpdated":
+		if e.complexity.TokenStats.LastUpdated == nil {
+			break
+		}
+
+		return e.complexity.TokenStats.LastUpdated(childComplexity), true
 	case "TokenStats.totalCachedTokensAllTime":
 		if e.complexity.TokenStats.TotalCachedTokensAllTime == nil {
 			break
@@ -31476,6 +31483,8 @@ func (ec *executionContext) fieldContext_Query_tokenStats(_ context.Context, fie
 				return ec.fieldContext_TokenStats_totalOutputTokensAllTime(ctx, field)
 			case "totalCachedTokensAllTime":
 				return ec.fieldContext_TokenStats_totalCachedTokensAllTime(ctx, field)
+			case "lastUpdated":
+				return ec.fieldContext_TokenStats_lastUpdated(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TokenStats", field.Name)
 		},
@@ -39840,6 +39849,35 @@ func (ec *executionContext) fieldContext_TokenStats_totalCachedTokensAllTime(_ c
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenStats_lastUpdated(ctx context.Context, field graphql.CollectedField, obj *TokenStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TokenStats_lastUpdated,
+		func(ctx context.Context) (any, error) {
+			return obj.LastUpdated, nil
+		},
+		nil,
+		ec.marshalOTime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TokenStats_lastUpdated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TokenStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -80436,6 +80474,8 @@ func (ec *executionContext) _TokenStats(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "lastUpdated":
+			out.Values[i] = ec._TokenStats_lastUpdated(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -311,6 +311,9 @@ type TokenStats struct {
 	TotalInputTokensThisMonth  int `json:"totalInputTokensThisMonth"`
 	TotalOutputTokensThisMonth int `json:"totalOutputTokensThisMonth"`
 	TotalCachedTokensThisMonth int `json:"totalCachedTokensThisMonth"`
+	TotalInputTokensAllTime    int `json:"totalInputTokensAllTime"`
+	TotalOutputTokensAllTime   int `json:"totalOutputTokensAllTime"`
+	TotalCachedTokensAllTime   int `json:"totalCachedTokensAllTime"`
 }
 
 type TokenStatsByAPIKey struct {

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -302,18 +302,19 @@ type TestChannelPayload struct {
 }
 
 type TokenStats struct {
-	TotalInputTokensToday      int `json:"totalInputTokensToday"`
-	TotalOutputTokensToday     int `json:"totalOutputTokensToday"`
-	TotalCachedTokensToday     int `json:"totalCachedTokensToday"`
-	TotalInputTokensThisWeek   int `json:"totalInputTokensThisWeek"`
-	TotalOutputTokensThisWeek  int `json:"totalOutputTokensThisWeek"`
-	TotalCachedTokensThisWeek  int `json:"totalCachedTokensThisWeek"`
-	TotalInputTokensThisMonth  int `json:"totalInputTokensThisMonth"`
-	TotalOutputTokensThisMonth int `json:"totalOutputTokensThisMonth"`
-	TotalCachedTokensThisMonth int `json:"totalCachedTokensThisMonth"`
-	TotalInputTokensAllTime    int `json:"totalInputTokensAllTime"`
-	TotalOutputTokensAllTime   int `json:"totalOutputTokensAllTime"`
-	TotalCachedTokensAllTime   int `json:"totalCachedTokensAllTime"`
+	TotalInputTokensToday      int        `json:"totalInputTokensToday"`
+	TotalOutputTokensToday     int        `json:"totalOutputTokensToday"`
+	TotalCachedTokensToday     int        `json:"totalCachedTokensToday"`
+	TotalInputTokensThisWeek   int        `json:"totalInputTokensThisWeek"`
+	TotalOutputTokensThisWeek  int        `json:"totalOutputTokensThisWeek"`
+	TotalCachedTokensThisWeek  int        `json:"totalCachedTokensThisWeek"`
+	TotalInputTokensThisMonth  int        `json:"totalInputTokensThisMonth"`
+	TotalOutputTokensThisMonth int        `json:"totalOutputTokensThisMonth"`
+	TotalCachedTokensThisMonth int        `json:"totalCachedTokensThisMonth"`
+	TotalInputTokensAllTime    int        `json:"totalInputTokensAllTime"`
+	TotalOutputTokensAllTime   int        `json:"totalOutputTokensAllTime"`
+	TotalCachedTokensAllTime   int        `json:"totalCachedTokensAllTime"`
+	LastUpdated                *time.Time `json:"lastUpdated,omitempty"`
 }
 
 type TokenStatsByAPIKey struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -98,6 +98,14 @@ func Run(opts ...fx.Option) {
 				tracing.SetupLogger(log.GetGlobalLogger())
 				slog.SetDefault(log.GetGlobalLogger().AsSlog())
 			}),
+			fx.Invoke(func(usageLogSvc *biz.UsageLogService) {
+				usageLogSvc.OnUsageLogCreated = gql.InvalidateAllTimeTokenStatsCache
+			}),
+			fx.Invoke(func(cfg Config) {
+				if cfg.Dashboard.AllTimeTokenStatsSoftTTL > 0 && cfg.Dashboard.AllTimeTokenStatsHardTTL > 0 {
+					gql.SetTokenStatsCacheTTL(cfg.Dashboard.AllTimeTokenStatsSoftTTL, cfg.Dashboard.AllTimeTokenStatsHardTTL)
+				}
+			}),
 			fx.Invoke(func(lc fx.Lifecycle, worker *gc.Worker) {
 				lc.Append(fx.Hook{
 					OnStart: func(ctx context.Context) error {


### PR DESCRIPTION
This PR adds all-time token statistics to the dashboard, showing cumulative token usage across the entire history of the system. The all-time stats are displayed alongside existing time-range filters (day, week, month) in the Token Stats card.

<img width="259" height="270" alt="Screenshot from 2026-03-03 13-13-48" src="https://github.com/user-attachments/assets/743d7d94-6429-4f3e-a080-41b636401c58" />


## Features

### All-Time Token Statistics
- **New "All" time range tab** in the Token Stats card showing cumulative statistics
- **Real-time aggregation** from usage logs for accurate totals
- **Stale-while-revalidate caching** for optimal performance without sacrificing freshness

### Data Freshness Indicator
- **Info icon with tooltip** (desktop) and **popover** (mobile) showing when all-time stats were last updated
- **Reserved space** prevents layout shift when the icon appears/disappears
- **44x44px touch targets** on mobile for accessibility compliance

### Backend Implementation
- **Stale-while-revalidate caching** with configurable TTL values:
  - Soft TTL (default: 1 hour): Serves stale data while refreshing asynchronously
  - Hard TTL (default: 24 hours): Forces synchronous refresh when exceeded
- **Automatic cache invalidation** when new usage logs are created
- **UTC timestamps** for consistent timezone handling
- **Singleflight pattern** prevents cache stampede under load
- **Thread-safe operations** with proper mutex locking

### Configuration
New optional `dashboard` section in `config.yml`:
```yaml
dashboard:
  all_time_token_stats_soft_ttl: 1h
  all_time_token_stats_hard_ttl: 24h
```

## Technical Details
- Aggregates data from `usage_logs` table for complete historical accuracy
- Cache is invalidated via callback when `UsageLogService` creates new logs
- Uses atomic operations and singleflight for concurrent request handling
- All timestamps use UTC to avoid timezone discrepancies

## UI/UX Improvements
- Added `IconInfoCircle` from @tabler/icons-react for the freshness indicator
- Responsive design with Tooltip for desktop and Popover for mobile
- Fixed-size containers prevent layout shifts when switching time ranges
