### PR TITLE
fix(llm): fix signature_delta attachment to wrong content block

### DIFF
--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -373,11 +373,18 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 		if message != nil {
 			var contentBlocks []MessageContentBlock
 
-			// Handle reasoning content (thinking) first if present
+			// Handle reasoning content (thinking) first if present.
+			// Also emit a thinking block when only a signature exists (no content),
+			// so the signature is not dropped — mirrors the streaming-side logic in
+			// flushPendingSignatureBlock().
 			if (message.ReasoningContent != nil && *message.ReasoningContent != "") || (message.ReasoningSignature != nil && *message.ReasoningSignature != "") {
+				thinkingContent := message.ReasoningContent
+				if thinkingContent == nil {
+					thinkingContent = lo.ToPtr("")
+				}
 				thinkingBlock := MessageContentBlock{
 					Type:     "thinking",
-					Thinking: message.ReasoningContent,
+					Thinking: thinkingContent,
 				}
 				if message.ReasoningSignature != nil {
 					thinkingBlock.Signature = message.ReasoningSignature

--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -72,6 +72,60 @@ func (s *anthropicInboundStream) flushPendingSignature() error {
 	})
 }
 
+// flushPendingSignatureBlock emits a complete empty thinking block containing the
+// buffered signature. Use this when a pending signature exists but no thinking
+// block was ever started — we must create one so the signature_delta targets a
+// valid thinking block.
+func (s *anthropicInboundStream) flushPendingSignatureBlock() error {
+	if s.pendingSignature == nil {
+		return nil
+	}
+
+	// If a thinking block is already open, just append the signature delta.
+	if s.hasThinkingContentStarted {
+		return s.flushPendingSignature()
+	}
+
+	sig := s.pendingSignature
+	s.pendingSignature = nil
+
+	// content_block_start (empty thinking)
+	if err := s.enqueEvent(&StreamEvent{
+		Type:  "content_block_start",
+		Index: &s.contentIndex,
+		ContentBlock: &MessageContentBlock{
+			Type:     "thinking",
+			Thinking: lo.ToPtr(""),
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue thinking content_block_start for pending signature: %w", err)
+	}
+
+	// signature_delta
+	if err := s.enqueEvent(&StreamEvent{
+		Type:  "content_block_delta",
+		Index: &s.contentIndex,
+		Delta: &StreamDelta{
+			Type:      lo.ToPtr("signature_delta"),
+			Signature: sig,
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue signature_delta for pending signature: %w", err)
+	}
+
+	// content_block_stop
+	if err := s.enqueEvent(&StreamEvent{
+		Type:  "content_block_stop",
+		Index: &s.contentIndex,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue content_block_stop for pending signature: %w", err)
+	}
+
+	s.contentIndex += 1
+
+	return nil
+}
+
 func (s *anthropicInboundStream) enqueEvent(ev *StreamEvent) error {
 	// Some providers have a bug that generates duplicate "content_block_stop" events. This check ignores the duplicate to ensure compatibility.
 	if s.lastEventType == "content_block_stop" && ev.Type == "content_block_stop" {
@@ -244,14 +298,15 @@ func (s *anthropicInboundStream) Next() bool {
 
 		// Handle redacted reasoning content (redacted_thinking)
 		if choice.Delta != nil && choice.Delta.RedactedReasoningContent != nil && *choice.Delta.RedactedReasoningContent != "" {
+			// Flush pending signature as a complete thinking block if thinking never started
+			if err := s.flushPendingSignatureBlock(); err != nil {
+				s.err = fmt.Errorf("failed to flush pending signature block: %w", err)
+				return false
+			}
+
 			// If the thinking content has started before the redacted thinking content, we need to stop it
 			if s.hasThinkingContentStarted {
 				s.hasThinkingContentStarted = false
-
-				if err := s.flushPendingSignature(); err != nil {
-					s.err = fmt.Errorf("failed to flush pending signature: %w", err)
-					return false
-				}
 
 				stopEvent := StreamEvent{
 					Type:  "content_block_stop",
@@ -333,14 +388,15 @@ func (s *anthropicInboundStream) Next() bool {
 
 		// Handle content delta
 		if choice.Delta != nil && choice.Delta.Content.Content != nil && *choice.Delta.Content.Content != "" {
+			// Flush pending signature as a complete thinking block if thinking never started
+			if err := s.flushPendingSignatureBlock(); err != nil {
+				s.err = fmt.Errorf("failed to flush pending signature block: %w", err)
+				return false
+			}
+
 			// If the thinking content has started before the text content, we need to stop it
 			if s.hasThinkingContentStarted {
 				s.hasThinkingContentStarted = false
-
-				if err := s.flushPendingSignature(); err != nil {
-					s.err = fmt.Errorf("failed to flush pending signature: %w", err)
-					return false
-				}
 
 				stopEvent := StreamEvent{
 					Type:  "content_block_stop",
@@ -413,15 +469,16 @@ func (s *anthropicInboundStream) Next() bool {
 
 		// Handle tool calls
 		if choice.Delta != nil && len(choice.Delta.ToolCalls) > 0 {
+			// Flush pending signature as a complete thinking block if thinking never started
+			if err := s.flushPendingSignatureBlock(); err != nil {
+				s.err = fmt.Errorf("failed to flush pending signature block: %w", err)
+				return false
+			}
+
 			// Support tool call when the thinking.
 			// If the thinking content has started before the text content, we need to stop it
 			if s.hasThinkingContentStarted {
 				s.hasThinkingContentStarted = false
-
-				if err := s.flushPendingSignature(); err != nil {
-					s.err = fmt.Errorf("failed to flush pending signature: %w", err)
-					return false
-				}
 
 				stopEvent := StreamEvent{
 					Type:  "content_block_stop",
@@ -553,8 +610,8 @@ func (s *anthropicInboundStream) Next() bool {
 		if choice.FinishReason != nil && !s.hasFinished {
 			s.hasFinished = true
 
-			if err := s.flushPendingSignature(); err != nil {
-				s.err = fmt.Errorf("failed to flush pending signature: %w", err)
+			if err := s.flushPendingSignatureBlock(); err != nil {
+				s.err = fmt.Errorf("failed to flush pending signature block: %w", err)
 				return false
 			}
 

--- a/llm/transformer/anthropic/inbound_stream_pending_signature_test.go
+++ b/llm/transformer/anthropic/inbound_stream_pending_signature_test.go
@@ -64,6 +64,23 @@ func withTextContent(text string) func(*llm.Response) {
 	}
 }
 
+func withToolCall(index int, id, name, args string) func(*llm.Response) {
+	return func(r *llm.Response) {
+		if r.Choices[0].Delta == nil {
+			r.Choices[0].Delta = &llm.Message{Role: "assistant"}
+		}
+		r.Choices[0].Delta.ToolCalls = append(r.Choices[0].Delta.ToolCalls, llm.ToolCall{
+			Index: index,
+			ID:    id,
+			Type:  "function",
+			Function: llm.FunctionCall{
+				Name:      name,
+				Arguments: args,
+			},
+		})
+	}
+}
+
 func withFinishReason(reason string) func(*llm.Response) {
 	return func(r *llm.Response) {
 		r.Choices[0].FinishReason = lo.ToPtr(reason)
@@ -294,4 +311,265 @@ func TestPendingSignature_NoSignature(t *testing.T) {
 			require.NotEqual(t, "signature_delta", *ev.Delta.Type, "signature_delta should not appear without signature")
 		}
 	}
+}
+
+// TestPendingSignature_EmptyThinkingWithSignature_TextAndToolUse reproduces the
+// exact bug from issue #1105: the upstream provider sends an empty thinking block
+// (ReasoningContent="") followed by a signature, then text and tool_use.
+// Previously the empty thinking block was discarded and the signature attached
+// to the last tool_use block.
+func TestPendingSignature_EmptyThinkingWithSignature_TextAndToolUse(t *testing.T) {
+	const (
+		id    = "msg_test_005"
+		model = "test-model"
+		sig   = "sig_empty_thinking"
+	)
+
+	responses := []*llm.Response{
+		buildChunk(id, model, withUsage(10, 1)),
+		// Signature without thinking block
+		buildChunk(id, model, withReasoningSignature(sig)),
+		// Text content
+		buildChunk(id, model, withTextContent("Sure!")),
+		// Tool use
+		buildChunk(id, model, withToolCall(0, "toolu_01", "Bash", `{"command":"pwd"}`)),
+		// Finish
+		buildChunk(id, model, withFinishReason("tool_calls")),
+		buildChunk(id, model, withUsage(10, 30)),
+	}
+
+	events := collectStreamEvents(t, responses)
+
+	// Expected event order:
+	// 0: message_start
+	// 1: content_block_start (thinking, thinking: "")
+	// 2: content_block_delta (signature_delta)       <-- on thinking block (index 0)
+	// 3: content_block_stop (index 0)
+	// 4: content_block_start (text, index 1)
+	// 5: content_block_delta (text_delta "Sure!")
+	// 6: content_block_stop (index 1)
+	// 7: content_block_start (tool_use, index 2)
+	// 8: content_block_delta (input_json_delta)
+	// 9: content_block_stop (index 2)
+	// 10: message_delta
+	// 11: message_stop
+
+	require.Len(t, events, 12)
+
+	// Thinking block at index 0
+	require.Equal(t, "content_block_start", events[1].Type)
+	require.Equal(t, "thinking", events[1].ContentBlock.Type)
+	require.Equal(t, int64(0), *events[1].Index)
+
+	// Signature on the thinking block (index 0)
+	require.Equal(t, "content_block_delta", events[2].Type)
+	require.Equal(t, "signature_delta", *events[2].Delta.Type)
+	require.Equal(t, sig, *events[2].Delta.Signature)
+	require.Equal(t, int64(0), *events[2].Index)
+
+	// Thinking block stop
+	require.Equal(t, "content_block_stop", events[3].Type)
+	require.Equal(t, int64(0), *events[3].Index)
+
+	// Text at index 1
+	require.Equal(t, "content_block_start", events[4].Type)
+	require.Equal(t, "text", events[4].ContentBlock.Type)
+	require.Equal(t, int64(1), *events[4].Index)
+
+	// Tool use at index 2
+	require.Equal(t, "content_block_start", events[7].Type)
+	require.Equal(t, "tool_use", events[7].ContentBlock.Type)
+	require.Equal(t, int64(2), *events[7].Index)
+
+	// No signature_delta on the tool_use block
+	for i := 7; i < len(events); i++ {
+		if events[i].Delta != nil && events[i].Delta.Type != nil {
+			require.NotEqual(t, "signature_delta", *events[i].Delta.Type,
+				"signature_delta must not appear on tool_use block")
+		}
+	}
+}
+
+// TestPendingSignature_SignatureWithoutThinking_ToolUse tests the defensive path:
+// signature arrives with no ReasoningContent at all, then tool_use directly.
+// The flushPendingSignatureBlock() creates a synthetic empty thinking block.
+func TestPendingSignature_SignatureWithoutThinking_ToolUse(t *testing.T) {
+	const (
+		id    = "msg_test_006"
+		model = "test-model"
+		sig   = "orphan_sig_tool"
+	)
+
+	responses := []*llm.Response{
+		buildChunk(id, model, withUsage(10, 1)),
+		// Signature without any thinking content
+		buildChunk(id, model, withReasoningSignature(sig)),
+		// Tool use directly
+		buildChunk(id, model, withToolCall(0, "toolu_01", "Bash", `{"command":"ls"}`)),
+		buildChunk(id, model, withFinishReason("tool_calls")),
+		buildChunk(id, model, withUsage(10, 20)),
+	}
+
+	events := collectStreamEvents(t, responses)
+
+	// Expected: synthetic thinking block created for the signature
+	// 0: message_start
+	// 1: content_block_start (thinking)
+	// 2: content_block_delta (signature_delta)
+	// 3: content_block_stop (index 0)
+	// 4: content_block_start (tool_use, index 1)
+	// 5: content_block_delta (input_json_delta)
+	// 6: content_block_stop (index 1)
+	// 7: message_delta
+	// 8: message_stop
+
+	require.Len(t, events, 9)
+
+	// Synthetic thinking block
+	require.Equal(t, "content_block_start", events[1].Type)
+	require.Equal(t, "thinking", events[1].ContentBlock.Type)
+	require.Equal(t, int64(0), *events[1].Index)
+
+	// Signature on the thinking block
+	require.Equal(t, "content_block_delta", events[2].Type)
+	require.Equal(t, "signature_delta", *events[2].Delta.Type)
+	require.Equal(t, sig, *events[2].Delta.Signature)
+	require.Equal(t, int64(0), *events[2].Index)
+
+	require.Equal(t, "content_block_stop", events[3].Type)
+	require.Equal(t, int64(0), *events[3].Index)
+
+	// Tool use at index 1
+	require.Equal(t, "content_block_start", events[4].Type)
+	require.Equal(t, "tool_use", events[4].ContentBlock.Type)
+	require.Equal(t, int64(1), *events[4].Index)
+}
+
+// TestPendingSignature_SignatureWithoutThinking_Text tests the defensive path:
+// signature arrives with no ReasoningContent, then text directly.
+func TestPendingSignature_SignatureWithoutThinking_Text(t *testing.T) {
+	const (
+		id    = "msg_test_007"
+		model = "test-model"
+		sig   = "orphan_sig_text"
+	)
+
+	responses := []*llm.Response{
+		buildChunk(id, model, withUsage(10, 1)),
+		// Signature without any thinking content
+		buildChunk(id, model, withReasoningSignature(sig)),
+		// Text directly
+		buildChunk(id, model, withTextContent("Hello")),
+		buildChunk(id, model, withFinishReason("stop")),
+		buildChunk(id, model, withUsage(10, 10)),
+	}
+
+	events := collectStreamEvents(t, responses)
+
+	// Expected: synthetic thinking block, then text
+	// 0: message_start
+	// 1: content_block_start (thinking)
+	// 2: content_block_delta (signature_delta)
+	// 3: content_block_stop (index 0)
+	// 4: content_block_start (text, index 1)
+	// 5: content_block_delta (text_delta "Hello")
+	// 6: content_block_stop (index 1)
+	// 7: message_delta
+	// 8: message_stop
+
+	require.Len(t, events, 9)
+
+	// Synthetic thinking block
+	require.Equal(t, "content_block_start", events[1].Type)
+	require.Equal(t, "thinking", events[1].ContentBlock.Type)
+	require.Equal(t, int64(0), *events[1].Index)
+
+	// Signature on the thinking block
+	require.Equal(t, "content_block_delta", events[2].Type)
+	require.Equal(t, "signature_delta", *events[2].Delta.Type)
+	require.Equal(t, sig, *events[2].Delta.Signature)
+	require.Equal(t, int64(0), *events[2].Index)
+
+	require.Equal(t, "content_block_stop", events[3].Type)
+
+	// Text at index 1
+	require.Equal(t, "content_block_start", events[4].Type)
+	require.Equal(t, "text", events[4].ContentBlock.Type)
+	require.Equal(t, int64(1), *events[4].Index)
+}
+
+// TestPendingSignature_NonStream_SignatureOnly verifies the non-streaming path:
+// when a response has only a ReasoningSignature (no ReasoningContent),
+// convertToAnthropicResponse still emits a thinking block so the signature
+// is not dropped.
+func TestPendingSignature_NonStream_SignatureOnly(t *testing.T) {
+	const sig = "sig_non_stream"
+
+	chatResp := &llm.Response{
+		ID:    "msg_ns_001",
+		Model: "test-model",
+		Choices: []llm.Choice{
+			{
+				Message: &llm.Message{
+					Role:               "assistant",
+					ReasoningSignature: lo.ToPtr(sig),
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("Hello"),
+					},
+				},
+				FinishReason: lo.ToPtr("stop"),
+			},
+		},
+	}
+
+	resp := convertToAnthropicResponse(chatResp)
+
+	// First content block must be a thinking block carrying the signature
+	require.GreaterOrEqual(t, len(resp.Content), 2)
+	require.Equal(t, "thinking", resp.Content[0].Type)
+	require.NotNil(t, resp.Content[0].Thinking)
+	require.Equal(t, "", *resp.Content[0].Thinking)
+	require.NotNil(t, resp.Content[0].Signature)
+	require.Equal(t, sig, *resp.Content[0].Signature)
+
+	// Second block is the text
+	require.Equal(t, "text", resp.Content[1].Type)
+	require.Equal(t, "Hello", *resp.Content[1].Text)
+}
+
+// TestPendingSignature_NonStream_ThinkingAndSignature verifies the non-streaming
+// path when both ReasoningContent and ReasoningSignature are present.
+func TestPendingSignature_NonStream_ThinkingAndSignature(t *testing.T) {
+	const (
+		thinking = "Let me think..."
+		sig      = "sig_with_thinking"
+	)
+
+	chatResp := &llm.Response{
+		ID:    "msg_ns_002",
+		Model: "test-model",
+		Choices: []llm.Choice{
+			{
+				Message: &llm.Message{
+					Role:               "assistant",
+					ReasoningContent:   lo.ToPtr(thinking),
+					ReasoningSignature: lo.ToPtr(sig),
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("Answer"),
+					},
+				},
+				FinishReason: lo.ToPtr("stop"),
+			},
+		},
+	}
+
+	resp := convertToAnthropicResponse(chatResp)
+
+	require.GreaterOrEqual(t, len(resp.Content), 2)
+	require.Equal(t, "thinking", resp.Content[0].Type)
+	require.Equal(t, thinking, *resp.Content[0].Thinking)
+	require.Equal(t, sig, *resp.Content[0].Signature)
+
+	require.Equal(t, "text", resp.Content[1].Type)
+	require.Equal(t, "Answer", *resp.Content[1].Text)
 }


### PR DESCRIPTION
**Fixes #1105**

通过 AxonHub 使用 Claude Agent SDK / Claude Code 时，Anthropic API 返回的空 thinking block（只有 signature 没有 thinking 内容）的 signature_delta 事件挂到了后续的 tool_use block 上。客户端校验到 signature delta 指向的不是 thinking block，报错 "Content block is not a thinking block" 后回退到非流式模式，造成重复请求和内容闪烁。

## 改动

仅修改 Inbound 端：如果有 thinking signature 但没有发送过 thinking block，就强行补一个 thinking block。

- **inbound_stream.go** — 新增 `flushPendingSignatureBlock()`，当存在 pending signature 但从未开启 thinking block 时，合成一个空 thinking block（content_block_start → signature_delta → content_block_stop）。在所有 block 转换点调用：redacted_thinking / text / tool_use / finish_reason
- **inbound_convert.go** — 非流式响应中，当只有 signature 没有 thinking 内容时，同样补一个空 thinking block 承载 signature

## Test plan

- 已有 4 个 `TestPendingSignature_*` 测试无回归
- 新增 `TestPendingSignature_EmptyThinkingWithSignature_TextAndToolUse` — 复现 issue 场景
- 新增 `TestPendingSignature_SignatureWithoutThinking_ToolUse` — 防御性路径
- 新增 `TestPendingSignature_SignatureWithoutThinking_Text` — 防御性路径
- 新增 `TestPendingSignature_NonStream_SignatureOnly` — 非流式 signature-only 路径
- 新增 `TestPendingSignature_NonStream_ThinkingAndSignature` — 非流式正常路径

## ⚠️ 声明

Patch 完全由 Claude (Opus 4.6) 生成，**我没有 review 过**。如果要合并的话，**AI 建议**仔细看一下改动，特别是 `flushPendingSignatureBlock()` 的逻辑和各个 transition point 的调用时机。

已手动测试内容：

- [x] 本地 Claude Code 通过 AxonHub 使用，streaming 正常工作，不再出现 streaming fallback 相关错误
- [x] 通过 AxonHub 连 Anthropic API 的场景，both streaming and non-streaming
- [x] 通过 AxonHub 连 Anthropic API 的场景，原 issue 中的 curl 命令产生结果如下

<details><summary>curl ...</summary>

```
event:message_start
data: {"type":"message_start","message":{"id":"msg_01UUUUUUUUUUUUUUUUUUUUUU","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","usage":{"input_tokens":714,"output_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}}

event:content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}

event:content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"QVhOMTAxNzUyNzFhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}}

event:content_block_stop
data: {"type":"content_block_stop","index":0}

event:content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Sure"}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"! Let me explore"}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" the repository structure"}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" to understand what it"}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" is"}}

event:content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"."}}

event:content_block_stop
data: {"type":"content_block_stop","index":1}

event:content_block_start
data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01KKKKKKKKKKKKKKKKKKKKKK","name":"Bash","input":{}}}

event:content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}}

event:content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"co"}}

event:content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"mmand\": \""}}

event:content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"pwd\"}"}}

event:content_block_stop
data: {"type":"content_block_stop","index":2}

event:content_block_start
data: {"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_01URRRRRRRRRRRRRRRRRRRRR","name":"Bash","input":{}}}

event:content_block_delta
data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":""}}

event:content_block_delta
data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\""}}

event:content_block_delta
data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"command\": \""}}

event:content_block_delta
data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"ls -la\"}"}}

event:content_block_stop
data: {"type":"content_block_stop","index":3}

event:message_delta
data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":714,"output_tokens":145,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}

event:message_stop
data: {"type":"message_stop"}


```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)