### PR TITLE
Add OpenAI GET /v1/models/{model} endpoint

### DIFF
--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -325,6 +325,15 @@ type OpenAIModel struct {
 	Type            string        `json:"type,omitempty"`
 }
 
+const (
+	openAIModelObjectType         = "model"
+	openAIErrorCodeInternalServer = "internal_server_error"
+	openAIErrorCodeModelNotFound  = "model_not_found"
+	openAIErrorTypeServer         = "server_error"
+	openAIErrorTypeInvalidRequest = "invalid_request_error"
+	openAIErrorParamModel         = "model"
+)
+
 func parseOpenAIModelInclude(includeParam string) (map[string]bool, bool) {
 	var (
 		include      map[string]bool
@@ -362,7 +371,7 @@ func parseOpenAIModelInclude(includeParam string) (map[string]bool, bool) {
 func convertModelFacadeToOpenAIModel(m biz.ModelFacade) OpenAIModel {
 	return OpenAIModel{
 		ID:      m.ID,
-		Object:  "model",
+		Object:  openAIModelObjectType,
 		Created: m.Created,
 		OwnedBy: m.OwnedBy,
 	}
@@ -375,7 +384,7 @@ func convertModelFacadeToOpenAIModel(m biz.ModelFacade) OpenAIModel {
 func convertModelToOpenAIExtended(m *ent.Model, include map[string]bool) OpenAIModel {
 	result := OpenAIModel{
 		ID:      m.ModelID,
-		Object:  "model",
+		Object:  openAIModelObjectType,
 		Created: m.CreatedAt.Unix(),
 		OwnedBy: m.Developer,
 	}
@@ -441,9 +450,27 @@ func (handlers *OpenAIHandlers) writeOpenAIInternalError(c *gin.Context, request
 	c.JSON(http.StatusInternalServerError, openai.OpenAIError{
 		StatusCode: http.StatusInternalServerError,
 		Detail: llm.ErrorDetail{
-			Code:      "internal_server_error",
+			Code:      openAIErrorCodeInternalServer,
 			Message:   err.Error(),
-			Type:      "server_error",
+			Type:      openAIErrorTypeServer,
+			RequestID: requestID,
+		},
+	})
+}
+
+func (handlers *OpenAIHandlers) writeOpenAIModelNotFoundError(c *gin.Context, requestID, modelID string) {
+	message := "The model does not exist or you do not have access to it."
+	if modelID != "" {
+		message = fmt.Sprintf("The model `%s` does not exist or you do not have access to it.", modelID)
+	}
+
+	c.JSON(http.StatusNotFound, openai.OpenAIError{
+		StatusCode: http.StatusNotFound,
+		Detail: llm.ErrorDetail{
+			Code:      openAIErrorCodeModelNotFound,
+			Message:   message,
+			Type:      openAIErrorTypeInvalidRequest,
+			Param:     openAIErrorParamModel,
 			RequestID: requestID,
 		},
 	})
@@ -457,16 +484,7 @@ func (handlers *OpenAIHandlers) RetrieveModel(c *gin.Context) {
 	requestID, _ := contexts.GetRequestID(ctx)
 	modelID := strings.TrimPrefix(c.Param("model"), "/")
 	if modelID == "" {
-		c.JSON(http.StatusNotFound, openai.OpenAIError{
-			StatusCode: http.StatusNotFound,
-			Detail: llm.ErrorDetail{
-				Code:      "model_not_found",
-				Message:   "The model does not exist or you do not have access to it.",
-				Type:      "invalid_request_error",
-				Param:     "model",
-				RequestID: requestID,
-			},
-		})
+		handlers.writeOpenAIModelNotFoundError(c, requestID, "")
 		return
 	}
 
@@ -482,16 +500,7 @@ func (handlers *OpenAIHandlers) RetrieveModel(c *gin.Context) {
 		return m.ID == modelID
 	})
 	if !found {
-		c.JSON(http.StatusNotFound, openai.OpenAIError{
-			StatusCode: http.StatusNotFound,
-			Detail: llm.ErrorDetail{
-				Code:      "model_not_found",
-				Message:   fmt.Sprintf("The model `%s` does not exist or you do not have access to it.", modelID),
-				Type:      "invalid_request_error",
-				Param:     "model",
-				RequestID: requestID,
-			},
-		})
+		handlers.writeOpenAIModelNotFoundError(c, requestID, modelID)
 		return
 	}
 

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -3,10 +3,12 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/samber/lo"
 	"go.uber.org/fx"
 
 	"github.com/looplj/axonhub/internal/contexts"
@@ -24,17 +26,17 @@ import (
 type OpenAIHandlersParams struct {
 	fx.In
 
-	VideoService    *biz.VideoService
-	ChannelService  *biz.ChannelService
-	ModelService    *biz.ModelService
-	RequestService  *biz.RequestService
-	SystemService   *biz.SystemService
-	UsageLogService *biz.UsageLogService
-	PromptService   *biz.PromptService
+	VideoService                *biz.VideoService
+	ChannelService              *biz.ChannelService
+	ModelService                *biz.ModelService
+	RequestService              *biz.RequestService
+	SystemService               *biz.SystemService
+	UsageLogService             *biz.UsageLogService
+	PromptService               *biz.PromptService
 	PromptProtectionRuleService *biz.PromptProtectionRuleService
-	QuotaService    *biz.QuotaService
-	HttpClient      *httpclient.HttpClient
-	Client          *ent.Client
+	QuotaService                *biz.QuotaService
+	HttpClient                  *httpclient.HttpClient
+	Client                      *ent.Client
 }
 
 type OpenAIHandlers struct {
@@ -323,7 +325,48 @@ type OpenAIModel struct {
 	Type            string        `json:"type,omitempty"`
 }
 
-// ListModels returns all available models.
+func parseOpenAIModelInclude(includeParam string) (map[string]bool, bool) {
+	var (
+		include      map[string]bool
+		needFullData bool
+	)
+
+	if includeParam == "" {
+		return nil, false
+	}
+
+	if includeParam == "all" {
+		return nil, true
+	}
+
+	fields := strings.Split(includeParam, ",")
+	include = make(map[string]bool)
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			include[field] = true
+		}
+	}
+
+	extendedFields := []string{"name", "description", "context_length", "max_output_tokens", "capabilities", "pricing", "icon", "type"}
+	for _, field := range extendedFields {
+		if include[field] {
+			needFullData = true
+			break
+		}
+	}
+
+	return include, needFullData
+}
+
+func convertModelFacadeToOpenAIModel(m biz.ModelFacade) OpenAIModel {
+	return OpenAIModel{
+		ID:      m.ID,
+		Object:  "model",
+		Created: m.Created,
+		OwnedBy: m.OwnedBy,
+	}
+}
 
 // convertModelToOpenAIExtended transforms an ent.Model to OpenAIModel with extended metadata fields.
 // It safely handles nil ModelCard, Cost, and Limit fields.
@@ -394,6 +437,88 @@ func convertModelToOpenAIExtended(m *ent.Model, include map[string]bool) OpenAIM
 	return result
 }
 
+func (handlers *OpenAIHandlers) writeOpenAIInternalError(c *gin.Context, requestID string, err error) {
+	c.JSON(http.StatusInternalServerError, openai.OpenAIError{
+		StatusCode: http.StatusInternalServerError,
+		Detail: llm.ErrorDetail{
+			Code:      "internal_server_error",
+			Message:   err.Error(),
+			Type:      "server_error",
+			RequestID: requestID,
+		},
+	})
+}
+
+// RetrieveModel returns a single available model.
+// This endpoint is compatible with OpenAI's /v1/models/{model} API.
+func (handlers *OpenAIHandlers) RetrieveModel(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	requestID, _ := contexts.GetRequestID(ctx)
+	modelID := strings.TrimPrefix(c.Param("model"), "/")
+	if modelID == "" {
+		c.JSON(http.StatusNotFound, openai.OpenAIError{
+			StatusCode: http.StatusNotFound,
+			Detail: llm.ErrorDetail{
+				Code:      "model_not_found",
+				Message:   "The model does not exist or you do not have access to it.",
+				Type:      "invalid_request_error",
+				Param:     "model",
+				RequestID: requestID,
+			},
+		})
+		return
+	}
+
+	include, needFullData := parseOpenAIModelInclude(c.Query("include"))
+
+	models, err := handlers.ModelService.ListEnabledModels(ctx)
+	if err != nil {
+		handlers.writeOpenAIInternalError(c, requestID, err)
+		return
+	}
+
+	visibleModel, found := lo.Find(models, func(m biz.ModelFacade) bool {
+		return m.ID == modelID
+	})
+	if !found {
+		c.JSON(http.StatusNotFound, openai.OpenAIError{
+			StatusCode: http.StatusNotFound,
+			Detail: llm.ErrorDetail{
+				Code:      "model_not_found",
+				Message:   fmt.Sprintf("The model `%s` does not exist or you do not have access to it.", modelID),
+				Type:      "invalid_request_error",
+				Param:     "model",
+				RequestID: requestID,
+			},
+		})
+		return
+	}
+
+	if !needFullData {
+		c.JSON(http.StatusOK, convertModelFacadeToOpenAIModel(visibleModel))
+		return
+	}
+
+	configuredModel, err := handlers.EntClient.Model.Query().
+		Where(
+			model.ModelID(modelID),
+			model.StatusEQ(model.StatusEnabled),
+		).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			c.JSON(http.StatusOK, convertModelFacadeToOpenAIModel(visibleModel))
+			return
+		}
+
+		handlers.writeOpenAIInternalError(c, requestID, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, convertModelToOpenAIExtended(configuredModel, include))
+}
+
 // ListModels returns all available models.
 // This endpoint is compatible with OpenAI's /v1/models API.
 // It uses QueryAllChannelModels setting from system config to determine model source.
@@ -402,37 +527,7 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 
 	requestID, _ := contexts.GetRequestID(ctx)
 
-	// Parse include query parameter (replaces old 'extended' parameter)
-	includeParam := c.Query("include")
-	var include map[string]bool
-	var needFullData bool
-
-	if includeParam == "" {
-		// No include parameter: backward compatible - basic fields only
-		needFullData = false
-	} else if includeParam == "all" {
-		// "all" means include all fields
-		needFullData = true
-		include = nil // nil means all fields in convertModelToOpenAIExtended
-	} else {
-		// Parse comma-separated list of field names
-		fields := strings.Split(includeParam, ",")
-		include = make(map[string]bool)
-		for _, field := range fields {
-			field = strings.TrimSpace(field)
-			if field != "" {
-				include[field] = true
-			}
-		}
-		// Check if any extended fields are requested
-		extendedFields := []string{"name", "description", "context_length", "max_output_tokens", "capabilities", "pricing", "icon", "type"}
-		for _, field := range extendedFields {
-			if include[field] {
-				needFullData = true
-				break
-			}
-		}
-	}
+	include, needFullData := parseOpenAIModelInclude(c.Query("include"))
 
 	var openaiModels []OpenAIModel
 	if needFullData {
@@ -441,15 +536,7 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 			Where(model.StatusEQ(model.StatusEnabled)).
 			All(ctx)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, openai.OpenAIError{
-				StatusCode: http.StatusInternalServerError,
-				Detail: llm.ErrorDetail{
-					Code:      "internal_server_error",
-					Message:   err.Error(),
-					Type:      "server_error",
-					RequestID: requestID,
-				},
-			})
+			handlers.writeOpenAIInternalError(c, requestID, err)
 			return
 		}
 
@@ -461,26 +548,13 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 		// Basic mode: only return basic fields (backward compatible)
 		models, err := handlers.ModelService.ListEnabledModels(ctx)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, openai.OpenAIError{
-				StatusCode: http.StatusInternalServerError,
-				Detail: llm.ErrorDetail{
-					Code:      "internal_server_error",
-					Message:   err.Error(),
-					Type:      "server_error",
-					RequestID: requestID,
-				},
-			})
+			handlers.writeOpenAIInternalError(c, requestID, err)
 			return
 		}
 
 		openaiModels = make([]OpenAIModel, 0, len(models))
 		for _, m := range models {
-			openaiModels = append(openaiModels, OpenAIModel{
-				ID:      m.ID,
-				Object:  "model",
-				Created: m.Created,
-				OwnedBy: m.OwnedBy,
-			})
+			openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
 		}
 	}
 

--- a/internal/server/api/openai_retrieve_test.go
+++ b/internal/server/api/openai_retrieve_test.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/model"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
+	"github.com/looplj/axonhub/internal/server/biz"
+	openaitypes "github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+func setupOpenAIRetrieveTest(t *testing.T) (*ent.Client, *biz.ChannelService, *gin.Engine, context.Context) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	channelSvc := biz.NewChannelServiceForTest(client)
+	systemSvc := biz.NewSystemService(biz.SystemServiceParams{
+		CacheConfig: xcache.Config{Mode: xcache.ModeMemory},
+		Ent:         client,
+	})
+	modelSvc := biz.NewModelService(biz.ModelServiceParams{
+		ChannelService: channelSvc,
+		SystemService:  systemSvc,
+		Ent:            client,
+	})
+
+	handlers := &OpenAIHandlers{
+		ModelService: modelSvc,
+		EntClient:    client,
+	}
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := ent.NewContext(c.Request.Context(), client)
+		ctx = authz.WithTestBypass(ctx)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.GET("/v1/models/*model", handlers.RetrieveModel)
+
+	ctx := ent.NewContext(context.Background(), client)
+	ctx = authz.WithTestBypass(ctx)
+
+	return client, channelSvc, router, ctx
+}
+
+func TestOpenAIHandlers_RetrieveModel_SupportsSlashModelIDs(t *testing.T) {
+	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+
+	createdAt := time.Unix(1712345678, 0)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("DeepSeek Channel").
+		SetBaseURL("https://api.deepseek.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"deepseek-chat"}).
+		SetDefaultTestModel("deepseek-chat").
+		SetSettings(&objects.ChannelSettings{ExtraModelPrefix: "deepseek"}).
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: ch}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/deepseek/deepseek-chat", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got OpenAIModel
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Equal(t, "deepseek/deepseek-chat", got.ID)
+	require.Equal(t, "model", got.Object)
+	require.Equal(t, createdAt.Unix(), got.Created)
+	require.Equal(t, "openai", got.OwnedBy)
+}
+
+func TestOpenAIHandlers_RetrieveModel_FallsBackToBasicWhenConfiguredMetadataMissing(t *testing.T) {
+	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+
+	createdAt := time.Unix(1712345688, 0)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4o-mini"}).
+		SetDefaultTestModel("gpt-4o-mini").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: ch}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/gpt-4o-mini?include=all", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got OpenAIModel
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Equal(t, "gpt-4o-mini", got.ID)
+	require.Equal(t, "model", got.Object)
+	require.Equal(t, createdAt.Unix(), got.Created)
+	require.Equal(t, "openai", got.OwnedBy)
+	require.Empty(t, got.Name)
+	require.Nil(t, got.Capabilities)
+	require.Nil(t, got.Pricing)
+}
+
+func TestOpenAIHandlers_RetrieveModel_ReturnsExtendedConfiguredModel(t *testing.T) {
+	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+
+	channelCreatedAt := time.Unix(1712345698, 0)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(channelCreatedAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: ch}})
+
+	remark := "GPT-4.1 reasoning model"
+	modelCreatedAt := time.Unix(1712345708, 0)
+	_, err = client.Model.Create().
+		SetDeveloper("openai").
+		SetModelID("gpt-4.1").
+		SetName("GPT-4.1").
+		SetType(model.TypeChat).
+		SetGroup("gpt").
+		SetIcon("openai").
+		SetRemark(remark).
+		SetModelCard(&objects.ModelCard{
+			Vision:    true,
+			ToolCall:  true,
+			Reasoning: objects.ModelCardReasoning{Supported: true},
+			Limit:     objects.ModelCardLimit{Context: 200000, Output: 8192},
+			Cost:      objects.ModelCardCost{Input: 2, Output: 8, CacheRead: 0.5, CacheWrite: 1},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{
+				{
+					Type: "channel_model",
+					ChannelModel: &objects.ChannelModelAssociation{
+						ChannelID: ch.ID,
+						ModelID:   "gpt-4.1",
+					},
+				},
+			},
+		}).
+		SetStatus(model.StatusEnabled).
+		SetCreatedAt(modelCreatedAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/gpt-4.1?include=all", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got OpenAIModel
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Equal(t, "gpt-4.1", got.ID)
+	require.Equal(t, "model", got.Object)
+	require.Equal(t, modelCreatedAt.Unix(), got.Created)
+	require.Equal(t, "openai", got.OwnedBy)
+	require.Equal(t, "GPT-4.1", got.Name)
+	require.Equal(t, remark, got.Description)
+	require.Equal(t, "chat", got.Type)
+	require.NotNil(t, got.Capabilities)
+	require.True(t, got.Capabilities.Vision)
+	require.True(t, got.Capabilities.ToolCall)
+	require.True(t, got.Capabilities.Reasoning)
+	require.Equal(t, 200000, got.ContextLength)
+	require.Equal(t, 8192, got.MaxOutputTokens)
+	require.NotNil(t, got.Pricing)
+	require.Equal(t, 2.0, got.Pricing.Input)
+	require.Equal(t, 8.0, got.Pricing.Output)
+	require.Equal(t, 0.5, got.Pricing.CacheRead)
+	require.Equal(t, 1.0, got.Pricing.CacheWrite)
+}
+
+func TestOpenAIHandlers_RetrieveModel_ReturnsNotFound(t *testing.T) {
+	_, _, router, _ := setupOpenAIRetrieveTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/missing-model", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	var got openaitypes.OpenAIError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Equal(t, "model_not_found", got.Detail.Code)
+	require.Equal(t, "invalid_request_error", got.Detail.Type)
+	require.Equal(t, "model", got.Detail.Param)
+	require.Contains(t, got.Detail.Message, "missing-model")
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -146,6 +146,7 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 		openaiGroup.POST("/responses/compact", handlers.OpenAI.CompactResponse)
 		openaiGroup.POST("/responses", handlers.OpenAI.CreateResponse)
 		openaiGroup.GET("/models", handlers.OpenAI.ListModels)
+		openaiGroup.GET("/models/*model", handlers.OpenAI.RetrieveModel)
 		openaiGroup.POST("/embeddings", handlers.OpenAI.CreateEmbedding)
 		openaiGroup.POST("/images/generations", handlers.OpenAI.CreateImage)
 		openaiGroup.POST("/images/edits", handlers.OpenAI.CreateImageEdit)


### PR DESCRIPTION
# English
## Summary

This PR adds OpenAI-compatible single model retrieval support via `GET /v1/models/{model}`.

OpenAI reference:
[https://developers.openai.com/api/reference/resources/models/methods/retrieve](https://developers.openai.com/api/reference/resources/models/methods/retrieve)

Before this change, AxonHub only supported `GET /v1/models`. Requests to `GET /v1/models/{model}` could miss the API route and fall through to the frontend SPA, returning HTML instead of JSON. This PR fixes that and aligns the behavior with OpenAI's Models Retrieve API.

## What Changed

- Added `GET /v1/models/*model` route to support model IDs containing `/`
- Implemented `RetrieveModel` in the OpenAI handlers
- Reused shared `include` parsing for model metadata fields
- Reused shared basic model serialization for consistency with `GET /v1/models`
- Added tests for:
  - model IDs containing `/`
  - basic JSON response for channel-exposed models
  - extended JSON response for configured models with `?include=all`
  - OpenAI-style JSON 404 when the model is not found

## Behavior

### Success

If the model is visible to the current API key, the endpoint returns a single JSON model object:

```json
{
  "id": "kimi-k2.5",
  "object": "model",
  "created": 1712345678,
  "owned_by": "openai"
}
```

If `?include=all` is used and the model has configured metadata, the response includes extended fields such as:

- `name`
- `description`
- `context_length`
- `max_output_tokens`
- `capabilities`
- `pricing`
- `icon`
- `type`

### Not Found

If the model does not exist or is not visible to the current API key, the endpoint returns JSON `404`:

```json
{
  "error": {
    "code": "model_not_found",
    "message": "The model `...` does not exist or you do not have access to it.",
    "type": "invalid_request_error",
    "param": "model"
  }
}
```

# 中文版
这个 PR 为 AxonHub 增加了 OpenAI 兼容的单模型查询接口：`GET /v1/models/{model}`。

OpenAI 官方参考文档：
[https://developers.openai.com/api/reference/resources/models/methods/retrieve](https://developers.openai.com/api/reference/resources/models/methods/retrieve)

在这次修改之前，AxonHub 只支持 `GET /v1/models`。当客户端请求 `GET /v1/models/{model}` 时，可能无法命中 API 路由，最终落到前端 SPA，返回 HTML，而不是 API JSON。这个 PR 修复了这个问题，并让行为与 OpenAI 的 Models Retrieve 接口保持一致。

## 变更内容

- 新增 `GET /v1/models/*model` 路由，支持包含 `/` 的模型 ID
- 在 OpenAI handler 中实现 `RetrieveModel`
- 抽出并复用 `include` 参数解析逻辑
- 抽出并复用基础模型序列化逻辑，保持与 `GET /v1/models` 一致
- 新增测试，覆盖以下场景：
  - 模型 ID 中包含 `/`
  - 仅来自 channel 暴露的模型返回基础 JSON
  - 配置了模型元数据时，`?include=all` 返回扩展 JSON
  - 模型不存在时返回 OpenAI 风格的 JSON 404

## 接口行为

### 查询成功

如果当前 API Key 可以访问该模型，接口返回单个模型对象，例如：

```json
{
  "id": "kimi-k2.5",
  "object": "model",
  "created": 1712345678,
  "owned_by": "openai"
}
```

如果带上 `?include=all`，并且该模型在 AxonHub 中存在显式配置的模型元数据，则会返回扩展字段，例如：

- `name`
- `description`
- `context_length`
- `max_output_tokens`
- `capabilities`
- `pricing`
- `icon`
- `type`

### 查询失败

如果模型不存在，或者当前 API Key 无权访问该模型，接口返回 JSON `404`：

```json
{
  "error": {
    "code": "model_not_found",
    "message": "The model `...` does not exist or you do not have access to it.",
    "type": "invalid_request_error",
    "param": "model"
  }
}
```
