### PR TITLE
feat: add NVIDIA as model provider

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -10,6 +10,7 @@ export const DEVELOPER_IDS = [
   'xiaomi',
   'longcat',
   'mistral',
+  'nvidia',
   'xai',
   'bytedance',
   'stepfun',
@@ -28,6 +29,7 @@ export const DEVELOPER_ICONS: Record<string, string> = {
   xiaomi: 'XiaomiMiMo',
   longcat: 'LongCat',
   mistral: 'Mistral',
+  nvidia: 'Nvidia',
   bytedance: 'Doubao',
   stepfun: 'Stepfun',
 };

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -1382,7 +1382,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -1473,7 +1474,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -1509,7 +1511,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -1668,7 +1671,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -1857,7 +1861,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -1983,7 +1988,8 @@
           "modalities": {
             "input": [
               "text",
-              "image"
+              "image",
+              "pdf"
             ],
             "output": [
               "text"
@@ -3182,64 +3188,6 @@
             "output": 64000
           },
           "display_name": "Claude Sonnet 3.7",
-          "type": "chat",
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": false,
-              "mode": "budget",
-              "budget": {
-                "min": 1024,
-                "unit": "tokens"
-              },
-              "interleaved": false,
-              "summaries": false,
-              "visibility": "full",
-              "continuation": [
-                "thinking_blocks"
-              ],
-              "notes": [
-                "Anthropic uses thinking budget tokens"
-              ]
-            }
-          }
-        },
-        {
-          "id": "claude-3-7-sonnet-latest",
-          "name": "Claude Sonnet 3.7 (latest)",
-          "family": "claude-sonnet",
-          "attachment": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "tool_call": true,
-          "temperature": true,
-          "knowledge": "2024-10-31",
-          "release_date": "2025-02-19",
-          "last_updated": "2025-02-19",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "open_weights": false,
-          "cost": {
-            "input": 3,
-            "output": 15,
-            "cache_read": 0.3,
-            "cache_write": 3.75
-          },
-          "limit": {
-            "context": 200000,
-            "output": 64000
-          },
-          "display_name": "Claude Sonnet 3.7 (latest)",
           "type": "chat",
           "extra_capabilities": {
             "reasoning": {
@@ -5175,12 +5123,546 @@
         }
       ]
     },
+    "nvidia": {
+      "id": "nvidia",
+      "api": "https://integrate.api.nvidia.com/v1",
+      "name": "Nvidia",
+      "doc": "https://docs.api.nvidia.com/nim/",
+      "display_name": "Nvidia",
+      "models": [
+        {
+          "id": "nvidia/nemotron-3-super-120b-a12b",
+          "name": "Nemotron 3 Super",
+          "family": "nemotron",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-04",
+          "release_date": "2026-03-11",
+          "last_updated": "2026-03-11",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0.2,
+            "output": 0.8
+          },
+          "limit": {
+            "context": 262144,
+            "output": 262144
+          },
+          "display_name": "Nemotron 3 Super",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/nvidia-nemotron-nano-9b-v2",
+          "name": "nvidia-nemotron-nano-9b-v2",
+          "family": "nemotron",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-09",
+          "release_date": "2025-08-18",
+          "last_updated": "2025-08-18",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 131072,
+            "output": 131072
+          },
+          "display_name": "nvidia-nemotron-nano-9b-v2",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-embed-nemotron-8b",
+          "name": "Llama Embed Nemotron 8B",
+          "family": "llama",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "temperature": false,
+          "knowledge": "2025-03",
+          "release_date": "2025-03-18",
+          "last_updated": "2025-03-18",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 32768,
+            "output": 2048
+          },
+          "display_name": "Llama Embed Nemotron 8B",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+          "name": "Llama 3.3 Nemotron Super 49b V1.5",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "structured_output": false,
+          "temperature": true,
+          "release_date": "2025-03-16",
+          "last_updated": "2025-03-16",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama 3.3 Nemotron Super 49b V1.5",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-3.3-nemotron-super-49b-v1",
+          "name": "Llama 3.3 Nemotron Super 49b V1",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "structured_output": false,
+          "temperature": true,
+          "release_date": "2025-03-16",
+          "last_updated": "2025-03-16",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama 3.3 Nemotron Super 49b V1",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/nemotron-3-nano-30b-a3b",
+          "name": "nemotron-3-nano-30b-a3b",
+          "family": "nemotron",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-09",
+          "release_date": "2024-12",
+          "last_updated": "2024-12",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 131072,
+            "output": 131072
+          },
+          "display_name": "nemotron-3-nano-30b-a3b",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-3.1-nemotron-70b-instruct",
+          "name": "Llama 3.1 Nemotron 70b Instruct",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2024-10-12",
+          "last_updated": "2024-10-12",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama 3.1 Nemotron 70b Instruct",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-3.1-nemotron-51b-instruct",
+          "name": "Llama 3.1 Nemotron 51b Instruct",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2024-09-22",
+          "last_updated": "2024-09-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama 3.1 Nemotron 51b Instruct",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+          "name": "Llama-3.1-Nemotron-Ultra-253B-v1",
+          "family": "llama",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-07",
+          "release_date": "2024-07-01",
+          "last_updated": "2025-09-05",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 131072,
+            "output": 8192
+          },
+          "display_name": "Llama-3.1-Nemotron-Ultra-253B-v1",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/nemotron-4-340b-instruct",
+          "name": "Nemotron 4 340b Instruct",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2024-06-13",
+          "last_updated": "2024-06-13",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Nemotron 4 340b Instruct",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/llama3-chatqa-1.5-70b",
+          "name": "Llama3 Chatqa 1.5 70b",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2024-04-28",
+          "last_updated": "2024-04-28",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama3 Chatqa 1.5 70b",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/cosmos-nemotron-34b",
+          "name": "Cosmos Nemotron 34B",
+          "family": "nemotron",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": false,
+          "temperature": true,
+          "knowledge": "2024-01",
+          "release_date": "2024-01-01",
+          "last_updated": "2025-09-05",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 131072,
+            "output": 8192
+          },
+          "display_name": "Cosmos Nemotron 34B",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/nemoretriever-ocr-v1",
+          "name": "NeMo Retriever OCR v1",
+          "family": "nemoretriever",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "temperature": false,
+          "knowledge": "2024-01",
+          "release_date": "2024-01-01",
+          "last_updated": "2025-09-05",
+          "modalities": {
+            "input": [
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 8192,
+            "output": 4096
+          },
+          "display_name": "NeMo Retriever OCR v1",
+          "type": "chat"
+        },
+        {
+          "id": "nvidia/parakeet-tdt-0.6b-v2",
+          "name": "Parakeet TDT 0.6B v2",
+          "family": "parakeet",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "temperature": false,
+          "knowledge": "2024-01",
+          "release_date": "2024-01-01",
+          "last_updated": "2025-09-05",
+          "modalities": {
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 8192,
+            "output": 4096
+          },
+          "display_name": "Parakeet TDT 0.6B v2",
+          "type": "chat"
+        }
+      ]
+    },
     "google": {
       "id": "google",
       "name": "google",
       "doc": "https://ai.google.dev/gemini-api/docs/pricing",
       "display_name": "google",
       "models": [
+        {
+          "id": "gemma-4-26b-it",
+          "name": "Gemma 4 26B",
+          "family": "gemma",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2026-04-02",
+          "last_updated": "2026-04-02",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 256000,
+            "output": 8192
+          },
+          "display_name": "Gemma 4 26B",
+          "type": "chat"
+        },
+        {
+          "id": "gemma-4-31b-it",
+          "name": "Gemma 4 31B",
+          "family": "gemma",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2026-04-02",
+          "last_updated": "2026-04-02",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 256000,
+            "output": 8192
+          },
+          "display_name": "Gemma 4 31B",
+          "type": "chat"
+        },
         {
           "id": "gemini-3.1-flash-lite-preview",
           "name": "Gemini 3.1 Flash Lite Preview",
@@ -7815,6 +8297,49 @@
       "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
       "display_name": "alibaba",
       "models": [
+        {
+          "id": "qwen3.6-plus",
+          "name": "Qwen3.6 Plus",
+          "family": "qwen",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2025-04",
+          "release_date": "2026-04-02",
+          "last_updated": "2026-04-02",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "cost": {
+            "input": 0.276,
+            "output": 1.651,
+            "cache_read": 0.028,
+            "cache_write": 0.344
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 65536
+          },
+          "display_name": "Qwen3.6 Plus",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          },
+          "type": "chat"
+        },
         {
           "id": "qwen3.5-plus",
           "name": "Qwen3.5 Plus",

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -15,9 +15,9 @@ function fetchJSON(url) {
   return new Promise((resolve, reject) => {
     const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
                      process.env.HTTP_PROXY || process.env.http_proxy;
-    
+
     if (!proxyUrl) {
-      // 无代理，直接请求
+      // 无代理,直接请求
       https.get(url, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -31,12 +31,12 @@ function fetchJSON(url) {
       }).on('error', reject);
       return;
     }
-    
+
     // 使用代理
     console.log('Using proxy:', proxyUrl);
     const targetUrl = new URL(url);
     const proxy = new URL(proxyUrl);
-    
+
     const connectOptions = {
       method: 'CONNECT',
       host: proxy.hostname,
@@ -44,27 +44,27 @@ function fetchJSON(url) {
       path: `${targetUrl.hostname}:443`,
       headers: { Host: targetUrl.hostname }
     };
-    
-    // 添加代理认证（如果有）
+
+    // 添加代理认证(如果有)
     if (proxy.username || proxy.password) {
       const auth = Buffer.from(`${proxy.username}:${proxy.password}`).toString('base64');
       connectOptions.headers['Proxy-Authorization'] = `Basic ${auth}`;
     }
-    
+
     const connectReq = http.request(connectOptions);
-    
+
     connectReq.on('connect', (res, socket) => {
       if (res.statusCode !== 200) {
         return reject(new Error(`Proxy CONNECT failed: ${res.statusCode}`));
       }
-      
+
       const tlsOptions = {
         socket: socket,
         hostname: targetUrl.hostname,
         path: targetUrl.pathname + targetUrl.search,
         method: 'GET'
       };
-      
+
       const tlsReq = https.request(tlsOptions, (tlsRes) => {
         let data = '';
         tlsRes.on('data', (chunk) => { data += chunk; });
@@ -76,11 +76,11 @@ function fetchJSON(url) {
           }
         });
       });
-      
+
       tlsReq.on('error', reject);
       tlsReq.end();
     });
-    
+
     connectReq.on('error',reject);
     connectReq.end();
   });
@@ -89,18 +89,18 @@ function fetchJSON(url) {
 function extractDeveloperIds(constantsPath) {
   const content = fs.readFileSync(constantsPath, 'utf8');
   const match = content.match(/export const DEVELOPER_IDS = \[([\s\S]*?)\]/);
-  
+
   if (!match) {
     throw new Error('Could not find DEVELOPER_IDS in constants.ts');
   }
-  
+
   const idsString = match[1];
   const ids = idsString
     .split(',')
     .map(line => line.trim())
     .filter(line => line.startsWith("'") || line.startsWith('"'))
     .map(line => line.replace(/^['"]|['"]$/g, ''));
-  
+
   return ids;
 }
 
@@ -108,15 +108,15 @@ function filterProviders(data, allowedIds) {
   if (!data.providers) {
     throw new Error('Invalid data structure: missing providers field');
   }
-  
+
   const filtered = {};
-  
+
   for (const [key, value] of Object.entries(data.providers)) {
     if (allowedIds.includes(value.id)) {
       filtered[key] = value;
     }
   }
-  
+
   // Map doubao channel's doubao models to bytedance developer
   if (allowedIds.includes('bytedance') && data.providers['doubao']) {
     const doubaoProvider = data.providers['doubao'];
@@ -134,7 +134,22 @@ function filterProviders(data, allowedIds) {
       console.log(`Mapped ${doubaoModels.length} doubao models to bytedance developer`);
     }
   }
-  
+
+  // Filter NVIDIA models to only include NVIDIA-created models (nvidia/* prefix)
+  if (allowedIds.includes('nvidia') && filtered['nvidia']) {
+    const nvidiaProvider = filtered['nvidia'];
+    const nvidiaModels = (nvidiaProvider.models || []).filter(m =>
+      m.id && m.id.toLowerCase().startsWith('nvidia/')
+    );
+    if (nvidiaModels.length > 0) {
+      filtered['nvidia'] = {
+        ...nvidiaProvider,
+        models: nvidiaModels,
+      };
+      console.log(`Filtered ${nvidiaModels.length} NVIDIA-created models from ${nvidiaProvider.models.length} total`);
+    }
+  }
+
   return { providers: filtered };
 }
 
@@ -166,9 +181,9 @@ function mergeWithModelsJson(data, modelsJsonPath) {
       if (!existingProvider.models) {
         existingProvider.models = [];
       }
-      
+
       const existingIds = new Set(existingProvider.models.map(m => m.id));
-      
+
       for (const model of models) {
         if (!existingIds.has(model.id)) {
           existingProvider.models.push(model);
@@ -190,26 +205,26 @@ async function main() {
   try {
     console.log('Fetching model developers data from:', SOURCE_URL);
     const data = await fetchJSON(SOURCE_URL);
-    
+
     console.log('Extracting allowed developer IDs from:', CONSTANTS_PATH);
     const allowedIds = extractDeveloperIds(CONSTANTS_PATH);
     console.log('Allowed developer IDs:', allowedIds);
-    
+
     console.log('Filtering providers...');
     const filtered = filterProviders(data, allowedIds);
-    
+
     const providerCount = Object.keys(filtered.providers).length;
     console.log(`Filtered to ${providerCount} providers`);
-    
+
     console.log('Merging with models.json...');
     mergeWithModelsJson(filtered, MODELS_JSON_PATH);
-    
+
     console.log('Sorting models by release date...');
     sortModelsByDate(filtered);
-    
+
     console.log('Writing to:', OUTPUT_PATH);
     fs.writeFileSync(OUTPUT_PATH, JSON.stringify(filtered, null, 2) + '\n');
-    
+
     console.log('Sync completed successfully!');
   } catch (error) {
     console.error('Error during sync:', error.message);


### PR DESCRIPTION

## Summary
Add NVIDIA NIM model support following the stepfun pattern from commit 75c92166

## Spirit/Intent
Enable users to access NVIDIA NIM models through existing OpenAI-compatible channels

## Key Changes
- Added 'nvidia' to developer constants (DEVELOPER_IDS and DEVELOPER_ICONS)
- Synced 14 NVIDIA models from upstream PublicProviderConf
- Files changed:
  - frontend/src/features/models/data/constants.ts
  - frontend/src/features/models/data/providers.json

## NVIDIA Models (Exclusive to NVIDIA)

| Model ID | Display Name | Type |
|----------|--------------|------|
| `nvidia/cosmos-nemotron-34b` | Cosmos Nemotron 34B | Multimodal (text/image/video) |
| `nvidia/llama-3.1-nemotron-51b-instruct` | Llama 3.1 Nemotron 51B Instruct | Chat |
| `nvidia/llama-3.1-nemotron-70b-instruct` | Llama 3.1 Nemotron 70B Instruct | Chat |
| `nvidia/llama-3.1-nemotron-ultra-253b-v1` | Llama 3.1 Nemotron Ultra 253B | Chat |
| `nvidia/llama-3.3-nemotron-super-49b-v1` | Llama 3.3 Nemotron Super 49B V1 | Chat |
| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Llama 3.3 Nemotron Super 49B V1.5 | Chat |
| `nvidia/llama3-chatqa-1.5-70b` | Llama3 ChatQA 1.5 70B | Chat |
| `nvidia/llama-embed-nemotron-8b` | Llama Embed Nemotron 8B | Embedding |
| `nvidia/nemoretriever-ocr-v1` | NeMo Retriever OCR v1 | OCR |
| `nvidia/nemotron-3-nano-30b-a3b` | Nemotron 3 Nano 30B | Chat |
| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B | Chat |
| `nvidia/nemotron-4-340b-instruct` | Nemotron 4 340B Instruct | Chat |
| `nvidia/nvidia-nemotron-nano-9b-v2` | Nemotron Nano 9B v2 | Chat |
| `nvidia/parakeet-tdt-0.6b-v2` | Parakeet TDT 0.6B v2 | Audio transcription |
