### PR TITLE
style: remove width limit on model list

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -118,7 +118,7 @@ const FetchedModelItem = memo(({
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          className='max-w-[200px] flex-1 cursor-pointer truncate'
+          className='flex-1 cursor-pointer truncate'
           onClick={onToggle}
         >
           {model}


### PR DESCRIPTION
display full model names in list

更改前
<img width="488" height="603" alt="图片" src="https://github.com/user-attachments/assets/67b463ed-27cd-478b-a6dc-78e6c6be1179" />

更改后
<img width="420" height="557" alt="图片" src="https://github.com/user-attachments/assets/0e0bf0b3-a993-4877-94ce-ed250b8aebf7" />


