### PR TITLE
fix(frontend): correct base URL display and update for search channels

### DIFF
--- a/frontend/src/features/channels/components/search-channel-dialog.tsx
+++ b/frontend/src/features/channels/components/search-channel-dialog.tsx
@@ -81,12 +81,17 @@ export function SearchChannelDialog({
   const [selectedType, setSelectedType] = useState<ChannelType>(defaultType);
   const [showApiKey, setShowApiKey] = useState(false);
 
+  const getInitialBaseURL = (row: typeof initialRow) => {
+    const stored = row?.baseURL;
+    return stored != null && stored !== '' ? stored : getDefaultBaseURL(defaultType);
+  };
+
   const form = useForm<FormValues>({
     resolver: zodResolver(createSchema),
     defaultValues: {
       type: defaultType,
       name: initialRow?.name || '',
-      baseURL: initialRow?.baseURL || getDefaultBaseURL(defaultType),
+      baseURL: getInitialBaseURL(initialRow),
       apiKeysText: (initialRow?.credentials?.apiKeys || []).join('\n'),
       tags: initialRow?.tags || [],
       orderingWeight: initialRow?.orderingWeight || 0,
@@ -101,7 +106,7 @@ export function SearchChannelDialog({
     form.reset({
       type: defaultType,
       name: initialRow?.name || '',
-      baseURL: initialRow?.baseURL || getDefaultBaseURL(defaultType),
+      baseURL: getInitialBaseURL(initialRow),
       apiKeysText: (initialRow?.credentials?.apiKeys || []).join('\n'),
       tags: initialRow?.tags || [],
       orderingWeight: initialRow?.orderingWeight || 0,
@@ -110,11 +115,14 @@ export function SearchChannelDialog({
   }, [open, defaultType, initialRow, form]);
 
   useEffect(() => {
-    const url = getDefaultBaseURL(selectedType);
-    if (url) {
-      form.setValue('baseURL', url, { shouldDirty: true });
-    }
     form.setValue('type', selectedType, { shouldDirty: true });
+    const currentBaseURL = form.getValues('baseURL');
+    if (!currentBaseURL) {
+      const url = getDefaultBaseURL(selectedType);
+      if (url) {
+        form.setValue('baseURL', url, { shouldDirty: true });
+      }
+    }
   }, [selectedType, form]);
 
   const title = isEdit
@@ -135,7 +143,6 @@ export function SearchChannelDialog({
       await updateChannel.mutateAsync({
         id: currentRow.id,
         input: {
-          type: channelType,
           name: values.name,
           baseURL: values.baseURL,
           supportedModels,

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -211,7 +211,7 @@ export const channelSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   type: channelTypeSchema,
-  baseURL: z.string(),
+  baseURL: z.string().optional().nullable(),
   name: z.string(),
   status: channelStatusSchema,
   policies: channelPoliciesSchema.optional().nullable(),


### PR DESCRIPTION
## Summary

Fixes two issues with web search channel editing:

### Problem

1. **Base URL not displayed**: When editing a web search channel, the Base URL field showed the default URL instead of the actual custom URL stored for the channel.

2. **Unknown field error**: Attempting to update a web search channel resulted in an unknown field error because the type field was being sent in the update mutation, but type is marked as immutable in the backend schema and is not included in UpdateChannelInput.

### Root Cause

1. The baseURL in channelSchema was typed as a non-optional z.string(), but GraphQL returns null for empty base URLs. Zod converted these null values to empty strings, causing the UI to fall back to defaults.

2. The useEffect for type changes unconditionally overwrote the baseURL with the default for the selected type, even when editing existing channels.

3. The update mutation incorrectly included type: channelType which is not allowed in UpdateChannelInput.

### Fix

- Updated channelSchema.baseURL to z.string().optional().nullable() to properly handle null values from GraphQL
- Added getInitialBaseURL() helper to preserve custom non-empty URLs over defaults
- Modified type-change effect to only set default baseURL when current value is falsy
- Removed type field from update mutation (type is immutable and cannot be changed after creation)

### Files Changed

- frontend/src/features/channels/data/schema.ts
- frontend/src/features/channels/components/search-channel-dialog.tsx