### PR TITLE
feat(system): add prefer language during initialization

### DIFF
--- a/frontend/src/features/auth/data/initialization.ts
+++ b/frontend/src/features/auth/data/initialization.ts
@@ -14,6 +14,7 @@ export interface InitializeSystemInput {
   ownerFirstName: string;
   ownerLastName: string;
   brandName: string;
+  preferLanguage?: string;
 }
 
 export interface InitializeSystemPayload {

--- a/frontend/src/features/auth/initialization/components/initialization-form.tsx
+++ b/frontend/src/features/auth/initialization/components/initialization-form.tsx
@@ -9,6 +9,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input';
 import { PasswordInput } from '@/components/password-input';
 import { useInitializeSystem } from '@/features/auth/data/initialization';
+import i18n from '@/lib/i18n';
 
 type InitializationFormProps = HTMLAttributes<HTMLFormElement>;
 
@@ -57,6 +58,7 @@ export function InitializationForm({ className, ...props }: InitializationFormPr
       ownerFirstName: data.ownerFirstName,
       ownerLastName: data.ownerLastName,
       brandName: data.brandName,
+      preferLanguage: i18n.language,
     };
     initializeSystemMutation.mutate(input);
   }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -123,6 +123,7 @@ export const systemApi = {
     ownerFirstName: string;
     ownerLastName: string;
     brandName: string;
+    preferLanguage?: string;
   }): Promise<{ success: boolean; message: string }> =>
     apiRequest('/admin/system/initialize', {
       method: 'POST',

--- a/internal/server/api/system.go
+++ b/internal/server/api/system.go
@@ -54,6 +54,7 @@ type InitializeSystemRequest struct {
 	OwnerFirstName string `json:"ownerFirstName" binding:"required"`
 	OwnerLastName  string `json:"ownerLastName"  binding:"required"`
 	BrandName      string `json:"brandName"      binding:"required"`
+	PreferLanguage string `json:"preferLanguage,omitempty"`
 }
 
 // InitializeSystemResponse 系统初始化响应.
@@ -125,6 +126,7 @@ func (h *SystemHandlers) InitializeSystem(c *gin.Context) {
 		OwnerFirstName: req.OwnerFirstName,
 		OwnerLastName:  req.OwnerLastName,
 		BrandName:      req.BrandName,
+		PreferLanguage: req.PreferLanguage,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, InitializeSystemResponse{

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -365,6 +365,7 @@ type InitializeSystemParams struct {
 	OwnerFirstName string
 	OwnerLastName  string
 	BrandName      string
+	PreferLanguage string
 }
 
 // Initialize initializes the system with a secret key and sets the initialized flag.
@@ -407,11 +408,16 @@ func (s *SystemService) Initialize(ctx context.Context, params *InitializeSystem
 	}
 
 	// Create owner user.
+	preferLanguage := params.PreferLanguage
+	if preferLanguage == "" {
+		preferLanguage = "en" // Default to English if not specified
+	}
 	user, err := tx.User.Create().
 		SetEmail(params.OwnerEmail).
 		SetPassword(hashedPassword).
 		SetFirstName(params.OwnerFirstName).
 		SetLastName(params.OwnerLastName).
+		SetPreferLanguage(preferLanguage).
 		SetIsOwner(true).
 		SetScopes([]string{"*"}). // Give owner all scopes
 		Save(ctx)


### PR DESCRIPTION
Captures the user's language preference during system initialization and sets it on the owner account. Defaults to English if not specified.

现在首次登录后，自动切换到英文了，导致无法查看到中文的引导教程（要关闭教程弹窗才能切换语言）。