### PR TITLE
chore: 为 Codex 计划补充 gpt-5.3-codex-spark 和 gpt-5.4-mini 模型

### DIFF
--- a/llm/transformer/openai/codex/constants.go
+++ b/llm/transformer/openai/codex/constants.go
@@ -16,7 +16,9 @@ func DefaultModels() []string {
 		"gpt-5.2",
 		"gpt-5.2-codex",
 		"gpt-5.3-codex",
+		"gpt-5.3-codex-spark",
 		"gpt-5.4",
+		"gpt-5.4-mini",
 	}
 }
 


### PR DESCRIPTION
## 摘要
- 为 Codex 默认模型列表补充 `gpt-5.3-codex-spark` 与 `gpt-5.4-mini`

## 变更说明
- 更新 `llm/transformer/openai/codex/constants.go`
- 在 `DefaultModels()` 中加入两个新增模型名，不涉及其他逻辑改动

## 验证
- 对比 `release/v0.9.x...HEAD`，确认本 PR 仅包含上述模型列表调整