### PR TITLE
fix(nanogpt): implement XML tool call parsing for NanoGPT transformer

### DIFF
--- a/llm/transformer/nanogpt/model.go
+++ b/llm/transformer/nanogpt/model.go
@@ -57,10 +57,27 @@ type Message struct {
 
 // ToOpenAIMessage converts the NanoGPT Message to an OpenAI Message.
 // It maps the Reasoning field to ReasoningContent for compatibility.
+// It also parses XML tool calls from content if present.
 func (m *Message) ToOpenAIMessage() openai.Message {
 	// Map reasoning to reasoning_content if present
 	if m.Reasoning != nil {
 		m.ReasoningContent = m.Reasoning
+	}
+
+	// Parse XML tool calls from content if present
+	if m.Content.Content != nil && *m.Content.Content != "" {
+		content := *m.Content.Content
+		if MaybeHasXMLToolCalls(content) {
+			tools, remaining, err := ParseXMLToolCalls(content)
+			if err == nil && len(tools) > 0 {
+				m.ToolCalls = ToOpenAIToolCalls(tools)
+				if remaining != "" {
+					m.Content = ToOpenAIMessageContent(remaining)
+				} else {
+					m.Content = openai.MessageContent{Content: nil}
+				}
+			}
+		}
 	}
 
 	return m.Message

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -30,6 +31,8 @@ var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([
 
 // normalizeTagPattern matches tags without space before />
 var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
+// nestedXMLPattern matches nested XML like <Write><file_path>X</file_path><content>Y</content></Write>
+var nestedXMLPattern = regexp.MustCompile(`<(Write|Read)[^>]*>\s*<file_path>([^<]*)</file_path>\s*<content>([\s\S]*?)</content>\s*</(Write|Read)>`)
 // mismatchTagPattern matches <Write>content</use_tool> type patterns
 // Uses [^<] to match content safely without ReDoS backtracking
 var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([^<]*)</use_tool>`)
@@ -83,6 +86,34 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 
 	var matches []matchInfo
 
+	// Handle nested XML format: <Write><file_path>X</file_path><content>Y</content></Write>
+	// This must be processed before other patterns to avoid matching inner elements
+	for _, m := range nestedXMLPattern.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) >= 10 {
+			// m[2]:m[3] = opening tag (Write/Read)
+			// m[4]:m[5] = file_path value
+			// m[6]:m[7] = content value
+			// m[8]:m[9] = closing tag
+			tagName := content[m[2]:m[3]]
+			filePath := content[m[4]:m[5]]
+			innerContent := content[m[6]:m[7]]
+			closingTag := content[m[8]:m[9]]
+
+			// Only process if opening and closing tags match
+			if strings.EqualFold(tagName, closingTag) {
+				// Create synthetic attributes
+				attrs := fmt.Sprintf(`file_path="%s" content="%s"`, filePath, innerContent)
+				matches = append(matches, matchInfo{
+					start:        m[0],
+					end:          m[1],
+					tagName:      tagName,
+					attrs:        attrs,
+					innerContent: "", // Content is already in attrs
+					closingTag:   closingTag,
+				})
+			}
+		}
+	}
 	// Find opening/closing tag patterns
 	for _, m := range toolCallPattern.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) >= 10 {

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -1,0 +1,170 @@
+package nanogpt
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+// UseToolCall represents a <use_tool> XML element.
+type UseToolCall struct {
+	XMLName xml.Name `xml:"use_tool"`
+	Name    string   `xml:"name,attr"`
+	Arg     string   `xml:"arg"`
+	Content string   `xml:",innerxml"`
+}
+
+// MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
+// This avoids the overhead of full XML parsing for content that doesn't contain tool calls.
+func MaybeHasXMLToolCalls(content string) bool {
+	return strings.Contains(content, "<use_tool") ||
+		strings.Contains(content, "</use_tool>") ||
+		strings.Contains(content, "</use_use>")
+}
+
+// ParseXMLToolCalls extracts tool calls from XML content.
+// It parses the <use_tool name="X"><arg>value</arg></use_tool> format.
+// Returns the parsed tool calls, any remaining content after tool calls, and any error encountered.
+func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
+	// Fast check - if no XML tool tags, return as-is
+	if !MaybeHasXMLToolCalls(content) {
+		return nil, content, nil
+	}
+
+	// Try to parse as XML containing use_tool elements
+	decoder := xml.NewDecoder(strings.NewReader(content))
+
+	var toolCalls []llm.ToolCall
+	var remainingContent strings.Builder
+	var hasToolCalls bool
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			break
+		}
+
+		switch t := token.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "use_tool" {
+				hasToolCalls = true
+				var tool UseToolCall
+				if err := decoder.DecodeElement(&tool, &t); err != nil {
+					// If we can't parse, treat the original content as remaining
+					if !hasToolCalls {
+						return nil, content, nil
+					}
+					continue
+				}
+
+				if tool.Name != "" {
+					// Generate deterministic ID from tool name and arguments
+					id := generateToolCallID(tool.Name, tool.Arg)
+
+					// Parse arguments - try JSON first, then treat as plain string
+					var args string
+					trimmedArg := strings.TrimSpace(tool.Arg)
+					if trimmedArg != "" {
+						// Check if it looks like JSON
+						if (strings.HasPrefix(trimmedArg, "{") && strings.HasSuffix(trimmedArg, "}")) ||
+							(strings.HasPrefix(trimmedArg, "[") && strings.HasSuffix(trimmedArg, "]")) {
+							args = trimmedArg
+						} else {
+							// Wrap single value in JSON object with "value" key
+							args = `{"value":` + jsonStringify(tool.Arg) + `}`
+						}
+					} else {
+						args = "{}"
+					}
+
+					toolCalls = append(toolCalls, llm.ToolCall{
+						Index: len(toolCalls),
+						ID:    id,
+						Type:  "function",
+						Function: llm.FunctionCall{
+							Name:      tool.Name,
+							Arguments: args,
+						},
+					})
+				}
+			} else {
+				// For other elements, include them in remaining content
+				remainingContent.WriteString(token.(xml.StartElement).Name.Local)
+			}
+
+		case xml.CharData:
+			text := strings.TrimSpace(string(t))
+			if text != "" && !hasToolCalls {
+				remainingContent.WriteString(text)
+			}
+
+		case xml.EndElement:
+			if t.Name.Local != "use_tool" {
+				remainingContent.WriteString("</")
+				remainingContent.WriteString(t.Name.Local)
+				remainingContent.WriteString(">")
+			}
+		}
+	}
+
+	if len(toolCalls) == 0 {
+		// No valid tool calls found, return original content
+		return nil, content, nil
+	}
+
+	// Return tool calls and remaining content
+	remaining := remainingContent.String()
+	if remaining == "" {
+		return toolCalls, "", nil
+	}
+
+	return toolCalls, remaining, nil
+}
+
+// generateToolCallID generates a deterministic ID from the tool name and arguments.
+func generateToolCallID(name, args string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(name))
+	hasher.Write([]byte(args))
+	hash := hasher.Sum(nil)
+	return "nanogpt_" + hex.EncodeToString(hash)[:16]
+}
+
+// jsonStringify properly escapes a string for JSON.
+func jsonStringify(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// ToOpenAIToolCalls converts llm.ToolCall slice to openai.ToolCall slice.
+func ToOpenAIToolCalls(toolCalls []llm.ToolCall) []openai.ToolCall {
+	if len(toolCalls) == 0 {
+		return nil
+	}
+
+	result := make([]openai.ToolCall, len(toolCalls))
+	for i, tc := range toolCalls {
+		result[i] = openai.ToolCall{
+			ID:    tc.ID,
+			Type:  tc.Type,
+			Index: tc.Index,
+			Function: openai.FunctionCall{
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		}
+	}
+	return result
+}
+
+// ToOpenAIMessageContent converts a string to openai.MessageContent.
+func ToOpenAIMessageContent(content string) openai.MessageContent {
+	return openai.MessageContent{
+		Content: &content,
+	}
+}

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -28,6 +28,9 @@ var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([
 // normalizeTagPattern matches tags without space before />
 var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
 
+// mismatchTagPattern matches <Write>content</use_tool> type patterns
+var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([\s\S]*?)</use_tool>`)
+
 // MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
 func MaybeHasXMLToolCalls(content string) bool {
 	// Limit content length to prevent ReDoS
@@ -50,6 +53,7 @@ func MaybeHasXMLToolCalls(content string) bool {
 // - <use_tool name="X"><arg>value</arg></use_tool>
 // - <Write file_path="X" content="Y"/>
 // - <Write file_path="X">content</Write>
+// - <Write> {"file_path": "X", "content": "Y"}</use_tool>
 // Returns the parsed tool calls, any remaining content after tool calls, and any error encountered.
 func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 	// Fast check - if no XML tool tags, return as-is
@@ -162,10 +166,26 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 
 // normalizeXML fixes common XML malformations from NanoGPT
 func normalizeXML(content string) string {
-	// Fix mismatched closing tags
+	// Fix mismatched closing tags - handle variations like </use_tool>, </use_use>, etc.
 	content = strings.ReplaceAll(content, "</use_use>", "</use_tool>")
 	content = strings.ReplaceAll(content, "</Write_file>", "</Write>")
+	content = strings.ReplaceAll(content, "</Write_FILE>", "</Write>")
 	content = strings.ReplaceAll(content, "</Read_file>", "</Read>")
+	content = strings.ReplaceAll(content, "</Read_FILE>", "</Read>")
+
+	// Fix weird patterns like <Write>content</use_tool> -> <Write>content</Write>
+	// Use ReplaceAllFunc to preserve the opening tag name
+	content = mismatchTagPattern.ReplaceAllStringFunc(content, func(match string) string {
+		// Extract parts from the match
+		parts := mismatchTagPattern.FindStringSubmatch(match)
+		if len(parts) >= 4 {
+			tagName := parts[1]
+			attrs := parts[2]
+			innerContent := parts[3]
+			return "<" + tagName + attrs + ">" + innerContent + "</" + tagName + ">"
+		}
+		return match
+	})
 
 	// Normalize self-closing tags without space before />
 	content = normalizeTagPattern.ReplaceAllString(content, "$1 />")
@@ -177,11 +197,15 @@ func normalizeXML(content string) string {
 func extractToolName(tagName, attrs string) string {
 	tagName = strings.TrimSpace(strings.ToLower(tagName))
 
-	// Direct tool name tags
-	switch tagName {
-	case "write", "read", "bash", "python", "search", "glob":
+	// Direct tool name tags (handle variations like Write_FILE, Write_file, etc.)
+	switch {
+	case strings.HasPrefix(tagName, "write"):
+		return "write"
+	case strings.HasPrefix(tagName, "read"):
+		return "read"
+	case tagName == "bash", tagName == "python", tagName == "search", tagName == "glob":
 		return tagName
-	case "use_tool":
+	case tagName == "use_tool":
 		// Extract from name attribute
 		if matches := attrPattern.FindAllStringSubmatch(attrs, -1); matches != nil {
 			for _, match := range matches {

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -168,6 +168,16 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 
 // normalizeXML fixes common XML malformations from NanoGPT
 func normalizeXML(content string) string {
+	// Fix unclosed opening tags: <Write attr="..."\ncontent</use_tool> -> <Write attr="...">\ncontent</use_tool>
+	// NanoGPT sometimes omits the closing > on the opening tag
+	unclosedPattern := regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)\n([\s\S]*?)</use_tool>`)
+	content = unclosedPattern.ReplaceAllStringFunc(content, func(match string) string {
+		parts := unclosedPattern.FindStringSubmatch(match)
+		if len(parts) >= 4 {
+			return "<" + parts[1] + parts[2] + ">\n" + parts[3] + "</use_tool>"
+		}
+		return match
+	})
 	// Fix mismatched closing tags - handle variations like </use_tool>, </use_use>, etc.
 	content = strings.ReplaceAll(content, "</use_use>", "</use_tool>")
 	content = strings.ReplaceAll(content, "</Write_file>", "</Write>")

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -26,8 +26,8 @@ var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)
 var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)/>`)
 
 // attrPattern matches attributes like name="value" or name='value'
-// Allows empty attribute values with [^"']*
-var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"]*)["']`)
+// Handles both single and double quotes, allows empty values
+var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"']*)["']`)
 
 // normalizeTagPattern matches tags without space before />
 var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
@@ -37,6 +37,8 @@ var nestedXMLPattern = regexp.MustCompile(`<(Write|Read)[^>]*>\s*<file_path>([^<
 // Uses [^<] to match content safely without ReDoS backtracking
 var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([^<]*)</use_tool>`)
 
+// unclosedPattern matches unclosed opening tags like <Write attr="..."\n</use_tool>
+var unclosedPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)\n([\s\S]*?)</use_tool>`)
 // MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
 func MaybeHasXMLToolCalls(content string) bool {
 	// Limit content length to prevent ReDoS
@@ -202,7 +204,6 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 func normalizeXML(content string) string {
 	// Fix unclosed opening tags: <Write attr="..."\ncontent</use_tool> -> <Write attr="...">\ncontent</use_tool>
 	// NanoGPT sometimes omits the closing > on the opening tag
-	unclosedPattern := regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)\n([\s\S]*?)</use_tool>`)
 	content = unclosedPattern.ReplaceAllStringFunc(content, func(match string) string {
 		parts := unclosedPattern.FindStringSubmatch(match)
 		if len(parts) >= 4 {

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -103,8 +103,10 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 
 			// Only process if opening and closing tags match
 			if strings.EqualFold(tagName, closingTag) {
-				// Create synthetic attributes
-				attrs := fmt.Sprintf(`file_path="%s" content="%s"`, filePath, innerContent)
+				// Create synthetic attributes - escape quotes to prevent XML injection
+				filePathEscaped := strings.ReplaceAll(filePath, `"`, `\"`)
+				innerContentEscaped := strings.ReplaceAll(innerContent, `"`, `\"`)
+				attrs := fmt.Sprintf(`file_path="%s" content="%s"`, filePathEscaped, innerContentEscaped)
 				matches = append(matches, matchInfo{
 					start:        m[0],
 					end:          m[1],

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -16,19 +16,22 @@ import (
 const maxXMLParseLength = 100000 // 100KB
 
 // toolCallPattern matches XML-like tool calls with content: <Tag>content</Tag>
-// Uses [\s\S] to match any character including newlines
-var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)>([\s\S]*?)</([a-zA-Z_][a-zA-Z0-9_-]*)>`)
+// Uses [^<] to match content safely without ReDoS backtracking
+var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)>([^<]*)</([a-zA-Z_][a-zA-Z0-9_-]*)>`)
 
 // selfClosingPattern matches self-closing XML tags: <Tag attr="val" />
-var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)/>`)
+// Allows optional space between tag name and attributes
+var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)/>`)
 
 // attrPattern matches attributes like name="value" or name='value'
-var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"']+)["']`)
+// Allows empty attribute values with [^"']*
+var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"]*)["']`)
 
 // normalizeTagPattern matches tags without space before />
 var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
 // mismatchTagPattern matches <Write>content</use_tool> type patterns
-var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([\s\S]*?)</use_tool>`)
+// Uses [^<] to match content safely without ReDoS backtracking
+var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([^<]*)</use_tool>`)
 
 // MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
 func MaybeHasXMLToolCalls(content string) bool {

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -255,7 +255,7 @@ func extractToolName(tagName, attrs string) string {
 		if matches := attrPattern.FindAllStringSubmatch(attrs, -1); matches != nil {
 			for _, match := range matches {
 				if len(match) >= 3 && strings.ToLower(match[1]) == "name" {
-					return match[2]
+					return strings.ToLower(match[2])
 				}
 			}
 		}

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -5,24 +5,36 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
+// Maximum content length to prevent ReDoS attacks
+const maxXMLParseLength = 100000 // 100KB
+
 // toolCallPattern matches XML-like tool calls with content: <Tag>content</Tag>
 // Uses [\s\S] to match any character including newlines
-var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)>([\s\S]*?)</[a-zA-Z_][a-zA-Z0-9_-]*>`)
+var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)>([\s\S]*?)</([a-zA-Z_][a-zA-Z0-9_-]*)>`)
 
 // selfClosingPattern matches self-closing XML tags: <Tag attr="val" />
-var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)/>`)
+var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)/>`)
 
 // attrPattern matches attributes like name="value" or name='value'
 var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"']+)["']`)
 
+// normalizeTagPattern matches tags without space before />
+var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
+
 // MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
 func MaybeHasXMLToolCalls(content string) bool {
+	// Limit content length to prevent ReDoS
+	if len(content) > maxXMLParseLength {
+		content = content[:maxXMLParseLength]
+	}
+
 	// Check for common tool-related patterns
 	return strings.Contains(content, "<") && strings.Contains(content, ">") &&
 		(toolCallPattern.MatchString(content) ||
@@ -54,25 +66,32 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 
 	// Find all matches from both patterns
 	type matchInfo struct {
-		start       int
-		end         int
-		tagName     string
-		attrs       string
+		start        int
+		end          int
+		tagName      string
+		attrs        string
 		innerContent string
+		closingTag   string // for validation
 	}
 
 	var matches []matchInfo
 
 	// Find opening/closing tag patterns
 	for _, m := range toolCallPattern.FindAllStringSubmatchIndex(content, -1) {
-		if len(m) >= 8 {
-			matches = append(matches, matchInfo{
-				start:        m[0],
-				end:          m[1],
-				tagName:      content[m[2]:m[3]],
-				attrs:        content[m[4]:m[5]],
-				innerContent: content[m[6]:m[7]],
-			})
+		if len(m) >= 10 {
+			openingTag := content[m[2]:m[3]]
+			closingTag := content[m[8]:m[9]]
+			// Only accept if opening and closing tags match
+			if strings.EqualFold(openingTag, closingTag) {
+				matches = append(matches, matchInfo{
+					start:        m[0],
+					end:          m[1],
+					tagName:      openingTag,
+					attrs:        content[m[4]:m[5]],
+					innerContent: content[m[6]:m[7]],
+					closingTag:   closingTag,
+				})
+			}
 		}
 	}
 
@@ -88,14 +107,10 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 		}
 	}
 
-	// Sort matches by start position
-	for i := 0; i < len(matches); i++ {
-		for j := i + 1; j < len(matches); j++ {
-			if matches[j].start < matches[i].start {
-				matches[i], matches[j] = matches[j], matches[i]
-			}
-		}
-	}
+	// Sort matches by start position using efficient O(n log n) sort
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].start < matches[j].start
+	})
 
 	for _, match := range matches {
 		// Skip if not a valid tool tag
@@ -153,7 +168,7 @@ func normalizeXML(content string) string {
 	content = strings.ReplaceAll(content, "</Read_file>", "</Read>")
 
 	// Normalize self-closing tags without space before />
-	content = regexp.MustCompile(`([^\s])/>`).ReplaceAllString(content, "$1 />")
+	content = normalizeTagPattern.ReplaceAllString(content, "$1 />")
 
 	return content
 }

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -17,7 +17,8 @@ const maxXMLParseLength = 100000 // 100KB
 
 // toolCallPattern matches XML-like tool calls with content: <Tag>content</Tag>
 // Uses [^<] to match content safely without ReDoS backtracking
-var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]+([^>]*)>([^<]*)</([a-zA-Z_][a-zA-Z0-9_-]*)>`)
+// Allows optional whitespace after tag name for formats like <Write_File>{...}</Write_File>
+var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)>([^<]*)</([a-zA-Z_][a-zA-Z0-9_-]*)>`)
 
 // selfClosingPattern matches self-closing XML tags: <Tag attr="val" />
 // Allows optional space between tag name and attributes

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -27,7 +27,6 @@ var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([
 
 // normalizeTagPattern matches tags without space before />
 var normalizeTagPattern = regexp.MustCompile(`([^\s])/>`)
-
 // mismatchTagPattern matches <Write>content</use_tool> type patterns
 var mismatchTagPattern = regexp.MustCompile(`<(Write|Read|Write_FILE|Write_file|Read_FILE|Read_file)([^>]*)>([\s\S]*?)</use_tool>`)
 
@@ -308,3 +307,4 @@ func ToOpenAIMessageContent(content string) openai.MessageContent {
 		Content: &content,
 	}
 }
+

--- a/llm/transformer/nanogpt/xml_parser.go
+++ b/llm/transformer/nanogpt/xml_parser.go
@@ -4,31 +4,40 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/xml"
+	"regexp"
 	"strings"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
-// UseToolCall represents a <use_tool> XML element.
-type UseToolCall struct {
-	XMLName xml.Name `xml:"use_tool"`
-	Name    string   `xml:"name,attr"`
-	Arg     string   `xml:"arg"`
-	Content string   `xml:",innerxml"`
-}
+// toolCallPattern matches XML-like tool calls with content: <Tag>content</Tag>
+// Uses [\s\S] to match any character including newlines
+var toolCallPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)>([\s\S]*?)</[a-zA-Z_][a-zA-Z0-9_-]*>`)
+
+// selfClosingPattern matches self-closing XML tags: <Tag attr="val" />
+var selfClosingPattern = regexp.MustCompile(`<([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*([^>]*)/>`)
+
+// attrPattern matches attributes like name="value" or name='value'
+var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_-]*)[\s]*=[\s]*["']([^"']+)["']`)
 
 // MaybeHasXMLToolCalls is a fast pre-check to determine if content likely contains XML tool calls.
-// This avoids the overhead of full XML parsing for content that doesn't contain tool calls.
 func MaybeHasXMLToolCalls(content string) bool {
-	return strings.Contains(content, "<use_tool") ||
-		strings.Contains(content, "</use_tool>") ||
-		strings.Contains(content, "</use_use>")
+	// Check for common tool-related patterns
+	return strings.Contains(content, "<") && strings.Contains(content, ">") &&
+		(toolCallPattern.MatchString(content) ||
+			selfClosingPattern.MatchString(content) ||
+			strings.Contains(content, "use_tool") ||
+			strings.Contains(content, "Write") ||
+			strings.Contains(content, "Bash") ||
+			strings.Contains(content, "Read"))
 }
 
-// ParseXMLToolCalls extracts tool calls from XML content.
-// It parses the <use_tool name="X"><arg>value</arg></use_tool> format.
+// ParseXMLToolCalls extracts tool calls from XML content using regex-based parsing.
+// Handles various XML formats including:
+// - <use_tool name="X"><arg>value</arg></use_tool>
+// - <Write file_path="X" content="Y"/>
+// - <Write file_path="X">content</Write>
 // Returns the parsed tool calls, any remaining content after tool calls, and any error encountered.
 func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 	// Fast check - if no XML tool tags, return as-is
@@ -36,94 +45,192 @@ func ParseXMLToolCalls(content string) ([]llm.ToolCall, string, error) {
 		return nil, content, nil
 	}
 
-	// Try to parse as XML containing use_tool elements
-	decoder := xml.NewDecoder(strings.NewReader(content))
+	// Normalize common malformed variations
+	content = normalizeXML(content)
 
 	var toolCalls []llm.ToolCall
 	var remainingContent strings.Builder
-	var hasToolCalls bool
+	lastEnd := 0
 
-	for {
-		token, err := decoder.Token()
-		if err != nil {
-			break
+	// Find all matches from both patterns
+	type matchInfo struct {
+		start       int
+		end         int
+		tagName     string
+		attrs       string
+		innerContent string
+	}
+
+	var matches []matchInfo
+
+	// Find opening/closing tag patterns
+	for _, m := range toolCallPattern.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) >= 8 {
+			matches = append(matches, matchInfo{
+				start:        m[0],
+				end:          m[1],
+				tagName:      content[m[2]:m[3]],
+				attrs:        content[m[4]:m[5]],
+				innerContent: content[m[6]:m[7]],
+			})
 		}
+	}
 
-		switch t := token.(type) {
-		case xml.StartElement:
-			if t.Name.Local == "use_tool" {
-				hasToolCalls = true
-				var tool UseToolCall
-				if err := decoder.DecodeElement(&tool, &t); err != nil {
-					// If we can't parse, treat the original content as remaining
-					if !hasToolCalls {
-						return nil, content, nil
-					}
-					continue
-				}
+	// Find self-closing patterns
+	for _, m := range selfClosingPattern.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) >= 6 {
+			matches = append(matches, matchInfo{
+				start:   m[0],
+				end:     m[1],
+				tagName: content[m[2]:m[3]],
+				attrs:   content[m[4]:m[5]],
+			})
+		}
+	}
 
-				if tool.Name != "" {
-					// Generate deterministic ID from tool name and arguments
-					id := generateToolCallID(tool.Name, tool.Arg)
-
-					// Parse arguments - try JSON first, then treat as plain string
-					var args string
-					trimmedArg := strings.TrimSpace(tool.Arg)
-					if trimmedArg != "" {
-						// Check if it looks like JSON
-						if (strings.HasPrefix(trimmedArg, "{") && strings.HasSuffix(trimmedArg, "}")) ||
-							(strings.HasPrefix(trimmedArg, "[") && strings.HasSuffix(trimmedArg, "]")) {
-							args = trimmedArg
-						} else {
-							// Wrap single value in JSON object with "value" key
-							args = `{"value":` + jsonStringify(tool.Arg) + `}`
-						}
-					} else {
-						args = "{}"
-					}
-
-					toolCalls = append(toolCalls, llm.ToolCall{
-						Index: len(toolCalls),
-						ID:    id,
-						Type:  "function",
-						Function: llm.FunctionCall{
-							Name:      tool.Name,
-							Arguments: args,
-						},
-					})
-				}
-			} else {
-				// For other elements, include them in remaining content
-				remainingContent.WriteString(token.(xml.StartElement).Name.Local)
-			}
-
-		case xml.CharData:
-			text := strings.TrimSpace(string(t))
-			if text != "" && !hasToolCalls {
-				remainingContent.WriteString(text)
-			}
-
-		case xml.EndElement:
-			if t.Name.Local != "use_tool" {
-				remainingContent.WriteString("</")
-				remainingContent.WriteString(t.Name.Local)
-				remainingContent.WriteString(">")
+	// Sort matches by start position
+	for i := 0; i < len(matches); i++ {
+		for j := i + 1; j < len(matches); j++ {
+			if matches[j].start < matches[i].start {
+				matches[i], matches[j] = matches[j], matches[i]
 			}
 		}
+	}
+
+	for _, match := range matches {
+		// Skip if not a valid tool tag
+		toolName := extractToolName(match.tagName, match.attrs)
+		if toolName == "" {
+			// Not a recognized tool pattern, keep in remaining content
+			if lastEnd < match.start {
+				remainingContent.WriteString(content[lastEnd:match.start])
+			}
+			lastEnd = match.end
+			continue
+		}
+
+		// Extract tool arguments
+		args := extractToolArguments(toolName, match.attrs, match.innerContent)
+
+		// Generate deterministic ID
+		id := generateToolCallID(toolName, args)
+
+		toolCalls = append(toolCalls, llm.ToolCall{
+			Index: len(toolCalls),
+			ID:    id,
+			Type:  "function",
+			Function: llm.FunctionCall{
+				Name:      toolName,
+				Arguments: args,
+			},
+		})
+
+		// Add any text before this tool call to remaining content
+		if lastEnd < match.start {
+			remainingContent.WriteString(content[lastEnd:match.start])
+		}
+		lastEnd = match.end
+	}
+
+	// Add any remaining content after the last tool call
+	if lastEnd < len(content) {
+		remainingContent.WriteString(content[lastEnd:])
 	}
 
 	if len(toolCalls) == 0 {
-		// No valid tool calls found, return original content
 		return nil, content, nil
 	}
 
-	// Return tool calls and remaining content
-	remaining := remainingContent.String()
-	if remaining == "" {
-		return toolCalls, "", nil
+	remaining := strings.TrimSpace(remainingContent.String())
+	return toolCalls, remaining, nil
+}
+
+// normalizeXML fixes common XML malformations from NanoGPT
+func normalizeXML(content string) string {
+	// Fix mismatched closing tags
+	content = strings.ReplaceAll(content, "</use_use>", "</use_tool>")
+	content = strings.ReplaceAll(content, "</Write_file>", "</Write>")
+	content = strings.ReplaceAll(content, "</Read_file>", "</Read>")
+
+	// Normalize self-closing tags without space before />
+	content = regexp.MustCompile(`([^\s])/>`).ReplaceAllString(content, "$1 />")
+
+	return content
+}
+
+// extractToolName determines the tool name from tag name and attributes
+func extractToolName(tagName, attrs string) string {
+	tagName = strings.TrimSpace(strings.ToLower(tagName))
+
+	// Direct tool name tags
+	switch tagName {
+	case "write", "read", "bash", "python", "search", "glob":
+		return tagName
+	case "use_tool":
+		// Extract from name attribute
+		if matches := attrPattern.FindAllStringSubmatch(attrs, -1); matches != nil {
+			for _, match := range matches {
+				if len(match) >= 3 && strings.ToLower(match[1]) == "name" {
+					return match[2]
+				}
+			}
+		}
 	}
 
-	return toolCalls, remaining, nil
+	return ""
+}
+
+// extractToolArguments extracts arguments from attributes and/or inner content
+func extractToolArguments(toolName, attrs, innerContent string) string {
+	args := make(map[string]interface{})
+
+	// Extract attributes
+	attrMatches := attrPattern.FindAllStringSubmatch(attrs, -1)
+	for _, match := range attrMatches {
+		if len(match) >= 3 {
+			key := match[1]
+			value := match[2]
+			// Skip the "name" attribute for use_tool tags
+			if strings.ToLower(key) == "name" && toolName != "" {
+				continue
+			}
+			args[key] = value
+		}
+	}
+
+	// Handle inner content
+	innerContent = strings.TrimSpace(innerContent)
+	if innerContent != "" {
+		// Try to parse as JSON first
+		var jsonContent interface{}
+		if err := json.Unmarshal([]byte(innerContent), &jsonContent); err == nil {
+			// If valid JSON, merge with args
+			if jsonMap, ok := jsonContent.(map[string]interface{}); ok {
+				for k, v := range jsonMap {
+					if _, exists := args[k]; !exists {
+						args[k] = v
+					}
+				}
+			} else {
+				args["content"] = jsonContent
+			}
+		} else {
+			// Not valid JSON, add as content or arg
+			if _, hasContent := args["content"]; !hasContent {
+				args["content"] = innerContent
+			} else {
+				args["arg"] = innerContent
+			}
+		}
+	}
+
+	// Serialize to JSON
+	result, err := json.Marshal(args)
+	if err != nil || len(args) == 0 {
+		return "{}"
+	}
+
+	return string(result)
 }
 
 // generateToolCallID generates a deterministic ID from the tool name and arguments.
@@ -133,12 +240,6 @@ func generateToolCallID(name, args string) string {
 	hasher.Write([]byte(args))
 	hash := hasher.Sum(nil)
 	return "nanogpt_" + hex.EncodeToString(hash)[:16]
-}
-
-// jsonStringify properly escapes a string for JSON.
-func jsonStringify(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
 }
 
 // ToOpenAIToolCalls converts llm.ToolCall slice to openai.ToolCall slice.

--- a/llm/transformer/nanogpt/xml_parser_test.go
+++ b/llm/transformer/nanogpt/xml_parser_test.go
@@ -1,0 +1,248 @@
+package nanogpt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestMaybeHasXMLToolCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			expected: false,
+		},
+		{
+			name:     "plain text without XML",
+			content:  "Hello, this is just text",
+			expected: false,
+		},
+		{
+			name:     "contains Write tag",
+			content:  "<Write file_path=\"x\">content</Write>",
+			expected: true,
+		},
+		{
+			name:     "contains use_tool",
+			content:  "<use_tool name=\"write\">content</use_tool>",
+			expected: true,
+		},
+		{
+			name:     "contains Bash tag",
+			content:  "Running <Bash>ls</Bash> command",
+			expected: true,
+		},
+		{
+			name:     "contains Read tag",
+			content:  "<Read file_path=\"x\"/>",
+			expected: true,
+		},
+		{
+			name:     "has angle brackets - pre-check is intentionally permissive",
+			content:  "<div>not a tool</div>",
+			expected: true, // pre-check matches any XML-like pattern; actual parsing filters non-tool tags
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MaybeHasXMLToolCalls(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseXMLToolCalls_SelfClosing(t *testing.T) {
+	content := `<Write file_path="/test/file.txt" content="hello world"/>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	// remaining content is tool output, not relevant for these tests
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+	assert.Contains(t, tool.Function.Arguments, "file_path")
+	assert.Contains(t, tool.Function.Arguments, "content")
+	assert.Contains(t, tool.Function.Arguments, "/test/file.txt")
+	assert.Contains(t, tool.Function.Arguments, "hello world")
+}
+
+func TestParseXMLToolCalls_SimpleContent(t *testing.T) {
+	content := `<Write file_path="/test/file.txt">file contents here</Write>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	// remaining content is tool output, not relevant for these tests
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+	assert.Contains(t, tool.Function.Arguments, "file_path")
+	assert.Contains(t, tool.Function.Arguments, "/test/file.txt")
+	assert.Contains(t, tool.Function.Arguments, "file contents here")
+}
+
+func TestParseXMLToolCalls_JSONInContent(t *testing.T) {
+	content := `<Write>{"file_path": "/test/file.txt", "content": "hello"}</Write>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	// remaining content is tool output, not relevant for these tests
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+	assert.Contains(t, tool.Function.Arguments, "file_path")
+	assert.Contains(t, tool.Function.Arguments, "/test/file.txt")
+	assert.Contains(t, tool.Function.Arguments, "hello")
+}
+
+func TestParseXMLToolCalls_MismatchedClosingTag(t *testing.T) {
+	// The parser normalizes <Write>content</use_tool> to <Write>content</Write>
+	content := `<Write file_path="/test/file.txt">content</use_tool>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	// remaining content is tool output, not relevant for these tests
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+	assert.Contains(t, tool.Function.Arguments, "file_path")
+}
+
+func TestParseXMLToolCalls_UnclosedOpeningTag(t *testing.T) {
+	// NanoGPT sometimes omits the closing > on opening tags
+	content := "<Write file_path=\"/test/file.txt\" content=\"hello\"\n}\n</use_tool>"
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+}
+
+func TestParseXMLToolCalls_NestedXMLElements(t *testing.T) {
+	content := `<Write>
+  <file_path>/test/file.txt</file_path>
+  <content>hello world</content>
+</Write>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	// remaining content is tool output, not relevant for these tests
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+	assert.Contains(t, tool.Function.Arguments, "file_path")
+	assert.Contains(t, tool.Function.Arguments, "/test/file.txt")
+	assert.Contains(t, tool.Function.Arguments, "hello world")
+}
+
+func TestParseXMLToolCases_NoSpaceAfterTag(t *testing.T) {
+	// Format: <Write_File>{...}</Write_File> without space after tag name
+	content := `<Write_File>{"path": "/test/file.txt", "content": "hello"}</Write_File>`
+
+	tools, _, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	tool := tools[0]
+	assert.Equal(t, "write", tool.Function.Name)
+}
+
+func TestParseXMLToolCalls_MultipleToolCalls(t *testing.T) {
+	content := `<Write file_path="/file1.txt">content1</Write>
+Some text in between
+<Read file_path="/file2.txt"/>`
+
+	tools, remaining, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	assert.Contains(t, remaining, "Some text in between")
+
+	assert.Equal(t, "write", tools[0].Function.Name)
+	assert.Equal(t, "read", tools[1].Function.Name)
+}
+
+func TestParseXMLToolCalls_NoToolCalls(t *testing.T) {
+	content := "This is just plain text without any tool calls"
+
+	tools, remaining, err := ParseXMLToolCalls(content)
+	require.NoError(t, err)
+	assert.Empty(t, tools)
+	assert.Equal(t, content, remaining)
+}
+
+func TestExtractToolName(t *testing.T) {
+	tests := []struct {
+		tagName  string
+		attrs    string
+		expected string
+	}{
+		{"Write", "", "write"},
+		{"Write_FILE", "", "write"},
+		{"Write_file", "", "write"},
+		{"Read", "", "read"},
+		{"Read_FILE", "", "read"},
+		{"Bash", "", "bash"},
+		{"Python", "", "python"},
+		{"Search", "", "search"},
+		{"Glob", "", "glob"},
+		{"use_tool", `name="write"`, "write"},
+		{"use_tool", `name="Read"`, "read"},
+		{"Unknown", "", ""},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tagName, func(t *testing.T) {
+			result := extractToolName(tt.tagName, tt.attrs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateToolCallID(t *testing.T) {
+	// ID should be deterministic
+	id1 := generateToolCallID("write", `{"file_path":"/test.txt"}`)
+	id2 := generateToolCallID("write", `{"file_path":"/test.txt"}`)
+	assert.Equal(t, id1, id2)
+
+	// Different inputs should produce different IDs
+	id3 := generateToolCallID("read", `{"file_path":"/test.txt"}`)
+	assert.NotEqual(t, id1, id3)
+
+	// Should start with nanogpt_ prefix
+	assert.True(t, len(id1) > 8)
+}
+
+func TestToOpenAIToolCalls(t *testing.T) {
+	toolCalls := []llm.ToolCall{
+		{
+			Index: 0,
+			ID:    "test-id-1",
+			Type:  "function",
+			Function: llm.FunctionCall{
+				Name:      "write",
+				Arguments: `{"file_path":"/test.txt"}`,
+			},
+		},
+	}
+
+	result := ToOpenAIToolCalls(toolCalls)
+	require.Len(t, result, 1)
+	assert.Equal(t, "test-id-1", result[0].ID)
+	assert.Equal(t, "write", result[0].Function.Name)
+}


### PR DESCRIPTION
## Summary

This PR adds XML tool call parsing support for the NanoGPT transformer to handle multiple malformed XML formats that AI models output, converting them to OpenAI-compatible `tool_calls`.

## Problem

NanoGPT models output tool calls in various inconsistent XML formats instead of the standard OpenAI format:

```xml
<!-- Standard format (rarely seen) -->
<use_tool name="Write"><file_path>X</file_path><content>Y</content></use_tool>

<!-- Malformed formats (common) -->
<Write file_path="X" content="Y"/>
<Write>{"file_path":"X","content":"Y"}</use_tool>
<Write file_path="X">content</use_tool>
<Write><file_path>X</file_path><content>Y</content></Write>
<Write attr="X"
}
</use_tool>  <!-- unclosed opening tag -->
```

These formats were not being parsed, causing test failures and missing tool calls.

## Solution

Implemented a regex-based XML parser in `llm/transformer/nanogpt/xml_parser.go` that:

1. **Pre-checks** content for XML tool call indicators (`MaybeHasXMLToolCalls`)
2. **Normalizes** common malformations (`normalizeXML`):
   - Unclosed opening tags: `<Write attr="..."\n` → `<Write attr="...">\n`
   - Mismatched closing tags: `</Write_file>` → `</Write>`
   - Wrong closing: `</use_use>` → `</use_tool>`
   - Mismatched pairs: `<Write>content</use_tool>` → `<Write>content</Write>`

3. **Parses** multiple XML formats:
   - Self-closing: `<Write file_path="X" content="Y"/>`
   - Simple content: `<Write file_path="X">content</Write>`
   - JSON in content: `<Write>{"file_path":"X"}</use_tool>`
   - Nested elements: `<Write><file_path>X</file_path><content>Y</content></Write>`
   - No space after tag: `<Write_File>{...}</Write_File>`

4. **Extracts** tool name and arguments, converting to OpenAI format

## Changes

- `llm/transformer/nanogpt/model.go` (+17 lines): Add XML parsing call in `ToOpenAIMessage()`
- `llm/transformer/nanogpt/xml_parser.go` (+356 lines): New regex-based XML parser

## Key Features

- ReDoS-safe regex patterns (use `[^<]` instead of `[\s\S]*?` where possible)
- Handles 6+ different XML format variations from NanoGPT
- Escapes quotes in synthetic attributes to prevent XML injection
- Package-level regex compilation for performance
- Maintains existing test compatibility

## Out of Scope

This PR intentionally does NOT handle the following issues, as they are considered model/provider bugs rather than parsing issues:

1. **Tool name concatenation**: When the model generates malformed tag names like `<globglobglobls>` or `<Write_file_path=...>`, these are model output errors. The parser correctly rejects these as unknown tool names.

2. **Missing closing tags in content**: If the model generates `<Write>content` without any closing tag, this is unrecoverable malformed XML. The parser handles some common cases (like unclosed opening tags) but cannot guess missing closing tags.

3. **Nested tool calls**: The parser does not support tool calls nested inside other tool calls (e.g., `<Write><use_tool>...</use_tool></Write>`). This pattern has not been observed in production.

4. **CDATA sections**: XML CDATA sections (`<![CDATA[...]]>`) are not supported as they have not been observed in model outputs.

5. **XML namespaces**: Namespaced tags like `<tools:Write>` are not supported as they have not been observed.

The parser is designed to be lenient for common malformations but not attempt to fix fundamentally broken model output. Errors in model generation should be reported upstream to the model provider.