### PR TITLE
fix: passthrough X-Initiator header in Copilot channel for billing control

### DIFF
--- a/llm/httpclient/utils.go
+++ b/llm/httpclient/utils.go
@@ -111,6 +111,10 @@ var blockedHeaders = map[string]bool{
 	// NOTE: user customized trace/thread headers will be sent to upstream.
 	"Ah-Trace-Id":  true,
 	"Ah-Thread-Id": true,
+
+	// X-Initiator is used by specific channels (e.g. Copilot) for billing control.
+	// Block from auto-merge so it is only forwarded by the channel that explicitly needs it.
+	"X-Initiator": true,
 }
 
 // blockedHeaderPrefixes lists header prefixes that should not be forwarded to upstream.

--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -34,6 +34,7 @@ const (
 	RequestIDHeader                = "x-request-id"
 	VSCodeUserAgentLibHeader       = "x-vscode-user-agent-library-version"
 	CopilotVisionRequestHeader     = "Copilot-Vision-Request"
+	InitiatorHeader                = "X-Initiator"
 	// Default editor header values (VSCode pattern) - from LiteLLM
 	DefaultEditorVersion        = "vscode/1.95.0"
 	DefaultEditorPluginVersion  = "copilot-chat/0.26.7"
@@ -156,6 +157,13 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	// Add vision header if request contains image content.
 	if hasVisionContent(llmReq) {
 		headers.Set(CopilotVisionRequestHeader, "true")
+	}
+
+	// Forward X-Initiator from inbound request for Copilot billing control.
+	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
+		if initiator := llmReq.RawRequest.Headers.Get(InitiatorHeader); initiator != "" {
+			headers.Set(InitiatorHeader, initiator)
+		}
 	}
 
 	// Build authentication config.
@@ -574,6 +582,13 @@ func (t *OutboundTransformer) transformResponsesRequest(ctx context.Context, llm
 	// Add vision header if request contains image content.
 	if hasVisionContent(llmReq) {
 		responsesReq.Headers.Set(CopilotVisionRequestHeader, "true")
+	}
+
+	// Forward X-Initiator from inbound request for Copilot billing control.
+	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
+		if initiator := llmReq.RawRequest.Headers.Get(InitiatorHeader); initiator != "" {
+			responsesReq.Headers.Set(InitiatorHeader, initiator)
+		}
 	}
 
 	return responsesReq, nil


### PR DESCRIPTION
## Summary

- **Block** `X-Initiator` from the global header auto-merge pipeline (`blockedHeaders`) to prevent it from leaking to non-Copilot upstream providers
- **Explicitly forward** `X-Initiator` in the Copilot outbound transformer for both Chat Completions and Responses API (Codex) request paths

## Problem

When using [opencode](https://github.com/sst/opencode) (or oh-my-opencode) with AxonHub's Copilot channel, every tool call is billed as a separate premium request, causing quota to deplete dozens of times faster than expected.

opencode already sends `X-Initiator: agent` for agent-initiated requests (tool calls, compaction, subagent flows) and `X-Initiator: user` for user-initiated turns. GitHub Copilot's server uses this header to skip billing for agent requests. However, AxonHub's `MergeInboundRequest` pipeline silently forwards ALL non-blocked inbound headers to ALL upstream providers — so `X-Initiator` either gets forwarded everywhere (undesirable) or needs to be explicitly controlled per channel.

## Solution

1. Add `X-Initiator` to `blockedHeaders` in `llm/httpclient/utils.go` — this prevents the header from being auto-forwarded to any upstream provider via the merge pipeline
2. In `llm/transformer/openai/copilot/outbound.go`, explicitly read `X-Initiator` from the inbound request headers and set it on the outgoing Copilot request — following the same pattern used by the Codex transformer for `Originator`, `Session_id`, and `User-Agent`

This ensures **only the Copilot channel** forwards `X-Initiator` to GitHub's API, while all other channels remain unaffected.

## Changes

| File | Change |
|------|--------|
| `llm/httpclient/utils.go` | Add `X-Initiator` to `blockedHeaders` |
| `llm/transformer/openai/copilot/outbound.go` | Add `InitiatorHeader` constant; forward header in `TransformRequest()` and `transformResponsesRequest()` |

## Testing

The header forwarding follows the exact same pattern as `codex/outbound.go` (lines 94-98, 157-174) which reads `Session_id`, `Originator`, `User-Agent` from `llmReq.RawRequest.Headers` and sets them on the outgoing request. The pattern is battle-tested across the codebase.

Closes #820