### PR TITLE
Handle unsupported metrics exporter types

### DIFF
--- a/internal/metrics/provider.go
+++ b/internal/metrics/provider.go
@@ -64,6 +64,8 @@ func NewProvider(config Config) (*sdk.MeterProvider, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create otlphttp exporter: %w", err)
 		}
+	default:
+		return nil, fmt.Errorf("unsupported metrics exporter type: %q", config.Exporter.Type)
 	}
 
 	// Create meter provider

--- a/internal/metrics/provider_test.go
+++ b/internal/metrics/provider_test.go
@@ -6,10 +6,12 @@ import (
 
 func TestNewProvider_DisabledReturnsNoOp(t *testing.T) {
 	cfg := Config{Enabled: false}
+
 	provider, err := NewProvider(cfg)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
+
 	if provider == nil {
 		t.Fatal("expected non-nil provider")
 	}
@@ -22,6 +24,7 @@ func TestNewProvider_UnsupportedExporterType(t *testing.T) {
 			Type: "",
 		},
 	}
+
 	_, err := NewProvider(cfg)
 	if err == nil {
 		t.Fatal("expected error for empty exporter type, got nil")
@@ -35,6 +38,7 @@ func TestNewProvider_UnknownExporterType(t *testing.T) {
 			Type: "unknown",
 		},
 	}
+
 	_, err := NewProvider(cfg)
 	if err == nil {
 		t.Fatal("expected error for unknown exporter type, got nil")

--- a/internal/metrics/provider_test.go
+++ b/internal/metrics/provider_test.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func TestNewProvider_DisabledReturnsNoOp(t *testing.T) {
+	cfg := Config{Enabled: false}
+	provider, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewProvider_UnsupportedExporterType(t *testing.T) {
+	cfg := Config{
+		Enabled: true,
+		Exporter: ExporterConfig{
+			Type: "",
+		},
+	}
+	_, err := NewProvider(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty exporter type, got nil")
+	}
+}
+
+func TestNewProvider_UnknownExporterType(t *testing.T) {
+	cfg := Config{
+		Enabled: true,
+		Exporter: ExporterConfig{
+			Type: "unknown",
+		},
+	}
+	_, err := NewProvider(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown exporter type, got nil")
+	}
+}


### PR DESCRIPTION
When metrics are enabled with an unsupported exporter type, the code would panic because the switch statement was missing a default case. Added proper error handling for that scenario, plus tests for disabled metrics and unsupported exporter types.