### PR TITLE
fix(channels): prevent ChannelsTypeTabs from wrapping on small screens

### DIFF
--- a/frontend/src/features/channels/components/channels-type-tabs.tsx
+++ b/frontend/src/features/channels/components/channels-type-tabs.tsx
@@ -70,8 +70,11 @@ export const ChannelsTypeTabs = memo(function ChannelsTypeTabs({ typeCounts, sel
   };
 
   return (
-    <div className='mb-6 w-full'>
-      <div className='hide-scroll flex flex-wrap items-center gap-2 md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden md:scroll-smooth'>
+    <div className='mb-6 w-full overflow-hidden'>
+      <div
+        className='hide-scroll flex flex-nowrap items-center gap-2 overflow-x-auto scroll-smooth'
+        onWheel={(e) => { e.currentTarget.scrollLeft += e.deltaY; }}
+      >
         {/* All tab */}
         <button
           onClick={() => onTabChange('all')}


### PR DESCRIPTION
Prevent ChannelsTypeTabs from wrapping on small screens. Switch to a single-row horizontal scroll layout with mouse wheel support.
<img width="955" height="662" alt="CleanShot 2026-03-28 at 16 33 21" src="https://github.com/user-attachments/assets/0e5912ec-2e0e-4b97-a93c-060c8938d7a2" />
