### PR TITLE
build: add freebsd support for releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - linux
       - windows
       - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64
@@ -44,6 +45,12 @@ builds:
       - goos: darwin
         goarch: s390x
       - goos: darwin
+        goarch: loong64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: s390x
+      - goos: freebsd
         goarch: loong64
 
 release:


### PR DESCRIPTION
## Description
This PR adds FreeBSD support to Goreleaser so Axonhub can natively run on FreeBSD servers.

- Added `freebsd` to `goos`
- Ignored unsupported freebsd architectures (`arm`, `s390x`, `loong64`)

Closes no issues, generated to help a user deploy on FreeBSD environments (e.g. Serv00).