### PR TITLE
fix: sqlite "database is locked" error

### DIFF
--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -46,6 +46,8 @@ func NewEntClient(cfg Config) *ent.Client {
 		if err != nil {
 			panic(err)
 		}
+		// fix database is locked
+		sqlDB.SetMaxOpenConns(1)
 
 		dbDialect = dialect.SQLite
 	case "mysql", "tidb":

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -46,8 +46,10 @@ func NewEntClient(cfg Config) *ent.Client {
 		if err != nil {
 			panic(err)
 		}
-		// fix database is locked
+		// 将 SQLite 的最大打开连接数限制为 1，以防止在高并发写入时出现 "database is locked" 错误。
+		// 这有效地序列化了所有数据库访问。
 		sqlDB.SetMaxOpenConns(1)
+		sqlDB.SetMaxIdleConns(1)
 
 		dbDialect = dialect.SQLite
 	case "mysql", "tidb":


### PR DESCRIPTION
在sqllite+hdd+trace很容易出现 database is locked 错误, 导致trace记录不完整

通过限制sqlite并发数避免这个问题

已实际测试有效 fix https://github.com/looplj/axonhub/issues/907