### PR TITLE
feat: add user agent pass-through settings

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -904,9 +904,23 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       }
 
       if (isEdit && currentRow) {
+        const proxyConfig = {
+          type: proxyType as 'disabled' | 'environment' | 'url',
+          ...(proxyType === ProxyType.URL && {
+            url: proxyUrl,
+            username: proxyUsername || undefined,
+            password: proxyPassword || undefined,
+          }),
+        };
+
+        const nextSettings = mergeChannelSettingsForUpdate(values.settings, {
+          proxy: proxyConfig,
+          passThroughUserAgent,
+        });
+
         const updateInput = {
           ...dataWithModels,
-          settings: undefined,
+          settings: nextSettings,
           ...(isOAuthChannel ? { type: undefined } : {}),
         } as z.infer<typeof updateChannelInputSchema>;
 

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -511,6 +511,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                 jsonData: currentRow.credentials?.gcp?.jsonData || '',
               },
             },
+            settings: currentRow.settings ?? undefined,
           }
         : duplicateFromRow
           ? {
@@ -904,17 +905,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       }
 
       if (isEdit && currentRow) {
-        const proxyConfig = {
-          type: proxyType as 'disabled' | 'environment' | 'url',
-          ...(proxyType === ProxyType.URL && {
-            url: proxyUrl,
-            username: proxyUsername || undefined,
-            password: proxyPassword || undefined,
-          }),
-        };
-
         const nextSettings = mergeChannelSettingsForUpdate(values.settings, {
-          proxy: proxyConfig,
           passThroughUserAgent,
         });
 

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -278,6 +278,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const [proxyUrl, setProxyUrl] = useState(() => initialRow?.settings?.proxy?.url || '');
   const [proxyUsername, setProxyUsername] = useState(() => initialRow?.settings?.proxy?.username || '');
   const [proxyPassword, setProxyPassword] = useState(() => initialRow?.settings?.proxy?.password || '');
+  const [passThroughUserAgent, setPassThroughUserAgent] = useState<boolean | null>(() => {
+    return initialRow?.settings?.passThroughUserAgent ?? null;
+  });
 
   // Memoized proxy config for OAuth exchange
   const proxyConfig: ProxyConfig | undefined = useMemo(() => {
@@ -939,6 +942,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
         const nextSettings = mergeChannelSettingsForUpdate(values.settings, {
           proxy: proxyConfig,
+          passThroughUserAgent,
         });
 
         await createChannel.mutateAsync({
@@ -1338,6 +1342,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
             setProxyUrl(initialRow?.settings?.proxy?.url || '');
             setProxyUsername(initialRow?.settings?.proxy?.username || '');
             setProxyPassword(initialRow?.settings?.proxy?.password || '');
+            setPassThroughUserAgent(initialRow?.settings?.passThroughUserAgent ?? null);
             // Reset provider and API format state
             if (initialRow) {
               setSelectedProvider(getProviderFromChannelType(initialRow.type) || 'openai');
@@ -1691,6 +1696,27 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                           </div>
                         </FormItem>
                       )}
+
+                      <FormItem className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>
+                        <FormLabel className='pt-2 font-medium md:col-span-2'>
+                          {t('channels.dialogs.userAgentPassThrough.label')}
+                        </FormLabel>
+                        <div className='space-y-1 md:col-span-6'>
+                          <Select
+                            value={passThroughUserAgent === null ? 'inherit' : passThroughUserAgent ? 'enabled' : 'disabled'}
+                            onValueChange={(value) => setPassThroughUserAgent(value === 'inherit' ? null : value === 'enabled')}
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder={t('channels.dialogs.userAgentPassThrough.inherit')} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value='inherit'>{t('channels.dialogs.userAgentPassThrough.inherit')}</SelectItem>
+                              <SelectItem value='enabled'>{t('channels.dialogs.userAgentPassThrough.enabled')}</SelectItem>
+                              <SelectItem value='disabled'>{t('channels.dialogs.userAgentPassThrough.disabled')}</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </FormItem>
 
                       {(isCodexType || isClaudeCodeType) && (
                         <div className='grid grid-cols-1 items-start gap-x-6 gap-y-2 md:grid-cols-8'>

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -98,6 +98,7 @@ const CREATE_CHANNEL_MUTATION = `
             forceArrayInputs
             replaceDeveloperRoleWithSystem
           }
+          passThroughUserAgent
         }
       orderingWeight
       remark
@@ -144,6 +145,7 @@ const BULK_CREATE_CHANNELS_MUTATION = `
             forceArrayInputs
             replaceDeveloperRoleWithSystem
           }
+          passThroughUserAgent
         }
       orderingWeight
       remark
@@ -190,6 +192,7 @@ const UPDATE_CHANNEL_MUTATION = `
             forceArrayInputs
             replaceDeveloperRoleWithSystem
           }
+          passThroughUserAgent
         }
       orderingWeight
       errorMessage
@@ -283,6 +286,7 @@ const BULK_IMPORT_CHANNELS_MUTATION = `
             forceArrayInputs
             replaceDeveloperRoleWithSystem
           }
+          passThroughUserAgent
         }
       }
     }
@@ -448,6 +452,7 @@ const BULK_UPDATE_CHANNEL_ORDERING_MUTATION = `
             forceArrayInputs
             replaceDeveloperRoleWithSystem
           }
+          passThroughUserAgent
         }
       }
     }
@@ -580,6 +585,7 @@ const QUERY_CHANNELS_QUERY = `
               forceArrayInputs
               replaceDeveloperRoleWithSystem
             }
+            passThroughUserAgent
           }
           orderingWeight
           errorMessage

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -153,7 +153,9 @@ export const channelSettingsSchema = z.object({
   headerOverrideOperations: z.array(overrideOperationSchema).optional(),
   proxy: proxyConfigSchema.optional().nullable(),
   transformOptions: transformOptionsSchema.optional(),
+  passThroughUserAgent: z.boolean().optional().nullable(),
 });
+
 export type ChannelSettings = z.infer<typeof channelSettingsSchema>;
 
 // Channel Model Entry

--- a/frontend/src/features/channels/utils/merge.ts
+++ b/frontend/src/features/channels/utils/merge.ts
@@ -106,6 +106,7 @@ export function mergeChannelSettingsForUpdate(
     headerOverrideOperations: pick('headerOverrideOperations', existing?.headerOverrideOperations ?? []),
     proxy: pick('proxy', existing?.proxy ?? null),
     transformOptions: pick('transformOptions', existing?.transformOptions ?? undefined),
+    passThroughUserAgent: pick('passThroughUserAgent', existing?.passThroughUserAgent ?? null),
   };
 }
 

--- a/frontend/src/features/system/components/general-settings.tsx
+++ b/frontend/src/features/system/components/general-settings.tsx
@@ -1,15 +1,21 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Loader2, Save } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { useSystemContext } from '../context/system-context';
 import { currencyCodes } from '../data/currencies';
-import { useGeneralSettings, useUpdateGeneralSettings } from '../data/system';
+import {
+  useGeneralSettings,
+  useUpdateGeneralSettings,
+  useUserAgentPassThroughSettings,
+  useUpdateUserAgentPassThroughSettings,
+} from '../data/system';
 import { GMTTimeZoneOptions } from '../data/timezones';
 
 export function GeneralSettings() {
@@ -17,6 +23,11 @@ export function GeneralSettings() {
   const { data: settings, isLoading: isLoadingSettings } = useGeneralSettings();
   const updateSettings = useUpdateGeneralSettings();
   const { isLoading, setIsLoading } = useSystemContext();
+
+  // User-Agent Pass-Through settings
+  const { data: uaSettings, isLoading: isLoadingUASettings } = useUserAgentPassThroughSettings();
+  const updateUASettings = useUpdateUserAgentPassThroughSettings();
+  const [uaPassThroughEnabled, setUaPassThroughEnabled] = useState(false);
 
   const [currencyCode, setCurrencyCode] = useState('USD');
   const [timezone, setTimezone] = useState('UTC');
@@ -33,12 +44,19 @@ export function GeneralSettings() {
   const timezoneItems = React.useMemo(() => GMTTimeZoneOptions, []);
 
   // Update local state when settings are loaded
-  React.useEffect(() => {
+  useEffect(() => {
     if (settings) {
       setCurrencyCode(settings.currencyCode || 'USD');
       setTimezone(settings.timezone || 'UTC');
     }
   }, [settings]);
+
+  // Update UA pass-through state when loaded
+  useEffect(() => {
+    if (uaSettings) {
+      setUaPassThroughEnabled(uaSettings.enabled);
+    }
+  }, [uaSettings]);
 
   const handleSave = async () => {
     setIsLoading(true);
@@ -52,7 +70,20 @@ export function GeneralSettings() {
     }
   };
 
-  const hasChanges = settings ? settings.currencyCode !== currencyCode || settings.timezone !== timezone : false;
+  const handleUAPassThroughChange = async (enabled: boolean) => {
+    const previousValue = uaPassThroughEnabled;
+    setUaPassThroughEnabled(enabled);
+    try {
+      await updateUASettings.mutateAsync({ enabled });
+    } catch {
+      // Revert state on error
+    setUaPassThroughEnabled(previousValue);
+  }
+};
+
+  const hasChanges = settings
+    ? settings.currencyCode !== currencyCode || settings.timezone !== timezone
+    : false;
 
   if (isLoadingSettings) {
     return (
@@ -97,6 +128,27 @@ export function GeneralSettings() {
               />
             </div>
             <div className='text-muted-foreground text-sm'>{t('system.general.timezone.description')}</div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('system.userAgentPassThrough.title')}</CardTitle>
+          <CardDescription>{t('system.userAgentPassThrough.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className='space-y-6'>
+          <div className='flex items-center justify-between'>
+            <div className='space-y-0.5'>
+              <Label htmlFor='ua-pass-through'>{t('system.userAgentPassThrough.label')}</Label>
+              <div className='text-muted-foreground text-sm'>{t('system.userAgentPassThrough.helpText')}</div>
+            </div>
+            <Switch
+              id='ua-pass-through'
+              checked={uaPassThroughEnabled}
+              onCheckedChange={handleUAPassThroughChange}
+              disabled={isLoadingUASettings || updateUASettings.isPending}
+            />
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/features/system/components/general-settings.tsx
+++ b/frontend/src/features/system/components/general-settings.tsx
@@ -77,9 +77,9 @@ export function GeneralSettings() {
       await updateUASettings.mutateAsync({ enabled });
     } catch {
       // Revert state on error
-    setUaPassThroughEnabled(previousValue);
-  }
-};
+      setUaPassThroughEnabled(previousValue);
+    }
+  };
 
   const hasChanges = settings
     ? settings.currencyCode !== currencyCode || settings.timezone !== timezone

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -1106,3 +1106,62 @@ export function useDeleteProxyPreset() {
     },
   });
 }
+
+
+// User-Agent Pass-Through Settings
+const USER_AGENT_PASS_THROUGH_SETTINGS_QUERY = `
+  query UserAgentPassThroughSettings {
+    userAgentPassThroughSettings {
+      enabled
+    }
+  }
+`;
+
+const UPDATE_USER_AGENT_PASS_THROUGH_SETTINGS_MUTATION = `
+  mutation UpdateUserAgentPassThroughSettings($input: UpdateUserAgentPassThroughSettingsInput!) {
+    updateUserAgentPassThroughSettings(input: $input)
+  }
+`;
+
+export interface UserAgentPassThroughSettings {
+  enabled: boolean;
+}
+
+export interface UpdateUserAgentPassThroughSettingsInput {
+  enabled: boolean;
+}
+
+export function useUserAgentPassThroughSettings() {
+  const { handleError } = useErrorHandler();
+
+  return useQuery({
+    queryKey: ['userAgentPassThroughSettings'],
+    queryFn: async () => {
+      try {
+        const data = await graphqlRequest<{ userAgentPassThroughSettings: UserAgentPassThroughSettings }>(USER_AGENT_PASS_THROUGH_SETTINGS_QUERY);
+        return data.userAgentPassThroughSettings;
+      } catch (error) {
+        handleError(error, i18n.t('common.errors.internalServerError'));
+        throw error;
+      }
+    },
+  });
+}
+
+export function useUpdateUserAgentPassThroughSettings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: UpdateUserAgentPassThroughSettingsInput) => {
+      const data = await graphqlRequest<{ updateUserAgentPassThroughSettings: boolean }>(UPDATE_USER_AGENT_PASS_THROUGH_SETTINGS_MUTATION, { input });
+      return data.updateUserAgentPassThroughSettings;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userAgentPassThroughSettings'] });
+      toast.success(i18n.t('common.success.systemUpdated'));
+    },
+    onError: () => {
+      toast.error(i18n.t('common.errors.systemUpdateFailed'));
+    },
+  });
+}

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -615,5 +615,9 @@
   "channels.messages.deleteDisabledAPIKeysPreserved": "API keys deleted, but at least one key was preserved to keep the channel available",
   "channels.messages.deleteDisabledAPIKeysError": "Failed to delete API keys: {{error}}",
   "channels.messages.syncModelsSuccess": "Models synced successfully",
-  "channels.messages.syncModelsError": "Failed to sync models: {{error}}"
+  "channels.messages.syncModelsError": "Failed to sync models: {{error}}",
+  "channels.dialogs.userAgentPassThrough.label": "User-Agent Pass-Through",
+  "channels.dialogs.userAgentPassThrough.inherit": "Inherit from system",
+  "channels.dialogs.userAgentPassThrough.enabled": "Enabled",
+  "channels.dialogs.userAgentPassThrough.disabled": "Disabled"
 }

--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -253,6 +253,9 @@
   "system.proxy.deleteConfirm": "Are you sure you want to delete this proxy preset?",
   "system.proxy.deleteSuccess": "Proxy preset deleted",
   "system.proxy.columns.url": "Proxy URL",
-  "system.proxy.columns.username": "Username",
-  "system.proxy.columns.actions": "Actions"
+  "system.proxy.columns.actions": "Actions",
+  "system.userAgentPassThrough.title": "User-Agent Pass-Through",
+  "system.userAgentPassThrough.description": "Control whether to pass through the original User-Agent header from client requests to upstream AI providers.",
+  "system.userAgentPassThrough.label": "Enable User-Agent Pass-Through",
+  "system.userAgentPassThrough.helpText": "When enabled, the original User-Agent header from client requests will be sent to upstream AI providers. When disabled, AxonHub will use its own User-Agent."
 }

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -615,6 +615,9 @@
   "channels.messages.deleteDisabledAPIKeysSuccess": "API 密钥删除成功",
   "channels.messages.deleteDisabledAPIKeysPreserved": "API 密钥已删除，但至少保留了一个密钥以确保渠道可用",
   "channels.messages.deleteDisabledAPIKeysError": "删除 API 密钥失败：{{error}}",
-  "channels.messages.syncModelsSuccess": "模型同步成功",
-  "channels.messages.syncModelsError": "同步模型失败：{{error}}"
+  "channels.messages.syncModelsError": "同步模型失败：{{error}}",
+  "channels.dialogs.userAgentPassThrough.label": "User-Agent 穿透",
+  "channels.dialogs.userAgentPassThrough.inherit": "继承系统设置",
+  "channels.dialogs.userAgentPassThrough.enabled": "已启用",
+  "channels.dialogs.userAgentPassThrough.disabled": "已禁用"
 }

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -253,6 +253,9 @@
   "system.proxy.deleteConfirm": "确定要删除此代理预设吗？",
   "system.proxy.deleteSuccess": "代理预设已删除",
   "system.proxy.columns.url": "代理 URL",
-  "system.proxy.columns.username": "用户名",
-  "system.proxy.columns.actions": "操作"
+  "system.proxy.columns.actions": "操作",
+  "system.userAgentPassThrough.title": "User-Agent 透传",
+  "system.userAgentPassThrough.description": "控制是否将客户端请求中的原始 User-Agent 请求头透传给上游 AI 提供商。",
+  "system.userAgentPassThrough.label": "启用 User-Agent 透传",
+  "system.userAgentPassThrough.helpText": "启用后，客户端请求中的原始 User-Agent 请求头将发送给上游 AI 提供商。禁用时，AxonHub 将使用自身的 User-Agent。"
 }

--- a/internal/objects/channel.go
+++ b/internal/objects/channel.go
@@ -128,6 +128,11 @@ type ChannelSettings struct {
 
 	// TransformOptions configures the transform options for the channel.
 	TransformOptions TransformOptions `json:"transformOptions"`
+
+	// PassThroughUserAgent controls whether to pass through the original User-Agent header to upstream AI providers.
+	// When set to nil, it inherits from the global system setting.
+	// When set to true/false, it overrides the global setting.
+	PassThroughUserAgent *bool `json:"passThroughUserAgent,omitempty"`
 }
 
 // DisabledAPIKey 记录被禁用的 API key 信息（敏感，按 credentials 同级保护）

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -84,6 +84,10 @@ const (
 	// SystemKeyVideoStorageSettings is the key used to store video storage settings.
 	// The value is JSON-encoded VideoStorageSettings struct.
 	SystemKeyVideoStorageSettings = "system_video_storage_settings"
+
+	// SystemKeyUserAgentPassThrough is the key used to store the user agent pass-through setting.
+	// When set to true, the system will pass through the original User-Agent header to upstream AI providers.
+	SystemKeyUserAgentPassThrough = "system_user_agent_pass_through"
 )
 
 // SystemGeneralSettings represents general system configuration settings.
@@ -995,6 +999,28 @@ func (s *SystemService) SetVideoStorageSettings(ctx context.Context, settings Vi
 	}
 
 	return nil
+}
+
+// UserAgentPassThrough retrieves the user agent pass-through setting.
+// When enabled, the original User-Agent header from the client request is passed through to upstream AI providers.
+func (s *SystemService) UserAgentPassThrough(ctx context.Context) (bool, error) {
+	value, err := s.getSystemValue(ctx, SystemKeyUserAgentPassThrough)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get user-agent pass-through: %w", err)
+	}
+	return value == "true", nil
+}
+
+// SetUserAgentPassThrough sets the user agent pass-through setting.
+func (s *SystemService) SetUserAgentPassThrough(ctx context.Context, enabled bool) error {
+	strValue := "false"
+	if enabled {
+		strValue = "true"
+	}
+	return s.setSystemValue(ctx, SystemKeyUserAgentPassThrough, strValue)
 }
 
 // UpdateAutoBackupLastRun updates the last backup timestamp and error status.

--- a/internal/server/biz/system_test.go
+++ b/internal/server/biz/system_test.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -746,4 +747,140 @@ func TestSystemService_Initialize_TransactionRollback(t *testing.T) {
 	dsCount, err := client.DataStorage.Query().Count(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0, dsCount)
+}
+
+
+// TestSystemService_UserAgentPassThrough tests the User-Agent pass-through setting.
+// This table-driven test covers: default value, set true/false, round-trip, cache behavior, and database errors.
+func TestSystemService_UserAgentPassThrough(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupCache  xcache.Config
+		setupFunc   func(ctx context.Context, s *SystemService, client *ent.Client) error
+		want        bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "default_value_returns_false",
+			setupCache: xcache.Config{Mode: xcache.ModeMemory},
+			setupFunc:  nil,
+			want:       false,
+		},
+		{
+			name:       "set_true_returns_true",
+			setupCache: xcache.Config{Mode: xcache.ModeMemory},
+			setupFunc: func(ctx context.Context, s *SystemService, client *ent.Client) error {
+				return s.SetUserAgentPassThrough(ctx, true)
+			},
+			want: true,
+		},
+		{
+			name:       "set_false_returns_false",
+			setupCache: xcache.Config{Mode: xcache.ModeMemory},
+			setupFunc: func(ctx context.Context, s *SystemService, client *ent.Client) error {
+				return s.SetUserAgentPassThrough(ctx, false)
+			},
+			want: false,
+		},
+		{
+			name:       "round_trip_toggle",
+			setupCache: xcache.Config{Mode: xcache.ModeMemory},
+			setupFunc: func(ctx context.Context, s *SystemService, client *ent.Client) error {
+				// Start false, set true
+				if err := s.SetUserAgentPassThrough(ctx, true); err != nil {
+					return err
+				}
+				// Verify true
+				val, _ := s.UserAgentPassThrough(ctx)
+				if !val {
+					return fmt.Errorf("expected true after setting")
+				}
+				// Set false
+				if err := s.SetUserAgentPassThrough(ctx, false); err != nil {
+					return err
+				}
+				// Verify false
+				val, _ = s.UserAgentPassThrough(ctx)
+				if val {
+					return fmt.Errorf("expected false after unsetting")
+				}
+				// Set true again
+				return s.SetUserAgentPassThrough(ctx, true)
+			},
+			want: true,
+		},
+}
+
+for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, client := setupTestSystemService(t, tt.setupCache)
+			defer client.Close()
+
+			ctx := context.Background()
+			ctx = ent.NewContext(ctx, client)
+			ctx = authz.WithTestBypass(ctx)
+
+			if tt.setupFunc != nil {
+				if err := tt.setupFunc(ctx, service, client); err != nil {
+					t.Fatalf("setup failed: %v", err)
+				}
+			}
+
+			got, err := service.UserAgentPassThrough(ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got, "UserAgentPassThrough() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSystemService_UserAgentPassThrough_WithCache tests cache behavior specifically.
+func TestSystemService_UserAgentPassThrough_WithCache(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cacheConfig := xcache.Config{
+		Mode: xcache.ModeRedis,
+		Redis: xredis.Config{
+			Addr: mr.Addr(),
+		},
+	}
+
+	service, client := setupTestSystemService(t, cacheConfig)
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	// Set UserAgentPassThrough to true
+	err := service.SetUserAgentPassThrough(ctx, true)
+	require.NoError(t, err)
+
+	// First call should hit database and cache the result
+	uaPassThrough1, err := service.UserAgentPassThrough(ctx)
+	require.NoError(t, err)
+	require.True(t, uaPassThrough1)
+
+	// Second call should hit cache
+	uaPassThrough2, err := service.UserAgentPassThrough(ctx)
+	require.NoError(t, err)
+	require.True(t, uaPassThrough2)
+
+	// Update value should invalidate cache
+	err = service.SetUserAgentPassThrough(ctx, false)
+	require.NoError(t, err)
+
+	// Should get updated value
+	uaPassThrough3, err := service.UserAgentPassThrough(ctx)
+	require.NoError(t, err)
+	require.False(t, uaPassThrough3)
 }

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -83,6 +83,7 @@ type ChannelSettings {
   transformOptions: TransformOptions
   headerOverrideOperations: [OverrideOperation!]! @goField(forceResolver: true)
   bodyOverrideOperations: [OverrideOperation!]! @goField(forceResolver: true)
+  passThroughUserAgent: Boolean
 }
 
 enum CapabilityPolicy {
@@ -114,6 +115,7 @@ input ChannelSettingsInput {
   transformOptions: TransformOptionsInput
   headerOverrideOperations: [OverrideOperationInput!]
   bodyOverrideOperations: [OverrideOperationInput!]
+  passThroughUserAgent: Boolean
 }
 
 type ChannelCredentials {

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -444,6 +444,7 @@ type ComplexityRoot struct {
 		HideMappedModels         func(childComplexity int) int
 		HideOriginalModels       func(childComplexity int) int
 		ModelMappings            func(childComplexity int) int
+		PassThroughUserAgent     func(childComplexity int) int
 		Proxy                    func(childComplexity int) int
 		TransformOptions         func(childComplexity int) int
 	}
@@ -837,6 +838,7 @@ type ComplexityRoot struct {
 		UpdateSystemGeneralSettings          func(childComplexity int, input biz.SystemGeneralSettings) int
 		UpdateSystemModelSettings            func(childComplexity int, input biz.SystemModelSettings) int
 		UpdateUser                           func(childComplexity int, id objects.GUID, input ent.UpdateUserInput) int
+		UpdateUserAgentPassThroughSettings   func(childComplexity int, input UpdateUserAgentPassThroughSettingsInput) int
 		UpdateUserStatus                     func(childComplexity int, id objects.GUID, status user.Status) int
 		UpdateVideoStorageSettings           func(childComplexity int, input biz.VideoStorageSettings) int
 	}
@@ -1082,6 +1084,7 @@ type ComplexityRoot struct {
 		TopRequestsProjects          func(childComplexity int) int
 		Traces                       func(childComplexity int, after *entgql.Cursor[int], first *int, before *entgql.Cursor[int], last *int, orderBy *ent.TraceOrder, where *ent.TraceWhereInput) int
 		UsageLogs                    func(childComplexity int, after *entgql.Cursor[int], first *int, before *entgql.Cursor[int], last *int, orderBy *ent.UsageLogOrder, where *ent.UsageLogWhereInput) int
+		UserAgentPassThroughSettings func(childComplexity int) int
 		Users                        func(childComplexity int, after *entgql.Cursor[int], first *int, before *entgql.Cursor[int], last *int, orderBy *ent.UserOrder, where *ent.UserWhereInput) int
 		VideoStorageSettings         func(childComplexity int) int
 	}
@@ -1602,6 +1605,10 @@ type ComplexityRoot struct {
 		UserRoles                func(childComplexity int) int
 	}
 
+	UserAgentPassThroughSettings struct {
+		Enabled func(childComplexity int) int
+	}
+
 	UserConnection struct {
 		Edges      func(childComplexity int) int
 		PageInfo   func(childComplexity int) int
@@ -1792,6 +1799,7 @@ type MutationResolver interface {
 	TriggerGcCleanup(ctx context.Context) (bool, error)
 	SaveProxyPreset(ctx context.Context, input biz.ProxyPreset) (bool, error)
 	DeleteProxyPreset(ctx context.Context, url string) (bool, error)
+	UpdateUserAgentPassThroughSettings(ctx context.Context, input UpdateUserAgentPassThroughSettingsInput) (bool, error)
 	CreateModel(ctx context.Context, input ent.CreateModelInput) (*ent.Model, error)
 	BulkCreateModels(ctx context.Context, inputs []*ent.CreateModelInput) ([]*ent.Model, error)
 	UpdateModel(ctx context.Context, id objects.GUID, input ent.UpdateModelInput) (*ent.Model, error)
@@ -1895,6 +1903,7 @@ type QueryResolver interface {
 	SystemGeneralSettings(ctx context.Context) (*biz.SystemGeneralSettings, error)
 	VideoStorageSettings(ctx context.Context) (*biz.VideoStorageSettings, error)
 	ProxyPresets(ctx context.Context) ([]*biz.ProxyPreset, error)
+	UserAgentPassThroughSettings(ctx context.Context) (*UserAgentPassThroughSettings, error)
 	FetchModels(ctx context.Context, input biz.FetchModelsInput) (*FetchModelsPayload, error)
 	QueryModels(ctx context.Context, input QueryModelsInput) ([]*biz.ModelIdentityWithStatus, error)
 	QueryModelChannelConnections(ctx context.Context, associations []*objects.ModelAssociation) ([]*biz.ModelChannelConnection, error)
@@ -3338,6 +3347,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ChannelSettings.ModelMappings(childComplexity), true
+	case "ChannelSettings.passThroughUserAgent":
+		if e.complexity.ChannelSettings.PassThroughUserAgent == nil {
+			break
+		}
+
+		return e.complexity.ChannelSettings.PassThroughUserAgent(childComplexity), true
 	case "ChannelSettings.proxy":
 		if e.complexity.ChannelSettings.Proxy == nil {
 			break
@@ -5339,6 +5354,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateUser(childComplexity, args["id"].(objects.GUID), args["input"].(ent.UpdateUserInput)), true
+	case "Mutation.updateUserAgentPassThroughSettings":
+		if e.complexity.Mutation.UpdateUserAgentPassThroughSettings == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateUserAgentPassThroughSettings_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateUserAgentPassThroughSettings(childComplexity, args["input"].(UpdateUserAgentPassThroughSettingsInput)), true
 	case "Mutation.updateUserStatus":
 		if e.complexity.Mutation.UpdateUserStatus == nil {
 			break
@@ -6619,6 +6645,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.UsageLogs(childComplexity, args["after"].(*entgql.Cursor[int]), args["first"].(*int), args["before"].(*entgql.Cursor[int]), args["last"].(*int), args["orderBy"].(*ent.UsageLogOrder), args["where"].(*ent.UsageLogWhereInput)), true
+	case "Query.userAgentPassThroughSettings":
+		if e.complexity.Query.UserAgentPassThroughSettings == nil {
+			break
+		}
+
+		return e.complexity.Query.UserAgentPassThroughSettings(childComplexity), true
 	case "Query.users":
 		if e.complexity.Query.Users == nil {
 			break
@@ -8673,6 +8705,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.User.UserRoles(childComplexity), true
 
+	case "UserAgentPassThroughSettings.enabled":
+		if e.complexity.UserAgentPassThroughSettings.Enabled == nil {
+			break
+		}
+
+		return e.complexity.UserAgentPassThroughSettings.Enabled(childComplexity), true
+
 	case "UserConnection.edges":
 		if e.complexity.UserConnection.Edges == nil {
 			break
@@ -9128,6 +9167,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateThreadInput,
 		ec.unmarshalInputUpdateTraceInput,
 		ec.unmarshalInputUpdateUsageLogInput,
+		ec.unmarshalInputUpdateUserAgentPassThroughSettingsInput,
 		ec.unmarshalInputUpdateUserInput,
 		ec.unmarshalInputUpdateVideoStorageSettingsInput,
 		ec.unmarshalInputUsageLogOrder,
@@ -10493,6 +10533,17 @@ func (ec *executionContext) field_Mutation_updateSystemModelSettings_args(ctx co
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateSystemModelSettingsInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐSystemModelSettings)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateUserAgentPassThroughSettings_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateUserAgentPassThroughSettingsInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpdateUserAgentPassThroughSettingsInput)
 	if err != nil {
 		return nil, err
 	}
@@ -15475,6 +15526,8 @@ func (ec *executionContext) fieldContext_Channel_settings(_ context.Context, fie
 				return ec.fieldContext_ChannelSettings_headerOverrideOperations(ctx, field)
 			case "bodyOverrideOperations":
 				return ec.fieldContext_ChannelSettings_bodyOverrideOperations(ctx, field)
+			case "passThroughUserAgent":
+				return ec.fieldContext_ChannelSettings_passThroughUserAgent(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ChannelSettings", field.Name)
 		},
@@ -19271,6 +19324,35 @@ func (ec *executionContext) fieldContext_ChannelSettings_bodyOverrideOperations(
 				return ec.fieldContext_OverrideOperation_condition(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OverrideOperation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ChannelSettings_passThroughUserAgent(ctx context.Context, field graphql.CollectedField, obj *objects.ChannelSettings) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ChannelSettings_passThroughUserAgent,
+		func(ctx context.Context) (any, error) {
+			return obj.PassThroughUserAgent, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ChannelSettings_passThroughUserAgent(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ChannelSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -27797,6 +27879,47 @@ func (ec *executionContext) fieldContext_Mutation_deleteProxyPreset(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_updateUserAgentPassThroughSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_updateUserAgentPassThroughSettings,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().UpdateUserAgentPassThroughSettings(ctx, fc.Args["input"].(UpdateUserAgentPassThroughSettingsInput))
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateUserAgentPassThroughSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateUserAgentPassThroughSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createModel(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -35286,6 +35409,39 @@ func (ec *executionContext) fieldContext_Query_proxyPresets(_ context.Context, f
 				return ec.fieldContext_ProxyPreset_password(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProxyPreset", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_userAgentPassThroughSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_userAgentPassThroughSettings,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().UserAgentPassThroughSettings(ctx)
+		},
+		nil,
+		ec.marshalNUserAgentPassThroughSettings2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUserAgentPassThroughSettings,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_userAgentPassThroughSettings(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_UserAgentPassThroughSettings_enabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserAgentPassThroughSettings", field.Name)
 		},
 	}
 	return fc, nil
@@ -46474,6 +46630,35 @@ func (ec *executionContext) fieldContext_User_userRoles(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _UserAgentPassThroughSettings_enabled(ctx context.Context, field graphql.CollectedField, obj *UserAgentPassThroughSettings) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserAgentPassThroughSettings_enabled,
+		func(ctx context.Context) (any, error) {
+			return obj.Enabled, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserAgentPassThroughSettings_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserAgentPassThroughSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserConnection_edges(ctx context.Context, field graphql.CollectedField, obj *ent.UserConnection) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -53458,7 +53643,7 @@ func (ec *executionContext) unmarshalInputChannelSettingsInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"extraModelPrefix", "modelMappings", "autoTrimedModelPrefixes", "hideOriginalModels", "hideMappedModels", "proxy", "transformOptions", "headerOverrideOperations", "bodyOverrideOperations"}
+	fieldsInOrder := [...]string{"extraModelPrefix", "modelMappings", "autoTrimedModelPrefixes", "hideOriginalModels", "hideMappedModels", "proxy", "transformOptions", "headerOverrideOperations", "bodyOverrideOperations", "passThroughUserAgent"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -53528,6 +53713,13 @@ func (ec *executionContext) unmarshalInputChannelSettingsInput(ctx context.Conte
 				return it, err
 			}
 			it.BodyOverrideOperations = data
+		case "passThroughUserAgent":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("passThroughUserAgent"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PassThroughUserAgent = data
 		}
 	}
 
@@ -68410,6 +68602,33 @@ func (ec *executionContext) unmarshalInputUpdateUsageLogInput(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateUserAgentPassThroughSettingsInput(ctx context.Context, obj any) (UpdateUserAgentPassThroughSettingsInput, error) {
+	var it UpdateUserAgentPassThroughSettingsInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"enabled"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "enabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Enabled = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateUserInput(ctx context.Context, obj any) (ent.UpdateUserInput, error) {
 	var it ent.UpdateUserInput
 	asMap := map[string]any{}
@@ -75506,6 +75725,8 @@ func (ec *executionContext) _ChannelSettings(ctx context.Context, sel ast.Select
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "passThroughUserAgent":
+			out.Values[i] = ec._ChannelSettings_passThroughUserAgent(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -78382,6 +78603,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteProxyPreset":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteProxyPreset(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateUserAgentPassThroughSettings":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateUserAgentPassThroughSettings(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -81587,6 +81815,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_proxyPresets(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "userAgentPassThroughSettings":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_userAgentPassThroughSettings(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -87230,6 +87480,45 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var userAgentPassThroughSettingsImplementors = []string{"UserAgentPassThroughSettings"}
+
+func (ec *executionContext) _UserAgentPassThroughSettings(ctx context.Context, sel ast.SelectionSet, obj *UserAgentPassThroughSettings) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, userAgentPassThroughSettingsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UserAgentPassThroughSettings")
+		case "enabled":
+			out.Values[i] = ec._UserAgentPassThroughSettings_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -93138,6 +93427,11 @@ func (ec *executionContext) unmarshalNUpdateSystemModelSettingsInput2githubᚗco
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNUpdateUserAgentPassThroughSettingsInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpdateUserAgentPassThroughSettingsInput(ctx context.Context, v any) (UpdateUserAgentPassThroughSettingsInput, error) {
+	res, err := ec.unmarshalInputUpdateUserAgentPassThroughSettingsInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNUpdateUserInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋentᚐUpdateUserInput(ctx context.Context, v any) (ent.UpdateUserInput, error) {
 	res, err := ec.unmarshalInputUpdateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -93221,6 +93515,20 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋin
 		return graphql.Null
 	}
 	return ec._User(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNUserAgentPassThroughSettings2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUserAgentPassThroughSettings(ctx context.Context, sel ast.SelectionSet, v UserAgentPassThroughSettings) graphql.Marshaler {
+	return ec._UserAgentPassThroughSettings(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUserAgentPassThroughSettings2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUserAgentPassThroughSettings(ctx context.Context, sel ast.SelectionSet, v *UserAgentPassThroughSettings) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UserAgentPassThroughSettings(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNUserConnection2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋentᚐUserConnection(ctx context.Context, sel ast.SelectionSet, v ent.UserConnection) graphql.Marshaler {

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -441,6 +441,14 @@ type UpdateProjectUserInput struct {
 	RemoveRoleIDs []*objects.GUID `json:"removeRoleIDs,omitempty"`
 }
 
+type UpdateUserAgentPassThroughSettingsInput struct {
+	Enabled bool `json:"enabled"`
+}
+
+type UserAgentPassThroughSettings struct {
+	Enabled bool `json:"enabled"`
+}
+
 type VersionCheck struct {
 	CurrentVersion string `json:"currentVersion"`
 	LatestVersion  string `json:"latestVersion"`

--- a/internal/server/gql/system.graphql
+++ b/internal/server/gql/system.graphql
@@ -193,6 +193,14 @@ input UpdateVideoStorageSettingsInput {
   scanIntervalMinutes: Int
   scanLimit: Int
 }
+type UserAgentPassThroughSettings {
+  enabled: Boolean!
+}
+
+input UpdateUserAgentPassThroughSettingsInput {
+  enabled: Boolean!
+}
+
 
 type ProxyPreset {
   url: String!
@@ -222,6 +230,7 @@ extend type Mutation {
   triggerGcCleanup: Boolean!
   saveProxyPreset(input: SaveProxyPresetInput!): Boolean!
   deleteProxyPreset(url: String!): Boolean!
+  updateUserAgentPassThroughSettings(input: UpdateUserAgentPassThroughSettingsInput!): Boolean!
 }
 
 type SystemVersion {
@@ -254,4 +263,5 @@ extend type Query {
   systemGeneralSettings: SystemGeneralSettings!
   videoStorageSettings: VideoStorageSettings!
   proxyPresets: [ProxyPreset!]!
+  userAgentPassThroughSettings: UserAgentPassThroughSettings!
 }

--- a/internal/server/gql/system.resolvers.go
+++ b/internal/server/gql/system.resolvers.go
@@ -189,6 +189,16 @@ func (r *mutationResolver) DeleteProxyPreset(ctx context.Context, url string) (b
 	return true, nil
 }
 
+// UpdateUserAgentPassThroughSettings is the resolver for the updateUserAgentPassThroughSettings field.
+func (r *mutationResolver) UpdateUserAgentPassThroughSettings(ctx context.Context, input UpdateUserAgentPassThroughSettingsInput) (bool, error) {
+	err := r.systemService.SetUserAgentPassThrough(ctx, input.Enabled)
+	if err != nil {
+		return false, fmt.Errorf("failed to update user-agent pass-through settings: %w", err)
+	}
+
+	return true, nil
+}
+
 // SystemStatus is the resolver for the systemStatus field.
 func (r *queryResolver) SystemStatus(ctx context.Context) (*SystemStatus, error) {
 	isInitialized, err := r.systemService.IsInitialized(ctx)
@@ -337,4 +347,16 @@ func (r *queryResolver) ProxyPresets(ctx context.Context) ([]*biz.ProxyPreset, e
 	}
 
 	return lo.ToSlicePtr(presets), nil
+}
+
+// UserAgentPassThroughSettings is the resolver for the userAgentPassThroughSettings field.
+func (r *queryResolver) UserAgentPassThroughSettings(ctx context.Context) (*UserAgentPassThroughSettings, error) {
+	enabled, err := r.systemService.UserAgentPassThrough(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user-agent pass-through settings: %w", err)
+	}
+
+	return &UserAgentPassThroughSettings{
+		Enabled: enabled,
+	}, nil
 }

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -213,6 +213,9 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 	middlewares = append(middlewares,
 		applyOverrideRequestBody(outbound),
 		applyOverrideRequestHeaders(outbound),
+		// applyUserAgentPassThrough runs after header overrides to ensure that when
+		// pass-through is enabled, the original client's User-Agent takes precedence.
+		applyUserAgentPassThrough(outbound, processor.SystemService),
 
 		// Unified performance tracking middleware.
 		withPerformanceRecording(outbound),

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -316,8 +316,6 @@ func applyUserAgentPassThrough(outbound *PersistentOutboundTransformer, systemSe
 			}
 		}
 
-		request.PassThroughUserAgent = &passThroughEnabled
-
 		// Handle User-Agent header based on pass-through setting
 		// This must be done here (before persistRequestExecution) to ensure
 		// the correct User-Agent is logged in request execution records.
@@ -336,7 +334,6 @@ func applyUserAgentPassThrough(outbound *PersistentOutboundTransformer, systemSe
 			// Pass-through disabled: use AxonHub's default User-Agent
 			request.Headers.Set("User-Agent", "axonhub/1.0")
 		}
-
 		return request, nil
 	})
 }

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
@@ -288,6 +289,42 @@ func applyOverrideRequestHeaders(outbound *PersistentOutboundTransformer) pipeli
 
 		for _, op := range overrideHeaders {
 			applyOverrideOperationToHeaders(ctx, request.Headers, op, renderCtx)
+		}
+
+		return request, nil
+	})
+}
+
+// applyUserAgentPassThrough creates a middleware that applies the User-Agent pass-through setting.
+func applyUserAgentPassThrough(outbound *PersistentOutboundTransformer, systemService *biz.SystemService) pipeline.Middleware {
+	return pipeline.OnRawRequest("user-agent-pass-through", func(ctx context.Context, request *httpclient.Request) (*httpclient.Request, error) {
+		channel := outbound.GetCurrentChannel()
+		if channel == nil {
+			return request, nil
+		}
+
+		var passThroughEnabled bool
+		if channel.Settings != nil && channel.Settings.PassThroughUserAgent != nil {
+			passThroughEnabled = *channel.Settings.PassThroughUserAgent
+		} else {
+			globalPassThrough, err := systemService.UserAgentPassThrough(ctx)
+			if err != nil {
+				log.Warn(ctx, "failed to get global user agent pass through setting", log.Cause(err))
+				passThroughEnabled = false
+			} else {
+				passThroughEnabled = globalPassThrough
+			}
+		}
+
+		request.PassThroughUserAgent = &passThroughEnabled
+
+		if passThroughEnabled && outbound.state.LlmRequest != nil && outbound.state.LlmRequest.RawRequest != nil {
+			if clientUA := outbound.state.LlmRequest.RawRequest.Headers.Get("User-Agent"); clientUA != "" {
+				if request.Headers == nil {
+					request.Headers = make(http.Header)
+				}
+				request.Headers.Set("User-Agent", clientUA)
+			}
 		}
 
 		return request, nil

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -318,13 +318,23 @@ func applyUserAgentPassThrough(outbound *PersistentOutboundTransformer, systemSe
 
 		request.PassThroughUserAgent = &passThroughEnabled
 
-		if passThroughEnabled && outbound.state.LlmRequest != nil && outbound.state.LlmRequest.RawRequest != nil {
-			if clientUA := outbound.state.LlmRequest.RawRequest.Headers.Get("User-Agent"); clientUA != "" {
-				if request.Headers == nil {
-					request.Headers = make(http.Header)
+		// Handle User-Agent header based on pass-through setting
+		// This must be done here (before persistRequestExecution) to ensure
+		// the correct User-Agent is logged in request execution records.
+		if request.Headers == nil {
+			request.Headers = make(http.Header)
+		}
+
+		if passThroughEnabled {
+			// Pass-through enabled: use the original client's User-Agent
+			if outbound.state.LlmRequest != nil && outbound.state.LlmRequest.RawRequest != nil {
+				if clientUA := outbound.state.LlmRequest.RawRequest.Headers.Get("User-Agent"); clientUA != "" {
+					request.Headers.Set("User-Agent", clientUA)
 				}
-				request.Headers.Set("User-Agent", clientUA)
 			}
+		} else {
+			// Pass-through disabled: use AxonHub's default User-Agent
+			request.Headers.Set("User-Agent", "axonhub/1.0")
 		}
 
 		return request, nil

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -1797,3 +1797,151 @@ func TestIssue632Override(t *testing.T) {
 		})
 	}
 }
+// TestApplyUserAgentPassThrough tests the User-Agent pass-through middleware.
+func TestApplyUserAgentPassThrough(t *testing.T) {
+	tests := []struct {
+		name             string
+		channelUASetting *bool // Channel-level override
+		globalUAEnabled  bool  // System-level setting
+		clientUA         string
+		wantPassThrough  *bool // Expected PassThroughUserAgent on request
+		wantUAHeader     string
+	}{
+		{
+			name:             "channel_disabled_ignores_global",
+			channelUASetting: boolPtr(false),
+			globalUAEnabled:  true,
+			clientUA:         "Client/1.0",
+			wantPassThrough:  boolPtr(false),
+			wantUAHeader:     "",
+		},
+		{
+			name:             "channel_enabled_ignores_global",
+			channelUASetting: boolPtr(true),
+			globalUAEnabled:  false,
+			clientUA:         "Client/1.0",
+			wantPassThrough:  boolPtr(true),
+			wantUAHeader:     "Client/1.0",
+		},
+		{
+			name:             "channel_nil_inherits_global_disabled",
+			channelUASetting: nil,
+			globalUAEnabled:  false,
+			clientUA:         "Client/1.0",
+			wantPassThrough:  boolPtr(false),
+			wantUAHeader:     "",
+		},
+		{
+			name:             "channel_nil_inherits_global_enabled",
+			channelUASetting: nil,
+			globalUAEnabled:  true,
+			clientUA:         "Client/1.0",
+			wantPassThrough:  boolPtr(true),
+			wantUAHeader:     "Client/1.0",
+		},
+		{
+			name:             "enabled_but_no_client_ua",
+			channelUASetting: boolPtr(true),
+			globalUAEnabled:  true,
+			clientUA:         "",
+			wantPassThrough:  boolPtr(true),
+			wantUAHeader:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, client := setupTest(t)
+
+			// Create real system service with test database
+			systemService := newTestSystemService(client)
+
+			// Set global User-Agent pass-through setting
+			err := systemService.SetUserAgentPassThrough(ctx, tt.globalUAEnabled)
+			require.NoError(t, err)
+
+			// Create mock channel with optional pass-through setting
+			channelSettings := &objects.ChannelSettings{}
+			if tt.channelUASetting != nil {
+				channelSettings.PassThroughUserAgent = tt.channelUASetting
+			}
+
+			channel := &biz.Channel{
+				Channel: &ent.Channel{
+					ID:       1,
+					Name:     "test-channel",
+					Settings: channelSettings,
+				},
+				Outbound: &mockTransformer{},
+			}
+
+			// Create raw request with client UA - RawRequest is *httpclient.Request in llm.Request
+			rawHeaders := make(http.Header)
+			if tt.clientUA != "" {
+				rawHeaders.Set("User-Agent", tt.clientUA)
+			}
+
+			llmRequest := &llm.Request{
+				Model: "gpt-4",
+				RawRequest: &httpclient.Request{
+					Headers: rawHeaders,
+				},
+			}
+
+			// Create outbound transformer
+			outbound := &PersistentOutboundTransformer{
+				wrapped: &mockTransformer{},
+				state: &PersistenceState{
+					CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+					LlmRequest:       llmRequest,
+				},
+			}
+
+			// Create middleware
+			middleware := applyUserAgentPassThrough(outbound, systemService)
+
+			// Execute middleware
+			rawRequest := &httpclient.Request{
+				Headers: make(http.Header),
+			}
+			processedRequest, err := middleware.OnOutboundRawRequest(ctx, rawRequest)
+
+			require.NoError(t, err)
+			require.NotNil(t, processedRequest)
+
+			// Verify PassThroughUserAgent flag
+			require.Equal(t, tt.wantPassThrough, processedRequest.PassThroughUserAgent)
+
+			// Verify User-Agent header when pass-through is enabled
+			if tt.wantUAHeader != "" {
+				require.Equal(t, tt.wantUAHeader, processedRequest.Headers.Get("User-Agent"))
+			}
+		})
+	}
+}
+
+// TestApplyUserAgentPassThrough_NoChannel tests the middleware when no channel is selected.
+func TestApplyUserAgentPassThrough_NoChannel(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	// Create real system service with test database
+	systemService := newTestSystemService(client)
+
+	// Create outbound without a channel
+	outbound := &PersistentOutboundTransformer{
+		wrapped: &mockTransformer{},
+		state:   &PersistenceState{},
+	}
+
+	// Create middleware
+	middleware := applyUserAgentPassThrough(outbound, systemService)
+
+	// Execute middleware
+	rawRequest := &httpclient.Request{
+		Headers: make(http.Header),
+	}
+	processedRequest, err := middleware.OnOutboundRawRequest(ctx, rawRequest)
+	require.NoError(t, err)
+	require.NotNil(t, processedRequest)
+	require.Nil(t, processedRequest.PassThroughUserAgent) // Should remain unset
+}

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -1813,7 +1813,7 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 			globalUAEnabled:  true,
 			clientUA:         "Client/1.0",
 			wantPassThrough:  boolPtr(false),
-			wantUAHeader:     "",
+			wantUAHeader:     "axonhub/1.0", // Pass-through disabled: should use AxonHub default
 		},
 		{
 			name:             "channel_enabled_ignores_global",
@@ -1829,7 +1829,7 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 			globalUAEnabled:  false,
 			clientUA:         "Client/1.0",
 			wantPassThrough:  boolPtr(false),
-			wantUAHeader:     "",
+			wantUAHeader:     "axonhub/1.0", // Pass-through disabled: should use AxonHub default
 		},
 		{
 			name:             "channel_nil_inherits_global_enabled",
@@ -1912,9 +1912,12 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 			// Verify PassThroughUserAgent flag
 			require.Equal(t, tt.wantPassThrough, processedRequest.PassThroughUserAgent)
 
-			// Verify User-Agent header when pass-through is enabled
+			// Verify User-Agent header is set correctly
 			if tt.wantUAHeader != "" {
 				require.Equal(t, tt.wantUAHeader, processedRequest.Headers.Get("User-Agent"))
+			} else {
+				// When no User-Agent expected, header should be empty
+				require.Empty(t, processedRequest.Headers.Get("User-Agent"))
 			}
 		})
 	}

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -1804,39 +1804,34 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 		channelUASetting *bool // Channel-level override
 		globalUAEnabled  bool  // System-level setting
 		clientUA         string
-		wantPassThrough  *bool // Expected PassThroughUserAgent on request
 		wantUAHeader     string
 	}{
 		{
-			name:             "channel_disabled_ignores_global",
-			channelUASetting: boolPtr(false),
-			globalUAEnabled:  true,
-			clientUA:         "Client/1.0",
-			wantPassThrough:  boolPtr(false),
-			wantUAHeader:     "axonhub/1.0", // Pass-through disabled: should use AxonHub default
-		},
-		{
-			name:             "channel_enabled_ignores_global",
-			channelUASetting: boolPtr(true),
-			globalUAEnabled:  false,
-			clientUA:         "Client/1.0",
-			wantPassThrough:  boolPtr(true),
-			wantUAHeader:     "Client/1.0",
-		},
-		{
-			name:             "channel_nil_inherits_global_disabled",
-			channelUASetting: nil,
-			globalUAEnabled:  false,
-			clientUA:         "Client/1.0",
-			wantPassThrough:  boolPtr(false),
-			wantUAHeader:     "axonhub/1.0", // Pass-through disabled: should use AxonHub default
-		},
+		name:             "channel_disabled_ignores_global",
+		channelUASetting: boolPtr(false),
+		globalUAEnabled:  true,
+		clientUA:         "Client/1.0",
+		wantUAHeader:     "axonhub/1.0", // Pass-through disabled: middleware sets default UA
+	},
+	{
+		name:             "channel_enabled_ignores_global",
+		channelUASetting: boolPtr(true),
+		globalUAEnabled:  false,
+		clientUA:         "Client/1.0",
+		wantUAHeader:     "Client/1.0",
+	},
+	{
+		name:             "channel_nil_inherits_global_disabled",
+		channelUASetting: nil,
+		globalUAEnabled:  false,
+		clientUA:         "Client/1.0",
+		wantUAHeader:     "axonhub/1.0", // Pass-through disabled: middleware sets default UA
+	},
 		{
 			name:             "channel_nil_inherits_global_enabled",
 			channelUASetting: nil,
 			globalUAEnabled:  true,
 			clientUA:         "Client/1.0",
-			wantPassThrough:  boolPtr(true),
 			wantUAHeader:     "Client/1.0",
 		},
 		{
@@ -1844,7 +1839,6 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 			channelUASetting: boolPtr(true),
 			globalUAEnabled:  true,
 			clientUA:         "",
-			wantPassThrough:  boolPtr(true),
 			wantUAHeader:     "",
 		},
 	}
@@ -1909,9 +1903,6 @@ func TestApplyUserAgentPassThrough(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, processedRequest)
 
-			// Verify PassThroughUserAgent flag
-			require.Equal(t, tt.wantPassThrough, processedRequest.PassThroughUserAgent)
-
 			// Verify User-Agent header is set correctly
 			if tt.wantUAHeader != "" {
 				require.Equal(t, tt.wantUAHeader, processedRequest.Headers.Get("User-Agent"))
@@ -1946,5 +1937,4 @@ func TestApplyUserAgentPassThrough_NoChannel(t *testing.T) {
 	processedRequest, err := middleware.OnOutboundRawRequest(ctx, rawRequest)
 	require.NoError(t, err)
 	require.NotNil(t, processedRequest)
-	require.Nil(t, processedRequest.PassThroughUserAgent) // Should remain unset
 }

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -339,12 +339,9 @@ func BuildHttpRequest(
 	if httpReq.Header == nil {
 		httpReq.Header = make(http.Header)
 	}
-	// Handle User-Agent header based on pass-through setting
-	if request.PassThroughUserAgent != nil && !*request.PassThroughUserAgent {
-		// Pass-through is explicitly disabled, always set AxonHub default
-		httpReq.Header.Set("User-Agent", "axonhub/1.0")
-	} else if httpReq.Header.Get("User-Agent") == "" {
-		// No User-Agent set (or pass-through is nil/undefined), use default
+	// Handle User-Agent header - only set default if not already present
+	if httpReq.Header.Get("User-Agent") == "" {
+		// No User-Agent set, use default
 		httpReq.Header.Set("User-Agent", "axonhub/1.0")
 	}
 

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -339,8 +339,12 @@ func BuildHttpRequest(
 	if httpReq.Header == nil {
 		httpReq.Header = make(http.Header)
 	}
-
-	if httpReq.Header.Get("User-Agent") == "" {
+	// Handle User-Agent header based on pass-through setting
+	if request.PassThroughUserAgent != nil && !*request.PassThroughUserAgent {
+		// Pass-through is explicitly disabled, always set AxonHub default
+		httpReq.Header.Set("User-Agent", "axonhub/1.0")
+	} else if httpReq.Header.Get("User-Agent") == "" {
+		// No User-Agent set (or pass-through is nil/undefined), use default
 		httpReq.Header.Set("User-Agent", "axonhub/1.0")
 	}
 

--- a/llm/httpclient/client_test.go
+++ b/llm/httpclient/client_test.go
@@ -640,61 +640,56 @@ func TestBuildHttpRequest_UserAgentPassThrough(t *testing.T) {
 		request       *Request
 		wantUserAgent string
 	}{
-		{
-			name: "pass_through_disabled_uses_default_ua",
-			request: &Request{
-				Method: http.MethodPost,
-				URL:    "https://api.example.com/test",
-				Headers: http.Header{
-					"User-Agent": []string{"ClientUserAgent/1.0"},
-				},
-				PassThroughUserAgent: boolPtr(false),
+	{
+		name: "existing_ua_is_preserved",
+		request: &Request{
+			Method: http.MethodPost,
+			URL:    "https://api.example.com/test",
+			Headers: http.Header{
+				"User-Agent": []string{"ClientUserAgent/1.0"},
 			},
-			wantUserAgent: "axonhub/1.0",
 		},
-		{
-			name: "pass_through_nil_with_existing_ua_uses_existing",
-			request: &Request{
-				Method: http.MethodPost,
-				URL:    "https://api.example.com/test",
-				Headers: http.Header{
-					"User-Agent": []string{"ExistingClient/2.0"},
-				},
-				PassThroughUserAgent: nil,
+		wantUserAgent: "ClientUserAgent/1.0",
+	},
+	{
+		name: "another_existing_ua_is_preserved",
+		request: &Request{
+			Method: http.MethodPost,
+			URL:    "https://api.example.com/test",
+			Headers: http.Header{
+				"User-Agent": []string{"ExistingClient/2.0"},
 			},
-			wantUserAgent: "ExistingClient/2.0",
 		},
-		{
-			name: "no_ua_set_uses_default",
-			request: &Request{
-				Method:               http.MethodPost,
-				URL:                  "https://api.example.com/test",
-				PassThroughUserAgent: nil,
+		wantUserAgent: "ExistingClient/2.0",
+	},
+	{
+		name: "no_ua_set_uses_default",
+		request: &Request{
+			Method: http.MethodPost,
+			URL:    "https://api.example.com/test",
+		},
+		wantUserAgent: "axonhub/1.0",
+	},
+	{
+		name: "third_existing_ua_is_preserved",
+		request: &Request{
+			Method: http.MethodPost,
+			URL:    "https://api.example.com/test",
+			Headers: http.Header{
+				"User-Agent": []string{"PassedThrough/3.0"},
 			},
-			wantUserAgent: "axonhub/1.0",
 		},
-		{
-			name: "pass_through_true_with_existing_ua_uses_existing",
-			request: &Request{
-				Method: http.MethodPost,
-				URL:    "https://api.example.com/test",
-				Headers: http.Header{
-					"User-Agent": []string{"PassedThrough/3.0"},
-				},
-				PassThroughUserAgent: boolPtr(true),
-			},
-			wantUserAgent: "PassedThrough/3.0",
+		wantUserAgent: "PassedThrough/3.0",
+	},
+	{
+		name: "empty_ua_uses_default",
+		request: &Request{
+			Method: http.MethodPost,
+			URL:    "https://api.example.com/test",
 		},
-		{
-			name: "pass_through_true_with_no_ua_uses_default",
-			request: &Request{
-				Method:               http.MethodPost,
-				URL:                  "https://api.example.com/test",
-				PassThroughUserAgent: boolPtr(true),
-			},
-			wantUserAgent: "axonhub/1.0",
-		},
-	}
+		wantUserAgent: "axonhub/1.0",
+	},
+}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/llm/httpclient/client_test.go
+++ b/llm/httpclient/client_test.go
@@ -627,3 +627,87 @@ data: [DONE]
 		t.Errorf("Err() should return nil initially")
 	}
 }
+
+
+// TestBuildHttpRequest_UserAgentPassThrough tests the User-Agent handling with pass-through settings.
+func TestBuildHttpRequest_UserAgentPassThrough(t *testing.T) {
+	client := &HttpClient{
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	tests := []struct {
+		name          string
+		request       *Request
+		wantUserAgent string
+	}{
+		{
+			name: "pass_through_disabled_uses_default_ua",
+			request: &Request{
+				Method: http.MethodPost,
+				URL:    "https://api.example.com/test",
+				Headers: http.Header{
+					"User-Agent": []string{"ClientUserAgent/1.0"},
+				},
+				PassThroughUserAgent: boolPtr(false),
+			},
+			wantUserAgent: "axonhub/1.0",
+		},
+		{
+			name: "pass_through_nil_with_existing_ua_uses_existing",
+			request: &Request{
+				Method: http.MethodPost,
+				URL:    "https://api.example.com/test",
+				Headers: http.Header{
+					"User-Agent": []string{"ExistingClient/2.0"},
+				},
+				PassThroughUserAgent: nil,
+			},
+			wantUserAgent: "ExistingClient/2.0",
+		},
+		{
+			name: "no_ua_set_uses_default",
+			request: &Request{
+				Method:               http.MethodPost,
+				URL:                  "https://api.example.com/test",
+				PassThroughUserAgent: nil,
+			},
+			wantUserAgent: "axonhub/1.0",
+		},
+		{
+			name: "pass_through_true_with_existing_ua_uses_existing",
+			request: &Request{
+				Method: http.MethodPost,
+				URL:    "https://api.example.com/test",
+				Headers: http.Header{
+					"User-Agent": []string{"PassedThrough/3.0"},
+				},
+				PassThroughUserAgent: boolPtr(true),
+			},
+			wantUserAgent: "PassedThrough/3.0",
+		},
+		{
+			name: "pass_through_true_with_no_ua_uses_default",
+			request: &Request{
+				Method:               http.MethodPost,
+				URL:                  "https://api.example.com/test",
+				PassThroughUserAgent: boolPtr(true),
+			},
+			wantUserAgent: "axonhub/1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := client.BuildHttpRequest(t.Context(), tt.request)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			ua := result.Header.Get("User-Agent")
+			require.Equal(t, tt.wantUserAgent, ua)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -56,10 +56,6 @@ type Request struct {
 	// inbound request from being merged into this request during MergeInboundRequest.
 	SkipInboundQueryMerge bool `json:"-"`
 
-	// PassThroughUserAgent controls whether to pass through the original User-Agent header.
-	// When set to true, the original User-Agent from the client request will be used for upstream requests.
-	// When set to false, the User-Agent will be set to the AxonHub default.
-	PassThroughUserAgent *bool `json:"-"`
 }
 
 

--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -55,7 +55,13 @@ type Request struct {
 	// SkipInboundQueryMerge when set to true, prevents query parameters from the original
 	// inbound request from being merged into this request during MergeInboundRequest.
 	SkipInboundQueryMerge bool `json:"-"`
+
+	// PassThroughUserAgent controls whether to pass through the original User-Agent header.
+	// When set to true, the original User-Agent from the client request will be used for upstream requests.
+	// When set to false, the User-Agent will be set to the AxonHub default.
+	PassThroughUserAgent *bool `json:"-"`
 }
+
 
 // AuthConfig represents authentication configuration.
 type AuthConfig struct {


### PR DESCRIPTION
Clean implementation of user agent pass-through settings for channels.

Replaces #1204 which had Git contamination issues.

## Changes
- Add user agent pass-through configuration options
- Allow channels to forward original client user agent to upstream providers