### PR TITLE
refactor: 登录页背景动画循环并补充调试入口

### DIFF
--- a/frontend/src/features/auth/components/two-column-auth.tsx
+++ b/frontend/src/features/auth/components/two-column-auth.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import AutoRouterDiagram from '../sign-in/components/auto-router-diagram';
@@ -64,14 +64,16 @@ export default function TwoColumnAuth({
           <div className='absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(148,163,184,0.1)_0%,transparent_70%)]'></div>
         </div>
 
-        <div className={`relative z-10 w-full ${rightMaxWidthClassName} px-6 py-8 sm:px-8 sm:py-12`}>
+        <div id='auth-card-wrapper' data-testid='auth-card-wrapper' className={`relative z-10 w-full ${rightMaxWidthClassName} px-6 py-8 sm:px-8 sm:py-12`}>
           <Card
             className='animate-fade-in-up border-slate-200/60 bg-white/90 text-slate-800 shadow-xl shadow-slate-900/10 backdrop-blur-sm transition-all duration-500 hover:shadow-2xl hover:shadow-slate-900/15'
-            style={{
-              // Ensure shadcn variable-based components render with dark-on-light colors inside the white card
-              ['--foreground' as any]: '#1e293b', // slate-800
-              ['--muted-foreground' as any]: '#94a3b8', // slate-400 (for placeholders, help texts)
-            }}
+            style={
+              {
+                // Ensure shadcn variable-based components render with dark-on-light colors inside the white card
+                '--foreground': '#1e293b', // slate-800
+                '--muted-foreground': '#94a3b8', // slate-400 (for placeholders, help texts)
+              } as React.CSSProperties
+            }
           >
             <CardHeader className='px-6 pt-8 pb-6 text-center sm:px-8 sm:pb-8'>
               <CardTitle className='mb-3 text-2xl font-light text-slate-800 sm:text-3xl'>{title}</CardTitle>

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
@@ -12,6 +12,20 @@ export interface MouseArea {
   max: number;
 }
 
+export interface AnimationConfig {
+  targetFps: number;
+  frameIntervalMs: number;
+  maxCatchUpMs: number;
+  maxStepsPerFrame: number;
+}
+
+export const animationConfig: AnimationConfig = {
+  targetFps: 60,
+  frameIntervalMs: 1000 / 60,
+  maxCatchUpMs: 100,
+  maxStepsPerFrame: 5,
+};
+
 interface FormBounds {
   formCenterX: number;
   formCenterY: number;
@@ -103,18 +117,8 @@ export function initParticles(canvasWidth: number, canvasHeight: number): Partic
   return particles;
 }
 
-export function stepAnimation(
-  ctx: CanvasRenderingContext2D,
-  canvasWidth: number,
-  canvasHeight: number,
-  particles: Particle[],
-  mouseArea: MouseArea,
-): void {
+export function updateParticles(canvasWidth: number, canvasHeight: number, particles: Particle[], mouseArea: MouseArea): void {
   const bounds = getFormBounds(canvasWidth, canvasHeight);
-
-  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-
-  const ndots: DrawNode[] = [mouseArea, ...particles];
 
   particles.forEach((dot) => {
     dot.x += dot.xa;
@@ -137,6 +141,33 @@ export function stepAnimation(
       }
     }
 
+    if (mouseArea.x !== null && mouseArea.y !== null) {
+      const xc = dot.x - mouseArea.x;
+      const yc = dot.y - mouseArea.y;
+      const dis = xc * xc + yc * yc;
+
+      if (dis < mouseArea.max && dis > mouseArea.max / 2) {
+        dot.x -= xc * 0.015;
+        dot.y -= yc * 0.015;
+      }
+    }
+  });
+}
+
+export function renderParticles(
+  ctx: CanvasRenderingContext2D,
+  canvasWidth: number,
+  canvasHeight: number,
+  particles: Particle[],
+  mouseArea: MouseArea
+): void {
+  const bounds = getFormBounds(canvasWidth, canvasHeight);
+
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+
+  const ndots: DrawNode[] = [mouseArea, ...particles];
+
+  particles.forEach((dot) => {
     if (!isInFormArea(dot.x, dot.y, bounds)) {
       const isLeftSide = dot.x < canvasWidth / 2;
       ctx.fillStyle = isLeftSide ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.3)';
@@ -152,11 +183,6 @@ export function stepAnimation(
       const dis = xc * xc + yc * yc;
 
       if (dis < d2.max) {
-        if (d2 === mouseArea && dis > d2.max / 2) {
-          dot.x -= xc * 0.015;
-          dot.y -= yc * 0.015;
-        }
-
         const ratio = (d2.max - dis) / d2.max;
         const lineIntersectsForm =
           (dot.x < bounds.formLeft && d2.x > bounds.formRight) ||
@@ -184,4 +210,15 @@ export function stepAnimation(
 
     ndots.splice(ndots.indexOf(dot), 1);
   });
+}
+
+export function stepAnimation(
+  ctx: CanvasRenderingContext2D,
+  canvasWidth: number,
+  canvasHeight: number,
+  particles: Particle[],
+  mouseArea: MouseArea
+): void {
+  updateParticles(canvasWidth, canvasHeight, particles, mouseArea);
+  renderParticles(ctx, canvasWidth, canvasHeight, particles, mouseArea);
 }

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
@@ -1,0 +1,187 @@
+export interface Particle {
+  x: number;
+  y: number;
+  xa: number;
+  ya: number;
+  max: number;
+}
+
+export interface MouseArea {
+  x: number | null;
+  y: number | null;
+  max: number;
+}
+
+interface FormBounds {
+  formCenterX: number;
+  formCenterY: number;
+  formLeft: number;
+  formRight: number;
+  formTop: number;
+  formBottom: number;
+}
+
+type DrawNode = Particle | MouseArea;
+
+export function getFormBounds(canvasWidth: number, canvasHeight: number): FormBounds {
+  const rightSideStart = canvasWidth / 2;
+  const formCenterX = rightSideStart + canvasWidth / 2 / 2;
+  const formCenterY = canvasHeight / 2;
+  const formWidth = 360;
+  const formHeight = 500;
+
+  return {
+    formCenterX,
+    formCenterY,
+    formLeft: formCenterX - formWidth / 2,
+    formRight: formCenterX + formWidth / 2,
+    formTop: formCenterY - formHeight / 2,
+    formBottom: formCenterY + formHeight / 2,
+  };
+}
+
+export function isInFormArea(x: number, y: number, bounds: FormBounds): boolean {
+  return x >= bounds.formLeft && x <= bounds.formRight && y >= bounds.formTop && y <= bounds.formBottom;
+}
+
+export function initParticles(canvasWidth: number, canvasHeight: number): Particle[] {
+  const particles: Particle[] = [];
+  const particleCount = 120;
+  const bounds = getFormBounds(canvasWidth, canvasHeight);
+  const leftSideCount = Math.floor(particleCount * 0.6);
+  const rightSideCount = particleCount - leftSideCount;
+
+  for (let i = 0; i < leftSideCount; i++) {
+    const x = Math.random() * (canvasWidth / 2 - 20);
+    const y = Math.random() * canvasHeight;
+    const xa = (Math.random() * 1 - 0.5) * 0.6;
+    const ya = (Math.random() * 1 - 0.5) * 0.6;
+
+    particles.push({
+      x,
+      y,
+      xa,
+      ya,
+      max: 7000,
+    });
+  }
+
+  for (let i = 0; i < rightSideCount; i++) {
+    let x = 0;
+    let y = 0;
+    let attempts = 0;
+
+    do {
+      x = canvasWidth / 2 + 20 + Math.random() * (canvasWidth / 2 - 20);
+      y = Math.random() * canvasHeight;
+      attempts++;
+    } while (isInFormArea(x, y, bounds) && attempts < 30);
+
+    if (isInFormArea(x, y, bounds)) {
+      if (Math.random() > 0.5) {
+        x =
+          Math.random() > 0.5
+            ? canvasWidth / 2 + 20 + Math.random() * (bounds.formLeft - canvasWidth / 2 - 20)
+            : bounds.formRight + Math.random() * (canvasWidth - bounds.formRight - 20);
+      } else {
+        y = Math.random() > 0.5 ? Math.random() * bounds.formTop : bounds.formBottom + Math.random() * (canvasHeight - bounds.formBottom);
+      }
+    }
+
+    const xa = (Math.random() * 1 - 0.5) * 0.5;
+    const ya = (Math.random() * 1 - 0.5) * 0.5;
+
+    particles.push({
+      x,
+      y,
+      xa,
+      ya,
+      max: 5000,
+    });
+  }
+
+  return particles;
+}
+
+export function stepAnimation(
+  ctx: CanvasRenderingContext2D,
+  canvasWidth: number,
+  canvasHeight: number,
+  particles: Particle[],
+  mouseArea: MouseArea,
+): void {
+  const bounds = getFormBounds(canvasWidth, canvasHeight);
+
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+
+  const ndots: DrawNode[] = [mouseArea, ...particles];
+
+  particles.forEach((dot) => {
+    dot.x += dot.xa;
+    dot.y += dot.ya;
+
+    dot.xa *= dot.x > canvasWidth || dot.x < 0 ? -1 : 1;
+    dot.ya *= dot.y > canvasHeight || dot.y < 0 ? -1 : 1;
+
+    if (isInFormArea(dot.x, dot.y, bounds)) {
+      const pushForce = 0.5;
+      if (dot.x < bounds.formCenterX) {
+        dot.xa -= pushForce;
+      } else {
+        dot.xa += pushForce;
+      }
+      if (dot.y < bounds.formCenterY) {
+        dot.ya -= pushForce;
+      } else {
+        dot.ya += pushForce;
+      }
+    }
+
+    if (!isInFormArea(dot.x, dot.y, bounds)) {
+      const isLeftSide = dot.x < canvasWidth / 2;
+      ctx.fillStyle = isLeftSide ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.3)';
+      ctx.fillRect(dot.x - 1.5, dot.y - 1.5, 3, 3);
+    }
+
+    for (let i = 0; i < ndots.length; i++) {
+      const d2 = ndots[i];
+      if (dot === d2 || d2.x === null || d2.y === null) continue;
+
+      const xc = dot.x - d2.x;
+      const yc = dot.y - d2.y;
+      const dis = xc * xc + yc * yc;
+
+      if (dis < d2.max) {
+        if (d2 === mouseArea && dis > d2.max / 2) {
+          dot.x -= xc * 0.015;
+          dot.y -= yc * 0.015;
+        }
+
+        const ratio = (d2.max - dis) / d2.max;
+        const lineIntersectsForm =
+          (dot.x < bounds.formLeft && d2.x > bounds.formRight) ||
+          (dot.x > bounds.formRight && d2.x < bounds.formLeft) ||
+          (dot.y < bounds.formTop && d2.y > bounds.formBottom) ||
+          (dot.y > bounds.formBottom && d2.y < bounds.formTop) ||
+          isInFormArea(dot.x, dot.y, bounds) ||
+          isInFormArea(d2.x, d2.y, bounds);
+
+        if (!lineIntersectsForm) {
+          ctx.beginPath();
+          ctx.lineWidth = ratio / 2 + 0.5;
+
+          const avgX = (dot.x + d2.x) / 2;
+          const isLeftSide = avgX < canvasWidth / 2;
+          const lineColor = isLeftSide ? `rgba(148, 163, 184, ${ratio * 0.4 + 0.1})` : `rgba(100, 116, 139, ${ratio * 0.3 + 0.1})`;
+
+          ctx.strokeStyle = lineColor;
+          ctx.moveTo(dot.x, dot.y);
+          ctx.lineTo(d2.x, d2.y);
+          ctx.stroke();
+        }
+      }
+    }
+
+    ndots.splice(ndots.indexOf(dot), 1);
+  });
+}

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts
@@ -26,7 +26,7 @@ export const animationConfig: AnimationConfig = {
   maxStepsPerFrame: 5,
 };
 
-interface FormBounds {
+export interface FormBounds {
   formCenterX: number;
   formCenterY: number;
   formLeft: number;
@@ -35,7 +35,49 @@ interface FormBounds {
   formBottom: number;
 }
 
-type DrawNode = Particle | MouseArea;
+const LEFT_PARTICLE_FILL_STYLE = 'rgba(148, 163, 184, 0.4)';
+const RIGHT_PARTICLE_FILL_STYLE = 'rgba(100, 116, 139, 0.3)';
+
+function getLineIntersectsForm(startX: number, startY: number, endX: number, endY: number, bounds: FormBounds): boolean {
+  return (
+    (startX < bounds.formLeft && endX > bounds.formRight) ||
+    (startX > bounds.formRight && endX < bounds.formLeft) ||
+    (startY < bounds.formTop && endY > bounds.formBottom) ||
+    (startY > bounds.formBottom && endY < bounds.formTop) ||
+    isInFormArea(startX, startY, bounds) ||
+    isInFormArea(endX, endY, bounds)
+  );
+}
+
+function drawConnection(
+  ctx: CanvasRenderingContext2D,
+  canvasWidth: number,
+  bounds: FormBounds,
+  dot: Particle,
+  targetX: number,
+  targetY: number,
+  targetMax: number
+): void {
+  const xc = dot.x - targetX;
+  const yc = dot.y - targetY;
+  const dis = xc * xc + yc * yc;
+
+  if (dis >= targetMax || getLineIntersectsForm(dot.x, dot.y, targetX, targetY, bounds)) {
+    return;
+  }
+
+  const ratio = (targetMax - dis) / targetMax;
+  const avgX = (dot.x + targetX) / 2;
+  const isLeftSide = avgX < canvasWidth / 2;
+  const lineColor = isLeftSide ? `rgba(148, 163, 184, ${ratio * 0.4 + 0.1})` : `rgba(100, 116, 139, ${ratio * 0.3 + 0.1})`;
+
+  ctx.beginPath();
+  ctx.lineWidth = ratio / 2 + 0.5;
+  ctx.strokeStyle = lineColor;
+  ctx.moveTo(dot.x, dot.y);
+  ctx.lineTo(targetX, targetY);
+  ctx.stroke();
+}
 
 export function getFormBounds(canvasWidth: number, canvasHeight: number): FormBounds {
   const rightSideStart = canvasWidth / 2;
@@ -58,10 +100,9 @@ export function isInFormArea(x: number, y: number, bounds: FormBounds): boolean 
   return x >= bounds.formLeft && x <= bounds.formRight && y >= bounds.formTop && y <= bounds.formBottom;
 }
 
-export function initParticles(canvasWidth: number, canvasHeight: number): Particle[] {
+export function initParticles(canvasWidth: number, canvasHeight: number, bounds: FormBounds = getFormBounds(canvasWidth, canvasHeight)): Particle[] {
   const particles: Particle[] = [];
   const particleCount = 120;
-  const bounds = getFormBounds(canvasWidth, canvasHeight);
   const leftSideCount = Math.floor(particleCount * 0.6);
   const rightSideCount = particleCount - leftSideCount;
 
@@ -117,10 +158,15 @@ export function initParticles(canvasWidth: number, canvasHeight: number): Partic
   return particles;
 }
 
-export function updateParticles(canvasWidth: number, canvasHeight: number, particles: Particle[], mouseArea: MouseArea): void {
-  const bounds = getFormBounds(canvasWidth, canvasHeight);
-
-  particles.forEach((dot) => {
+export function updateParticles(
+  canvasWidth: number,
+  canvasHeight: number,
+  particles: Particle[],
+  mouseArea: MouseArea,
+  bounds: FormBounds = getFormBounds(canvasWidth, canvasHeight)
+): void {
+  for (let index = 0; index < particles.length; index += 1) {
+    const dot = particles[index];
     dot.x += dot.xa;
     dot.y += dot.ya;
 
@@ -151,7 +197,7 @@ export function updateParticles(canvasWidth: number, canvasHeight: number, parti
         dot.y -= yc * 0.015;
       }
     }
-  });
+  }
 }
 
 export function renderParticles(
@@ -159,57 +205,52 @@ export function renderParticles(
   canvasWidth: number,
   canvasHeight: number,
   particles: Particle[],
-  mouseArea: MouseArea
+  mouseArea: MouseArea,
+  bounds: FormBounds = getFormBounds(canvasWidth, canvasHeight)
 ): void {
-  const bounds = getFormBounds(canvasWidth, canvasHeight);
-
   ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
-  const ndots: DrawNode[] = [mouseArea, ...particles];
+  let hasLeftParticles = false;
+  ctx.beginPath();
+  for (let index = 0; index < particles.length; index += 1) {
+    const dot = particles[index];
+    if (!isInFormArea(dot.x, dot.y, bounds) && dot.x < canvasWidth / 2) {
+      ctx.rect(dot.x - 1.5, dot.y - 1.5, 3, 3);
+      hasLeftParticles = true;
+    }
+  }
+  if (hasLeftParticles) {
+    ctx.fillStyle = LEFT_PARTICLE_FILL_STYLE;
+    ctx.fill();
+  }
 
-  particles.forEach((dot) => {
-    if (!isInFormArea(dot.x, dot.y, bounds)) {
-      const isLeftSide = dot.x < canvasWidth / 2;
-      ctx.fillStyle = isLeftSide ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.3)';
-      ctx.fillRect(dot.x - 1.5, dot.y - 1.5, 3, 3);
+  let hasRightParticles = false;
+  ctx.beginPath();
+  for (let index = 0; index < particles.length; index += 1) {
+    const dot = particles[index];
+    if (!isInFormArea(dot.x, dot.y, bounds) && dot.x >= canvasWidth / 2) {
+      ctx.rect(dot.x - 1.5, dot.y - 1.5, 3, 3);
+      hasRightParticles = true;
+    }
+  }
+  if (hasRightParticles) {
+    ctx.fillStyle = RIGHT_PARTICLE_FILL_STYLE;
+    ctx.fill();
+  }
+
+  const hasMouseArea = mouseArea.x !== null && mouseArea.y !== null;
+  for (let index = 0; index < particles.length; index += 1) {
+    const dot = particles[index];
+
+    if (hasMouseArea) {
+      drawConnection(ctx, canvasWidth, bounds, dot, mouseArea.x, mouseArea.y, mouseArea.max);
     }
 
-    for (let i = 0; i < ndots.length; i++) {
-      const d2 = ndots[i];
-      if (dot === d2 || d2.x === null || d2.y === null) continue;
-
-      const xc = dot.x - d2.x;
-      const yc = dot.y - d2.y;
-      const dis = xc * xc + yc * yc;
-
-      if (dis < d2.max) {
-        const ratio = (d2.max - dis) / d2.max;
-        const lineIntersectsForm =
-          (dot.x < bounds.formLeft && d2.x > bounds.formRight) ||
-          (dot.x > bounds.formRight && d2.x < bounds.formLeft) ||
-          (dot.y < bounds.formTop && d2.y > bounds.formBottom) ||
-          (dot.y > bounds.formBottom && d2.y < bounds.formTop) ||
-          isInFormArea(dot.x, dot.y, bounds) ||
-          isInFormArea(d2.x, d2.y, bounds);
-
-        if (!lineIntersectsForm) {
-          ctx.beginPath();
-          ctx.lineWidth = ratio / 2 + 0.5;
-
-          const avgX = (dot.x + d2.x) / 2;
-          const isLeftSide = avgX < canvasWidth / 2;
-          const lineColor = isLeftSide ? `rgba(148, 163, 184, ${ratio * 0.4 + 0.1})` : `rgba(100, 116, 139, ${ratio * 0.3 + 0.1})`;
-
-          ctx.strokeStyle = lineColor;
-          ctx.moveTo(dot.x, dot.y);
-          ctx.lineTo(d2.x, d2.y);
-          ctx.stroke();
-        }
-      }
+    for (let nextIndex = index + 1; nextIndex < particles.length; nextIndex += 1) {
+      const nextDot = particles[nextIndex];
+      drawConnection(ctx, canvasWidth, bounds, dot, nextDot.x, nextDot.y, nextDot.max);
     }
-
-    ndots.splice(ndots.indexOf(dot), 1);
-  });
+  }
 }
 
 export function stepAnimation(
@@ -217,8 +258,9 @@ export function stepAnimation(
   canvasWidth: number,
   canvasHeight: number,
   particles: Particle[],
-  mouseArea: MouseArea
+  mouseArea: MouseArea,
+  bounds: FormBounds = getFormBounds(canvasWidth, canvasHeight)
 ): void {
-  updateParticles(canvasWidth, canvasHeight, particles, mouseArea);
-  renderParticles(ctx, canvasWidth, canvasHeight, particles, mouseArea);
+  updateParticles(canvasWidth, canvasHeight, particles, mouseArea, bounds);
+  renderParticles(ctx, canvasWidth, canvasHeight, particles, mouseArea, bounds);
 }

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
@@ -1,8 +1,8 @@
 import { type FC, useCallback, useEffect, useRef } from 'react';
+import type { FormBounds, MouseArea, Particle } from './animated-line-background.engine';
 import {
-  type MouseArea,
-  type Particle,
   animationConfig,
+  getFormBounds,
   initParticles,
   renderParticles,
   updateParticles,
@@ -64,10 +64,12 @@ const shouldExposeAnimationDiagnostics = (): boolean => {
 
 const AnimatedLineBackground: FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const animationRef = useRef<number>(null);
+  const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
+  const animationRef = useRef<number | null>(null);
   const particlesRef = useRef<Particle[]>([]);
   const diagnosticsInitialParticlesRef = useRef<Particle[] | null>(null);
   const diagnosticsCanvasSizeRef = useRef<{ width: number; height: number } | null>(null);
+  const formBoundsRef = useRef<FormBounds | null>(null);
   const mouseAreaRef = useRef<MouseArea>(createMouseArea());
   const frameCountRef = useRef(0);
   const simulationStepCountRef = useRef(0);
@@ -86,32 +88,51 @@ const AnimatedLineBackground: FC = () => {
 
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
+
+    ctxRef.current = ctxRef.current ?? canvas.getContext('2d');
+    formBoundsRef.current = getFormBounds(canvas.width, canvas.height);
   }, []);
 
   const initializeParticles = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    particlesRef.current = initParticles(canvas.width, canvas.height);
+    const formBounds = formBoundsRef.current ?? getFormBounds(canvas.width, canvas.height);
+    formBoundsRef.current = formBounds;
+    particlesRef.current = initParticles(canvas.width, canvas.height, formBounds);
+  }, []);
+
+  const handleResize = useCallback(() => {
+    resize();
+    initializeParticles();
+  }, [resize, initializeParticles]);
+
+  const resetFrameTimingState = useCallback(() => {
+    accumulatorRef.current = 0;
+    lastTimestampRef.current = null;
+    lastFrameDeltaMsRef.current = 0;
+    lastClampedDeltaMsRef.current = 0;
+    lastFrameStepCountRef.current = 0;
+    lastAppliedDeltaMsRef.current = 0;
   }, []);
 
   const renderFrame = useCallback(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    const ctx = ctxRef.current;
+    const formBounds = formBoundsRef.current;
+    if (!canvas || !ctx || !formBounds) return;
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    renderParticles(ctx, canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
+    renderParticles(ctx, canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current, formBounds);
 
     renderCountRef.current += 1;
   }, []);
 
   const applyAnimationStep = useCallback((deltaMs: number) => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    const formBounds = formBoundsRef.current;
+    if (!canvas || !formBounds) return;
 
-    updateParticles(canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
+    updateParticles(canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current, formBounds);
 
     simulationStepCountRef.current += 1;
     simulatedMsRef.current += deltaMs;
@@ -152,12 +173,7 @@ const AnimatedLineBackground: FC = () => {
     simulationStepCountRef.current = 0;
     renderCountRef.current = 0;
     simulatedMsRef.current = 0;
-    accumulatorRef.current = 0;
-    lastTimestampRef.current = null;
-    lastFrameDeltaMsRef.current = 0;
-    lastClampedDeltaMsRef.current = 0;
-    lastFrameStepCountRef.current = 0;
-    lastAppliedDeltaMsRef.current = 0;
+    resetFrameTimingState();
     mouseAreaRef.current = createMouseArea();
 
     resize();
@@ -169,14 +185,16 @@ const AnimatedLineBackground: FC = () => {
       diagnosticsCanvasSizeRef.current?.height !== nextCanvasSize.height;
 
     if (needsNewInitialParticles) {
-      diagnosticsInitialParticlesRef.current = initParticles(nextCanvasSize.width, nextCanvasSize.height);
+      const formBounds = formBoundsRef.current ?? getFormBounds(nextCanvasSize.width, nextCanvasSize.height);
+      formBoundsRef.current = formBounds;
+      diagnosticsInitialParticlesRef.current = initParticles(nextCanvasSize.width, nextCanvasSize.height, formBounds);
       diagnosticsCanvasSizeRef.current = nextCanvasSize;
     }
 
     particlesRef.current = cloneParticles(diagnosticsInitialParticlesRef.current);
     renderFrame();
     renderCountRef.current = 0;
-  }, [renderFrame, resize]);
+  }, [renderFrame, resize, resetFrameTimingState]);
 
   const snapshotDiagnostics = useCallback<() => AnimationDiagnosticsSnapshot>(() => {
     return {
@@ -222,6 +240,11 @@ const AnimatedLineBackground: FC = () => {
 
   const animate = useCallback(
     (timestamp: number) => {
+      if (document.visibilityState !== 'visible') {
+        animationRef.current = null;
+        return;
+      }
+
       frameCountRef.current += 1;
 
       if (lastTimestampRef.current === null) {
@@ -236,6 +259,23 @@ const AnimatedLineBackground: FC = () => {
     [processAnimationFrame]
   );
 
+  const stopAnimation = useCallback(() => {
+    if (animationRef.current === null) {
+      return;
+    }
+
+    cancelAnimationFrame(animationRef.current);
+    animationRef.current = null;
+  }, []);
+
+  const startAnimation = useCallback(() => {
+    if (animationRef.current !== null || document.visibilityState !== 'visible') {
+      return;
+    }
+
+    animationRef.current = requestAnimationFrame(animate);
+  }, [animate]);
+
   const handleMouseMove = useCallback((e: MouseEvent) => {
     mouseAreaRef.current.x = e.clientX;
     mouseAreaRef.current.y = e.clientY;
@@ -247,42 +287,36 @@ const AnimatedLineBackground: FC = () => {
   }, []);
 
   useEffect(() => {
-    resize();
-    // 强制重新初始化粒子
-    const initTimer = setTimeout(() => {
-      initializeParticles();
-    }, 50);
+    handleResize();
 
-    window.addEventListener('resize', resize);
+    window.addEventListener('resize', handleResize);
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseout', handleMouseOut);
 
-    // 延迟200ms开始动画，确保粒子初始化完成
-    const timer = setTimeout(() => {
-      animationRef.current = requestAnimationFrame(animate);
-    }, 200);
+    startAnimation();
 
     return () => {
-      window.removeEventListener('resize', resize);
+      window.removeEventListener('resize', handleResize);
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseout', handleMouseOut);
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
-      clearTimeout(initTimer);
-      clearTimeout(timer);
+      stopAnimation();
     };
-  }, [resize, initializeParticles, animate, handleMouseMove, handleMouseOut]);
+  }, [handleResize, handleMouseMove, handleMouseOut, startAnimation, stopAnimation]);
 
   useEffect(() => {
-    const handleResize = () => {
-      resize();
-      initializeParticles();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        stopAnimation();
+        return;
+      }
+
+      resetFrameTimingState();
+      startAnimation();
     };
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [resize, initializeParticles]);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [resetFrameTimingState, startAnimation, stopAnimation]);
 
   useEffect(() => {
     if (!shouldExposeAnimationDiagnostics()) {

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
@@ -1,24 +1,63 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import { useCallback, useEffect, useRef, type FC } from 'react';
 
-interface Particle {
-  x: number;
-  y: number;
-  xa: number;
-  ya: number;
-  max: number;
+import { type MouseArea, type Particle, initParticles, stepAnimation } from './animated-line-background.engine';
+
+interface AnimationDiagnosticsSnapshot {
+  targetFps: number;
+  frameIntervalMs: number;
+  frameCount: number;
+  renderCount: number;
+  simulatedMs: number;
+  lastAppliedDeltaMs: number;
+  particleChecksum: number;
 }
 
-interface MouseArea {
-  x: number | null;
-  y: number | null;
-  max: number;
+interface AnimationDiagnostics {
+  reset(): void;
+  snapshot(): AnimationDiagnosticsSnapshot;
+  simulate(stepMs: number, steps: number): void;
+  simulateLargeGap(deltaMs: number): void;
 }
 
-const AnimatedLineBackground: React.FC = () => {
+declare global {
+  interface Window {
+    __AXONHUB_SIGNIN_ANIMATION__?: AnimationDiagnostics;
+  }
+}
+
+const TARGET_FPS = 60;
+const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+const DEBUG_QUERY_PARAM = '__axonhub_debug_animation';
+
+const createMouseArea = (): MouseArea => ({ x: null, y: null, max: 20000 });
+
+const getParticleChecksum = (particles: Particle[]): number => {
+  return particles.reduce((checksum, particle, index) => {
+    const x = Math.round(particle.x * 1000);
+    const y = Math.round(particle.y * 1000);
+    const factor = index + 1;
+
+    return checksum + x * factor * 31 + y * factor * 17;
+  }, 0);
+};
+
+const shouldExposeAnimationDiagnostics = (): boolean => {
+  if (!import.meta.env.DEV || typeof window === 'undefined') {
+    return false;
+  }
+
+  return new URLSearchParams(window.location.search).get(DEBUG_QUERY_PARAM) === '1';
+};
+
+const AnimatedLineBackground: FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(null);
   const particlesRef = useRef<Particle[]>([]);
-  const mouseAreaRef = useRef<MouseArea>({ x: null, y: null, max: 20000 });
+  const mouseAreaRef = useRef<MouseArea>(createMouseArea());
+  const frameCountRef = useRef(0);
+  const renderCountRef = useRef(0);
+  const simulatedMsRef = useRef(0);
+  const lastAppliedDeltaMsRef = useRef(0);
 
   const resize = useCallback(() => {
     const canvas = canvasRef.current;
@@ -26,195 +65,81 @@ const AnimatedLineBackground: React.FC = () => {
 
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
-  }, [canvasRef]);
+  }, []);
 
-  const initParticles = useCallback(() => {
+  const initializeParticles = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    particlesRef.current = [];
-    const particleCount = 120; // Reduced for better performance with split layout
+    particlesRef.current = initParticles(canvas.width, canvas.height);
+  }, []);
 
-    // 定义表单区域 (与animate函数中的定义保持一致)
-    const rightSideStart = canvas.width / 2;
-    const formCenterX = rightSideStart + canvas.width / 2 / 2; // 右侧区域的中心
-    const formCenterY = canvas.height / 2;
-    const formWidth = 360;
-    const formHeight = 500;
-    const formLeft = formCenterX - formWidth / 2;
-    const formRight = formCenterX + formWidth / 2;
-    const formTop = formCenterY - formHeight / 2;
-    const formBottom = formCenterY + formHeight / 2;
-
-    const isInFormArea = (x: number, y: number) => {
-      return x >= formLeft && x <= formRight && y >= formTop && y <= formBottom;
-    };
-
-    // 分别为左右两侧生成粒子
-    const leftSideCount = Math.floor(particleCount * 0.6); // 左侧更多粒子
-    const rightSideCount = particleCount - leftSideCount;
-
-    // 左侧粒子 (品牌区域)
-    for (let i = 0; i < leftSideCount; i++) {
-      const x = Math.random() * (canvas.width / 2 - 20); // 避免太靠近中线
-      const y = Math.random() * canvas.height;
-      const xa = (Math.random() * 1 - 0.5) * 0.6;
-      const ya = (Math.random() * 1 - 0.5) * 0.6;
-
-      particlesRef.current.push({
-        x,
-        y,
-        xa,
-        ya,
-        max: 7000,
-      });
-    }
-
-    // 右侧粒子 (表单区域) - 避开表单区域
-    for (let i = 0; i < rightSideCount; i++) {
-      let x, y;
-      let attempts = 0;
-
-      do {
-        x = canvas.width / 2 + 20 + Math.random() * (canvas.width / 2 - 20);
-        y = Math.random() * canvas.height;
-        attempts++;
-      } while (isInFormArea(x, y) && attempts < 30);
-
-      // 如果仍在表单区域，放置在表单区域外
-      if (isInFormArea(x, y)) {
-        if (Math.random() > 0.5) {
-          x =
-            Math.random() > 0.5
-              ? canvas.width / 2 + 20 + Math.random() * (formLeft - canvas.width / 2 - 20)
-              : formRight + Math.random() * (canvas.width - formRight - 20);
-        } else {
-          y = Math.random() > 0.5 ? Math.random() * formTop : formBottom + Math.random() * (canvas.height - formBottom);
-        }
-      }
-
-      const xa = (Math.random() * 1 - 0.5) * 0.5;
-      const ya = (Math.random() * 1 - 0.5) * 0.5;
-
-      particlesRef.current.push({
-        x,
-        y,
-        xa,
-        ya,
-        max: 5000,
-      });
-    }
-  }, [canvasRef]);
-
-  const animate = useCallback(() => {
+  const applyAnimationStep = useCallback((deltaMs: number) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    stepAnimation(ctx, canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
 
-    // 定义登录表单区域 (右侧区域，适应新的左右布局)
-    const rightSideStart = canvas.width / 2;
-    const formCenterX = rightSideStart + canvas.width / 2 / 2; // 右侧区域的中心
-    const formCenterY = canvas.height / 2;
-    const formWidth = 360;
-    const formHeight = 500;
-    const formLeft = formCenterX - formWidth / 2;
-    const formRight = formCenterX + formWidth / 2;
-    const formTop = formCenterY - formHeight / 2;
-    const formBottom = formCenterY + formHeight / 2;
+    renderCountRef.current += 1;
+    simulatedMsRef.current += deltaMs;
+    lastAppliedDeltaMsRef.current = deltaMs;
+  }, []);
 
-    // 检查点是否在表单区域内
-    const isInFormArea = (x: number, y: number) => {
-      return x >= formLeft && x <= formRight && y >= formTop && y <= formBottom;
+  const resetDiagnosticsState = useCallback(() => {
+    frameCountRef.current = 0;
+    renderCountRef.current = 0;
+    simulatedMsRef.current = 0;
+    lastAppliedDeltaMsRef.current = 0;
+    mouseAreaRef.current = createMouseArea();
+
+    resize();
+    initializeParticles();
+  }, [initializeParticles, resize]);
+
+  const snapshotDiagnostics = useCallback<() => AnimationDiagnosticsSnapshot>(() => {
+    return {
+      targetFps: TARGET_FPS,
+      frameIntervalMs: FRAME_INTERVAL_MS,
+      frameCount: frameCountRef.current,
+      renderCount: renderCountRef.current,
+      simulatedMs: simulatedMsRef.current,
+      lastAppliedDeltaMs: lastAppliedDeltaMsRef.current,
+      particleChecksum: getParticleChecksum(particlesRef.current),
     };
+  }, []);
 
-    const ndots = [mouseAreaRef.current, ...particlesRef.current];
+  const simulateDiagnostics = useCallback(
+    (stepMs: number, steps: number) => {
+      const safeStepMs = Number.isFinite(stepMs) ? stepMs : 0;
+      const safeSteps = Number.isFinite(steps) ? Math.max(0, Math.floor(steps)) : 0;
 
-    particlesRef.current.forEach((dot) => {
-      // 粒子位移
-      dot.x += dot.xa;
-      dot.y += dot.ya;
-
-      // 遇到边界将加速度反向
-      dot.xa *= dot.x > canvas.width || dot.x < 0 ? -1 : 1;
-      dot.ya *= dot.y > canvas.height || dot.y < 0 ? -1 : 1;
-
-      // 如果粒子进入表单区域，推开它们
-      if (isInFormArea(dot.x, dot.y)) {
-        const pushForce = 0.5;
-        if (dot.x < formCenterX) {
-          dot.xa -= pushForce;
-        } else {
-          dot.xa += pushForce;
-        }
-        if (dot.y < formCenterY) {
-          dot.ya -= pushForce;
-        } else {
-          dot.ya += pushForce;
-        }
+      for (let index = 0; index < safeSteps; index += 1) {
+        frameCountRef.current += 1;
+        applyAnimationStep(safeStepMs);
       }
+    },
+    [applyAnimationStep],
+  );
 
-      // 只在表单区域外绘制点，使用不同颜色
-      if (!isInFormArea(dot.x, dot.y)) {
-        // Use different colors for left and right sides
-        const isLeftSide = dot.x < canvas.width / 2;
-        ctx.fillStyle = isLeftSide ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.3)';
-        ctx.fillRect(dot.x - 1.5, dot.y - 1.5, 3, 3);
-      }
+  const simulateLargeGapDiagnostics = useCallback(
+    (deltaMs: number) => {
+      const safeDeltaMs = Number.isFinite(deltaMs) ? Math.max(0, deltaMs) : 0;
 
-      // 循环比对粒子间的距离
-      for (let i = 0; i < ndots.length; i++) {
-        const d2 = ndots[i];
-        if (dot === d2 || d2.x === null || d2.y === null) continue;
+      frameCountRef.current += 1;
+      applyAnimationStep(safeDeltaMs);
+    },
+    [applyAnimationStep],
+  );
 
-        const xc = dot.x - d2.x;
-        const yc = dot.y - d2.y;
-        const dis = xc * xc + yc * yc;
-
-        if (dis < d2.max) {
-          // 如果是鼠标，则让粒子向鼠标的位置移动
-          if (d2 === mouseAreaRef.current && dis > d2.max / 2) {
-            dot.x -= xc * 0.015; // 降低鼠标吸引力
-            dot.y -= yc * 0.015;
-          }
-
-          // 计算距离比
-          const ratio = (d2.max - dis) / d2.max;
-
-          // 检查连线是否穿过表单区域，如果是则不绘制
-          const lineIntersectsForm =
-            (dot.x < formLeft && d2.x > formRight) ||
-            (dot.x > formRight && d2.x < formLeft) ||
-            (dot.y < formTop && d2.y > formBottom) ||
-            (dot.y > formBottom && d2.y < formTop) ||
-            isInFormArea(dot.x, dot.y) ||
-            isInFormArea(d2.x, d2.y);
-
-          // 只在不穿过表单区域时画线
-          if (!lineIntersectsForm) {
-            ctx.beginPath();
-            ctx.lineWidth = ratio / 2 + 0.5;
-            // Use elegant colors for lines based on position
-            const avgX = (dot.x + d2.x) / 2;
-            const isLeftSide = avgX < canvas.width / 2;
-            const lineColor = isLeftSide ? `rgba(148, 163, 184, ${ratio * 0.4 + 0.1})` : `rgba(100, 116, 139, ${ratio * 0.3 + 0.1})`;
-            ctx.strokeStyle = lineColor;
-            ctx.moveTo(dot.x, dot.y);
-            ctx.lineTo(d2.x, d2.y);
-            ctx.stroke();
-          }
-        }
-      }
-
-      // 将已经计算过的粒子从数组中删除
-      ndots.splice(ndots.indexOf(dot), 1);
-    });
+  const animate = useCallback(() => {
+    frameCountRef.current += 1;
+    applyAnimationStep(FRAME_INTERVAL_MS);
 
     animationRef.current = requestAnimationFrame(animate);
-  }, []);
+  }, [applyAnimationStep]);
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
     mouseAreaRef.current.x = e.clientX;
@@ -229,8 +154,8 @@ const AnimatedLineBackground: React.FC = () => {
   useEffect(() => {
     resize();
     // 强制重新初始化粒子
-    setTimeout(() => {
-      initParticles();
+    const initTimer = setTimeout(() => {
+      initializeParticles();
     }, 50);
 
     window.addEventListener('resize', resize);
@@ -249,21 +174,40 @@ const AnimatedLineBackground: React.FC = () => {
       if (animationRef.current) {
         cancelAnimationFrame(animationRef.current);
       }
+      clearTimeout(initTimer);
       clearTimeout(timer);
     };
-  }, [resize, initParticles, animate, handleMouseMove, handleMouseOut]);
+  }, [resize, initializeParticles, animate, handleMouseMove, handleMouseOut]);
 
   useEffect(() => {
     const handleResize = () => {
       resize();
-      initParticles();
+      initializeParticles();
     };
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [resize, initParticles]);
+  }, [resize, initializeParticles]);
 
-  return <canvas ref={canvasRef} className='pointer-events-none fixed inset-0' style={{ zIndex: 0 }} />;
+  useEffect(() => {
+    if (!shouldExposeAnimationDiagnostics()) {
+      delete window.__AXONHUB_SIGNIN_ANIMATION__;
+      return;
+    }
+
+    window.__AXONHUB_SIGNIN_ANIMATION__ = {
+      reset: resetDiagnosticsState,
+      snapshot: snapshotDiagnostics,
+      simulate: simulateDiagnostics,
+      simulateLargeGap: simulateLargeGapDiagnostics,
+    };
+
+    return () => {
+      delete window.__AXONHUB_SIGNIN_ANIMATION__;
+    };
+  }, [resetDiagnosticsState, simulateDiagnostics, simulateLargeGapDiagnostics, snapshotDiagnostics]);
+
+  return <canvas ref={canvasRef} data-testid='sign-in-animation-canvas' className='pointer-events-none fixed inset-0' style={{ zIndex: 0 }} />;
 };
 
 export default AnimatedLineBackground;

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
@@ -81,31 +81,66 @@ const AnimatedLineBackground: FC = () => {
   const lastClampedDeltaMsRef = useRef(0);
   const lastFrameStepCountRef = useRef(0);
   const lastAppliedDeltaMsRef = useRef(0);
+  const lastRenderedMouseAreaRef = useRef<MouseArea>(createMouseArea());
+  const lastRenderedFormBoundsRef = useRef<FormBounds | null>(null);
+
+  const getMeasuredFormBounds = useCallback((): FormBounds | null => {
+    const el = document.getElementById('auth-card-wrapper');
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return {
+      formCenterX: rect.left + rect.width / 2,
+      formCenterY: rect.top + rect.height / 2,
+      formLeft: rect.left,
+      formRight: rect.right,
+      formTop: rect.top,
+      formBottom: rect.bottom,
+    };
+  }, []);
+
+  const updateFormBounds = useCallback((canvasWidth: number, canvasHeight: number) => {
+    const newBounds = getMeasuredFormBounds() ?? getFormBounds(canvasWidth, canvasHeight);
+    const prev = formBoundsRef.current;
+    
+    if (!prev || 
+        prev.formLeft !== newBounds.formLeft || 
+        prev.formRight !== newBounds.formRight || 
+        prev.formTop !== newBounds.formTop || 
+        prev.formBottom !== newBounds.formBottom) {
+      formBoundsRef.current = newBounds;
+      return true;
+    }
+    return false;
+  }, [getMeasuredFormBounds]);
 
   const resize = useCallback(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas) return { sizeChanged: false, boundsChanged: false };
+
+    const prevWidth = canvas.width;
+    const prevHeight = canvas.height;
 
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
     ctxRef.current = ctxRef.current ?? canvas.getContext('2d');
-    formBoundsRef.current = getFormBounds(canvas.width, canvas.height);
-  }, []);
+    const boundsChanged = updateFormBounds(canvas.width, canvas.height);
+    const sizeChanged = prevWidth !== canvas.width || prevHeight !== canvas.height;
 
-  const initializeParticles = useCallback(() => {
+    return { sizeChanged, boundsChanged };
+  }, [updateFormBounds]);
+
+  const handleResize = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const formBounds = formBoundsRef.current ?? getFormBounds(canvas.width, canvas.height);
-    formBoundsRef.current = formBounds;
-    particlesRef.current = initParticles(canvas.width, canvas.height, formBounds);
-  }, []);
+    const { sizeChanged } = resize();
 
-  const handleResize = useCallback(() => {
-    resize();
-    initializeParticles();
-  }, [resize, initializeParticles]);
+    if (sizeChanged || particlesRef.current.length === 0) {
+      const formBounds = formBoundsRef.current ?? getFormBounds(canvas.width, canvas.height);
+      particlesRef.current = initParticles(canvas.width, canvas.height, formBounds);
+    }
+  }, [resize]);
 
   const resetFrameTimingState = useCallback(() => {
     accumulatorRef.current = 0;
@@ -160,7 +195,17 @@ const AnimatedLineBackground: FC = () => {
         lastAppliedDeltaMsRef.current = 0;
       }
 
-      renderFrame();
+      const mouseMoved =
+        lastRenderedMouseAreaRef.current.x !== mouseAreaRef.current.x ||
+        lastRenderedMouseAreaRef.current.y !== mouseAreaRef.current.y;
+      const formBoundsChanged = lastRenderedFormBoundsRef.current !== formBoundsRef.current;
+
+      if (steps > 0 || mouseMoved || formBoundsChanged) {
+        renderFrame();
+        lastRenderedMouseAreaRef.current.x = mouseAreaRef.current.x;
+        lastRenderedMouseAreaRef.current.y = mouseAreaRef.current.y;
+        lastRenderedFormBoundsRef.current = formBoundsRef.current;
+      }
     },
     [applyAnimationStep, renderFrame]
   );
@@ -176,17 +221,18 @@ const AnimatedLineBackground: FC = () => {
     resetFrameTimingState();
     mouseAreaRef.current = createMouseArea();
 
-    resize();
+    const { sizeChanged, boundsChanged } = resize();
 
     const nextCanvasSize = { width: canvas.width, height: canvas.height };
     const needsNewInitialParticles =
+      sizeChanged ||
+      boundsChanged ||
       diagnosticsInitialParticlesRef.current === null ||
       diagnosticsCanvasSizeRef.current?.width !== nextCanvasSize.width ||
       diagnosticsCanvasSizeRef.current?.height !== nextCanvasSize.height;
 
     if (needsNewInitialParticles) {
       const formBounds = formBoundsRef.current ?? getFormBounds(nextCanvasSize.width, nextCanvasSize.height);
-      formBoundsRef.current = formBounds;
       diagnosticsInitialParticlesRef.current = initParticles(nextCanvasSize.width, nextCanvasSize.height, formBounds);
       diagnosticsCanvasSizeRef.current = nextCanvasSize;
     }
@@ -293,12 +339,24 @@ const AnimatedLineBackground: FC = () => {
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseout', handleMouseOut);
 
+    const el = document.getElementById('auth-card-wrapper');
+    let observer: ResizeObserver | null = null;
+    if (el) {
+      observer = new ResizeObserver(() => {
+        handleResize();
+      });
+      observer.observe(el);
+    }
+
     startAnimation();
 
     return () => {
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseout', handleMouseOut);
+      if (observer) {
+        observer.disconnect();
+      }
       stopAnimation();
     };
   }, [handleResize, handleMouseMove, handleMouseOut, startAnimation, stopAnimation]);

--- a/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
+++ b/frontend/src/features/auth/sign-in/components/animated-line-background.tsx
@@ -1,13 +1,26 @@
-import { useCallback, useEffect, useRef, type FC } from 'react';
-
-import { type MouseArea, type Particle, initParticles, stepAnimation } from './animated-line-background.engine';
+import { type FC, useCallback, useEffect, useRef } from 'react';
+import {
+  type MouseArea,
+  type Particle,
+  animationConfig,
+  initParticles,
+  renderParticles,
+  updateParticles,
+} from './animated-line-background.engine';
 
 interface AnimationDiagnosticsSnapshot {
   targetFps: number;
   frameIntervalMs: number;
+  maxCatchUpMs: number;
+  maxStepsPerFrame: number;
   frameCount: number;
+  simulationStepCount: number;
   renderCount: number;
   simulatedMs: number;
+  accumulatorMs: number;
+  lastFrameDeltaMs: number;
+  lastClampedDeltaMs: number;
+  lastFrameStepCount: number;
   lastAppliedDeltaMs: number;
   particleChecksum: number;
 }
@@ -25,11 +38,11 @@ declare global {
   }
 }
 
-const TARGET_FPS = 60;
-const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
 const DEBUG_QUERY_PARAM = '__axonhub_debug_animation';
 
 const createMouseArea = (): MouseArea => ({ x: null, y: null, max: 20000 });
+
+const cloneParticles = (particles: Particle[]): Particle[] => particles.map((particle) => ({ ...particle }));
 
 const getParticleChecksum = (particles: Particle[]): number => {
   return particles.reduce((checksum, particle, index) => {
@@ -53,10 +66,18 @@ const AnimatedLineBackground: FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(null);
   const particlesRef = useRef<Particle[]>([]);
+  const diagnosticsInitialParticlesRef = useRef<Particle[] | null>(null);
+  const diagnosticsCanvasSizeRef = useRef<{ width: number; height: number } | null>(null);
   const mouseAreaRef = useRef<MouseArea>(createMouseArea());
   const frameCountRef = useRef(0);
+  const simulationStepCountRef = useRef(0);
   const renderCountRef = useRef(0);
   const simulatedMsRef = useRef(0);
+  const accumulatorRef = useRef(0);
+  const lastTimestampRef = useRef<number | null>(null);
+  const lastFrameDeltaMsRef = useRef(0);
+  const lastClampedDeltaMsRef = useRef(0);
+  const lastFrameStepCountRef = useRef(0);
   const lastAppliedDeltaMsRef = useRef(0);
 
   const resize = useCallback(() => {
@@ -74,38 +95,103 @@ const AnimatedLineBackground: FC = () => {
     particlesRef.current = initParticles(canvas.width, canvas.height);
   }, []);
 
-  const applyAnimationStep = useCallback((deltaMs: number) => {
+  const renderFrame = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    stepAnimation(ctx, canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
+    renderParticles(ctx, canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
 
     renderCountRef.current += 1;
+  }, []);
+
+  const applyAnimationStep = useCallback((deltaMs: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    updateParticles(canvas.width, canvas.height, particlesRef.current, mouseAreaRef.current);
+
+    simulationStepCountRef.current += 1;
     simulatedMsRef.current += deltaMs;
     lastAppliedDeltaMsRef.current = deltaMs;
   }, []);
 
+  const processAnimationFrame = useCallback(
+    (deltaMs: number) => {
+      const safeDeltaMs = Number.isFinite(deltaMs) ? Math.max(0, deltaMs) : 0;
+      const clampedDeltaMs = Math.min(safeDeltaMs, animationConfig.maxCatchUpMs);
+
+      lastFrameDeltaMsRef.current = safeDeltaMs;
+      lastClampedDeltaMsRef.current = clampedDeltaMs;
+      accumulatorRef.current += clampedDeltaMs;
+
+      let steps = 0;
+      while (accumulatorRef.current >= animationConfig.frameIntervalMs && steps < animationConfig.maxStepsPerFrame) {
+        accumulatorRef.current -= animationConfig.frameIntervalMs;
+        applyAnimationStep(animationConfig.frameIntervalMs);
+        steps += 1;
+      }
+
+      lastFrameStepCountRef.current = steps;
+      if (steps === 0) {
+        lastAppliedDeltaMsRef.current = 0;
+      }
+
+      renderFrame();
+    },
+    [applyAnimationStep, renderFrame]
+  );
+
   const resetDiagnosticsState = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
     frameCountRef.current = 0;
+    simulationStepCountRef.current = 0;
     renderCountRef.current = 0;
     simulatedMsRef.current = 0;
+    accumulatorRef.current = 0;
+    lastTimestampRef.current = null;
+    lastFrameDeltaMsRef.current = 0;
+    lastClampedDeltaMsRef.current = 0;
+    lastFrameStepCountRef.current = 0;
     lastAppliedDeltaMsRef.current = 0;
     mouseAreaRef.current = createMouseArea();
 
     resize();
-    initializeParticles();
-  }, [initializeParticles, resize]);
+
+    const nextCanvasSize = { width: canvas.width, height: canvas.height };
+    const needsNewInitialParticles =
+      diagnosticsInitialParticlesRef.current === null ||
+      diagnosticsCanvasSizeRef.current?.width !== nextCanvasSize.width ||
+      diagnosticsCanvasSizeRef.current?.height !== nextCanvasSize.height;
+
+    if (needsNewInitialParticles) {
+      diagnosticsInitialParticlesRef.current = initParticles(nextCanvasSize.width, nextCanvasSize.height);
+      diagnosticsCanvasSizeRef.current = nextCanvasSize;
+    }
+
+    particlesRef.current = cloneParticles(diagnosticsInitialParticlesRef.current);
+    renderFrame();
+    renderCountRef.current = 0;
+  }, [renderFrame, resize]);
 
   const snapshotDiagnostics = useCallback<() => AnimationDiagnosticsSnapshot>(() => {
     return {
-      targetFps: TARGET_FPS,
-      frameIntervalMs: FRAME_INTERVAL_MS,
+      targetFps: animationConfig.targetFps,
+      frameIntervalMs: animationConfig.frameIntervalMs,
+      maxCatchUpMs: animationConfig.maxCatchUpMs,
+      maxStepsPerFrame: animationConfig.maxStepsPerFrame,
       frameCount: frameCountRef.current,
+      simulationStepCount: simulationStepCountRef.current,
       renderCount: renderCountRef.current,
       simulatedMs: simulatedMsRef.current,
+      accumulatorMs: accumulatorRef.current,
+      lastFrameDeltaMs: lastFrameDeltaMsRef.current,
+      lastClampedDeltaMs: lastClampedDeltaMsRef.current,
+      lastFrameStepCount: lastFrameStepCountRef.current,
       lastAppliedDeltaMs: lastAppliedDeltaMsRef.current,
       particleChecksum: getParticleChecksum(particlesRef.current),
     };
@@ -118,10 +204,10 @@ const AnimatedLineBackground: FC = () => {
 
       for (let index = 0; index < safeSteps; index += 1) {
         frameCountRef.current += 1;
-        applyAnimationStep(safeStepMs);
+        processAnimationFrame(safeStepMs);
       }
     },
-    [applyAnimationStep],
+    [processAnimationFrame]
   );
 
   const simulateLargeGapDiagnostics = useCallback(
@@ -129,17 +215,26 @@ const AnimatedLineBackground: FC = () => {
       const safeDeltaMs = Number.isFinite(deltaMs) ? Math.max(0, deltaMs) : 0;
 
       frameCountRef.current += 1;
-      applyAnimationStep(safeDeltaMs);
+      processAnimationFrame(safeDeltaMs);
     },
-    [applyAnimationStep],
+    [processAnimationFrame]
   );
 
-  const animate = useCallback(() => {
-    frameCountRef.current += 1;
-    applyAnimationStep(FRAME_INTERVAL_MS);
+  const animate = useCallback(
+    (timestamp: number) => {
+      frameCountRef.current += 1;
 
-    animationRef.current = requestAnimationFrame(animate);
-  }, [applyAnimationStep]);
+      if (lastTimestampRef.current === null) {
+        lastTimestampRef.current = timestamp;
+      }
+
+      processAnimationFrame(timestamp - lastTimestampRef.current);
+      lastTimestampRef.current = timestamp;
+
+      animationRef.current = requestAnimationFrame(animate);
+    },
+    [processAnimationFrame]
+  );
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
     mouseAreaRef.current.x = e.clientX;
@@ -164,7 +259,7 @@ const AnimatedLineBackground: FC = () => {
 
     // 延迟200ms开始动画，确保粒子初始化完成
     const timer = setTimeout(() => {
-      animate();
+      animationRef.current = requestAnimationFrame(animate);
     }, 200);
 
     return () => {
@@ -207,7 +302,9 @@ const AnimatedLineBackground: FC = () => {
     };
   }, [resetDiagnosticsState, simulateDiagnostics, simulateLargeGapDiagnostics, snapshotDiagnostics]);
 
-  return <canvas ref={canvasRef} data-testid='sign-in-animation-canvas' className='pointer-events-none fixed inset-0' style={{ zIndex: 0 }} />;
+  return (
+    <canvas ref={canvasRef} data-testid='sign-in-animation-canvas' className='pointer-events-none fixed inset-0' style={{ zIndex: 0 }} />
+  );
 };
 
 export default AnimatedLineBackground;

--- a/frontend/src/features/auth/sign-in/index.tsx
+++ b/frontend/src/features/auth/sign-in/index.tsx
@@ -10,7 +10,9 @@ export default function SignIn() {
 
   return (
     <AuthLayout>
-      <AnimatedLineBackground key='optimized-layout' />
+      <div data-testid='sign-in-animation-layer'>
+        <AnimatedLineBackground key='optimized-layout' />
+      </div>
       <TwoColumnAuth
         title={t('auth.signIn.title')}
         description={t('auth.signIn.subtitle')}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -283,6 +283,7 @@ const AuthenticatedProjectRequestsRequestIdRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof AuthenticatedIndexRoute
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/forgot-password': typeof authForgotPasswordRoute
   '/initialization': typeof authInitializationRoute
@@ -294,35 +295,34 @@ export interface FileRoutesByFullPath {
   '/500': typeof errors500Route
   '/503': typeof errors503Route
   '/permission': typeof AuthenticatedPermissionRoute
-  '/': typeof AuthenticatedIndexRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
   '/settings/profile': typeof AuthenticatedSettingsProfileRoute
-  '/api-keys': typeof AuthenticatedApiKeysIndexRoute
-  '/channels': typeof AuthenticatedChannelsIndexRoute
-  '/chats': typeof AuthenticatedChatsIndexRoute
-  '/data-storages': typeof AuthenticatedDataStoragesIndexRoute
-  '/help-center': typeof AuthenticatedHelpCenterIndexRoute
-  '/models': typeof AuthenticatedModelsIndexRoute
-  '/permission-demo': typeof AuthenticatedPermissionDemoIndexRoute
-  '/projects': typeof AuthenticatedProjectsIndexRoute
-  '/prompt-protection-rules': typeof AuthenticatedPromptProtectionRulesIndexRoute
-  '/roles': typeof AuthenticatedRolesIndexRoute
+  '/api-keys/': typeof AuthenticatedApiKeysIndexRoute
+  '/channels/': typeof AuthenticatedChannelsIndexRoute
+  '/chats/': typeof AuthenticatedChatsIndexRoute
+  '/data-storages/': typeof AuthenticatedDataStoragesIndexRoute
+  '/help-center/': typeof AuthenticatedHelpCenterIndexRoute
+  '/models/': typeof AuthenticatedModelsIndexRoute
+  '/permission-demo/': typeof AuthenticatedPermissionDemoIndexRoute
+  '/projects/': typeof AuthenticatedProjectsIndexRoute
+  '/prompt-protection-rules/': typeof AuthenticatedPromptProtectionRulesIndexRoute
+  '/roles/': typeof AuthenticatedRolesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/system': typeof AuthenticatedSystemIndexRoute
-  '/users': typeof AuthenticatedUsersIndexRoute
+  '/system/': typeof AuthenticatedSystemIndexRoute
+  '/users/': typeof AuthenticatedUsersIndexRoute
   '/project/requests/$requestId': typeof AuthenticatedProjectRequestsRequestIdRoute
   '/project/threads/$threadId': typeof AuthenticatedProjectThreadsThreadIdRoute
   '/project/traces/$traceId': typeof AuthenticatedProjectTracesTraceIdRoute
-  '/project/api-keys': typeof AuthenticatedProjectApiKeysIndexRoute
-  '/project/playground': typeof AuthenticatedProjectPlaygroundIndexRoute
-  '/project/prompts': typeof AuthenticatedProjectPromptsIndexRoute
-  '/project/requests': typeof AuthenticatedProjectRequestsIndexRoute
-  '/project/roles': typeof AuthenticatedProjectRolesIndexRoute
-  '/project/threads': typeof AuthenticatedProjectThreadsIndexRoute
-  '/project/traces': typeof AuthenticatedProjectTracesIndexRoute
-  '/project/users': typeof AuthenticatedProjectUsersIndexRoute
+  '/project/api-keys/': typeof AuthenticatedProjectApiKeysIndexRoute
+  '/project/playground/': typeof AuthenticatedProjectPlaygroundIndexRoute
+  '/project/prompts/': typeof AuthenticatedProjectPromptsIndexRoute
+  '/project/requests/': typeof AuthenticatedProjectRequestsIndexRoute
+  '/project/roles/': typeof AuthenticatedProjectRolesIndexRoute
+  '/project/threads/': typeof AuthenticatedProjectThreadsIndexRoute
+  '/project/traces/': typeof AuthenticatedProjectTracesIndexRoute
+  '/project/users/': typeof AuthenticatedProjectUsersIndexRoute
 }
 export interface FileRoutesByTo {
   '/forgot-password': typeof authForgotPasswordRoute
@@ -412,6 +412,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/settings'
     | '/forgot-password'
     | '/initialization'
@@ -423,35 +424,34 @@ export interface FileRouteTypes {
     | '/500'
     | '/503'
     | '/permission'
-    | '/'
     | '/settings/appearance'
     | '/settings/display'
     | '/settings/notifications'
     | '/settings/profile'
-    | '/api-keys'
-    | '/channels'
-    | '/chats'
-    | '/data-storages'
-    | '/help-center'
-    | '/models'
-    | '/permission-demo'
-    | '/projects'
-    | '/prompt-protection-rules'
-    | '/roles'
+    | '/api-keys/'
+    | '/channels/'
+    | '/chats/'
+    | '/data-storages/'
+    | '/help-center/'
+    | '/models/'
+    | '/permission-demo/'
+    | '/projects/'
+    | '/prompt-protection-rules/'
+    | '/roles/'
     | '/settings/'
-    | '/system'
-    | '/users'
+    | '/system/'
+    | '/users/'
     | '/project/requests/$requestId'
     | '/project/threads/$threadId'
     | '/project/traces/$traceId'
-    | '/project/api-keys'
-    | '/project/playground'
-    | '/project/prompts'
-    | '/project/requests'
-    | '/project/roles'
-    | '/project/threads'
-    | '/project/traces'
-    | '/project/users'
+    | '/project/api-keys/'
+    | '/project/playground/'
+    | '/project/prompts/'
+    | '/project/requests/'
+    | '/project/roles/'
+    | '/project/threads/'
+    | '/project/traces/'
+    | '/project/users/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/forgot-password'
@@ -556,7 +556,7 @@ declare module '@tanstack/react-router' {
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -647,14 +647,14 @@ declare module '@tanstack/react-router' {
     '/_authenticated/users/': {
       id: '/_authenticated/users/'
       path: '/users'
-      fullPath: '/users'
+      fullPath: '/users/'
       preLoaderRoute: typeof AuthenticatedUsersIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/system/': {
       id: '/_authenticated/system/'
       path: '/system'
-      fullPath: '/system'
+      fullPath: '/system/'
       preLoaderRoute: typeof AuthenticatedSystemIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
@@ -668,70 +668,70 @@ declare module '@tanstack/react-router' {
     '/_authenticated/roles/': {
       id: '/_authenticated/roles/'
       path: '/roles'
-      fullPath: '/roles'
+      fullPath: '/roles/'
       preLoaderRoute: typeof AuthenticatedRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/prompt-protection-rules/': {
       id: '/_authenticated/prompt-protection-rules/'
       path: '/prompt-protection-rules'
-      fullPath: '/prompt-protection-rules'
+      fullPath: '/prompt-protection-rules/'
       preLoaderRoute: typeof AuthenticatedPromptProtectionRulesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/projects/': {
       id: '/_authenticated/projects/'
       path: '/projects'
-      fullPath: '/projects'
+      fullPath: '/projects/'
       preLoaderRoute: typeof AuthenticatedProjectsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/permission-demo/': {
       id: '/_authenticated/permission-demo/'
       path: '/permission-demo'
-      fullPath: '/permission-demo'
+      fullPath: '/permission-demo/'
       preLoaderRoute: typeof AuthenticatedPermissionDemoIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/models/': {
       id: '/_authenticated/models/'
       path: '/models'
-      fullPath: '/models'
+      fullPath: '/models/'
       preLoaderRoute: typeof AuthenticatedModelsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/help-center/': {
       id: '/_authenticated/help-center/'
       path: '/help-center'
-      fullPath: '/help-center'
+      fullPath: '/help-center/'
       preLoaderRoute: typeof AuthenticatedHelpCenterIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/data-storages/': {
       id: '/_authenticated/data-storages/'
       path: '/data-storages'
-      fullPath: '/data-storages'
+      fullPath: '/data-storages/'
       preLoaderRoute: typeof AuthenticatedDataStoragesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/chats/': {
       id: '/_authenticated/chats/'
       path: '/chats'
-      fullPath: '/chats'
+      fullPath: '/chats/'
       preLoaderRoute: typeof AuthenticatedChatsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/channels/': {
       id: '/_authenticated/channels/'
       path: '/channels'
-      fullPath: '/channels'
+      fullPath: '/channels/'
       preLoaderRoute: typeof AuthenticatedChannelsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/api-keys/': {
       id: '/_authenticated/api-keys/'
       path: '/api-keys'
-      fullPath: '/api-keys'
+      fullPath: '/api-keys/'
       preLoaderRoute: typeof AuthenticatedApiKeysIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
@@ -766,56 +766,56 @@ declare module '@tanstack/react-router' {
     '/_authenticated/project/users/': {
       id: '/_authenticated/project/users/'
       path: '/project/users'
-      fullPath: '/project/users'
+      fullPath: '/project/users/'
       preLoaderRoute: typeof AuthenticatedProjectUsersIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/traces/': {
       id: '/_authenticated/project/traces/'
       path: '/project/traces'
-      fullPath: '/project/traces'
+      fullPath: '/project/traces/'
       preLoaderRoute: typeof AuthenticatedProjectTracesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/threads/': {
       id: '/_authenticated/project/threads/'
       path: '/project/threads'
-      fullPath: '/project/threads'
+      fullPath: '/project/threads/'
       preLoaderRoute: typeof AuthenticatedProjectThreadsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/roles/': {
       id: '/_authenticated/project/roles/'
       path: '/project/roles'
-      fullPath: '/project/roles'
+      fullPath: '/project/roles/'
       preLoaderRoute: typeof AuthenticatedProjectRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/requests/': {
       id: '/_authenticated/project/requests/'
       path: '/project/requests'
-      fullPath: '/project/requests'
+      fullPath: '/project/requests/'
       preLoaderRoute: typeof AuthenticatedProjectRequestsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/prompts/': {
       id: '/_authenticated/project/prompts/'
       path: '/project/prompts'
-      fullPath: '/project/prompts'
+      fullPath: '/project/prompts/'
       preLoaderRoute: typeof AuthenticatedProjectPromptsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/playground/': {
       id: '/_authenticated/project/playground/'
       path: '/project/playground'
-      fullPath: '/project/playground'
+      fullPath: '/project/playground/'
       preLoaderRoute: typeof AuthenticatedProjectPlaygroundIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/project/api-keys/': {
       id: '/_authenticated/project/api-keys/'
       path: '/project/api-keys'
-      fullPath: '/project/api-keys'
+      fullPath: '/project/api-keys/'
       preLoaderRoute: typeof AuthenticatedProjectApiKeysIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }


### PR DESCRIPTION
## 变更说明
- 将登录页粒子背景的粒子初始化、位置更新、连线绘制和表单避让逻辑拆分到独立的 `animated-line-background.engine.ts`，组件只保留画布生命周期和调度逻辑
- 将动画循环改为基于固定步长的帧调度：增加 `targetFps`、累计器、最大补帧时长和单帧步数限制，并在页面隐藏/恢复时停止或重启动画，避免刷新率和长时间切后台直接影响动画推进
- 仅在开发环境且带 `__axonhub_debug_animation=1` 查询参数时，向 `window.__AXONHUB_SIGNIN_ANIMATION__` 暴露重置、快照和模拟方法，便于排查动画帧推进与粒子状态
- 为登录页动画层和画布补充 `data-testid`，并在登录页外层增加单独的动画容器节点，方便测试与定位
- 同步更新 `frontend/src/routeTree.gen.ts` 生成结果

## 影响文件
- `frontend/src/features/auth/sign-in/components/animated-line-background.engine.ts`
- `frontend/src/features/auth/sign-in/components/animated-line-background.tsx`
- `frontend/src/features/auth/sign-in/index.tsx`
- `frontend/src/routeTree.gen.ts`

Closes #1217