### PR TITLE
feat: allow type editing for third-party codex/claudecode channels and make channel name clickable

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -195,8 +195,24 @@ function getNextDuplicateName(name: string, existingNames: Set<string>) {
   }
 }
 
-// OAuth provider keys that require special auth flow
-const oauthProviderKeys = ['codex', 'claudecode', 'antigravity', 'github_copilot'];
+// Providers that are always OAuth (no third-party API key mode)
+const alwaysOAuthProviderKeys = ['antigravity', 'github_copilot'];
+
+function isOfficialCodexChannel(channel: { credentials?: { apiKey?: string } }): boolean {
+  try {
+    const apiKey = channel.credentials?.apiKey || '';
+    const json = JSON.parse(apiKey);
+    return !!(json.access_token && json.refresh_token);
+  } catch {
+    return false;
+  }
+}
+
+function isOfficialClaudeCodeChannel(channel: { credentials?: { apiKey?: string }; baseURL: string }): boolean {
+  const apiKey = channel.credentials?.apiKey || '';
+  const defaultURL = getDefaultBaseURL('claudecode');
+  return apiKey.includes('sk-ant-oat') || apiKey.includes('sk-ant-api03') || channel.baseURL === defaultURL;
+}
 
 export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpenChange, showModelsPanel = false }: Props) {
   const { t } = useTranslation();
@@ -343,26 +359,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
     // Detect authMode for codex and claudecode
     if (initialRow.type === 'codex') {
-      try {
-        const apiKey = initialRow.credentials?.apiKey || '';
-        const json = JSON.parse(apiKey);
-        if (json.access_token && json.refresh_token) {
-          setAuthMode('official');
-        } else {
-          setAuthMode('third-party');
-        }
-      } catch {
-        setAuthMode('third-party');
-      }
+      setAuthMode(isOfficialCodexChannel(initialRow) ? 'official' : 'third-party');
     } else if (initialRow.type === 'claudecode') {
-      const apiKey = initialRow.credentials?.apiKey || '';
-      const defaultURL = getDefaultBaseURL('claudecode');
-      // For Claude Code, it's official if it's an official token (sk-ant-oat or sk-ant-api03) or uses the default base URL
-      if (apiKey.includes('sk-ant-oat') || apiKey.includes('sk-ant-api03') || initialRow.baseURL === defaultURL) {
-        setAuthMode('official');
-      } else {
-        setAuthMode('third-party');
-      }
+      setAuthMode(isOfficialClaudeCodeChannel(initialRow) ? 'official' : 'third-party');
     }
   }, [initialRow]);
 
@@ -576,15 +575,23 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
 
 
-  // OAuth providers cannot have their provider/API format changed during edit
-  const isOAuthChannel = isEdit && currentRow && oauthProviderKeys.includes(currentRow.type);
+  // OAuth providers cannot have their provider/API format changed during edit.
+  // Derived from currentRow credentials so it stays stable across re-renders
+  // and is not affected by mutable authMode state.
+  const isOAuthChannel = useMemo(() => {
+    if (!isEdit || !currentRow) return false;
+    if (alwaysOAuthProviderKeys.includes(currentRow.type)) return true;
+    if (currentRow.type === 'codex') return isOfficialCodexChannel(currentRow);
+    if (currentRow.type === 'claudecode') return isOfficialClaudeCodeChannel(currentRow);
+    return false;
+  }, [isEdit, currentRow]);
 
   useEffect(() => {
-    // Only force stream: 'require' for new Codex channels, not when editing existing ones
-    if (isCodexType && !isEdit) {
+    // Codex always requires stream
+    if (isCodexType) {
       form.setValue('policies.stream', 'require');
     }
-  }, [isCodexType, isEdit, form]);
+  }, [isCodexType, form]);
 
   const wrapUnsupported = useCallback(
     (enabled: boolean, children: React.ReactNode, wrapperClassName: string) => {
@@ -616,9 +623,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const handleProviderChange = useCallback(
     (provider: string) => {
       if (isOAuthChannel) return;
-      if (isEdit && oauthProviderKeys.includes(provider)) return;
+      if (isEdit && alwaysOAuthProviderKeys.includes(provider)) return;
       setSelectedProvider(provider);
-      setAuthMode('official');
+      setAuthMode(isEdit && ['codex', 'claudecode'].includes(provider) ? 'third-party' : 'official');
 
       if (provider !== 'gemini') {
         setUseGeminiVertex(false);
@@ -630,8 +637,8 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       if (provider === 'codex') {
         setSelectedApiFormat(OPENAI_RESPONSES);
         form.setValue('type', 'codex');
+        form.setValue('policies.stream', 'require');
         if (!isEdit) {
-          form.setValue('policies.stream', 'require');
           setFetchedModels([]);
           setUseFetchedModels(false);
         }
@@ -683,7 +690,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     },
-    [form, useGeminiVertex, useAnthropicAws, isDuplicate, isEdit, selectedApiFormat]
+    [form, useGeminiVertex, useAnthropicAws, isDuplicate, isEdit, selectedApiFormat, isOAuthChannel]
   );
 
   const handleApiFormatChange = useCallback(
@@ -723,7 +730,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     },
-    [selectedProvider, form, useGeminiVertex, useAnthropicAws, isDuplicate, isEdit]
+    [selectedProvider, form, useGeminiVertex, useAnthropicAws, isDuplicate, isEdit, isOAuthChannel]
   );
 
   const handleGeminiVertexChange = useCallback(
@@ -746,7 +753,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     },
-    [selectedApiFormat, form, isDuplicate, isEdit]
+    [selectedApiFormat, form, isDuplicate, isEdit, isOAuthChannel]
   );
 
   const handleAnthropicAwsChange = useCallback(
@@ -769,7 +776,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     },
-    [selectedApiFormat, form, isDuplicate, isEdit]
+    [selectedApiFormat, form, isDuplicate, isEdit, isOAuthChannel]
   );
 
   useEffect(() => {
@@ -1365,7 +1372,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             {availableProviders.map((provider) => {
                               const Icon = provider.icon;
                               const isSelected = provider.key === selectedProvider;
-                              const isProviderDisabled = isOAuthChannel || (isEdit && !isOAuthChannel && oauthProviderKeys.includes(provider.key));
+                              const isProviderDisabled = isOAuthChannel || (isEdit && !isOAuthChannel && alwaysOAuthProviderKeys.includes(provider.key));
                               return (
                                 <div
                                   key={provider.key}

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -252,6 +252,15 @@ const ExpandCell = ({ row }: { row: any }) => (
 
 // ExpandCell.displayName = 'ExpandCell'; // Removed since it's not memoized now, but can keep if desired
 
+function getChannelWebsiteURL(baseURL: string): string | null {
+  try {
+    const url = new URL(baseURL);
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
 // Memoized cell components to avoid recreating on every render
 const NameCell = memo(({ row }: { row: Row<Channel> }) => {
   const { t } = useTranslation();
@@ -259,13 +268,28 @@ const NameCell = memo(({ row }: { row: Row<Channel> }) => {
   const hasError = !!channel.errorMessage;
   const disabledKeysCount = channel.disabledAPIKeys?.length ?? 0;
   const hasDisabledKeys = disabledKeysCount > 0;
+  const websiteURL = getChannelWebsiteURL(channel.baseURL);
+
+  const nameElement = websiteURL ? (
+    <a
+      href={websiteURL}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={cn('truncate font-medium hover:underline', hasError ? 'text-destructive' : '')}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {row.getValue('name')}
+    </a>
+  ) : (
+    <div className={cn('truncate font-medium', hasError && 'text-destructive')}>{row.getValue('name')}</div>
+  );
 
   const content = (
     <div className='flex justify-center'>
       <div className='flex max-w-56 items-center gap-2'>
         {hasError && <IconAlertTriangle className='text-destructive h-4 w-4 shrink-0' />}
         {!hasError && hasDisabledKeys && <IconKeyOff className='h-4 w-4 shrink-0 text-amber-500' />}
-        <div className={cn('truncate font-medium', hasError && 'text-destructive')}>{row.getValue('name')}</div>
+        {nameElement}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Allow codex and claudecode channels using third-party API keys to freely switch between all provider types during edit; other channels can also switch to codex/claudecode (defaulting to third-party auth mode). Always-OAuth providers (antigravity, github_copilot) remain locked.
- `isOAuthChannel` is now a stable `useMemo` derived from `currentRow` credentials, fixing stale closure and re-locking issues across all handler callbacks.
- Codex stream policy (`require`) is enforced regardless of create/edit mode.
- Channel name in the table is now a clickable link that opens the provider's website (origin of the base URL, path stripped).