### PR TITLE
fix: unnecessary exposure of DB port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-axonhub_password}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     networks:
       - axonhub-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,6 @@ services:
   #     MYSQL_PASSWORD: ${MYSQL_PASSWORD:-axonhub_password}
   #   volumes:
   #     - mysql_data:/var/lib/mysql
-  #   ports:
-  #     - "3306:3306"
   #   networks:
   #     - axonhub-network
   #   restart: unless-stopped


### PR DESCRIPTION
There's no need to expose PG's port, cuz Axonhub can connect to PG via its internal network. The same for MySQL.
Exposure by default may introduce high risks of data lose (especially with default passwd of `axonhub_password`).
Please consider merge this patch ASAP.