### PR TITLE
fix(orchestrator): preserve completed responses on client disconnect

### DIFF
--- a/integration_test/openai/responses/streaming/client_disconnect_test.go
+++ b/integration_test/openai/responses/streaming/client_disconnect_test.go
@@ -178,6 +178,88 @@ func TestResponsesStreamingClientDisconnectMidStream(t *testing.T) {
 
 // TestResponsesStreamingRapidDisconnects tests multiple rapid connect/disconnect cycles
 // to ensure the server handles them correctly
+
+// TestResponsesStreamingClientDisconnectAfterOutputTextDone simulates a client
+// that stops reading immediately after the final text payload is available,
+// before the explicit response.completed event is observed locally.
+//
+// This is closer to a real proxy/client chain such as Claude Code -> AxonHub -> Codex,
+// where downstream teardown can happen very close to completion and the transport may be
+// canceled before the terminal event is processed in the expected order.
+func TestResponsesStreamingClientDisconnectAfterOutputTextDone(t *testing.T) {
+	helper := testutil.NewTestHelper(t, "TestResponsesStreamingClientDisconnectAfterOutputTextDone")
+
+	ctx := helper.CreateTestContext()
+	question := "Write exactly one short sentence about oceans."
+
+	t.Logf("Sending streaming request: %s", question)
+
+	params := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(helper.GetModel()),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String(question),
+		},
+	}
+
+	clientCtx, clientCancel := context.WithCancel(ctx)
+	defer clientCancel()
+
+	stream := helper.CreateResponseStreamingWithHeaders(clientCtx, params)
+	helper.AssertNoError(t, stream.Err(), "Failed to start Responses streaming")
+
+	var fullContent strings.Builder
+	var chunks int
+	var sawOutputTextDone bool
+	var sawResponseCompleted bool
+
+	for stream.Next() {
+		event := stream.Current()
+		chunks++
+
+		if event.Type == "response.output_text.delta" && event.Delta != "" {
+			fullContent.WriteString(event.Delta)
+		}
+
+		if event.Type == "response.output_text.done" {
+			sawOutputTextDone = true
+			t.Log("Received response.output_text.done, canceling before response.completed is consumed")
+			clientCancel()
+			break
+		}
+
+		if event.Type == "response.completed" {
+			sawResponseCompleted = true
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := stream.Err(); err != nil {
+		t.Logf("Stream error after early teardown: %v", err)
+	}
+
+	finalContent := fullContent.String()
+	t.Logf("Received %d events before disconnect", chunks)
+	t.Logf("Final content collected before disconnect: %s", finalContent)
+	t.Logf("sawOutputTextDone=%v sawResponseCompleted=%v", sawOutputTextDone, sawResponseCompleted)
+
+	if chunks == 0 {
+		t.Error("Expected at least one event from Responses streaming")
+	}
+	if finalContent == "" {
+		t.Error("Expected non-empty text content before disconnect")
+	}
+	if !sawOutputTextDone {
+		t.Skip("Provider did not emit response.output_text.done in this run; cannot verify near-completion teardown path")
+	}
+	if sawResponseCompleted {
+		t.Log("response.completed was observed before cancellation in this run; near-completion timing may vary by provider")
+	}
+
+	t.Log("Near-completion teardown test finished. Verify AxonHub logs / request execution status:")
+	t.Log("  - final decision should still resolve to completed when aggregation proves completion")
+	t.Log("  - this is the closest integration-level regression to Claude Code style early stop")
+}
 func TestResponsesStreamingRapidDisconnects(t *testing.T) {
 	helper := testutil.NewTestHelper(t, "TestResponsesStreamingRapidDisconnects")
 

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -106,6 +106,7 @@ func (ts *OutboundPersistentStream) Close() error {
 	// even if there's a context cancellation error. This handles the case where
 	// the client disconnects immediately after receiving the last chunk.
 	if ts.state.StreamCompleted {
+		ts.logFinalizationDecision(ctx, "terminal_event_completed", streamErr, ctxErr, true, nil)
 		// Stream completed successfully - perform final persistence
 		log.Debug(ctx, "Stream completed successfully (received [DONE]), performing final persistence")
 		ts.persistResponseChunks(ctx)
@@ -113,16 +114,52 @@ func (ts *OutboundPersistentStream) Close() error {
 		return ts.stream.Close()
 	}
 
-	// Check if context was canceled (client disconnected before [DONE])
-	if ctxErr != nil || streamErr != nil {
-		// Use context without cancellation to ensure persistence even if client canceled
+	// If there's an explicit stream error (not just context cancellation), treat as failure
+	// regardless of what chunks we have. Stream errors indicate the upstream response
+	// was incomplete or corrupted.
+	if streamErr != nil && !errors.Is(streamErr, context.Canceled) && !errors.Is(streamErr, context.DeadlineExceeded) {
+		ts.logFinalizationDecision(ctx, "explicit_stream_error", streamErr, ctxErr, false, nil)
 		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
-		// Determine the actual error to report
+		if ts.requestExec != nil {
+			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, streamErr); err != nil {
+				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
+			}
+		}
+
+		return ts.stream.Close()
+	}
+
+	var responseBody []byte
+	var meta llm.ResponseMeta
+	var aggErr error
+	aggregatedCompleted := false
+
+	if len(ts.responseChunks) > 0 {
+		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.responseChunks)
+		aggregatedCompleted = aggErr == nil && isCompletedAggregatedOutboundResponse(meta)
+		ts.logFinalizationDecision(ctx, "aggregated_outbound_chunks", streamErr, ctxErr, aggregatedCompleted, aggErr)
+		if aggregatedCompleted {
+			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
+			ts.state.StreamCompleted = true
+		}
+	} else {
+		ts.logFinalizationDecision(ctx, "no_outbound_chunks_to_aggregate", streamErr, ctxErr, false, nil)
+	}
+
+	// ended without a terminal event / complete aggregated response.
+	if (ctxErr != nil || streamErr != nil) && !ts.state.StreamCompleted {
+		ts.logFinalizationDecision(ctx, "incomplete_stream_with_error", streamErr, ctxErr, aggregatedCompleted, aggErr)
+		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
 		errToReport := streamErr
 		if errToReport == nil {
 			errToReport = ctxErr
+		}
+		if errToReport == nil {
+			errToReport = errors.New("stream ended without terminal event or completed response")
 		}
 
 		if ts.requestExec != nil {
@@ -134,12 +171,58 @@ func (ts *OutboundPersistentStream) Close() error {
 		return ts.stream.Close()
 	}
 
+	if !ts.state.StreamCompleted {
+		ts.logFinalizationDecision(ctx, "incomplete_stream_without_terminal_event", streamErr, ctxErr, aggregatedCompleted, aggErr)
+		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		errToReport := errors.New("stream ended without terminal event or completed response")
+		if ts.requestExec != nil {
+			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport); err != nil {
+				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
+			}
+		}
+
+		return ts.stream.Close()
+	}
+
 	// Stream completed successfully - perform final persistence
 	log.Debug(ctx, "Stream completed successfully, performing final persistence")
+	decision := "completed_after_aggregation"
+	if len(responseBody) == 0 {
+		decision = "completed_via_chunk_persistence"
+	}
+	ts.logFinalizationDecision(ctx, decision, streamErr, ctxErr, aggregatedCompleted, aggErr)
 
-	ts.persistResponseChunks(ctx)
+	if len(responseBody) > 0 {
+		ts.persistAggregatedResponse(context.WithoutCancel(ctx), responseBody, meta)
+	} else {
+		ts.persistResponseChunks(ctx)
+	}
 
 	return ts.stream.Close()
+}
+
+func (ts *OutboundPersistentStream) logFinalizationDecision(ctx context.Context, decision string, streamErr error, ctxErr error, aggregatedCompleted bool, aggregatedErr error) {
+	fields := []log.Field{
+		log.String("decision", decision),
+		log.Bool("terminal_event_seen", ts.state.StreamCompleted),
+		log.Int("chunk_count", len(ts.responseChunks)),
+		log.String("api_format", string(ts.transformer.APIFormat())),
+		log.Bool("aggregated_completed", aggregatedCompleted),
+	}
+
+	if streamErr != nil {
+		fields = append(fields, log.String("stream_err", streamErr.Error()))
+	}
+	if ctxErr != nil {
+		fields = append(fields, log.String("ctx_err", ctxErr.Error()))
+	}
+	if aggregatedErr != nil {
+		fields = append(fields, log.String("aggregated_err", aggregatedErr.Error()))
+	}
+
+	log.Debug(ctx, "Outbound stream finalization decision", fields...)
 }
 
 func (ts *OutboundPersistentStream) persistResponseChunks(ctx context.Context) {
@@ -161,57 +244,69 @@ func (ts *OutboundPersistentStream) persistResponseChunks(ctx context.Context) {
 			return
 		}
 
-		// Try to create usage log from aggregated response
-		if usage := meta.Usage; usage != nil {
-			_, err = ts.UsageLogService.CreateUsageLogFromRequest(persistCtx, ts.request, ts.requestExec, usage)
-			if err != nil {
-				log.Warn(persistCtx, "Failed to create usage log from request", log.Cause(err))
-			}
-		}
-
-		// Build latency metrics from performance record
-		var metrics *biz.LatencyMetrics
-
-		if ts.perf != nil {
-			firstTokenLatencyMs, requestLatencyMs, _ := ts.perf.Calculate()
-
-			metrics = &biz.LatencyMetrics{
-				LatencyMs: &requestLatencyMs,
-			}
-			if ts.perf.Stream && ts.perf.FirstTokenTime != nil {
-				metrics.FirstTokenLatencyMs = &firstTokenLatencyMs
-			}
-		}
-
-		err = ts.RequestService.UpdateRequestExecutionCompleted(
-			persistCtx,
-			ts.requestExec.ID,
-			meta.ID,
-			responseBody,
-			metrics,
-		)
-		if err != nil {
-			log.Warn(
-				persistCtx,
-				"Failed to update request execution with chunks, trying basic completion",
-				log.Cause(err),
-			)
-		}
-
-		// Save all response chunks at once
-		if err := ts.RequestService.SaveRequestExecutionChunks(persistCtx, ts.requestExec.ID, ts.responseChunks); err != nil {
-			log.Warn(persistCtx, "Failed to save request execution chunks", log.Cause(err))
-		}
+		ts.persistAggregatedResponse(persistCtx, responseBody, meta)
 	}
 }
 
-// PersistentOutboundTransformer wraps an outbound transformer with enhanced capabilities.
+func (ts *OutboundPersistentStream) persistAggregatedResponse(ctx context.Context, responseBody []byte, meta llm.ResponseMeta) {
+	if ts.requestExec == nil {
+		return
+	}
+
+	// Try to create usage log from aggregated response
+	if usage := meta.Usage; usage != nil {
+		_, err := ts.UsageLogService.CreateUsageLogFromRequest(ctx, ts.request, ts.requestExec, usage)
+		if err != nil {
+			log.Warn(ctx, "Failed to create usage log from request", log.Cause(err))
+		}
+	}
+
+	// Build latency metrics from performance record
+	var metrics *biz.LatencyMetrics
+
+	if ts.perf != nil {
+		firstTokenLatencyMs, requestLatencyMs, _ := ts.perf.Calculate()
+
+		metrics = &biz.LatencyMetrics{
+			LatencyMs: &requestLatencyMs,
+		}
+		if ts.perf.Stream && ts.perf.FirstTokenTime != nil {
+			metrics.FirstTokenLatencyMs = &firstTokenLatencyMs
+		}
+	}
+
+	err := ts.RequestService.UpdateRequestExecutionCompleted(
+		ctx,
+		ts.requestExec.ID,
+		meta.ID,
+		responseBody,
+		metrics,
+	)
+	if err != nil {
+		log.Warn(
+			ctx,
+			"Failed to update request execution with chunks, trying basic completion",
+			log.Cause(err),
+		)
+	}
+
+	// Save all response chunks at once
+	if err := ts.RequestService.SaveRequestExecutionChunks(ctx, ts.requestExec.ID, ts.responseChunks); err != nil {
+		log.Warn(ctx, "Failed to save request execution chunks", log.Cause(err))
+	}
+}
+
+func isCompletedAggregatedOutboundResponse(meta llm.ResponseMeta) bool {
+	return meta.Usage != nil
+}
+
+var errSkipCandidateByCircuitBreaker = errors.New("skip candidate by circuit breaker")
+
+// PersistentOutboundTransformer wraps an outbound transformer with shared persistence state.
 type PersistentOutboundTransformer struct {
 	wrapped transformer.Outbound
 	state   *PersistenceState
 }
-
-var errSkipCandidateByCircuitBreaker = errors.New("skip candidate by circuit breaker")
 
 // APIFormat returns the API format of the transformer.
 func (p *PersistentOutboundTransformer) APIFormat() llm.APIFormat {

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -9,7 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -17,7 +21,12 @@ import (
 )
 
 // mockTransformer is a simple mock transformer for testing.
-type mockTransformer struct{}
+type mockTransformer struct {
+	aggregatedResponse []byte
+	aggregatedMeta     llm.ResponseMeta
+	aggregatedErr      error
+	apiFormat          llm.APIFormat
+}
 
 func (m *mockTransformer) TransformRequest(ctx context.Context, req *llm.Request) (*httpclient.Request, error) {
 	body, err := json.Marshal(map[string]any{
@@ -50,10 +59,14 @@ func (m *mockTransformer) TransformError(ctx context.Context, err *httpclient.Er
 }
 
 func (m *mockTransformer) AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {
-	return nil, llm.ResponseMeta{}, nil
+	return m.aggregatedResponse, m.aggregatedMeta, m.aggregatedErr
 }
 
 func (m *mockTransformer) APIFormat() llm.APIFormat {
+	if m.apiFormat != "" {
+		return m.apiFormat
+	}
+
 	return llm.APIFormatOpenAIChatCompletion
 }
 
@@ -298,7 +311,236 @@ func TestPersistentOutboundTransformer_CanRetry(t *testing.T) {
 	})
 }
 
-func TestPersistentOutboundTransformer_TransformRequest_WithChannelSelection(t *testing.T) {
+func TestIsCompletedAggregatedOutboundResponse(t *testing.T) {
+	t.Run("usage means completed", func(t *testing.T) {
+		require.True(t, isCompletedAggregatedOutboundResponse(llm.ResponseMeta{Usage: &llm.Usage{TotalTokens: 15}}))
+	})
+
+	t.Run("missing usage is not completed", func(t *testing.T) {
+		require.False(t, isCompletedAggregatedOutboundResponse(llm.ResponseMeta{}))
+	})
+}
+
+type sliceEventStream struct {
+	events []*httpclient.StreamEvent
+	index  int
+	err    error
+	closed bool
+}
+
+func (s *sliceEventStream) Next() bool {
+	if s.index >= len(s.events) {
+		return false
+	}
+
+	s.index++
+	return true
+}
+
+func (s *sliceEventStream) Current() *httpclient.StreamEvent {
+	if s.index == 0 || s.index > len(s.events) {
+		return nil
+	}
+
+	return s.events[s.index-1]
+}
+
+func (s *sliceEventStream) Err() error {
+	return s.err
+}
+
+func (s *sliceEventStream) Close() error {
+	s.closed = true
+	return nil
+}
+
+func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t *testing.T) {
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+
+	t.Run("response in_progress without terminal event is not completed", func(t *testing.T) {
+		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+		defer client.Close()
+
+		ctx := ent.NewContext(ctx, client)
+		project := createTestProject(t, ctx, client)
+		ch := createTestChannel(t, ctx, client)
+		_, requestService, _, usageLogService := setupTestServices(t, client)
+
+		req, err := client.Request.Create().
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetStatus(request.StatusPending).
+			SetRequestBody([]byte(`{"stream":true}`)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		exec, err := client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetRequestBody([]byte(`{"stream":true}`)).
+			SetFormat("openai/responses").
+			SetStatus(requestexecution.StatusPending).
+			SetStream(true).
+			Save(ctx)
+		require.NoError(t, err)
+
+		stream := &sliceEventStream{
+			events: []*httpclient.StreamEvent{{Type: "response.in_progress", Data: []byte(`{"type":"response.in_progress"}`)}},
+		}
+		transformer := &mockTransformer{
+			apiFormat:          llm.APIFormatOpenAIResponse,
+			aggregatedResponse: []byte(`{"id":"resp_123","status":"in_progress"}`),
+		}
+		state := &PersistenceState{}
+
+		persistentStream := NewOutboundPersistentStream(ctx, stream, req, exec, requestService, usageLogService, transformer, nil, state)
+		for persistentStream.Next() {
+			_ = persistentStream.Current()
+		}
+		require.NoError(t, persistentStream.Close())
+
+		dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+		require.NoError(t, err)
+		require.NotEqual(t, requestexecution.StatusCompleted, dbExec.Status)
+		require.Equal(t, requestexecution.StatusFailed, dbExec.Status)
+		require.Contains(t, dbExec.ErrorMessage, "stream ended without terminal event or completed response")
+		require.False(t, state.StreamCompleted)
+	})
+
+	t.Run("aggregated completed response without terminal event is completed", func(t *testing.T) {
+		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+		defer client.Close()
+
+		ctx := ent.NewContext(ctx, client)
+		project := createTestProject(t, ctx, client)
+		ch := createTestChannel(t, ctx, client)
+		_, requestService, _, usageLogService := setupTestServices(t, client)
+
+		req, err := client.Request.Create().
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetStatus(request.StatusPending).
+			SetRequestBody([]byte(`{"stream":true}`)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		exec, err := client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetRequestBody([]byte(`{"stream":true}`)).
+			SetFormat("openai/responses").
+			SetStatus(requestexecution.StatusPending).
+			SetStream(true).
+			Save(ctx)
+		require.NoError(t, err)
+
+		aggregated := []byte(`{"id":"resp_456","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}]}`)
+		stream := &sliceEventStream{
+			events: []*httpclient.StreamEvent{{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","delta":"hi"}`)}},
+		}
+		transformer := &mockTransformer{
+			apiFormat:          llm.APIFormatOpenAIResponse,
+			aggregatedResponse: aggregated,
+			aggregatedMeta: llm.ResponseMeta{
+				ID: "resp_456",
+				Usage: &llm.Usage{
+					PromptTokens:     10,
+					CompletionTokens: 2,
+					TotalTokens:      12,
+				},
+			},
+		}
+		state := &PersistenceState{}
+
+		persistentStream := NewOutboundPersistentStream(ctx, stream, req, exec, requestService, usageLogService, transformer, nil, state)
+		for persistentStream.Next() {
+			_ = persistentStream.Current()
+		}
+		require.NoError(t, persistentStream.Close())
+
+		dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+		require.NoError(t, err)
+		require.Equal(t, requestexecution.StatusCompleted, dbExec.Status)
+		require.JSONEq(t, string(aggregated), string(dbExec.ResponseBody))
+		require.Equal(t, "resp_456", dbExec.ExternalID)
+		require.True(t, state.StreamCompleted)
+	})
+
+	t.Run("canceled client with aggregated completed response is still completed", func(t *testing.T) {
+		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+		defer client.Close()
+
+		baseCtx := ent.NewContext(ctx, client)
+		project := createTestProject(t, baseCtx, client)
+		ch := createTestChannel(t, baseCtx, client)
+		_, requestService, _, usageLogService := setupTestServices(t, client)
+
+		req, err := client.Request.Create().
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetStatus(request.StatusPending).
+			SetRequestBody([]byte(`{"stream":true}`)).
+			Save(baseCtx)
+		require.NoError(t, err)
+
+		exec, err := client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetRequestBody([]byte(`{"stream":true}`)).
+			SetFormat("openai/responses").
+			SetStatus(requestexecution.StatusPending).
+			SetStream(true).
+			Save(baseCtx)
+		require.NoError(t, err)
+
+		aggregated := []byte(`{"id":"resp_codex_like","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}`)
+		stream := &sliceEventStream{
+			events: []*httpclient.StreamEvent{{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","delta":"done"}`)}},
+			err:    context.Canceled,
+		}
+		transformer := &mockTransformer{
+			apiFormat:          llm.APIFormatOpenAIResponse,
+			aggregatedResponse: aggregated,
+			aggregatedMeta: llm.ResponseMeta{
+				ID: "resp_codex_like",
+				Usage: &llm.Usage{
+					PromptTokens:     20,
+					CompletionTokens: 1,
+					TotalTokens:      21,
+				},
+			},
+		}
+		state := &PersistenceState{}
+
+		requestCtx, cancel := context.WithCancel(baseCtx)
+		cancel()
+
+		persistentStream := NewOutboundPersistentStream(requestCtx, stream, req, exec, requestService, usageLogService, transformer, nil, state)
+		for persistentStream.Next() {
+			_ = persistentStream.Current()
+		}
+		require.NoError(t, persistentStream.Close())
+
+		dbExec, err := client.RequestExecution.Get(baseCtx, exec.ID)
+		require.NoError(t, err)
+		require.Equal(t, requestexecution.StatusCompleted, dbExec.Status)
+		require.JSONEq(t, string(aggregated), string(dbExec.ResponseBody))
+		require.Equal(t, "resp_codex_like", dbExec.ExternalID)
+		require.True(t, state.StreamCompleted)
+	})
+}
+
+func TestPersistentOutboundTransformer_TransformRequest_WithPrepopulatedState(t *testing.T) {
 	// Setup
 	ctx := context.Background()
 


### PR DESCRIPTION
## What this fixes

When the client disconnects near the end of a streamed response, AxonHub may observe `ctx` cancellation before the local stream consumer sees the terminal event.

In the `Claude Code -> AxonHub -> Codex` chain, that can misclassify an actually completed response as canceled / failed even though the full response has already been streamed upstream.

## Approach

This update keeps the completion proof generic instead of special-casing OpenAI Responses status values.

The outbound finalization logic now treats a response as completed when either:

- an explicit terminal event was observed
- or aggregation succeeds and `meta.Usage != nil`

At the same time:

- explicit upstream stream errors still remain failures
- `ctx` cancellation alone is no longer treated as automatic failure if completion has already been proven
- missing usage is not treated as proof of failure; it is just absence of one completion signal

## Why this shape

The maintainer feedback was to avoid protocol-specific completion handling in the orchestrator.

Using aggregated usage as an additional positive completion signal makes the rule work across providers / formats that already populate usage on complete responses, while still preserving terminal-event-based completion for streams that do not rely on usage.

## Tests

This PR includes:

- targeted orchestrator regression coverage in `internal/server/orchestrator/outbound_test.go`
- an integration-style client-disconnect regression in `integration_test/openai/responses/streaming/client_disconnect_test.go`

Covered cases include:

- missing usage does not count as aggregated completion
- aggregated usage counts as completion
- client cancel after the response is effectively complete is still persisted as completed
- explicit stream errors still remain failures

## Verification

- `go test ./internal/server/orchestrator/...`
