### PR TITLE
feat(requests): add quick-view drawer and improve JSON display

### DIFF
--- a/frontend/src/components/json-tree-view.tsx
+++ b/frontend/src/components/json-tree-view.tsx
@@ -26,23 +26,50 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE. 
+SOFTWARE.
 */
+
+/** Context that broadcasts global string-expansion state down the tree. */
+const JsonExpandContext = React.createContext<{
+  globalStringExpanded: boolean;
+  hideArrayIndices: boolean;
+  expandDepth: number | 'all';
+}>({
+  globalStringExpanded: false,
+  hideArrayIndices: false,
+  expandDepth: 2,
+});
 
 type JsonViewerProps = {
   data: any;
   rootName?: string;
   defaultExpanded?: boolean;
+  /** Object expansion depth when defaultExpanded=true, or "all" to expand all levels. */
+  expandDepth?: number | 'all';
+  /** Hide array entry index labels (0,1,2...) for a cleaner JSON view. */
+  hideArrayIndices?: boolean;
+  /** When true, all string values render their full content. */
+  globalStringExpanded?: boolean;
   className?: string;
 };
 
-export function JsonViewer({ data, rootName = 'root', defaultExpanded = true, className }: JsonViewerProps) {
+export function JsonViewer({
+  data,
+  rootName = 'root',
+  defaultExpanded = true,
+  expandDepth = 2,
+  hideArrayIndices = false,
+  globalStringExpanded = false,
+  className,
+}: JsonViewerProps) {
   return (
-    <TooltipProvider>
-      <div className={cn('font-mono text-sm', className)}>
-        <JsonNode name={rootName} data={data} isRoot={true} defaultExpanded={defaultExpanded} />
-      </div>
-    </TooltipProvider>
+    <JsonExpandContext.Provider value={{ globalStringExpanded, hideArrayIndices, expandDepth }}>
+      <TooltipProvider>
+        <div className={cn('w-full min-w-0 overflow-x-hidden [contain:inline-size] font-mono text-sm', className)}>
+          <JsonNode name={rootName} data={data} isRoot={true} defaultExpanded={defaultExpanded} />
+        </div>
+      </TooltipProvider>
+    </JsonExpandContext.Provider>
   );
 }
 
@@ -50,17 +77,17 @@ type JsonNodeProps = {
   name: string;
   data: any;
   isRoot?: boolean;
+  isArrayItem?: boolean;
   defaultExpanded?: boolean;
   level?: number;
 };
 
-function JsonNode({ name, data, isRoot = false, defaultExpanded = true, level = 0 }: JsonNodeProps) {
+function JsonNode({ name, data, isRoot = false, isArrayItem = false, defaultExpanded = true, level = 0 }: JsonNodeProps) {
+  const { hideArrayIndices, expandDepth } = React.useContext(JsonExpandContext);
   const [isExpanded, setIsExpanded] = React.useState(defaultExpanded);
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const handleToggle = () => {
-    setIsExpanded(!isExpanded);
-  };
+  const handleToggle = () => setIsExpanded((v) => !v);
 
   const copyToClipboard = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -70,133 +97,272 @@ function JsonNode({ name, data, isRoot = false, defaultExpanded = true, level = 
   };
 
   const dataType = data === null ? 'null' : Array.isArray(data) ? 'array' : typeof data;
-  const isExpandable = data !== null && data !== undefined && !(data instanceof Date) && (dataType === 'object' || dataType === 'array');
-  const itemCount = isExpandable && data !== null && data !== undefined ? Object.keys(data).length : 0;
+  const isExpandable =
+    data !== null &&
+    data !== undefined &&
+    !(data instanceof Date) &&
+    (dataType === 'object' || dataType === 'array');
+  const itemCount =
+    isExpandable && data !== null && data !== undefined ? Object.keys(data).length : 0;
+
+  const childDefaultExpanded =
+    !defaultExpanded ? false : expandDepth === 'all' ? true : dataType === 'array' ? true : level < expandDepth;
+  const hideArrayItemName = isArrayItem && hideArrayIndices;
+  const showName = !hideArrayItemName && name !== '';
 
   return (
-    <div className={cn('group/object pl-4', level > 0 && 'border-border border-l')}>
+    <div className={cn('group/object box-border min-w-0 overflow-hidden', level > 0 && 'border-border border-l pl-2')}>
+      {/* Row: use items-start so the key stays top-aligned when a value expands */}
       <div
         className={cn(
-          'hover:bg-muted/50 group/property -ml-4 flex cursor-pointer items-center gap-1 rounded px-1 py-1',
+          'hover:bg-muted/50 group/property relative flex w-full min-w-0 max-w-full cursor-pointer items-start gap-1 rounded px-0.5 py-0.5 pr-6',
           isRoot && 'text-primary font-semibold'
         )}
         onClick={isExpandable ? handleToggle : undefined}
       >
-        {isExpandable ? (
-          <div className='flex h-4 w-4 items-center justify-center'>
-            {isExpanded ? (
-              <ChevronDown className='text-muted-foreground h-3.5 w-3.5' />
-            ) : (
-              <ChevronRight className='text-muted-foreground h-3.5 w-3.5' />
-            )}
+        {/* Expand chevron — fixed width, top-aligned */}
+        {(isExpandable || !hideArrayItemName) && (
+          <div className='mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center'>
+            {isExpandable ? (
+              isExpanded ? (
+                <ChevronDown className='text-muted-foreground h-3 w-3' />
+              ) : (
+                <ChevronRight className='text-muted-foreground h-3 w-3' />
+              )
+            ) : null}
           </div>
-        ) : (
-          <div className='w-4' />
         )}
 
-        <span className='text-primary'>{name}</span>
+        {/* Key label */}
+        {showName && <span className='text-primary mt-px shrink-0'>{name}</span>}
 
-        <span className='text-muted-foreground'>
-          {isExpandable ? (
-            <>
-              {dataType === 'array' ? '[' : '{'}
-              {!isExpanded && (
-                <span className='text-muted-foreground'>
-                  {' '}
-                  {itemCount} {itemCount === 1 ? 'item' : 'items'} {dataType === 'array' ? ']' : '}'}
-                </span>
-              )}
-            </>
-          ) : (
-            ':'
-          )}
-        </span>
+        {/* Colon / bracket */}
+        {isExpandable ? (
+          <span className='text-muted-foreground mt-px shrink-0'>
+            {dataType === 'array' ? '[' : '{'}
+            {!isExpanded && (
+              <span className='text-muted-foreground'>
+                {' '}
+                {itemCount} {itemCount === 1 ? 'item' : 'items'} {dataType === 'array' ? ']' : '}'}
+              </span>
+            )}
+          </span>
+        ) : (
+          showName && <span className='text-muted-foreground mt-px shrink-0'>:</span>
+        )}
 
-        {!isExpandable && <JsonValue data={data} />}
+        {/* Leaf value — takes remaining width, allows text to truncate */}
+        {!isExpandable && (
+          <div className='min-w-0 flex-1 overflow-hidden'>
+            <JsonValue data={data} />
+          </div>
+        )}
 
-        {!isExpandable && <div className='w-3.5' />}
-
+        {/* Copy button */}
         <button
           onClick={copyToClipboard}
-          className='hover:bg-muted ml-auto rounded p-1 opacity-0 group-hover/property:opacity-100'
+          className='hover:bg-muted absolute top-0.5 right-0.5 shrink-0 rounded p-1 opacity-0 transition-opacity group-hover/property:opacity-100'
           title='Copy to clipboard'
         >
-          {isCopied ? <Check className='h-3.5 w-3.5 text-green-500' /> : <Copy className='text-muted-foreground h-3.5 w-3.5' />}
+          {isCopied ? (
+            <Check className='h-3 w-3 text-green-500' />
+          ) : (
+            <Copy className='text-muted-foreground h-3 w-3' />
+          )}
         </button>
       </div>
 
       {isExpandable && isExpanded && data !== null && data !== undefined && (
-        <div className='pl-4'>
+        <div className='pl-2'>
           {Object.keys(data).map((key) => (
             <JsonNode
               key={key}
-              name={dataType === 'array' ? `${key}` : key}
+              name={key}
               data={data[key]}
+              isArrayItem={dataType === 'array'}
               level={level + 1}
-              defaultExpanded={level < 1}
+              defaultExpanded={childDefaultExpanded}
             />
           ))}
-          <div className='text-muted-foreground py-1 pl-4'>{dataType === 'array' ? ']' : '}'}</div>
+          <div className='text-muted-foreground py-0.5 pl-2 text-xs'>
+            {dataType === 'array' ? ']' : '}'}
+          </div>
         </div>
       )}
     </div>
   );
 }
 
-// Update the JsonValue function to make the entire row clickable with an expand icon
+/** Unescape doubly-escaped JSON sequences (literal \n → newline, etc.). */
+function unescapeJsonString(str: string): string {
+  return str
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\r/g, '\r')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
+/** Try to parse a string as JSON. Returns parsed value or null. */
+function tryParseJson(str: string): any {
+  const trimmed = str.trim();
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      /* not valid JSON */
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalize multiline text for UI display so heavy leading indentation
+ * does not push content off-screen in narrow containers.
+ */
+function normalizeMultilineForDisplay(str: string): string {
+  const lines = str.replace(/\t/g, '  ').split('\n');
+  if (lines.length <= 1) return str;
+
+  // Ignore first line when measuring common indent because many values start
+  // at column 0 then have heavily-indented continuation lines.
+  const continuationLines = lines.slice(1);
+  const indents = continuationLines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      const match = line.match(/^\s+/u);
+      return match ? match[0].length : 0;
+    })
+    .filter((indent) => indent > 0);
+
+  if (indents.length === 0) return str;
+
+  const minIndent = Math.min(...indents);
+  return lines
+    .map((line, index) => {
+      if (index === 0) return line;
+      if (line.trim().length === 0) return line;
+
+      const dedented = line.replace(new RegExp(`^\\s{0,${minIndent}}`, 'u'), '');
+      const extraIndent = dedented.match(/^\s+/u)?.[0]?.length ?? 0;
+
+      // Keep only a tiny visual indent per line to avoid right-shift overflow.
+      if (extraIndent > 2) {
+        return `  ${dedented.trimStart()}`;
+      }
+      return dedented;
+    })
+    .join('\n');
+}
+
 function JsonValue({ data }: { data: any }) {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const { globalStringExpanded } = React.useContext(JsonExpandContext);
+  const [localExpanded, setLocalExpanded] = React.useState<boolean | null>(null);
+  const [showParsed, setShowParsed] = React.useState(false);
   const dataType = typeof data;
-  const TEXT_LIMIT = 80; // Character limit before truncation
 
-  if (data === null) {
-    return <span className='text-rose-500'>null</span>;
-  }
+  // Derived: local override takes precedence, otherwise follow global.
+  const isExpanded = localExpanded ?? globalStringExpanded;
 
-  if (data === undefined) {
-    return <span className='text-muted-foreground'>undefined</span>;
-  }
+  // Reset local override whenever the global toggle changes.
+  React.useEffect(() => {
+    setLocalExpanded(null);
+    setShowParsed(false);
+  }, [globalStringExpanded]);
 
-  if (data instanceof Date) {
-    return <span className='text-purple-500'>{data.toISOString()}</span>;
-  }
+  if (data === null) return <span className='text-rose-500'>null</span>;
+  if (data === undefined) return <span className='text-muted-foreground'>undefined</span>;
+  if (data instanceof Date) return <span className='text-purple-500'>{data.toISOString()}</span>;
 
   switch (dataType) {
-    case 'string':
-      if (data.length > TEXT_LIMIT) {
+    case 'string': {
+      const unescaped = unescapeJsonString(data);
+      const normalized = normalizeMultilineForDisplay(unescaped);
+      const parsedJson = tryParseJson(data);
+
+      if (parsedJson && showParsed) {
         return (
-          <div
-            className='group relative flex flex-1 cursor-pointer items-center text-emerald-500'
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded(!isExpanded);
-            }}
-          >
-            {`"`}
-            {isExpanded ? (
-              <span className='inline-block max-w-full'>{data}</span>
-            ) : (
-              <Tooltip delayDuration={300}>
-                <TooltipTrigger asChild>
-                  <span className='inline-block max-w-full'>{data.substring(0, TEXT_LIMIT)}...</span>
-                </TooltipTrigger>
-                <TooltipContent side='bottom' className='max-w-md p-2 text-xs break-words'>
-                  {data}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {`"`}
-            <div className='absolute top-1/2 right-0 translate-x-[calc(100%+4px)] -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100'>
-              {isExpanded ? (
-                <ChevronUp className='text-muted-foreground h-3 w-3' />
-              ) : (
-                <MoreHorizontal className='text-muted-foreground h-3 w-3' />
-              )}
+          <div className='flex w-full min-w-0 flex-col gap-1'>
+            <div className='flex items-center gap-2'>
+              <span className='text-muted-foreground text-[10px] italic'>JSON</span>
+              <button
+                className='text-muted-foreground hover:text-foreground text-[10px] underline'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowParsed(false);
+                }}
+              >
+                raw
+              </button>
+            </div>
+            <div className='border-border w-full min-w-0 rounded border p-2'>
+              <JsonNode name='' data={parsedJson} level={0} defaultExpanded={true} />
             </div>
           </div>
         );
       }
-      return <span className='text-emerald-500'>{`"${data}"`}</span>;
+
+      return (
+        <div
+          className='group/str flex w-full min-w-0 max-w-full cursor-pointer items-start text-emerald-500'
+          onClick={(e) => {
+            e.stopPropagation();
+            setLocalExpanded(!isExpanded);
+          }}
+        >
+          {isExpanded ? (
+            <pre
+              className='m-0 block min-w-0 max-w-full flex-1 overflow-hidden font-inherit text-inherit'
+              style={{
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'anywhere',
+                wordBreak: 'break-word',
+                tabSize: 2,
+              }}
+            >{`"${normalized}"`}</pre>
+          ) : (
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <span
+                  className='block min-w-0 max-w-full flex-1'
+                  style={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >{`"${normalized}"`}</span>
+              </TooltipTrigger>
+              <TooltipContent side='bottom' className='max-w-md p-2 text-xs break-words'>
+                <span className='whitespace-pre-wrap'>
+                  {`"${normalized.substring(0, 300)}${normalized.length > 300 ? '…' : ''}"`}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <span className='ml-1 shrink-0 opacity-0 transition-opacity group-hover/str:opacity-100'>
+            {isExpanded ? (
+              <ChevronUp className='text-muted-foreground h-3 w-3' />
+            ) : (
+              <MoreHorizontal className='text-muted-foreground h-3 w-3' />
+            )}
+          </span>
+          {parsedJson && isExpanded && (
+            <button
+              className='text-muted-foreground hover:text-foreground ml-1 shrink-0 rounded px-1 text-[10px] underline'
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowParsed(true);
+              }}
+            >
+              parse
+            </button>
+          )}
+        </div>
+      );
+    }
     case 'number':
       return <span className='text-amber-500'>{data}</span>;
     case 'boolean':

--- a/frontend/src/features/requests/components/data-table-view-options.tsx
+++ b/frontend/src/features/requests/components/data-table-view-options.tsx
@@ -31,7 +31,12 @@ export function DataTableViewOptions<TData>({ table }: DataTableViewOptionsProps
         <DropdownMenuSeparator />
         {table
           .getAllColumns()
-          .filter((column) => typeof column.accessorFn !== 'undefined' && column.getCanHide())
+          .filter((column) => {
+            const accessorKey = column.columnDef.accessorKey;
+            const isDataColumn = typeof column.accessorFn !== 'undefined' || typeof accessorKey !== 'undefined';
+            const isDetailsColumn = column.id === 'details' || column.id === 'detail';
+            return (isDataColumn || isDetailsColumn) && column.getCanHide();
+          })
           .map((column) => {
             return (
               <DropdownMenuCheckboxItem

--- a/frontend/src/features/requests/components/request-body-drawer.tsx
+++ b/frontend/src/features/requests/components/request-body-drawer.tsx
@@ -1,0 +1,369 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  FileText,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  Copy,
+  Terminal,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { extractNumberID } from '@/lib/utils';
+import { usePaginationSearch } from '@/hooks/use-pagination-search';
+import { useSelectedProjectId } from '@/stores/projectStore';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { JsonViewer } from '@/components/json-tree-view';
+import { useRequestPermissions } from '../../../hooks/useRequestPermissions';
+import { useRequest, fetchAdjacentRequestPage } from '../data';
+import { Request, RequestConnection } from '../data/schema';
+import { CurlPreviewDialog } from './curl-preview-dialog';
+import { getStatusColor } from './help';
+import { generateRequestCurl } from '../utils/curl-generator';
+
+interface RequestBodyDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** ID of the request that was clicked. */
+  initialRequestId: string | null;
+  /** Position of initialRequestId within initialRequests. */
+  initialIndex: number;
+  /** Current page's request list (DESC order). */
+  initialRequests: Request[];
+  pageInfo?: RequestConnection['pageInfo'];
+  /** Optional server-side filter currently applied to the table. */
+  queryWhere?: Record<string, any>;
+}
+
+export function RequestBodyDrawer({
+  open,
+  onOpenChange,
+  initialRequestId,
+  initialIndex,
+  initialRequests,
+  pageInfo: initialPageInfo,
+  queryWhere,
+}: RequestBodyDrawerProps) {
+  const { t } = useTranslation();
+  const { navigateWithSearch } = usePaginationSearch({ defaultPageSize: 20 });
+  const permissions = useRequestPermissions();
+  const selectedProjectId = useSelectedProjectId();
+
+  // ── internal navigation state ──────────────────────────────────────────────
+  // The drawer manages its own growing list so it can cross page boundaries.
+  const [allRequests, setAllRequests] = useState<Request[]>(initialRequests);
+  const [navPageInfo, setNavPageInfo] = useState(initialPageInfo);
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // Reset when the drawer is (re)opened for a different request.
+  const prevOpenRef = useRef(false);
+  useEffect(() => {
+    const justOpened = open && !prevOpenRef.current;
+    prevOpenRef.current = open;
+    if (justOpened) {
+      setAllRequests(initialRequests);
+      setNavPageInfo(initialPageInfo);
+      setCurrentIndex(initialIndex);
+    }
+  }, [open, initialRequests, initialPageInfo, initialIndex]);
+
+  const currentRequestId = allRequests[currentIndex]?.id ?? initialRequestId;
+
+  // ── toggle for expanding/collapsing all string values ────────────────────
+  const [globalExpanded, setGlobalExpanded] = useState(false);
+
+  // ── fetch detail for current request ──────────────────────────────────────
+  const { data: request, isLoading, isFetching } = useRequest(currentRequestId ?? '');
+
+  // Keep previous request data visible while loading the next one.
+  const displayedRequestRef = useRef<Request | null>(null);
+  if (request) displayedRequestRef.current = request;
+  const displayedRequest = displayedRequestRef.current;
+
+  // ── active tab ─────────────────────────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState('request');
+
+  // ── copy / curl ───────────────────────────────────────────────────────────
+  const [showCurlPreview, setShowCurlPreview] = useState(false);
+  const [curlCommand, setCurlCommand] = useState('');
+
+  const copyBody = useCallback(
+    (data: any) => {
+      try {
+        navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+      } catch {
+        navigator.clipboard.writeText(String(data));
+      }
+      toast.success(t('requests.actions.copy'));
+    },
+    [t]
+  );
+
+  const handleCurlPreview = useCallback(() => {
+    if (!displayedRequest) return;
+    const curl = generateRequestCurl(displayedRequest.requestHeaders, displayedRequest.requestBody, displayedRequest.format as any);
+    setCurlCommand(curl);
+    setShowCurlPreview(true);
+  }, [displayedRequest]);
+
+  // List-level data (always available, no loading flash).
+  const listRequest = allRequests[currentIndex];
+
+  // ── navigation ─────────────────────────────────────────────────────────────
+  // The list is DESC (newest first).
+  // → right arrow = "next" = newer = smaller index.
+  // ← left  arrow = "prev" = older = larger index.
+  const canGoPrev = currentIndex < allRequests.length - 1 || !!navPageInfo?.hasNextPage;
+  const canGoNext = currentIndex > 0 || !!navPageInfo?.hasPreviousPage;
+
+  const handlePrev = useCallback(async () => {
+    if (currentIndex < allRequests.length - 1) {
+      setCurrentIndex((i) => i + 1);
+      return;
+    }
+    // Need to load the next (older) page.
+    if (!navPageInfo?.hasNextPage || !navPageInfo.endCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const result = await fetchAdjacentRequestPage({
+        cursor: navPageInfo.endCursor,
+        direction: 'older',
+        pageSize: initialRequests.length || 20,
+        where: queryWhere,
+        permissions,
+        projectId: selectedProjectId,
+      });
+      setAllRequests((prev) => {
+        const merged = [...prev, ...result.requests];
+        setCurrentIndex(prev.length); // first item of the new batch
+        return merged;
+      });
+      setNavPageInfo((p) =>
+        p
+          ? { ...p, hasNextPage: result.pageInfo.hasNextPage, endCursor: result.pageInfo.endCursor }
+          : result.pageInfo
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [currentIndex, allRequests.length, navPageInfo, isLoadingMore, queryWhere, permissions, selectedProjectId, initialRequests.length]);
+
+  const handleNext = useCallback(async () => {
+    if (currentIndex > 0) {
+      setCurrentIndex((i) => i - 1);
+      return;
+    }
+    // Need to load the previous (newer) page.
+    if (!navPageInfo?.hasPreviousPage || !navPageInfo.startCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const result = await fetchAdjacentRequestPage({
+        cursor: navPageInfo.startCursor,
+        direction: 'newer',
+        pageSize: initialRequests.length || 20,
+        where: queryWhere,
+        permissions,
+        projectId: selectedProjectId,
+      });
+      // Prepend newer items; adjust index for shift.
+      setAllRequests((prev) => {
+        const merged = [...result.requests, ...prev];
+        // Navigate to the newest item in the just-fetched batch.
+        setCurrentIndex(result.requests.length - 1);
+        return merged;
+      });
+      setNavPageInfo((p) =>
+        p
+          ? { ...p, hasPreviousPage: result.pageInfo.hasPreviousPage, startCursor: result.pageInfo.startCursor }
+          : result.pageInfo
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [currentIndex, navPageInfo, isLoadingMore, queryWhere, permissions, selectedProjectId, initialRequests.length]);
+
+  const handleViewDetail = useCallback(() => {
+    if (currentRequestId) {
+      navigateWithSearch({
+        to: '/project/requests/$requestId',
+        params: { requestId: currentRequestId },
+      });
+      onOpenChange(false);
+    }
+  }, [currentRequestId, navigateWithSearch, onOpenChange]);
+
+  // ── render ─────────────────────────────────────────────────────────────────
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side='right'
+        className='flex w-[50vw] min-w-[500px] max-w-[800px] flex-col gap-0 p-0 sm:max-w-[800px]'
+      >
+        {/* Header */}
+        <SheetHeader className='flex-shrink-0 border-b px-6 py-4'>
+          <div className='flex items-center justify-between pr-6'>
+            <SheetTitle className='flex items-center gap-2 text-base'>
+              <FileText className='h-4 w-4' />
+              {listRequest ? (
+                <>
+                  <span className='font-mono'>#{extractNumberID(listRequest.id)}</span>
+                  <Badge className={getStatusColor(listRequest.status)} variant='secondary'>
+                    {t(`requests.status.${listRequest.status}`)}
+                  </Badge>
+                </>
+              ) : isLoading ? (
+                <Skeleton className='h-4 w-16' />
+              ) : null}
+            </SheetTitle>
+
+            <div className='flex items-center gap-1.5'>
+              <Button
+                variant='outline'
+                size='icon'
+                className='h-7 w-7'
+                onClick={handlePrev}
+                disabled={!canGoPrev || isLoadingMore}
+                title={t('requests.drawer.previous')}
+              >
+                <ChevronLeft className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='outline'
+                size='icon'
+                className='h-7 w-7'
+                onClick={handleNext}
+                disabled={!canGoNext || isLoadingMore}
+                title={t('requests.drawer.next')}
+              >
+                <ChevronRight className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={handleViewDetail}
+                className='ml-1 h-7 text-xs'
+              >
+                <ExternalLink className='mr-1 h-3.5 w-3.5' />
+                {t('requests.drawer.viewDetail')}
+              </Button>
+            </div>
+          </div>
+        </SheetHeader>
+
+        {/* Body */}
+        <div className='flex min-h-0 flex-1 flex-col'>
+          {displayedRequest ? (
+            <div className='relative flex min-h-0 flex-1 flex-col'>
+              {isFetching && (
+                <div className='absolute inset-x-0 top-0 z-10 h-0.5 animate-pulse bg-primary/40' />
+              )}
+              <Tabs value={activeTab} onValueChange={setActiveTab} className='flex h-full flex-col'>
+                {/* Tab bar + action buttons */}
+                <div className='mx-6 mt-4 flex flex-shrink-0 items-center gap-2'>
+                  <TabsList className='grid flex-1 grid-cols-2'>
+                    <TabsTrigger value='request'>{t('requests.detail.tabs.request')}</TabsTrigger>
+                    <TabsTrigger value='response'>{t('requests.detail.tabs.response')}</TabsTrigger>
+                  </TabsList>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='h-9 w-9 flex-shrink-0'
+                    onClick={() => setGlobalExpanded((v) => !v)}
+                    title={globalExpanded ? t('requests.drawer.collapseAll') : t('requests.drawer.expandAll')}
+                  >
+                    {globalExpanded ? (
+                      <ChevronsDownUp className='h-4 w-4' />
+                    ) : (
+                      <ChevronsUpDown className='h-4 w-4' />
+                    )}
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='h-9 w-9 flex-shrink-0'
+                    onClick={() =>
+                      copyBody(activeTab === 'request' ? displayedRequest.requestBody : displayedRequest.responseBody)
+                    }
+                    title={t('requests.actions.copy')}
+                  >
+                    <Copy className='h-4 w-4' />
+                  </Button>
+                  {activeTab === 'request' && (
+                    <Button
+                      variant='outline'
+                      size='icon'
+                      className='h-9 w-9 flex-shrink-0'
+                      onClick={handleCurlPreview}
+                      title={t('requests.actions.copyCurl')}
+                    >
+                      <Terminal className='h-4 w-4' />
+                    </Button>
+                  )}
+                </div>
+
+                <TabsContent value='request' className='m-0 min-h-0 flex-1 px-6 pb-6 pt-4'>
+                  <ScrollArea className='bg-muted/20 h-full w-full rounded-lg border p-4'>
+                    {displayedRequest.requestBody ? (
+                      <JsonViewer
+                        key={`req-${currentRequestId}`}
+                        data={displayedRequest.requestBody}
+                        rootName=''
+                        defaultExpanded={true}
+                        expandDepth='all'
+                        hideArrayIndices={true}
+                        globalStringExpanded={globalExpanded}
+                        className='text-sm'
+                      />
+                    ) : (
+                      <div className='flex h-32 items-center justify-center'>
+                        <p className='text-muted-foreground text-sm'>{t('requests.drawer.noRequestBody')}</p>
+                      </div>
+                    )}
+                  </ScrollArea>
+                </TabsContent>
+
+                <TabsContent value='response' className='m-0 min-h-0 flex-1 px-6 pb-6 pt-4'>
+                  <ScrollArea className='bg-muted/20 h-full w-full rounded-lg border p-4'>
+                    {displayedRequest.responseBody ? (
+                      <JsonViewer
+                        key={`res-${currentRequestId}`}
+                        data={displayedRequest.responseBody}
+                        rootName=''
+                        defaultExpanded={true}
+                        expandDepth='all'
+                        hideArrayIndices={true}
+                        globalStringExpanded={globalExpanded}
+                        className='text-sm'
+                      />
+                    ) : (
+                      <div className='flex h-32 items-center justify-center'>
+                        <p className='text-muted-foreground text-sm'>{t('requests.detail.noResponse')}</p>
+                      </div>
+                    )}
+                  </ScrollArea>
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : isLoading ? (
+            <div className='space-y-4 p-6'>
+              <Skeleton className='h-8 w-full' />
+              <Skeleton className='h-64 w-full' />
+              <Skeleton className='h-32 w-full' />
+            </div>
+          ) : null}
+        </div>
+      </SheetContent>
+      <CurlPreviewDialog open={showCurlPreview} onOpenChange={setShowCurlPreview} curlCommand={curlCommand} />
+    </Sheet>
+  );
+}

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -467,7 +467,14 @@ export default function RequestDetailPage() {
                         </div>
                       </div>
                       <div className='bg-muted/20 h-[300px] w-full overflow-auto rounded-lg border p-4'>
-                        <JsonViewer data={request.requestHeaders} rootName='' defaultExpanded={true} className='text-sm' />
+                        <JsonViewer
+                          data={request.requestHeaders}
+                          rootName=''
+                          defaultExpanded={true}
+                          expandDepth='all'
+                          hideArrayIndices={true}
+                          className='text-sm'
+                        />
                       </div>
                     </div>
                   )}
@@ -499,7 +506,14 @@ export default function RequestDetailPage() {
                       </div>
                     </div>
                     <div className='bg-muted/20 h-[500px] w-full overflow-auto rounded-lg border p-4'>
-                      <JsonViewer data={request.requestBody} rootName='' defaultExpanded={true} className='text-sm' />
+                      <JsonViewer
+                        data={request.requestBody}
+                        rootName=''
+                        defaultExpanded={true}
+                        expandDepth='all'
+                        hideArrayIndices={true}
+                        className='text-sm'
+                      />
                     </div>
                   </div>
                 </TabsContent>
@@ -560,7 +574,14 @@ export default function RequestDetailPage() {
                     </div>
                     {request.responseBody ? (
                       <div className='bg-muted/20 h-[500px] w-full overflow-auto rounded-lg border p-4'>
-                        <JsonViewer data={request.responseBody} rootName='' defaultExpanded={true} className='text-sm' />
+                        <JsonViewer
+                          data={request.responseBody}
+                          rootName=''
+                          defaultExpanded={true}
+                          expandDepth='all'
+                          hideArrayIndices={true}
+                          className='text-sm'
+                        />
                       </div>
                     ) : (
                       <div className='bg-muted/20 flex h-[500px] w-full items-center justify-center rounded-lg border'>
@@ -705,7 +726,13 @@ export default function RequestDetailPage() {
                                     </div>
                                   </div>
                                   <div className='bg-background h-64 w-full overflow-auto rounded-lg border p-3'>
-                                    <JsonViewer data={execution.requestHeaders} rootName='' defaultExpanded={false} className='text-xs' />
+                                    <JsonViewer
+                                      data={execution.requestHeaders}
+                                      rootName=''
+                                      defaultExpanded={false}
+                                      hideArrayIndices={true}
+                                      className='text-xs'
+                                    />
                                   </div>
                                 </div>
                               )}
@@ -739,7 +766,13 @@ export default function RequestDetailPage() {
                                     </div>
                                   </div>
                                   <div className='bg-background h-64 w-full overflow-auto rounded-lg border p-3'>
-                                    <JsonViewer data={execution.requestBody} rootName='' defaultExpanded={false} className='text-xs' />
+                                    <JsonViewer
+                                      data={execution.requestBody}
+                                      rootName=''
+                                      defaultExpanded={false}
+                                      hideArrayIndices={true}
+                                      className='text-xs'
+                                    />
                                   </div>
                                 </div>
                               )}
@@ -784,7 +817,13 @@ export default function RequestDetailPage() {
                                     </div>
                                   </div>
                                   <div className='bg-background h-64 w-full overflow-auto rounded-lg border p-3'>
-                                    <JsonViewer data={execution.responseBody} rootName='' defaultExpanded={false} className='text-xs' />
+                                    <JsonViewer
+                                      data={execution.responseBody}
+                                      rootName=''
+                                      defaultExpanded={false}
+                                      hideArrayIndices={true}
+                                      className='text-xs'
+                                    />
                                   </div>
                                 </div>
                               )}

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { useCallback } from 'react';
+
 import { format } from 'date-fns';
 import { ColumnDef } from '@tanstack/react-table';
 import { IconRoute, IconArrowsJoin2 } from '@tabler/icons-react';
 import { zhCN, enUS } from 'date-fns/locale';
-import { FileText, ArrowLeftRight } from 'lucide-react';
+import { ArrowLeftRight, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { extractNumberID } from '@/lib/utils';
 import { formatDuration } from '@/utils/format-duration';
-import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -20,7 +19,13 @@ import { Request } from '../data/schema';
 import { getStatusColor } from './help';
 import { calculateTokensPerSecond, useDisplayMode } from '../utils/tokens-per-second';
 
-export function useRequestsColumns(): ColumnDef<Request>[] {
+import { usePaginationSearch } from '@/hooks/use-pagination-search';
+
+interface UseRequestsColumnsOptions {
+  onBodyClick?: (requestId: string, index: number) => void;
+}
+
+export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnDef<Request>[] {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'zh' ? zhCN : enUS;
   const permissions = useRequestPermissions();
@@ -34,15 +39,11 @@ export function useRequestsColumns(): ColumnDef<Request>[] {
       accessorKey: 'id',
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('common.columns.id')} />,
       cell: ({ row }) => {
-        const handleClick = useCallback(() => {
-          navigateWithSearch({
-            to: '/project/requests/$requestId',
-            params: { requestId: row.original.id },
-          });
-        }, [row.original.id, navigateWithSearch]);
-
         return (
-          <button onClick={handleClick} className='text-primary cursor-pointer font-mono text-xs hover:underline'>
+          <button
+            onClick={() => options?.onBodyClick?.(row.original.id, row.index)}
+            className='text-primary cursor-pointer font-mono text-xs hover:underline'
+          >
             #{extractNumberID(row.getValue('id'))}
           </button>
         );
@@ -481,21 +482,21 @@ export function useRequestsColumns(): ColumnDef<Request>[] {
     {
       id: 'details',
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.details')} />,
-      cell: ({ row }) => {
-        const handleViewDetails = () => {
-          navigateWithSearch({
-            to: '/project/requests/$requestId',
-            params: { requestId: row.original.id },
-          });
-        };
-
-        return (
-          <Button variant='outline' size='sm' onClick={handleViewDetails}>
-            <FileText className='mr-2 h-4 w-4' />
-            {t('requests.actions.viewDetails')}
-          </Button>
-        );
-      },
+      cell: ({ row }) => (
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={() =>
+            navigateWithSearch({
+              to: '/project/requests/$requestId',
+              params: { requestId: row.original.id },
+            })
+          }
+        >
+          <FileText className='mr-2 h-4 w-4' />
+          {t('requests.actions.viewDetails')}
+        </Button>
+      ),
       enableHiding: true,
     },
     {

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   ColumnFiltersState,
   RowData,
@@ -22,9 +22,9 @@ import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Request, RequestConnection } from '../data/schema';
 import { DataTableToolbar } from './data-table-toolbar';
 import { useRequestsColumns } from './requests-columns';
+import { RequestBodyDrawer } from './request-body-drawer';
 
 const MotionTableRow = motion.create(TableRow);
-const MotionExpandedRow = motion.create(TableRow);
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -44,6 +44,7 @@ interface RequestsTableProps {
   channelFilter: string[];
   apiKeyFilter: string[];
   dateRange?: DateTimeRangeValue;
+  queryWhere?: Record<string, any>;
   onNextPage: () => void;
   onPreviousPage: () => void;
   onPageSizeChange: (pageSize: number) => void;
@@ -69,6 +70,7 @@ export function RequestsTable({
   channelFilter,
   apiKeyFilter,
   dateRange,
+  queryWhere,
   onNextPage,
   onPreviousPage,
   onPageSizeChange,
@@ -83,7 +85,18 @@ export function RequestsTable({
   onAutoRefreshChange,
 }: RequestsTableProps) {
   const { t } = useTranslation();
-  const requestsColumns = useRequestsColumns();
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerInitialRequestId, setDrawerInitialRequestId] = useState<string | null>(null);
+  const [drawerInitialIndex, setDrawerInitialIndex] = useState(0);
+
+  const handleBodyClick = useCallback((requestId: string, index: number) => {
+    setDrawerInitialRequestId(requestId);
+    setDrawerInitialIndex(index);
+    setDrawerOpen(true);
+  }, []);
+
+  const requestsColumns = useRequestsColumns({ onBodyClick: handleBodyClick });
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
@@ -263,6 +276,16 @@ export function RequestsTable({
           onPageSizeChange={onPageSizeChange}
         />
       </div>
+
+      <RequestBodyDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        initialRequestId={drawerInitialRequestId}
+        initialIndex={drawerInitialIndex}
+        initialRequests={data}
+        pageInfo={pageInfo}
+        queryWhere={queryWhere}
+      />
     </div>
   );
 }

--- a/frontend/src/features/requests/data/requests.ts
+++ b/frontend/src/features/requests/data/requests.ts
@@ -291,6 +291,38 @@ export function useRequest(id: string) {
   });
 }
 
+/**
+ * Imperative (non-hook) fetch of a page of requests for drawer navigation.
+ * direction 'older' fetches the page after endCursor (older in DESC order).
+ * direction 'newer' fetches the page before startCursor (newer in DESC order).
+ */
+export async function fetchAdjacentRequestPage(params: {
+  cursor: string;
+  direction: 'older' | 'newer';
+  pageSize: number;
+  where?: Record<string, any>;
+  permissions: { canViewApiKeys: boolean; canViewChannels: boolean };
+  projectId?: string | null;
+}): Promise<{ requests: Request[]; pageInfo: RequestConnection['pageInfo'] }> {
+  const query = buildRequestsQuery(params.permissions);
+  const variables =
+    params.direction === 'older'
+      ? { first: params.pageSize, after: params.cursor }
+      : { last: params.pageSize, before: params.cursor };
+
+  const where: Record<string, any> = { ...params.where };
+  if (params.projectId) where.projectID = params.projectId;
+
+  const headers = params.projectId ? { 'X-Project-ID': params.projectId } : undefined;
+  const data = await graphqlRequest<{ requests: RequestConnection }>(
+    query,
+    { ...variables, where: Object.keys(where).length > 0 ? where : undefined, orderBy: { field: 'CREATED_AT', direction: 'DESC' } },
+    headers
+  );
+  const result = requestConnectionSchema.parse(data?.requests);
+  return { requests: result.edges.map((e) => e.node), pageInfo: result.pageInfo };
+}
+
 export function useRequestExecutions(
   requestID: string,
   variables?: {

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -132,6 +132,7 @@ function RequestsContent() {
         channelFilter={channelFilter}
         apiKeyFilter={apiKeyFilter}
         dateRange={dateRange}
+        queryWhere={whereClause}
         onNextPage={handleNextPage}
         onPreviousPage={handlePreviousPage}
         onPageSizeChange={handlePageSizeChange}

--- a/frontend/src/locales/en/requests.json
+++ b/frontend/src/locales/en/requests.json
@@ -77,5 +77,11 @@
   "requests.dialogs.requestDetail.noExecutions": "No executions",
   "requests.dialogs.requestDetail.notFound": "Request not found",
   "requests.errors.loadRequestsFailed": "Failed to load requests",
-  "requests.errors.loadRequestDetailFailed": "Failed to load request details"
+  "requests.errors.loadRequestDetailFailed": "Failed to load request details",
+  "requests.drawer.previous": "Previous",
+  "requests.drawer.next": "Next",
+  "requests.drawer.viewDetail": "View Detail",
+  "requests.drawer.noRequestBody": "No request body",
+  "requests.drawer.expandAll": "Expand all",
+  "requests.drawer.collapseAll": "Collapse all"
 }

--- a/frontend/src/locales/zh-CN/requests.json
+++ b/frontend/src/locales/zh-CN/requests.json
@@ -77,5 +77,11 @@
   "requests.dialogs.requestDetail.noExecutions": "暂无执行记录",
   "requests.dialogs.requestDetail.notFound": "请求不存在",
   "requests.errors.loadRequestsFailed": "加载请求失败",
-  "requests.errors.loadRequestDetailFailed": "加载请求详情失败"
+  "requests.errors.loadRequestDetailFailed": "加载请求详情失败",
+  "requests.drawer.previous": "上一条",
+  "requests.drawer.next": "下一条",
+  "requests.drawer.viewDetail": "查看详情",
+  "requests.drawer.noRequestBody": "无请求体",
+  "requests.drawer.expandAll": "展开全部",
+  "requests.drawer.collapseAll": "折叠全部"
 }


### PR DESCRIPTION
## Summary

Adds a quick-view side drawer to the requests list page and improves JSON rendering in both the drawer and the detail page.

### Behavior changes

- **Click on request ID** → opens the quick-view drawer (previously navigated to detail page)
- **Click on Details column** → still navigates to the full detail page (behavior unchanged)
- The drawer includes a **"View Detail"** button to navigate to the full detail page from within it
- The **Details column** can now be hidden via view options to avoid duplication

### Quick-view drawer features

- Shows request body and response body side-by-side without leaving the list page
- **Previous / Next navigation** to browse through log entries while keeping filter context
- Copies the current active filters (`whereClause`) so navigation stays within the filtered result set
- One-click **"Expand all" / "Collapse all"** toggle for all string values in the JSON view
- Copy button and cURL command generation (same as detail page)

### JSON display improvements

- Arrays are **fully expanded by default** at all levels (e.g. the `messages` array in chat requests is always visible)
- Objects are expanded **2 levels deep** by default for a good initial overview
- **Array indices are hidden** in the drawer to save horizontal space and keep the view clean
- String values with escape sequences (`\n`, `\t`, `\\`) are **unescaped and rendered with `white-space: pre-wrap`**, so multiline content is readable without copying to an IDE
- JSON-encoded string values (a string whose content is valid JSON) are **auto-detected and offered as a nested JSON tree**, useful for nested serialized payloads
- Multiline strings default to **single-line display** with click-to-expand, keeping rows compact

## Screenshots

![Drawer open with request/response body](https://github.com/user-attachments/assets/453e781a-a1c0-4a96-ba85-9e07a58925c1)
![JSON expanded view in drawer](https://github.com/user-attachments/assets/1f29d7df-fbf2-4cdc-a4f5-d0a9b4f319e6)

## Test plan

- [ ] Click a request ID in the list → drawer opens showing request and response body
- [ ] Use Prev / Next buttons to navigate between entries; verify filter context is maintained
- [ ] Click "View Detail" inside the drawer → navigates to the full detail page
- [ ] Click the Details column → still navigates to the full detail page directly
- [ ] Hide the Details column via view options — no duplicate navigation entries
- [ ] Verify `messages` array in a chat request is expanded by default
- [ ] Check that `\n` in a JSON string value renders as an actual newline
- [ ] Find a request with a JSON-encoded string value; verify it offers to parse as nested JSON
- [ ] Toggle "Expand all" / "Collapse all" in the drawer and confirm all string nodes respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)