### PR TITLE
fix(codex): 修复下游无 system message 时 Codex 渠道返回 400 的问题

### DIFF
--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -145,6 +146,8 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, err
 	}
 
+	hreq.Body = ensureInstructionsField(hreq.Body)
+
 	// Overwrite auth.
 	hreq.Auth = &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: creds.AccessToken}
 	// Compact requests expect JSON response, others expect SSE stream.
@@ -252,4 +255,20 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 
 func (e *codexExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	return e.inner.DoStream(ctx, request)
+}
+
+func ensureInstructionsField(body []byte) []byte {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	if _, ok := m["instructions"]; ok {
+		return body
+	}
+	m["instructions"] = json.RawMessage(`""`)
+	patched, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return patched
 }

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -259,7 +259,7 @@ func (e *codexExecutor) DoStream(ctx context.Context, request *httpclient.Reques
 
 func ensureInstructionsField(body []byte) []byte {
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(body, &m); err != nil {
+	if err := json.Unmarshal(body, &m); err != nil || m == nil {
 		return body
 	}
 	if _, ok := m["instructions"]; ok {

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -2,7 +2,6 @@ package codex
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -146,8 +145,6 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, err
 	}
 
-	hreq.Body = ensureInstructionsField(hreq.Body)
-
 	// Overwrite auth.
 	hreq.Auth = &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: creds.AccessToken}
 	// Compact requests expect JSON response, others expect SSE stream.
@@ -255,20 +252,4 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 
 func (e *codexExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	return e.inner.DoStream(ctx, request)
-}
-
-func ensureInstructionsField(body []byte) []byte {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(body, &m); err != nil || m == nil {
-		return body
-	}
-	if _, ok := m["instructions"]; ok {
-		return body
-	}
-	m["instructions"] = json.RawMessage(`""`)
-	patched, err := json.Marshal(m)
-	if err != nil {
-		return body
-	}
-	return patched
 }

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -185,8 +185,9 @@ func TestCodexOutbound_DoesNotInjectCLIInstructions(t *testing.T) {
 
 	body := decodeCodexRequestBody(t, hreq)
 
-	_, hasInstructions := body["instructions"]
-	assert.False(t, hasInstructions)
+	instructions, hasInstructions := body["instructions"]
+	assert.True(t, hasInstructions, "instructions field must always be present for Codex")
+	assert.Equal(t, "", instructions)
 	assert.NotContains(t, string(hreq.Body), "You are a coding agent running in the Codex CLI")
 	assert.NotContains(t, string(hreq.Body), "You are Codex")
 	assert.Equal(t, false, body["store"])

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -71,7 +71,7 @@ type Request struct {
 	Model string `json:"model"`
 
 	// A system (or developer) message inserted into the model's context.
-	Instructions string `json:"instructions,omitempty"`
+	Instructions string `json:"instructions"`
 
 	Temperature *float64 `json:"temperature,omitempty"`
 


### PR DESCRIPTION
## 概要

- 修复 Codex 渠道在下游 ChatCompletion 请求无 system message 时返回 400 `{"detail":"Instructions are required"}` 的问题

## 原因

`responses.Request.Instructions` 类型为 `string`，JSON tag 带有 `omitempty`。当下游请求无 system message 时，`convertInstructionsFromMessages` 返回空字符串 `""`，被 `omitempty` 在序列化时丢弃，导致最终 JSON body 中缺少 `instructions` 字段。而 Codex 上游（`chatgpt.com/backend-api/codex/responses`）要求该字段必须存在，即使值为空。

## 修复方案

在 Codex outbound transformer 中新增 `ensureInstructionsField()`，在 `responsesOutbound.TransformRequest` 返回后检查序列化后的 JSON body，若缺少 `instructions` 字段则补入 `""`。该改动仅影响 Codex 渠道，不影响其他 Responses API 渠道。