### PR TITLE
fix(moonshot): normalize negative input tokens

### DIFF
--- a/llm/transformer/anthropic/usage.go
+++ b/llm/transformer/anthropic/usage.go
@@ -56,9 +56,8 @@ func convertToLlmUsage(usage *Usage, platformType PlatformType) *llm.Usage {
 		// Moonshot may return InputTokens as a net billed amount (can be negative with cache discounts),
 		// or as the standard positive count. We handle both formats.
 		if usage.InputTokens < 0 && usage.CacheReadInputTokens > 0 {
-			nonCachedTokens := usage.InputTokens + usage.CacheReadInputTokens
-			promptTokens = nonCachedTokens + usage.CacheReadInputTokens
-		} else if usage.InputTokens > 0 && usage.CacheReadInputTokens > 0 && usage.InputTokens < usage.CacheReadInputTokens {
+			promptTokens = usage.InputTokens + 2*usage.CacheReadInputTokens
+		} else if usage.InputTokens >= 0 && usage.CacheReadInputTokens > 0 && usage.InputTokens < usage.CacheReadInputTokens {
 			promptTokens = usage.InputTokens + usage.CacheReadInputTokens
 		} else {
 			promptTokens = usage.InputTokens

--- a/llm/transformer/anthropic/usage.go
+++ b/llm/transformer/anthropic/usage.go
@@ -53,9 +53,16 @@ func convertToLlmUsage(usage *Usage, platformType PlatformType) *llm.Usage {
 	//nolint:exhaustive
 	switch platformType {
 	case PlatformMoonshot:
-		// For Moonshot: InputTokens already includes cached tokens
-		// So we don't add cache tokens again
-		promptTokens = usage.InputTokens
+		// Moonshot may return InputTokens as a net billed amount (can be negative with cache discounts),
+		// or as the standard positive count. We handle both formats.
+		if usage.InputTokens < 0 && usage.CacheReadInputTokens > 0 {
+			nonCachedTokens := usage.InputTokens + usage.CacheReadInputTokens
+			promptTokens = nonCachedTokens + usage.CacheReadInputTokens
+		} else if usage.InputTokens > 0 && usage.CacheReadInputTokens > 0 && usage.InputTokens < usage.CacheReadInputTokens {
+			promptTokens = usage.InputTokens + usage.CacheReadInputTokens
+		} else {
+			promptTokens = usage.InputTokens
+		}
 	default:
 		// For Anthropic official (direct, bedrock, vertex) or other platform: InputTokens does NOT include cached tokens
 		// Total input tokens = input_tokens + cache_creation_input_tokens + cache_read_input_tokens

--- a/llm/transformer/anthropic/usage_test.go
+++ b/llm/transformer/anthropic/usage_test.go
@@ -283,6 +283,50 @@ func Test_convertUsage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Moonshot - negative input tokens with cache discount",
+			args: args{
+				usage: &Usage{
+					InputTokens:          -126648,
+					OutputTokens:         52,
+					CacheReadInputTokens: 126976,
+					ServiceTier:          "standard",
+				},
+				platformType: PlatformMoonshot,
+			},
+			want: &llm.Usage{
+				// nonCached = -126648 + 126976 = 328
+				// total = 328 + 126976 = 127304
+				PromptTokens:     127304,
+				CompletionTokens: 52,
+				TotalTokens:      127356,
+				PromptTokensDetails: &llm.PromptTokensDetails{
+					CachedTokens: 126976,
+				},
+			},
+		},
+		{
+			name: "Moonshot - future format where InputTokens doesn't include cached",
+			args: args{
+				usage: &Usage{
+					InputTokens:          100,
+					OutputTokens:         50,
+					CacheReadInputTokens: 150,
+					ServiceTier:          "standard",
+				},
+				platformType: PlatformMoonshot,
+			},
+			want: &llm.Usage{
+				// InputTokens (100) < CacheReadInputTokens (150), so we add them
+				// Total = 100 + 150 = 250
+				PromptTokens:     250,
+				CompletionTokens: 50,
+				TotalTokens:      300,
+				PromptTokensDetails: &llm.PromptTokensDetails{
+					CachedTokens: 150,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Moonshot returns input_tokens as a net billed amount when cache discounts apply, causing negative token counts and incorrect cache hit rate calculations.