### PR TITLE
fix(copilot): update API headers and endpoint selection logic

### DIFF
--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 	"github.com/tidwall/gjson"
 )
+
+// modelVersionRegex matches GPT model versions (e.g., "gpt-5", "gpt-6")
+// Compiled once at package initialization for efficiency.
+var modelVersionRegex = regexp.MustCompile(`^gpt-(\d+)`)
 
 const (
 	// DefaultCopilotBaseURL is the base URL for GitHub Copilot API.
@@ -36,10 +41,11 @@ const (
 	CopilotVisionRequestHeader     = "Copilot-Vision-Request"
 	InitiatorHeader                = "X-Initiator"
 	// Default editor header values (VSCode pattern) - from LiteLLM
-	DefaultEditorVersion        = "vscode/1.95.0"
-	DefaultEditorPluginVersion  = "copilot-chat/0.26.7"
-	DefaultUserAgent            = "GitHubCopilotChat/0.26.7"
-	DefaultOpenAIIntent         = "conversation-panel"
+	DefaultEditorVersion       = "vscode/1.95.0"
+	DefaultEditorPluginVersion = "copilot-chat/0.26.7"
+	DefaultUserAgent           = "GitHubCopilotChat/0.26.7"
+	// DefaultOpenAIIntent is used for proper quota aggregation (matches OpenCode behavior).
+	DefaultOpenAIIntent         = "conversation-edits"
 	DefaultCopilotIntegrationID = "vscode-chat"
 	DefaultGitHubAPIVersion     = "2025-04-01"
 	DefaultVSCodeUserAgentLib   = "electron-fetch"
@@ -160,11 +166,14 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	}
 
 	// Forward X-Initiator from inbound request for Copilot billing control.
+	// Default to "agent" if not provided to match OpenCode behavior.
+	initiator := "agent"
 	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
-		if initiator := llmReq.RawRequest.Headers.Get(InitiatorHeader); initiator != "" {
-			headers.Set(InitiatorHeader, initiator)
+		if val := llmReq.RawRequest.Headers.Get(InitiatorHeader); val != "" {
+			initiator = val
 		}
 	}
+	headers.Set(InitiatorHeader, initiator)
 
 	// Build authentication config.
 	authConfig := &httpclient.AuthConfig{
@@ -585,58 +594,36 @@ func (t *OutboundTransformer) transformResponsesRequest(ctx context.Context, llm
 	}
 
 	// Forward X-Initiator from inbound request for Copilot billing control.
+	// Default to "agent" if not provided to match OpenCode behavior.
+	initiator := "agent"
 	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
-		if initiator := llmReq.RawRequest.Headers.Get(InitiatorHeader); initiator != "" {
-			responsesReq.Headers.Set(InitiatorHeader, initiator)
+		if val := llmReq.RawRequest.Headers.Get(InitiatorHeader); val != "" {
+			initiator = val
 		}
 	}
+	responsesReq.Headers.Set(InitiatorHeader, initiator)
 
 	return responsesReq, nil
 }
 
 // usesResponsesAPI checks if the model uses the responses API.
+// GPT-5+ (except gpt-5-mini) uses /responses, everything else uses /chat/completions.
 func usesResponsesAPI(model string) bool {
 	normalizedModel := strings.ToLower(model)
 
-	if strings.Contains(normalizedModel, "codex") {
-		return true
-	}
-
-	if !strings.HasPrefix(normalizedModel, "gpt-") {
+	// Use package-level compiled regex
+	match := modelVersionRegex.FindStringSubmatch(normalizedModel)
+	if match == nil {
 		return false
 	}
 
-	version, _, _ := strings.Cut(strings.TrimPrefix(normalizedModel, "gpt-"), "-")
-	major, minor, ok := parseModelVersion(version)
-	if !ok {
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
 		return false
 	}
 
-	return major > 5 || (major == 5 && minor >= 4)
-}
-
-// parseModelVersion parses a model version string into major and minor components.
-func parseModelVersion(version string) (major int, minor int, ok bool) {
-	parts := strings.Split(version, ".")
-	if len(parts) == 0 || parts[0] == "" {
-		return 0, 0, false
-	}
-
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, false
-	}
-
-	if len(parts) == 1 || parts[1] == "" {
-		return major, 0, true
-	}
-
-	minor, err = strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, false
-	}
-
-	return major, minor, true
+	// Match OpenCode's pattern: GPT-5+ uses responses API (except gpt-5-mini)
+	return major >= 5 && !strings.HasPrefix(normalizedModel, "gpt-5-mini")
 }
 
 // prependedStream is a stream that yields a first event before forwarding to the upstream stream.

--- a/llm/transformer/openai/copilot/outbound_test.go
+++ b/llm/transformer/openai/copilot/outbound_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -85,82 +86,6 @@ func TestOutboundTransformer_APIFormat(t *testing.T) {
 	assert.Equal(t, llm.APIFormatOpenAIChatCompletion, transformer.APIFormat())
 }
 
-func TestParseModelVersion(t *testing.T) {
-	tests := []struct {
-		name          string
-		version       string
-		expectedMajor int
-		expectedMinor int
-		expectedOK    bool
-	}{
-		{
-			name:          "major only version",
-			version:       "6",
-			expectedMajor: 6,
-			expectedMinor: 0,
-			expectedOK:    true,
-		},
-		{
-			name:          "major minor version",
-			version:       "5.4",
-			expectedMajor: 5,
-			expectedMinor: 4,
-			expectedOK:    true,
-		},
-		{
-			name:          "double digit minor version",
-			version:       "5.10",
-			expectedMajor: 5,
-			expectedMinor: 10,
-			expectedOK:    true,
-		},
-		{
-			name:          "ignores extra segments after minor",
-			version:       "6.1.2",
-			expectedMajor: 6,
-			expectedMinor: 1,
-			expectedOK:    true,
-		},
-		{
-			name:          "empty version is invalid",
-			version:       "",
-			expectedMajor: 0,
-			expectedMinor: 0,
-			expectedOK:    false,
-		},
-		{
-			name:          "non numeric major is invalid",
-			version:       "preview",
-			expectedMajor: 0,
-			expectedMinor: 0,
-			expectedOK:    false,
-		},
-		{
-			name:          "non numeric minor is invalid",
-			version:       "5.preview",
-			expectedMajor: 0,
-			expectedMinor: 0,
-			expectedOK:    false,
-		},
-		{
-			name:          "empty minor is treated as major only",
-			version:       "6.",
-			expectedMajor: 6,
-			expectedMinor: 0,
-			expectedOK:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			major, minor, ok := parseModelVersion(tt.version)
-			assert.Equal(t, tt.expectedMajor, major)
-			assert.Equal(t, tt.expectedMinor, minor)
-			assert.Equal(t, tt.expectedOK, ok)
-		})
-	}
-}
-
 func TestUsesResponsesAPI(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -168,19 +93,19 @@ func TestUsesResponsesAPI(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "codex model uses responses API",
-			model:    "gpt-5.2-codex",
+			name:     "gpt-5 uses responses API",
+			model:    "gpt-5",
 			expected: true,
 		},
 		{
-			name:     "codex detection is case insensitive",
-			model:    "GPT-5.2-CODEX",
-			expected: true,
-		},
-		{
-			name:     "gpt-5.3 does not use responses API",
-			model:    "gpt-5.3",
+			name:     "gpt-5-mini does not use responses API",
+			model:    "gpt-5-mini",
 			expected: false,
+		},
+		{
+			name:     "gpt-5.3 uses responses API",
+			model:    "gpt-5.3",
+			expected: true,
 		},
 		{
 			name:     "gpt-5.4 uses responses API",
@@ -223,8 +148,13 @@ func TestUsesResponsesAPI(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "other model does not use responses API",
+			name:     "claude model does not use responses API",
 			model:    "claude-sonnet-4.6",
+			expected: false,
+		},
+		{
+			name:     "claude-3-5-sonnet does not use responses API",
+			model:    "claude-3-5-sonnet",
 			expected: false,
 		},
 	}
@@ -543,6 +473,86 @@ func TestOutboundTransformer_TransformRequest_VisionHeaders(t *testing.T) {
 			} else {
 				assert.Empty(t, visionHeader)
 			}
+		})
+	}
+}
+
+func TestXInitiatorDefault(t *testing.T) {
+	ctx := context.Background()
+	mockToken := "ghu_testtoken123"
+	transformer, err := NewOutboundTransformer(OutboundTransformerParams{
+		TokenProvider: &mockTokenProvider{token: mockToken},
+	})
+	require.NoError(t, err)
+
+	request := &llm.Request{
+		Model: "gpt-4o",
+		Messages: []llm.Message{
+			{
+				Role:    "user",
+				Content: llm.MessageContent{Content: lo.ToPtr("Hello")},
+			},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(ctx, request)
+	require.NoError(t, err)
+	require.NotNil(t, httpReq)
+	assert.Equal(t, "agent", httpReq.Headers.Get(InitiatorHeader))
+}
+
+func TestXInitiatorForwarding(t *testing.T) {
+	ctx := context.Background()
+	mockToken := "ghu_testtoken123"
+	transformer, err := NewOutboundTransformer(OutboundTransformerParams{
+		TokenProvider: &mockTokenProvider{token: mockToken},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		initiatorValue string
+		expected       string
+	}{
+		{
+			name:           "forwards custom initiator value",
+			initiatorValue: "editor",
+			expected:       "editor",
+		},
+		{
+			name:           "forwards agent initiator value",
+			initiatorValue: "agent",
+			expected:       "agent",
+		},
+		{
+			name:           "forwards empty string as empty",
+			initiatorValue: "",
+			expected:       "agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &llm.Request{
+				Model: "gpt-4o",
+				Messages: []llm.Message{
+					{
+						Role:    "user",
+						Content: llm.MessageContent{Content: lo.ToPtr("Hello")},
+					},
+				},
+				RawRequest: &httpclient.Request{
+					Headers: make(http.Header),
+				},
+			}
+			if tt.initiatorValue != "" {
+				request.RawRequest.Headers.Set(InitiatorHeader, tt.initiatorValue)
+			}
+
+			httpReq, err := transformer.TransformRequest(ctx, request)
+			require.NoError(t, err)
+			require.NotNil(t, httpReq)
+			assert.Equal(t, tt.expected, httpReq.Headers.Get(InitiatorHeader))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the GitHub Copilot quota counting issue where each API request was counted separately instead of aggregating conversation messages.

## Problem

Previously, Axon Hub's Copilot integration was using "conversation-panel" intent and not properly setting the x-initiator header, causing GitHub to count each API request as a separate quota usage. This differed from OpenCode's behavior where conversation messages are aggregated.

## Solution

Aligns Axon Hub's Copilot integration with OpenCode's implementation:

- **Intent Header**: Changed from "conversation-panel" to "conversation-edits" for proper quota aggregation
- **X-Initiator Header**: Added default "agent" value when not provided by the client
- **Endpoint Selection**: Updated to match OpenCode's pattern (GPT-5+ except mini → /responses)

## Changes

- `DefaultOpenAIIntent` constant updated to "conversation-edits"
- Default x-initiator logic added to both code paths
- `usesResponsesAPI()` simplified to match OpenCode logic
- Removed Codex special case (not present in OpenCode)
- All unit tests updated and passing (90 tests)

## Testing

- All unit tests pass
- Build succeeds with no errors
- Code quality checks pass (go vet clean)

## Impact

Users will see improved quota efficiency when using GitHub Copilot through Axon Hub, with conversation threads counting as fewer requests against their Copilot quota.
