### PR TITLE
fix: preserve JSON-like string values in header override

### DIFF
--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"text/template"
@@ -234,14 +233,14 @@ func applyOverrideOperationToHeaders(
 
 	switch op.Op {
 	case objects.OverrideOpSet:
-		renderedValue := renderOverrideValue(ctx, op.Value, renderCtx)
+		renderedValue := renderTemplate(ctx, op.Value, renderCtx)
 		// For backward compatibility, we still support "__AXONHUB_CLEAR__" to clear the header.
 		if renderedValue == "__AXONHUB_CLEAR__" {
 			headers.Del(op.Path)
 			return
 		}
 
-		headers.Set(op.Path, fmt.Sprintf("%v", renderedValue))
+		headers.Set(op.Path, renderedValue)
 	case objects.OverrideOpDelete:
 		headers.Del(op.Path)
 	case objects.OverrideOpRename:

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -248,6 +248,42 @@ func TestOverrideParametersNumeric(t *testing.T) {
 	require.Equal(t, "0.8", processedRequestWithHeaders.Headers.Get("X-Float-Header"))
 }
 
+func TestOverrideHeadersKeepJSONLikeString(t *testing.T) {
+	ctx := context.Background()
+
+	llmRequest := &llm.Request{Model: "gpt-4"}
+
+	expectedValue := `{"session_id":"843634473","camelCase":"AbC","xTraceId":"XyZ-001"}`
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "header-json-string-test",
+			Settings: &objects.ChannelSettings{
+				HeaderOverrideOperations: []objects.OverrideOperation{
+					{Op: objects.OverrideOpSet, Path: "Extra", Value: expectedValue},
+				},
+			},
+		},
+		Outbound: &mockTransformer{},
+	}
+
+	outbound := &PersistentOutboundTransformer{
+		wrapped: &mockTransformer{},
+		state: &PersistenceState{
+			CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+			LlmRequest:       llmRequest,
+		},
+	}
+
+	headerMiddleware := applyOverrideRequestHeaders(outbound)
+	rawRequest := &httpclient.Request{Headers: make(http.Header)}
+
+	processedRequest, err := headerMiddleware.OnOutboundRawRequest(ctx, rawRequest)
+	require.NoError(t, err)
+	require.Equal(t, expectedValue, processedRequest.Headers.Get("Extra"))
+}
+
 // TestOverrideParameters tests that TransformRequest works correctly.
 // Note: Override parameters are now applied via OnRawRequest middleware,
 // so this test only verifies the base transformation without overrides.


### PR DESCRIPTION
## Problem
When setting header override values with JSON-like strings (e.g., `{"session_id":"843634473"}`), the previous implementation used `fmt.Sprintf("%v", renderedValue)` which incorrectly formatted the value as a Go map literal with `map[` prefix (e.g., `map[session_id:843634473]`), corrupting the original JSON format.
## Solution
- Replace `renderOverrideValue` with `renderTemplate` to ensure proper string rendering
- Remove `fmt.Sprintf("%v", ...)` formatting and pass the rendered value directly to preserve the original JSON string format
## Changes
- `internal/server/orchestrator/override.go`: Fixed header value assignment in `applyOverrideOperationToHeaders`
- `internal/server/orchestrator/override_test.go`: Added `TestOverrideHeadersKeepJSONLikeString` to verify JSON-like strings are preserved without `map[` prefix
## Test Coverage
New test validates preservation of:
- Mixed-case JSON keys (camelCase)
- Underscore and hyphenated keys
- Complete JSON structure without `map[` prefix contamination