### PR TITLE
feat: auto fetch the latest version of antigravity for UA

### DIFF
--- a/cmd/axonhub/main.go
+++ b/cmd/axonhub/main.go
@@ -40,7 +40,6 @@ func main() {
 		}
 	}
 
-	antigravity.InitVersion()
 	startServer()
 }
 
@@ -87,6 +86,7 @@ func startServer() {
 							os.Exit(1)
 						}
 					}()
+					go antigravity.InitVersion(context.Background())
 
 					return nil
 				},

--- a/cmd/axonhub/main.go
+++ b/cmd/axonhub/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/metrics"
 	"github.com/looplj/axonhub/internal/server"
+	"github.com/looplj/axonhub/llm/transformer/antigravity"
 )
 
 func main() {
@@ -39,6 +40,7 @@ func main() {
 		}
 	}
 
+	antigravity.InitVersion()
 	startServer()
 }
 

--- a/internal/server/api/antigravity.go
+++ b/internal/server/api/antigravity.go
@@ -276,7 +276,7 @@ func (h *AntigravityHandlers) resolveProjectID(ctx context.Context, accessToken 
 			Headers: http.Header{
 				"Authorization":     []string{fmt.Sprintf("Bearer %s", accessToken)},
 				"Content-Type":      []string{"application/json"},
-				"User-Agent":        []string{antigravity.UserAgent},
+				"User-Agent":        []string{antigravity.GetUserAgent()},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
 				"Client-Metadata":   []string{antigravity.ClientMetadata},
 			},
@@ -365,7 +365,7 @@ func (h *AntigravityHandlers) onboardUser(ctx context.Context, accessToken, tier
 			Headers: http.Header{
 				"Authorization":     []string{fmt.Sprintf("Bearer %s", accessToken)},
 				"Content-Type":      []string{"application/json"},
-				"User-Agent":        []string{antigravity.UserAgent},
+				"User-Agent":        []string{antigravity.GetUserAgent()},
 				"X-Goog-Api-Client": []string{"google-cloud-sdk vscode_cloudshelleditor/0.1"},
 				"Client-Metadata":   []string{antigravity.ClientMetadata},
 			},

--- a/llm/transformer/antigravity/constants.go
+++ b/llm/transformer/antigravity/constants.go
@@ -24,8 +24,6 @@ const (
 	// EndpointProd is the production endpoint.
 	EndpointProd = "https://cloudcode-pa.googleapis.com"
 
-	// UserAgent used for requests.
-	UserAgent = "antigravity/1.15.8 windows/amd64"
 
 	// ApiClient used for X-Goog-Api-Client header.
 	ApiClient = "google-cloud-sdk vscode_cloudshelleditor/0.1"

--- a/llm/transformer/antigravity/token_provider.go
+++ b/llm/transformer/antigravity/token_provider.go
@@ -13,7 +13,7 @@ import (
 func NewTokenProvider(params oauth.TokenProviderParams) *oauth.TokenProvider {
 	params.OAuthUrls = DefaultTokenURLs
 	if params.UserAgent == "" {
-		params.UserAgent = UserAgent
+		params.UserAgent = GetUserAgent()
 	}
 
 	params.ExchangeStrategy = &AntigravityExchangeStrategy{

--- a/llm/transformer/antigravity/transformer.go
+++ b/llm/transformer/antigravity/transformer.go
@@ -197,7 +197,7 @@ func (t *Transformer) TransformRequest(ctx context.Context, llmReq *llm.Request)
 	// 5. Build new Headers
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
-	headers.Set("User-Agent", UserAgent)
+	headers.Set("User-Agent", GetUserAgent())
 	headers.Set("X-Goog-Api-Client", ApiClient)
 	headers.Set("Client-Metadata", ClientMetadata)
 	headers.Set("X-Opencode-Tools-Debug", "1")

--- a/llm/transformer/antigravity/transformer_test.go
+++ b/llm/transformer/antigravity/transformer_test.go
@@ -73,7 +73,7 @@ func TestTransformRequest_Antigravity(t *testing.T) {
 
 		// Check Headers
 		assert.Equal(t, "application/json", httpReq.Headers.Get("Content-Type"))
-		assert.Equal(t, UserAgent, httpReq.Headers.Get("User-Agent"))
+		assert.Equal(t, GetUserAgent(), httpReq.Headers.Get("User-Agent"))
 		assert.Equal(t, ApiClient, httpReq.Headers.Get("X-Goog-Api-Client"))
 		assert.Equal(t, ClientMetadata, httpReq.Headers.Get("Client-Metadata"))
 		// Since we mocked the token response, we expect the mock access token in Auth config
@@ -439,7 +439,7 @@ func TestOAuthOnlyHeaders(t *testing.T) {
 
 	// Verify other required headers are present
 	assert.Equal(t, "application/json", httpReq.Headers.Get("Content-Type"))
-	assert.Equal(t, UserAgent, httpReq.Headers.Get("User-Agent"))
+	assert.Equal(t, GetUserAgent(), httpReq.Headers.Get("User-Agent"))
 	assert.Equal(t, ApiClient, httpReq.Headers.Get("X-Goog-Api-Client"))
 	assert.Equal(t, ClientMetadata, httpReq.Headers.Get("Client-Metadata"))
 }

--- a/llm/transformer/antigravity/version.go
+++ b/llm/transformer/antigravity/version.go
@@ -1,0 +1,119 @@
+package antigravity
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"sync"
+	"time"
+)
+
+const (
+	// UserAgentVersionFallback is the hardcoded fallback version used when remote fetch fails.
+	UserAgentVersionFallback = "1.20.4"
+
+	// versionURL is the auto-updater endpoint that returns the latest Antigravity version as plain text.
+	versionURL = "https://antigravity-auto-updater-974169037036.us-central1.run.app"
+
+	// changelogURL is a fallback page to scrape the version from.
+	changelogURL = "https://antigravity.google/changelog"
+
+	// versionFetchTimeout is the maximum time allowed per fetch attempt.
+	versionFetchTimeout = 5 * time.Second
+
+	// changelogScanBytes is the number of bytes to read from the changelog page.
+	changelogScanBytes = 5000
+)
+
+var versionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+var (
+	mu              sync.RWMutex
+	currentVersion  = UserAgentVersionFallback
+	versionResolved = false
+)
+
+func GetUserAgent() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return "antigravity/" + currentVersion + " windows/amd64"
+}
+
+func GetVersion() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return currentVersion
+}
+
+func setVersion(v string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if versionResolved {
+		return
+	}
+	currentVersion = v
+	versionResolved = true
+}
+
+func InitVersion() {
+	fallback := UserAgentVersionFallback
+
+	if v := fetchVersion(versionURL, 0); v != "" {
+		if v != fallback {
+			slog.Info("antigravity: version updated from auto-updater", "version", v, "previous", fallback)
+		} else {
+			slog.Debug("antigravity: version unchanged", "version", v, "source", "api")
+		}
+		setVersion(v)
+		return
+	}
+
+	if v := fetchVersion(changelogURL, changelogScanBytes); v != "" {
+		if v != fallback {
+			slog.Info("antigravity: version updated from changelog", "version", v, "previous", fallback)
+		} else {
+			slog.Debug("antigravity: version unchanged", "version", v, "source", "changelog")
+		}
+		setVersion(v)
+		return
+	}
+
+	slog.Info("antigravity: version fetch failed, using fallback", "fallback", fallback)
+	setVersion(fallback)
+}
+
+func fetchVersion(url string, maxBytes int) string {
+	client := &http.Client{Timeout: versionFetchTimeout}
+	resp, err := client.Get(url) //nolint:noctx
+	if err != nil {
+		slog.Debug("antigravity: version fetch error", "url", url, "error", err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Debug("antigravity: version fetch non-200", "url", url, "status", resp.StatusCode)
+		return ""
+	}
+
+	var body []byte
+	if maxBytes > 0 {
+		buf := make([]byte, maxBytes)
+		n, _ := io.ReadFull(resp.Body, buf)
+		body = buf[:n]
+	} else {
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			slog.Debug("antigravity: version read error", "url", url, "error", err)
+			return ""
+		}
+	}
+
+	match := versionRegex.Find(body)
+	if match == nil {
+		slog.Debug("antigravity: no version found in response", "url", url)
+		return ""
+	}
+	return string(match)
+}

--- a/llm/transformer/antigravity/version.go
+++ b/llm/transformer/antigravity/version.go
@@ -1,6 +1,7 @@
 package antigravity
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,11 +14,11 @@ const (
 	// UserAgentVersionFallback is the hardcoded fallback version used when remote fetch fails.
 	UserAgentVersionFallback = "1.20.4"
 
-	// versionURL is the auto-updater endpoint that returns the latest Antigravity version as plain text.
-	versionURL = "https://antigravity-auto-updater-974169037036.us-central1.run.app"
+	// defaultVersionURL is the auto-updater endpoint that returns the latest Antigravity version as plain text.
+	defaultVersionURL = "https://antigravity-auto-updater-974169037036.us-central1.run.app"
 
-	// changelogURL is a fallback page to scrape the version from.
-	changelogURL = "https://antigravity.google/changelog"
+	// defaultChangelogURL is a fallback page to scrape the version from.
+	defaultChangelogURL = "https://antigravity.google/changelog"
 
 	// versionFetchTimeout is the maximum time allowed per fetch attempt.
 	versionFetchTimeout = 5 * time.Second
@@ -29,71 +30,90 @@ const (
 var versionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
 
 var (
-	mu              sync.RWMutex
-	currentVersion  = UserAgentVersionFallback
-	versionResolved = false
+	versionMu      sync.RWMutex
+	currentVersion = UserAgentVersionFallback
+	initOnce       sync.Once
 )
 
 func GetUserAgent() string {
-	mu.RLock()
-	defer mu.RUnlock()
+	versionMu.RLock()
+	defer versionMu.RUnlock()
 	return "antigravity/" + currentVersion + " windows/amd64"
 }
 
 func GetVersion() string {
-	mu.RLock()
-	defer mu.RUnlock()
+	versionMu.RLock()
+	defer versionMu.RUnlock()
 	return currentVersion
 }
 
 func setVersion(v string) {
-	mu.Lock()
-	defer mu.Unlock()
-	if versionResolved {
-		return
-	}
+	versionMu.Lock()
+	defer versionMu.Unlock()
 	currentVersion = v
-	versionResolved = true
 }
 
-func InitVersion() {
+type versionFetcher struct {
+	versionURL   string
+	changelogURL string
+	httpClient   *http.Client
+}
+
+var defaultFetcher = &versionFetcher{
+	versionURL:   defaultVersionURL,
+	changelogURL: defaultChangelogURL,
+	httpClient:   &http.Client{Timeout: versionFetchTimeout},
+}
+
+func InitVersion(ctx context.Context) {
+	initOnce.Do(func() {
+		defaultFetcher.init(ctx)
+	})
+}
+
+func (f *versionFetcher) init(ctx context.Context) {
 	fallback := UserAgentVersionFallback
 
-	if v := fetchVersion(versionURL, 0); v != "" {
+	if v := f.fetchVersion(ctx, f.versionURL, 0); v != "" {
 		if v != fallback {
-			slog.Info("antigravity: version updated from auto-updater", "version", v, "previous", fallback)
+			slog.InfoContext(ctx, "antigravity: version updated from auto-updater", "version", v, "previous", fallback)
 		} else {
-			slog.Debug("antigravity: version unchanged", "version", v, "source", "api")
+			slog.DebugContext(ctx, "antigravity: version unchanged", "version", v, "source", "api")
 		}
 		setVersion(v)
 		return
 	}
 
-	if v := fetchVersion(changelogURL, changelogScanBytes); v != "" {
+	if v := f.fetchVersion(ctx, f.changelogURL, changelogScanBytes); v != "" {
 		if v != fallback {
-			slog.Info("antigravity: version updated from changelog", "version", v, "previous", fallback)
+			slog.InfoContext(ctx, "antigravity: version updated from changelog", "version", v, "previous", fallback)
 		} else {
-			slog.Debug("antigravity: version unchanged", "version", v, "source", "changelog")
+			slog.DebugContext(ctx, "antigravity: version unchanged", "version", v, "source", "changelog")
 		}
 		setVersion(v)
 		return
 	}
 
-	slog.Info("antigravity: version fetch failed, using fallback", "fallback", fallback)
+	slog.InfoContext(ctx, "antigravity: version fetch failed, using fallback", "fallback", fallback)
 	setVersion(fallback)
 }
 
-func fetchVersion(url string, maxBytes int) string {
-	client := &http.Client{Timeout: versionFetchTimeout}
-	resp, err := client.Get(url) //nolint:noctx
+func (f *versionFetcher) fetchVersion(ctx context.Context, url string, maxBytes int) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.Debug("antigravity: version fetch error", "url", url, "error", err)
+		slog.DebugContext(ctx, "antigravity: failed to build version request", "url", url, "error", err)
+		return ""
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		slog.DebugContext(ctx, "antigravity: version fetch error", "url", url, "error", err)
 		return ""
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Debug("antigravity: version fetch non-200", "url", url, "status", resp.StatusCode)
+		slog.DebugContext(ctx, "antigravity: version fetch non-200", "url", url, "status", resp.StatusCode)
 		return ""
 	}
 
@@ -105,14 +125,14 @@ func fetchVersion(url string, maxBytes int) string {
 	} else {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			slog.Debug("antigravity: version read error", "url", url, "error", err)
+			slog.DebugContext(ctx, "antigravity: version read error", "url", url, "error", err)
 			return ""
 		}
 	}
 
 	match := versionRegex.Find(body)
 	if match == nil {
-		slog.Debug("antigravity: no version found in response", "url", url)
+		slog.DebugContext(ctx, "antigravity: no version found in response", "url", url)
 		return ""
 	}
 	return string(match)

--- a/llm/transformer/antigravity/version_test.go
+++ b/llm/transformer/antigravity/version_test.go
@@ -1,0 +1,177 @@
+package antigravity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetVersionState resets the package-level version state between tests.
+// Must be called at the start of each test that exercises InitVersion/fetchVersion.
+func resetVersionState(t *testing.T) {
+	t.Helper()
+	versionMu.Lock()
+	currentVersion = UserAgentVersionFallback
+	versionMu.Unlock()
+	initOnce = sync.Once{}
+}
+
+func newFetcher(versionSrv, changelogSrv *httptest.Server) *versionFetcher {
+	vURL := ""
+	if versionSrv != nil {
+		vURL = versionSrv.URL
+	}
+	cURL := ""
+	if changelogSrv != nil {
+		cURL = changelogSrv.URL
+	}
+	return &versionFetcher{
+		versionURL:   vURL,
+		changelogURL: cURL,
+		httpClient:   &http.Client{},
+	}
+}
+
+func TestFetchVersion_AutoUpdaterSuccess(t *testing.T) {
+	resetVersionState(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "1.99.0")
+	}))
+	defer srv.Close()
+
+	f := newFetcher(srv, nil)
+	f.init(context.Background())
+
+	assert.Equal(t, "1.99.0", GetVersion())
+	assert.Equal(t, "antigravity/1.99.0 windows/amd64", GetUserAgent())
+}
+
+// TestFetchVersion_ChangelogFallback verifies the changelog scrape path is used
+// when the auto-updater endpoint is unavailable.
+func TestFetchVersion_ChangelogFallback(t *testing.T) {
+	resetVersionState(t)
+
+	vSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer vSrv.Close()
+
+	cSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html>...Antigravity 1.21.0 released...</html>`)
+	}))
+	defer cSrv.Close()
+
+	f := newFetcher(vSrv, cSrv)
+	f.init(context.Background())
+
+	assert.Equal(t, "1.21.0", GetVersion())
+}
+
+// TestFetchVersion_HardcodedFallback verifies the hardcoded fallback is used when
+// both remote endpoints are unavailable.
+func TestFetchVersion_HardcodedFallback(t *testing.T) {
+	resetVersionState(t)
+
+	vSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer vSrv.Close()
+
+	cSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer cSrv.Close()
+
+	f := newFetcher(vSrv, cSrv)
+	f.init(context.Background())
+
+	assert.Equal(t, UserAgentVersionFallback, GetVersion())
+}
+
+// TestFetchVersion_NoSemverInResponse verifies that a response with no parseable
+// semver falls through to the next source.
+func TestFetchVersion_NoSemverInResponse(t *testing.T) {
+	resetVersionState(t)
+
+	vSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "no version here")
+	}))
+	defer vSrv.Close()
+
+	cSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "release: 2.0.1")
+	}))
+	defer cSrv.Close()
+
+	f := newFetcher(vSrv, cSrv)
+	f.init(context.Background())
+
+	assert.Equal(t, "2.0.1", GetVersion())
+}
+
+// TestInitVersion_OnceGuard verifies that InitVersion only initialises once even
+// when called concurrently multiple times.
+func TestInitVersion_OnceGuard(t *testing.T) {
+	resetVersionState(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		fmt.Fprint(w, "1.50.0")
+	}))
+	defer srv.Close()
+
+	f := &versionFetcher{
+		versionURL:   srv.URL,
+		changelogURL: srv.URL,
+		httpClient:   &http.Client{},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			initOnce.Do(func() { f.init(context.Background()) })
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, "1.50.0", GetVersion())
+	// auto-updater should have been contacted exactly once
+	require.Equal(t, 1, callCount, "version endpoint should only be called once")
+}
+
+// TestFetchVersion_ChangelogMaxBytes verifies that only the first changelogScanBytes
+// of the changelog body are inspected.
+func TestFetchVersion_ChangelogMaxBytes(t *testing.T) {
+	resetVersionState(t)
+
+	vSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer vSrv.Close()
+
+	padding := make([]byte, changelogScanBytes+100)
+	for i := range padding {
+		padding[i] = 'x'
+	}
+
+	cSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(padding)
+		fmt.Fprint(w, "9.9.9")
+	}))
+	defer cSrv.Close()
+
+	f := newFetcher(vSrv, cSrv)
+	f.init(context.Background())
+
+	assert.Equal(t, UserAgentVersionFallback, GetVersion())
+}


### PR DESCRIPTION
Auto fetch the latest version of antigravity instead of hard-coded version (but still hard-coded a version for fallback).

Before
<img width="1752" height="501" alt="image" src="https://github.com/user-attachments/assets/2c5b80ee-2707-41f1-a8c9-a14a638bf85e" />
After
<img width="2024" height="1114" alt="image" src="https://github.com/user-attachments/assets/184b97c2-abd5-4c29-a54d-b72fc73b2644" />
