### PR TITLE
feat: add image generation support to NanoGPT channel

### DIFF
--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -498,7 +498,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
   nanogpt: {
     channelType: 'nanogpt',
     baseURL: 'https://nano-gpt.com/api/v1',
-    defaultModels: ['zai-org/glm-4.7:thinking', 'zai-org/glm-4.7', 'zai-org/glm-4.6'],
+    defaultModels: ['hidream', 'flux-kontext', 'zai-org/glm-4.7:thinking', 'zai-org/glm-4.7', 'zai-org/glm-4.6'],
     apiFormat: OPENAI_CHAT_COMPLETIONS,
     color: 'bg-gradient-to-br from-[#015a9e] to-[#11e9bb] text-slate-900 border-transparent',
     icon: NanoGPTIcon,

--- a/llm/transformer/nanogpt/outbound.go
+++ b/llm/transformer/nanogpt/outbound.go
@@ -87,11 +87,14 @@ func (t *OutboundTransformer) TransformResponse(
 	}
 
 	// Route to embedded OpenAI transformer for embedding and image-related responses
-	if httpResp.Request != nil && (httpResp.Request.APIFormat == string(llm.APIFormatOpenAIEmbedding) ||
-		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageGeneration) ||
-		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageEdit) ||
-		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageVariation)) {
-		return t.Outbound.TransformResponse(ctx, httpResp)
+	if httpResp.Request != nil {
+		switch httpResp.Request.APIFormat {
+		case string(llm.APIFormatOpenAIEmbedding),
+			string(llm.APIFormatOpenAIImageGeneration),
+			string(llm.APIFormatOpenAIImageEdit),
+			string(llm.APIFormatOpenAIImageVariation):
+			return t.Outbound.TransformResponse(ctx, httpResp)
+		}
 	}
 
 	var nanoResp Response

--- a/llm/transformer/nanogpt/outbound.go
+++ b/llm/transformer/nanogpt/outbound.go
@@ -86,8 +86,11 @@ func (t *OutboundTransformer) TransformResponse(
 		return nil, fmt.Errorf("response body is empty")
 	}
 
-	// Route to embedded OpenAI transformer for embedding responses
-	if httpResp.Request != nil && httpResp.Request.APIFormat == string(llm.APIFormatOpenAIEmbedding) {
+	// Route to embedded OpenAI transformer for embedding and image-related responses
+	if httpResp.Request != nil && (httpResp.Request.APIFormat == string(llm.APIFormatOpenAIEmbedding) ||
+		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageGeneration) ||
+		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageEdit) ||
+		httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageVariation)) {
 		return t.Outbound.TransformResponse(ctx, httpResp)
 	}
 

--- a/llm/transformer/nanogpt/outbound_test.go
+++ b/llm/transformer/nanogpt/outbound_test.go
@@ -175,6 +175,31 @@ func TestOutboundTransformer_TransformResponse(t *testing.T) {
 			},
 		},
 		{
+			name: "image generation request routes to embedded OpenAI transformer",
+			httpResp: &httpclient.Response{
+				StatusCode: http.StatusOK,
+				Body: []byte(`{
+					"created": 1234567890,
+					"data": [{
+						"b64_json": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+						"revised_prompt": "A sunset over mountains"
+					}]
+				}`),
+				Request: &httpclient.Request{
+					APIFormat: string(llm.APIFormatOpenAIImageGeneration),
+				},
+			},
+			expectedErr: false,
+
+			validateResp: func(t *testing.T, resp *llm.Response) {
+				require.NotNil(t, resp)
+				require.NotNil(t, resp.Image)
+				require.NotNil(t, resp.Image.Data)
+				require.Len(t, resp.Image.Data, 1)
+				assert.NotEmpty(t, resp.Image.Data[0].B64JSON)
+			},
+		},
+		{
 			name: "chat request uses NanoGPT-specific parsing",
 			httpResp: &httpclient.Response{
 				StatusCode: http.StatusOK,


### PR DESCRIPTION
## Summary

Enable image generation via NanoGPT's OpenAI-compatible API.

## Spirit

Allow users to generate images through NanoGPT channel using hidream, flux-kontext models.

## Key Changes

- Route image generation/edit/variation responses to embedded OpenAI transformer
- Add hidream and flux-kontext to default models list
- Add test coverage for image generation handling

### Files Changed

- `llm/transformer/nanogpt/outbound.go` - Add APIFormatOpenAIImageGeneration routing to NanoGPT transformer
- `llm/transformer/nanogpt/outbound_test.go` - Test coverage for image generation handling
- `frontend/src/features/channels/data/config_channels.ts` - Add hidream and flux-kontext to default models list