### PR TITLE
feat: add Homebrew tap support for automated formula publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,4 @@ jobs:
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ locales_backup
 # Chunkhound local database
 .chunkhound/
 .superset/
+.snow/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,6 +75,43 @@ archives:
       - src: deploy/stop.bat
         dst: stop.bat
 
+brews:
+  - name: axonhub
+    ids: [archive]
+    repository:
+      owner: looplj
+      name: homebrew-axonhub
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/looplj/axonhub"
+    description: "All-in-one AI development platform. Use any SDK, access any model."
+    license: "Apache-2.0"
+    url_template: "https://github.com/looplj/axonhub/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: "github-actions[bot]"
+      email: "github-actions[bot]@users.noreply.github.com"
+    install: |
+      libexec.install "axonhub"
+      (etc/"axonhub").mkpath
+      (bin/"axonhub").write <<~SH
+        #!/bin/sh
+        cd "#{etc}/axonhub" || exit 1
+        exec "#{libexec}/axonhub" "$@"
+      SH
+    service: |
+      run [opt_bin/"axonhub"]
+      keep_alive true
+    test: |
+      system "#{bin}/axonhub", "version"
+    caveats: |
+      AxonHub runs with default configuration.
+      To customize, create a config file at: #{etc}/axonhub/config.yml
+
+      View current configuration:
+        axonhub config preview
+
+      The wrapper starts AxonHub from #{etc}/axonhub automatically.
+
 checksum:
   name_template: 'checksums.txt'
 


### PR DESCRIPTION
Closes #1076

## Summary

Add Homebrew tap support for automated formula publishing to `looplj/homebrew-axonhub`.

### Changes

- `.goreleaser.yml`: Add `brews` configuration for automatic formula publishing on release
- `.github/workflows/release.yml`: Add `HOMEBREW_TAP_GITHUB_TOKEN` env var to GoReleaser step

### Homebrew Formula Features

- Binary installed to `libexec/`, wrapper script in `bin/`
- Config directory: `/opt/homebrew/etc/axonhub/`
- Zero-config: AxonHub runs with built-in defaults
- Support `brew services` for background service management
- Include `axonhub version` test

### Installation (after merge)

```bash
brew tap looplj/axonhub
brew install axonhub
```

## Setup Required: Create HOMEBREW_TAP_GITHUB_TOKEN

GoReleaser needs a token with **read/write permissions to `looplj/homebrew-axonhub`** repository to push formula updates automatically.

### Step 1: Create Personal Access Token

1. Go to https://github.com/settings/personal-access-tokens/new (Fine-grained token)
2. Token name: `HOMEBREW_TAP_GITHUB_TOKEN`
3. Expiration: Choose appropriate duration
4. Resource owner: `looplj`
5. Repository access: Select **"Only select repositories"**, then choose `looplj/homebrew-axonhub`
6. Permissions:
   - Repository permissions -> Contents: **Read and write**
   - (This grants read/write access to the repository contents, allowing GoReleaser to push formula commits)
7. Generate and copy the token

Alternatively, use a Classic token:
1. Go to https://github.com/settings/tokens/new
2. Select scope: `repo` (Full control of private repositories)
3. This grants read/write access to all repositories, so Fine-grained token is recommended

### Step 2: Add to Repository Secrets

1. Go to https://github.com/looplj/axonhub/settings/secrets/actions
2. Click "New repository secret"
3. Name: `HOMEBREW_TAP_GITHUB_TOKEN`
4. Value: paste the token
5. Save

### Step 3: Verify

After merging, create a new release tag (e.g., `v0.9.18`):
1. Release workflow runs GoReleaser
2. GoReleaser builds binaries and archives
3. GoReleaser uses `HOMEBREW_TAP_GITHUB_TOKEN` to push formula to `looplj/homebrew-axonhub`
4. Users can `brew install looplj/axonhub/axonhub`

Note: If `HOMEBREW_TAP_GITHUB_TOKEN` is not configured, GoReleaser falls back to `GITHUB_TOKEN`, which only has permissions to the current repository and cannot push to `looplj/homebrew-axonhub`.

## Test Plan

- [x] Full GoReleaser + Homebrew publish workflow tested on fork
- [x] `brew tap` + `brew install axonhub` verified
- [x] `axonhub version` runs correctly
- [x] Zero-config startup verified

## Related PR

- Tap repository formula: https://github.com/looplj/homebrew-axonhub/pull/1