### PR TITLE
feat: unify configured model routing and normalize storage keys

### DIFF
--- a/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 // 扩展 schema 以包含模型映射的校验规则
-const createModelMappingFormSchema = (supportedModels: string[]) =>
+const createModelMappingFormSchema = () =>
   z.object({
     extraModelPrefix: z.string().optional(),
     modelMappings: z
@@ -45,15 +45,6 @@ const createModelMappingFormSchema = (supportedModels: string[]) =>
         },
         {
           message: 'Each original model can only be mapped once',
-        }
-      )
-      .refine(
-        (mappings) => {
-          // 检查所有目标模型是否在支持的模型列表中
-          return mappings.every((m) => supportedModels.includes(m.to));
-        },
-        {
-          message: 'Target model must be in supported models',
         }
       ),
     autoTrimedModelPrefixes: z.array(z.string()).optional(),
@@ -100,7 +91,7 @@ export function ChannelsModelMappingDialog({ open, onOpenChange, currentRow }: P
 
   const prefixSuggestions = useMemo(() => extractAllPrefixes(currentRow.supportedModels), [currentRow.supportedModels]);
 
-  const modelMappingFormSchema = createModelMappingFormSchema(currentRow.supportedModels);
+  const modelMappingFormSchema = createModelMappingFormSchema();
 
   const form = useForm<z.infer<typeof modelMappingFormSchema>>({
     resolver: zodResolver(modelMappingFormSchema),
@@ -181,11 +172,6 @@ export function ChannelsModelMappingDialog({ open, onOpenChange, currentRow }: P
     if (!normalized.from || !normalized.to) {
       return t('channels.dialogs.settings.modelMapping.validationRequired', {
         defaultValue: 'Both alias and target model are required',
-      });
-    }
-    if (!currentRow.supportedModels.includes(normalized.to)) {
-      return t('channels.dialogs.settings.modelMapping.targetInvalid', {
-        defaultValue: 'Target model must be in supported models',
       });
     }
     const isDuplicateFrom = modelMappings.some((mapping, idx) => idx !== skipIndex && mapping.from === normalized.from);

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -3,7 +3,6 @@ package biz
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -370,8 +369,7 @@ func (svc *ChannelService) ListModels(ctx context.Context, input ListModelsInput
 			// Add model mappings if requested
 			if input.IncludeMapping && ch.Settings != nil {
 				for _, mapping := range ch.Settings.ModelMappings {
-					// Only add the mapping if the target model is supported
-					if slices.Contains(ch.SupportedModels, mapping.To) {
+					if mapping.From != "" && mapping.To != "" {
 						setModelStatus(modelMap, mapping.From, ch.Status)
 					}
 				}

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -912,18 +911,19 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 
 	// 4. Model mappings
 	for _, mapping := range ch.Settings.ModelMappings {
-		// Only add if the target model is supported
-		if slices.Contains(ch.SupportedModels, mapping.To) {
-			if _, exists := entries[mapping.From]; !exists {
-				entries[mapping.From] = ChannelModelEntry{
-					RequestModel: mapping.From,
-					ActualModel:  mapping.To,
-					Source:       "mapping",
-				}
-				// When hideMappedModels is enabled, remove mapped models from the entries
-				if ch.Settings.HideMappedModels {
-					delete(entries, mapping.To)
-				}
+		if strings.TrimSpace(mapping.From) == "" || strings.TrimSpace(mapping.To) == "" {
+			continue
+		}
+
+		if _, exists := entries[mapping.From]; !exists {
+			entries[mapping.From] = ChannelModelEntry{
+				RequestModel: mapping.From,
+				ActualModel:  mapping.To,
+				Source:       "mapping",
+			}
+			// When hideMappedModels is enabled, remove mapped models from the entries
+			if ch.Settings.HideMappedModels {
+				delete(entries, mapping.To)
 			}
 		}
 	}

--- a/internal/server/biz/channel_llm_test.go
+++ b/internal/server/biz/channel_llm_test.go
@@ -293,7 +293,7 @@ func TestChannel_GetModelEntries_HideMappedModels(t *testing.T) {
 			shouldNotContain: []string{"gpt-4"},
 		},
 		{
-			name: "HideMappedModels=true with mapping to unsupported model does not hide original",
+			name: "HideMappedModels=true with mapping target outside supported models still exposes alias",
 			channel: &Channel{
 				Channel: &ent.Channel{
 					Name:            "Test Channel",
@@ -313,8 +313,13 @@ func TestChannel_GetModelEntries_HideMappedModels(t *testing.T) {
 					ActualModel:  "gpt-4",
 					Source:       "mapping",
 				},
+				"invalid-alias": {
+					RequestModel: "invalid-alias",
+					ActualModel:  "claude-3",
+					Source:       "mapping",
+				},
 			},
-			shouldNotContain: []string{"gpt-4", "invalid-alias", "claude-3"},
+			shouldNotContain: []string{"gpt-4", "claude-3"},
 		},
 		{
 			name: "HideMappedModels=true with no mappings shows all original models",

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -518,19 +518,24 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			return "", fmt.Errorf("failed to get file system: %w", err)
 		}
 
+		returnKey := key
+		fsKey := key
+
 		if ds.Type == datastorage.TypeFs {
-			key = filepath.FromSlash(key)
-			err = fs.MkdirAll(filepath.Dir(key), 0o777)
+			fsKey = filepath.FromSlash(key)
+
+			err = fs.MkdirAll(filepath.Dir(fsKey), 0o777)
 			if err != nil {
-				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if ds.Type == datastorage.TypeWebdav {
 			// For WebDAV, remove leading slash to avoid 405 error on some servers (e.g., Synology)
-			key = strings.TrimPrefix(key, "/")
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
 
-			err = s.mkdirAll(fs, filepath.Dir(key))
+			err = s.mkdirAll(fs, filepath.Dir(fsKey))
 			if err != nil {
-				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		}
 
@@ -538,23 +543,24 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			// For S3 with PathStyle enabled, remove leading slash from key
 			// to avoid InvalidArgument error from S3 compatible storage services
 			if isS3PathStyle(ds) {
-				key = strings.TrimPrefix(key, "/")
+				returnKey = strings.TrimPrefix(returnKey, "/")
+				fsKey = strings.TrimPrefix(fsKey, "/")
 			}
 
-			f, err := fs.Create(key)
+			f, err := fs.Create(fsKey)
 			if err != nil {
-				return "", fmt.Errorf("failed to create file: %w, key: %s", err, key)
+				return "", fmt.Errorf("failed to create file: %w, key: %s", err, fsKey)
 			}
 
 			_ = f.Close()
 		}
 
 		// Write data to file
-		if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
-			return "", fmt.Errorf("failed to write file: %w, key: %s", err, key)
+		if err := afero.WriteFile(fs, fsKey, data, 0o777); err != nil {
+			return "", fmt.Errorf("failed to write file: %w, key: %s", err, fsKey)
 		}
 
-		return key, nil
+		return returnKey, nil
 	default:
 		return "", fmt.Errorf("unsupported storage type: %s", ds.Type)
 	}
@@ -573,33 +579,38 @@ func (s *DataStorageService) SaveDataFromReader(ctx context.Context, ds *ent.Dat
 			return "", 0, fmt.Errorf("failed to get file system: %w", err)
 		}
 
+		returnKey := key
+		fsKey := key
+
 		if ds.Type == datastorage.TypeFs {
-			key = filepath.FromSlash(key)
-			if err := fs.MkdirAll(filepath.Dir(key), 0o777); err != nil {
-				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+			fsKey = filepath.FromSlash(key)
+			if err := fs.MkdirAll(filepath.Dir(fsKey), 0o777); err != nil {
+				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if ds.Type == datastorage.TypeWebdav {
 			// For WebDAV, remove leading slash to avoid 405 error on some servers (e.g., Synology)
-			key = strings.TrimPrefix(key, "/")
-			if err := s.mkdirAll(fs, filepath.Dir(key)); err != nil {
-				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
+			if err := s.mkdirAll(fs, filepath.Dir(fsKey)); err != nil {
+				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if isS3PathStyle(ds) {
-			key = strings.TrimPrefix(key, "/")
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
 		}
 
-		f, err := fs.Create(key)
+		f, err := fs.Create(fsKey)
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, key)
+			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, fsKey)
 		}
 		defer f.Close()
 
 		n, err := io.Copy(f, r)
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to write file: %w, key: %s", err, key)
+			return "", 0, fmt.Errorf("failed to write file: %w, key: %s", err, fsKey)
 		}
 
-		return key, n, nil
+		return returnKey, n, nil
 	default:
 		return "", 0, fmt.Errorf("unsupported storage type: %s", ds.Type)
 	}

--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -419,13 +419,17 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		}
 	}
 
-	// Query configured Model entities (used in both modes)
-	configuredModels, err := svc.queryConfiguredModelFacades(ctx, profile, channels)
+	settings := svc.systemService.ModelSettingsOrDefault(ctx)
+	configuredModels, err := svc.queryConfiguredModelFacades(
+		ctx,
+		profile,
+		channels,
+		settings.FallbackToChannelsOnModelNotFound,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	settings := svc.systemService.ModelSettingsOrDefault(ctx)
 	if !settings.QueryAllChannelModels {
 		return configuredModels, nil
 	}
@@ -475,7 +479,12 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 
 // queryConfiguredModelFacades queries enabled Model entities and returns them as ModelFacades
 // filtered by profile modelIDs and channel associations.
-func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, profile *objects.APIKeyProfile, channels []*Channel) ([]ModelFacade, error) {
+func (svc *ModelService) queryConfiguredModelFacades(
+	ctx context.Context,
+	profile *objects.APIKeyProfile,
+	channels []*Channel,
+	allowFallback bool,
+) ([]ModelFacade, error) {
 	query := svc.entFromContext(ctx).
 		Model.
 		Query().
@@ -489,28 +498,50 @@ func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, profil
 		return nil, fmt.Errorf("failed to list configured models: %w", err)
 	}
 
-	var models []ModelFacade
+	models := make([]ModelFacade, 0, len(enabledModels))
 
-	for _, m := range enabledModels {
-		if m.Settings == nil {
+	for _, configuredModel := range enabledModels {
+		if !svc.isConfiguredModelRoutable(configuredModel, channels, allowFallback) {
 			continue
 		}
 
-		associations := MatchAssociations(m.Settings.Associations, channels)
-		if len(associations) > 0 {
-			models = append(models, ModelFacade{
-				ID:          m.ModelID,
-				DisplayName: m.ModelID,
-				CreatedAt:   m.CreatedAt,
-				Created:     m.CreatedAt.Unix(),
-				OwnedBy:     "configured",
-			})
-		}
+		models = append(models, ModelFacade{
+			ID:          configuredModel.ModelID,
+			DisplayName: configuredModel.ModelID,
+			CreatedAt:   configuredModel.CreatedAt,
+			Created:     configuredModel.CreatedAt.Unix(),
+			OwnedBy:     "configured",
+		})
 	}
 
 	return models, nil
 }
 
+func (svc *ModelService) isConfiguredModelRoutable(configuredModel *ent.Model, channels []*Channel, allowFallback bool) bool {
+	if configuredModel == nil {
+		return false
+	}
+
+	if configuredModel.Settings != nil && len(configuredModel.Settings.Associations) > 0 {
+		associations := MatchAssociations(configuredModel.Settings.Associations, channels)
+		if len(associations) > 0 {
+			return true
+		}
+	}
+
+	if !allowFallback {
+		return false
+	}
+
+	for _, ch := range channels {
+		entries := ch.GetModelEntries()
+		if _, ok := entries[configuredModel.ModelID]; ok {
+			return true
+		}
+	}
+
+	return false
+}
 // CountAssociatedChannels counts the number of unique channels associated with the given model associations.
 func (svc *ModelService) CountAssociatedChannels(ctx context.Context, associations []*objects.ModelAssociation) (int, error) {
 	if len(associations) == 0 {

--- a/internal/server/biz/model_test.go
+++ b/internal/server/biz/model_test.go
@@ -601,7 +601,7 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 		require.False(t, resultMap["gpt-4-disabled"], "Disabled channel model should not be included")
 	})
 
-	t.Run("mapping to unsupported model should be ignored", func(t *testing.T) {
+	t.Run("mapping to model outside supported_models should still be available", func(t *testing.T) {
 		// Create channel with invalid mapping
 		_, err := client.Channel.Create().
 			SetType(channel.TypeOpenai).
@@ -645,7 +645,7 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 
 		require.True(t, resultMap["gpt-4"], "Valid model should be included")
 		require.True(t, resultMap["gpt-4-latest"], "Valid mapping should be included")
-		require.False(t, resultMap["invalid-mapping"], "Invalid mapping should not be included")
+		require.True(t, resultMap["invalid-mapping"], "Mapping target outside supported_models should still be included")
 	})
 
 	t.Run("auto-trimmed models", func(t *testing.T) {
@@ -1306,6 +1306,10 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 		// (ChannelIDs filter is applied first, then ChannelTags filter)
 		if len(result) > 0 {
 			for _, model := range result {
+				if model.OwnedBy == "configured" {
+					continue
+				}
+
 				require.Equal(t, channels[0].Channel.Type.String(), model.OwnedBy,
 					"Model %s should be from the first channel", model.ID)
 			}

--- a/internal/server/gql/model.resolvers.go
+++ b/internal/server/gql/model.resolvers.go
@@ -123,6 +123,15 @@ func (r *queryResolver) FetchModels(ctx context.Context, input biz.FetchModelsIn
 // When QueryAllChannelModels is true, returns all models from channels.
 // When false, returns only configured models (models with explicit Model entity configuration).
 func (r *queryResolver) QueryModels(ctx context.Context, input QueryModelsInput) ([]*biz.ModelIdentityWithStatus, error) {
+	// Convert channel status to model status
+	var modelStatusIn []model.Status
+
+	if len(input.StatusIn) > 0 {
+		for _, status := range input.StatusIn {
+			modelStatusIn = append(modelStatusIn, model.Status(status.String()))
+		}
+	}
+
 	// Check the QueryAllChannelModels setting
 	settings := r.systemService.ModelSettingsOrDefault(ctx)
 
@@ -135,20 +144,37 @@ func (r *queryResolver) QueryModels(ctx context.Context, input QueryModelsInput)
 			IncludeAllChannelModels: lo.FromPtrOr(input.IncludeAllChannelModels, false),
 		}
 
-		// Return all models from channels
-		return r.channelService.ListModels(ctx, bizInput)
+		channelModels, err := r.channelService.ListModels(ctx, bizInput)
+		if err != nil {
+			return nil, err
+		}
+
+		configuredModels, err := r.modelService.ListModels(ctx, modelStatusIn)
+		if err != nil {
+			return nil, err
+		}
+
+		merged := make([]*biz.ModelIdentityWithStatus, 0, len(channelModels)+len(configuredModels))
+		seen := make(map[string]struct{}, len(channelModels)+len(configuredModels))
+
+		for _, item := range channelModels {
+			merged = append(merged, item)
+			seen[item.ID] = struct{}{}
+		}
+
+		for _, item := range configuredModels {
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+
+			merged = append(merged, item)
+			seen[item.ID] = struct{}{}
+		}
+
+		return merged, nil
 	}
 
 	// Return only configured models
-	// Convert channel status to model status
-	var modelStatusIn []model.Status
-
-	if len(input.StatusIn) > 0 {
-		for _, status := range input.StatusIn {
-			modelStatusIn = append(modelStatusIn, model.Status(status.String()))
-		}
-	}
-
 	return r.modelService.ListModels(ctx, modelStatusIn)
 }
 

--- a/internal/server/orchestrator/candidates.go
+++ b/internal/server/orchestrator/candidates.go
@@ -125,9 +125,16 @@ func (s *DefaultSelector) selectModelCandidates(ctx context.Context, req *llm.Re
 		return nil, fmt.Errorf("failed to query AxonHub Model: %w", err)
 	}
 
+	settings := s.SystemService.ModelSettingsOrDefault(ctx)
+	allowFallback := settings.FallbackToChannelsOnModelNotFound
+
 	if model.Settings == nil || len(model.Settings.Associations) == 0 {
 		if log.DebugEnabled(ctx) {
 			log.Debug(ctx, "model has no associations", log.String("model", req.Model))
+		}
+
+		if allowFallback {
+			return s.selectChannelCadidates(ctx, req)
 		}
 
 		return []*ChannelModelsCandidate{}, nil
@@ -144,6 +151,10 @@ func (s *DefaultSelector) selectModelCandidates(ctx context.Context, req *llm.Re
 	candidates, err := s.resolveAssociations(ctx, model, model.Settings.Associations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve associations: %w", err)
+	}
+
+	if len(candidates) == 0 && allowFallback {
+		return s.selectChannelCadidates(ctx, req)
 	}
 
 	if log.DebugEnabled(ctx) {

--- a/internal/server/orchestrator/candidates.go
+++ b/internal/server/orchestrator/candidates.go
@@ -77,6 +77,11 @@ func (s *DefaultSelector) Select(ctx context.Context, req *llm.Request) ([]*Chan
 			return nil, fmt.Errorf("%w: %q", biz.ErrInvalidModel, req.Model)
 		}
 
+		log.Warn(ctx, "failed to select configured model candidates",
+			log.String("request_model", req.Model),
+			log.Cause(err),
+		)
+
 		return nil, fmt.Errorf("%w: %q", err, req.Model)
 	}
 
@@ -122,6 +127,9 @@ func (s *DefaultSelector) selectChannelCadidates(ctx context.Context, req *llm.R
 func (s *DefaultSelector) selectModelCandidates(ctx context.Context, req *llm.Request) ([]*ChannelModelsCandidate, error) {
 	model, err := s.ModelService.GetModelByModelID(ctx, req.Model, model.StatusEnabled)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("failed to query AxonHub Model: %w", err)
 	}
 

--- a/internal/server/orchestrator/candidates_cache_test.go
+++ b/internal/server/orchestrator/candidates_cache_test.go
@@ -120,6 +120,9 @@ func TestDefaultSelector_SelectModelCandidates_Cache(t *testing.T) {
 			Save(ctx)
 		require.NoError(t, err)
 
+		// Recreate channel service to ensure updated timestamps are loaded.
+		selector.ChannelService = newTestChannelServiceForChannels(client)
+
 		// Clear cache to force refresh
 		selector.cacheMu.Lock()
 		selector.associationCache = make(map[string]*associationCacheEntry)


### PR DESCRIPTION
## Summary
- unify configured models with channel models for query and routing
- allow model lookup and candidate selection to work consistently with configured model definitions
- keep returned storage keys slash-separated across platforms while still using OS-native paths for local filesystem writes

## Why
There are two related behavior issues here.

First, configured models and channel models were not treated consistently across query, routing, and candidate selection. That created gaps where a model could be configured in AxonHub but still behave differently depending on whether the code path looked at configured models or channel-native models. This change makes those paths converge so configured model definitions can participate in listing and routing more predictably.

Second, data storage keys are logical identifiers and should stay stable across platforms. On Windows, filesystem writes could convert a logical key like `test/key.txt` into `test\\key.txt` and return the converted value. This makes storage keys OS-dependent. The storage change keeps the externally visible key normalized while still using filesystem-specific paths internally where needed.

Putting these changes together keeps model behavior more consistent at the application layer, and keeps persisted storage keys stable at the storage layer.

## Testing
- `go test ./internal/server/biz -count=1`
- `go test ./internal/server/orchestrator -count=1`