### PR TITLE
fix: preserve final prompt tokens in anthropic stream usage

### DIFF
--- a/llm/transformer/anthropic/outbound_stream.go
+++ b/llm/transformer/anthropic/outbound_stream.go
@@ -246,13 +246,15 @@ func (s *outboundStream) transformStreamChunk(event *httpclient.StreamEvent) (*l
 		if streamEvent.Usage != nil {
 			usage := convertToLlmUsage(streamEvent.Usage, state.platformType)
 			if state.streamUsage != nil {
-				usage.PromptTokens = state.streamUsage.PromptTokens
+				if usage.PromptTokens == 0 && state.streamUsage.PromptTokens > 0 {
+					usage.PromptTokens = state.streamUsage.PromptTokens
+				}
 				if usage.PromptTokensDetails == nil && state.streamUsage.PromptTokensDetails != nil {
 					usage.PromptTokensDetails = state.streamUsage.PromptTokensDetails
 				}
-				// Recalculate total tokens
-				usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 			}
+			// Recalculate total tokens after merging prompt/completion usage.
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 
 			state.streamUsage = usage
 		}
@@ -306,7 +308,7 @@ func (s *outboundStream) transformStreamChunk(event *httpclient.StreamEvent) (*l
 	case "message_stop":
 		// Final event - return empty response to indicate completion
 		resp.Choices = []llm.Choice{}
-		// Include final usage information
+		// Include final merged usage information (OpenAI include_usage style).
 		if state.streamUsage != nil {
 			resp.Usage = state.streamUsage
 		}

--- a/llm/transformer/anthropic/outbound_stream_test.go
+++ b/llm/transformer/anthropic/outbound_stream_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
+	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 	"github.com/looplj/axonhub/llm/transformer/shared"
@@ -137,4 +139,72 @@ func TestOutboundTransformer_StreamTransformation_ErrorEvent(t *testing.T) {
 	_, err = streams.All(transformedStream)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "当前订阅套餐暂未开放GPT-6权限")
+}
+
+func TestOutboundTransformer_StreamTransformation_UsesFinalPromptTokensWhenPresent(t *testing.T) {
+	transformer, err := NewOutboundTransformerWithConfig(&Config{
+		Type:           PlatformZhipu,
+		BaseURL:        "https://example.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+	})
+	require.NoError(t, err)
+	stopReason := "end_turn"
+
+	messageStartData, err := json.Marshal(StreamEvent{
+		Type: "message_start",
+		Message: &StreamMessage{
+			ID:    "msg_1",
+			Type:  "message",
+			Role:  "assistant",
+			Model: "glm-5.1",
+			Usage: &Usage{
+				InputTokens:  0,
+				OutputTokens: 0,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	messageDeltaData, err := json.Marshal(StreamEvent{
+		Type: "message_delta",
+		Delta: &StreamDelta{
+			StopReason: &stopReason,
+		},
+		Usage: &Usage{
+			InputTokens:  10,
+			OutputTokens: 3,
+		},
+	})
+	require.NoError(t, err)
+
+	messageStopData, err := json.Marshal(StreamEvent{
+		Type: "message_stop",
+	})
+	require.NoError(t, err)
+
+	streamEvents := []*httpclient.StreamEvent{
+		{Type: "message_start", Data: messageStartData},
+		{Type: "message_delta", Data: messageDeltaData},
+		{Type: "message_stop", Data: messageStopData},
+	}
+
+	mockStream := streams.SliceStream(streamEvents)
+	ot := transformer.(*OutboundTransformer)
+	ctx := shared.ContextWithTransportScope(t.Context(), shared.TransportScope{
+		BaseURL: ot.config.BaseURL,
+	})
+	transformedStream, err := transformer.TransformStream(ctx, mockStream)
+	require.NoError(t, err)
+
+	var actualResponses []*llm.Response
+	for transformedStream.Next() {
+		actualResponses = append(actualResponses, transformedStream.Current())
+	}
+
+	require.NoError(t, transformedStream.Err())
+	require.Len(t, actualResponses, 4)
+	require.NotNil(t, actualResponses[2].Usage)
+	require.EqualValues(t, 10, actualResponses[2].Usage.PromptTokens)
+	require.EqualValues(t, 3, actualResponses[2].Usage.CompletionTokens)
+	require.EqualValues(t, 13, actualResponses[2].Usage.TotalTokens)
 }


### PR DESCRIPTION
## Summary
Fix Anthropic streaming usage merge logic so `message_delta` prompt token usage is not overwritten by `message_start` when the final chunk already contains a non-zero value.

## Problem
For Zhipu Anthropic-compatible streaming responses, `message_start.usage.input_tokens` may be `0`, while the final `message_delta.usage.input_tokens` contains the correct value.

AxonHub was always overwriting the final prompt token count with the value saved from `message_start`, which caused the final SSE usage to incorrectly report `input_tokens: 0`.

## Fix
Only fall back to the prompt token count from `message_start` when the final `message_delta` prompt token count is missing or zero.

## Verification
Reproduced locally by comparing `claude-code-hub` and local `axonhub`.

Before the fix:
- AxonHub final `message_delta.usage.input_tokens = 0`

After the fix:
- AxonHub final `message_delta.usage.input_tokens = 10`
- matches `claude-code-hub`