### PR TITLE
refactor: rename GraphQL mutation to triggerGcCleanup (follow-up to #1010)

### DIFF
--- a/frontend/src/features/system/components/storage-settings.tsx
+++ b/frontend/src/features/system/components/storage-settings.tsx
@@ -27,7 +27,7 @@ import {
   useUpdateStoragePolicy,
   useDefaultDataStorageID,
   useUpdateDefaultDataStorage,
-  useTriggerGarbageCollection,
+  useTriggerGcCleanup,
   CleanupOption,
 } from '../data/system';
 import { VideoStorageSettings } from './video-storage-settings';
@@ -42,7 +42,7 @@ export function StorageSettings() {
   });
   const updateStoragePolicy = useUpdateStoragePolicy();
   const updateDefaultDataStorage = useUpdateDefaultDataStorage();
-  const triggerGarbageCollection = useTriggerGarbageCollection();
+  const triggerGcCleanup = useTriggerGcCleanup();
   const { isLoading, setIsLoading } = useSystemContext();
 
   const [storagePolicyState, setStoragePolicyState] = useState({
@@ -193,9 +193,9 @@ export function StorageSettings() {
               <Button
                 variant='outline'
                 size='sm'
-                disabled={triggerGarbageCollection.isPending || isLoading}
+                disabled={triggerGcCleanup.isPending || isLoading}
               >
-                {triggerGarbageCollection.isPending ? (
+                {triggerGcCleanup.isPending ? (
                   <Loader2 className='mr-2 h-4 w-4 animate-spin' />
                 ) : (
                   <Play className='mr-2 h-4 w-4' />
@@ -212,7 +212,7 @@ export function StorageSettings() {
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>{t('system.storage.policy.runCleanupCancel')}</AlertDialogCancel>
-                <AlertDialogAction onClick={() => triggerGarbageCollection.mutate()}>
+                <AlertDialogAction onClick={() => triggerGcCleanup.mutate()}>
                   {t('system.storage.policy.runCleanupConfirm')}
                 </AlertDialogAction>
               </AlertDialogFooter>

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -138,9 +138,9 @@ const COMPLETE_AUTO_DISABLE_CHANNEL_ONBOARDING_MUTATION = `
   }
 `;
 
-const TRIGGER_GARBAGE_COLLECTION_MUTATION = `
-  mutation triggerGarbageCollection {
-    triggerGarbageCollection
+const TRIGGER_GC_CLEANUP_MUTATION = `
+  mutation triggerGcCleanup {
+    triggerGcCleanup
   }
 `;
 
@@ -363,11 +363,11 @@ export function useUpdateStoragePolicy() {
   });
 }
 
-export function useTriggerGarbageCollection() {
+export function useTriggerGcCleanup() {
   return useMutation({
     mutationFn: async () => {
-      const data = await graphqlRequest<{ triggerGarbageCollection: boolean }>(TRIGGER_GARBAGE_COLLECTION_MUTATION);
-      return data.triggerGarbageCollection;
+      const data = await graphqlRequest<{ triggerGcCleanup: boolean }>(TRIGGER_GC_CLEANUP_MUTATION);
+      return data.triggerGcCleanup;
     },
     onSuccess: () => {
       toast.success(i18n.t('system.storage.policy.runCleanupSuccess'));


### PR DESCRIPTION
This PR is a follow-up to PR #1010 as requested by the reviewer. It renames the GraphQL mutation from `triggerGarbageCollection` to `triggerGcCleanup` across the API schema, backend resolvers, and frontend components.