### PR TITLE
fix(dashboard): incorrect time conversion in MySQL

### DIFF
--- a/internal/pkg/xtime/time.go
+++ b/internal/pkg/xtime/time.go
@@ -1,6 +1,8 @@
 package xtime
 
-import "time"
+import (
+	"time"
+)
 
 func UTCNow() time.Time {
 	return time.Now().UTC()
@@ -87,4 +89,9 @@ func GetCalendarPeriods(loc *time.Location) CalendarPeriods {
 			End:   thisMonthEnd.UTC(),
 		},
 	}
+}
+
+func FormatUTCOffset(offsetSeconds int) string {
+	loc := time.FixedZone("", offsetSeconds)
+	return time.Unix(0, 0).In(loc).Format("-07:00")
 }

--- a/internal/pkg/xtime/time_test.go
+++ b/internal/pkg/xtime/time_test.go
@@ -214,3 +214,46 @@ func TestPeriodHalfOpenInterval(t *testing.T) {
 		t.Errorf("End should be after Start")
 	}
 }
+
+func TestFormatUTCOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{
+			name:          "UTC+0",
+			offsetSeconds: 0,
+			want:          "+00:00",
+		},
+		{
+			name:          "UTC+8",
+			offsetSeconds: 8 * 3600,
+			want:          "+08:00",
+		},
+		{
+			name:          "UTC+5:30",
+			offsetSeconds: 5*3600 + 30*60,
+			want:          "+05:30",
+		},
+		{
+			name:          "UTC-5",
+			offsetSeconds: -5 * 3600,
+			want:          "-05:00",
+		},
+		{
+			name:          "UTC-3:30",
+			offsetSeconds: -3*3600 - 30*60,
+			want:          "-03:30",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatUTCOffset(tt.offsetSeconds)
+			if got != tt.want {
+				t.Errorf("FormatUTCOffset(%d) = %q, want %q", tt.offsetSeconds, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -445,7 +445,8 @@ func (r *queryResolver) DailyRequestStats(ctx context.Context) ([]*DailyRequestS
 			case dialect.SQLite:
 				dateExpr = fmt.Sprintf("strftime('%%Y-%%m-%%d', datetime(substr(%s, 1, 19), '%+d seconds'))", createdAtCol, offsetSeconds)
 			case dialect.MySQL:
-				dateExpr = fmt.Sprintf("DATE_FORMAT(CONVERT_TZ(%s, '+00:00', '%s'), '%%Y-%%m-%%d')", createdAtCol, loc.String())
+				offsetStr := xtime.FormatUTCOffset(offsetSeconds)
+				dateExpr = fmt.Sprintf("DATE_FORMAT(CONVERT_TZ(%s, '+00:00', '%s'), '%%Y-%%m-%%d')", createdAtCol, offsetStr)
 			case dialect.Postgres:
 				dateExpr = fmt.Sprintf("to_char(%s AT TIME ZONE '%s', 'YYYY-MM-DD')", createdAtCol, loc.String())
 			default:

--- a/internal/server/gql/dashboard_helpers.go
+++ b/internal/server/gql/dashboard_helpers.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/looplj/axonhub/internal/ent/channelprobe"
+	"github.com/looplj/axonhub/internal/pkg/xtime"
 	"github.com/looplj/axonhub/internal/server/gql/qb"
 )
 
@@ -74,7 +75,8 @@ func buildDateExpression(dialectName string, timestampCol string, offsetSeconds 
 	case dialect.SQLite:
 		return fmt.Sprintf("strftime('%%Y-%%m-%%d', datetime(%s, 'unixepoch', '%+d seconds'))", timestampCol, offsetSeconds)
 	case dialect.MySQL:
-		return fmt.Sprintf("DATE(CONVERT_TZ(FROM_UNIXTIME(%s), '+00:00', '%s'))", timestampCol, locName)
+		offsetStr := xtime.FormatUTCOffset(offsetSeconds)
+		return fmt.Sprintf("DATE_FORMAT(CONVERT_TZ(FROM_UNIXTIME(%s), '+00:00', '%s'), '%%Y-%%m-%%d')", timestampCol, offsetStr)
 	case dialect.Postgres:
 		return fmt.Sprintf("to_char(to_timestamp(%s) AT TIME ZONE '%s', 'YYYY-MM-DD')", timestampCol, locName)
 	default:

--- a/internal/server/gql/qb/throughput_daily.go
+++ b/internal/server/gql/qb/throughput_daily.go
@@ -3,6 +3,8 @@ package qb
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/looplj/axonhub/internal/pkg/xtime"
 )
 
 // DailyThroughputQueryType identifies the type of daily throughput query to build.
@@ -59,7 +61,8 @@ func getDateExpression(dialect string, dateExpr string, timezone string, offsetS
 		return fmt.Sprintf("strftime('%%Y-%%m-%%d', datetime(substr(%s, 1, 19), '%+d seconds'))", dateExpr, offsetSeconds)
 	case "mysql":
 		// MySQL: DATE_FORMAT(CONVERT_TZ(created_at, '+00:00', timezone), '%Y-%m-%d')
-		return fmt.Sprintf("DATE_FORMAT(CONVERT_TZ(%s, '+00:00', '%s'), '%%Y-%%m-%%d')", dateExpr, timezone)
+		offsetStr := xtime.FormatUTCOffset(offsetSeconds)
+		return fmt.Sprintf("DATE_FORMAT(CONVERT_TZ(%s, '+00:00', '%s'), '%%Y-%%m-%%d')", dateExpr, offsetStr)
 	case "postgres", "postgresql":
 		// PostgreSQL: to_char(created_at AT TIME ZONE 'timezone', 'YYYY-MM-DD')
 		return fmt.Sprintf("to_char(%s AT TIME ZONE '%s', 'YYYY-MM-DD')", dateExpr, timezone)

--- a/internal/server/gql/qb/throughput_daily_test.go
+++ b/internal/server/gql/qb/throughput_daily_test.go
@@ -37,8 +37,8 @@ func TestGetDateExpression(t *testing.T) {
 			dialect:       "mysql",
 			dateExpr:      "se.created_at",
 			timezone:      "America/New_York",
-			offsetSeconds: 0,
-			wantContains:  []string{"DATE_FORMAT", "CONVERT_TZ", "America/New_York", "%Y-%m-%d"},
+			offsetSeconds: -14400,
+			wantContains:  []string{"DATE_FORMAT", "CONVERT_TZ", "-04:00", "%Y-%m-%d"},
 		},
 		{
 			name:          "postgres dialect",
@@ -351,7 +351,7 @@ func TestBuildDailyThroughputQuery_DateExpressions(t *testing.T) {
 			dialect:       "mysql",
 			timezone:      "UTC",
 			offsetSeconds: 0,
-			wantExpr:      "DATE_FORMAT(CONVERT_TZ(se.created_at, '+00:00', 'UTC'), '%Y-%m-%d')",
+			wantExpr:      "DATE_FORMAT(CONVERT_TZ(se.created_at, '+00:00', '+00:00'), '%Y-%m-%d')",
 		},
 		{
 			name:          "sqlite uses strftime",
@@ -480,7 +480,7 @@ func TestBuildDailyPerformanceStatsQuery(t *testing.T) {
 				"r.model_id",
 				"DATE_FORMAT",
 				"CONVERT_TZ",
-				"America/New_York",
+				"-04:00",
 				"NULLIF(",
 				", 0)",
 				"GROUP BY exec_date",


### PR DESCRIPTION
在 MySQL 中，[CONVERT_TZ](https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_convert-tz) 函数的 `from_tz` 和 `to_tz` 可以使用 `+08:00` 以及 `Asia/Shanghai` 形式

但是如果使用命名时区，需要提前将时区文件导入进来，这并非默认配置

我所使用的是类似 MySQL As A Service 的服务，我没有 root 权限，服务器也没有预设这个时区文件，因此我不能使用命名时区的写法

所以我将其改为了更具有兼容性的写法

`internal/server/gql/dashboard_helpers.go` 中我把他从 `DATE` 改成了 `DATE_FORMAT` 形式，虽然最后这个语句运行得到的都是 `2026-03-11`，但是前者的类型是 Date，Go 会先转换为 time.Time 再转换为字符串，最后会得到 `2026-03-11T00:00:00+08:00` 这样一个东西。

因而在进行「最佳渠道性能」的展示时就会有问题，在 `buildChannelPerformanceResponse` 方法中，把 statsMap 的 key 用 `2026-03-11T00:00:00+08:00` 和 `2026-03-11` 进行等于比较，显然不存在

---

修复前

<img width="941" height="460" alt="PixPin_2026-03-14_13-12-11" src="https://github.com/user-attachments/assets/fae0dd54-433e-4b0b-b23c-c40a796674b7" />

<img width="880" height="341" alt="PixPin_2026-03-14_13-12-27" src="https://github.com/user-attachments/assets/e6470991-bb90-4f11-a87f-b8d3402e94fe" />

<img width="644" height="338" alt="PixPin_2026-03-14_13-13-01" src="https://github.com/user-attachments/assets/bf7b64ad-5da4-45cc-b805-6616c6a2d03d" />

修复后 每日概览 最佳模型性能 最佳渠道性能 均有数据