### PR TITLE
feat: Add configurable default response mode for /v1/models

### DIFF
--- a/frontend/src/features/models/components/models-settings-dialog.tsx
+++ b/frontend/src/features/models/components/models-settings-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Loader2, Settings2, RefreshCcw, Layers } from 'lucide-react';
+import { Loader2, Settings2, RefreshCcw, Layers, ListTree } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -20,11 +20,13 @@ export function ModelSettingsDialog() {
 
   const [fallbackEnabled, setFallbackEnabled] = React.useState(false);
   const [queryAllChannelModels, setQueryAllChannelModels] = React.useState(false);
+  const [defaultModelAPIIncludeAll, setDefaultModelAPIIncludeAll] = React.useState(false);
 
   React.useEffect(() => {
     if (settings) {
       setFallbackEnabled(settings.fallbackToChannelsOnModelNotFound);
       setQueryAllChannelModels(settings.queryAllChannelModels);
+      setDefaultModelAPIIncludeAll(settings.defaultModelAPIIncludeAll);
     }
   }, [settings]);
 
@@ -32,10 +34,11 @@ export function ModelSettingsDialog() {
     const input: UpdateModelSettingsInput = {
       fallbackToChannelsOnModelNotFound: fallbackEnabled,
       queryAllChannelModels: queryAllChannelModels,
+      defaultModelAPIIncludeAll: defaultModelAPIIncludeAll,
     };
     await updateModelSettings.mutateAsync(input);
     setOpen(null);
-  }, [updateModelSettings, fallbackEnabled, queryAllChannelModels, setOpen]);
+  }, [updateModelSettings, fallbackEnabled, queryAllChannelModels, defaultModelAPIIncludeAll, setOpen]);
 
   const handleClose = useCallback(() => {
     setOpen(null);
@@ -92,6 +95,26 @@ export function ModelSettingsDialog() {
                     id='query-all-channel-models'
                     checked={queryAllChannelModels}
                     onCheckedChange={setQueryAllChannelModels}
+                    disabled={updateModelSettings.isPending}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className='pb-0'>
+                <CardTitle className='flex items-center gap-2 text-sm'>
+                  <ListTree className='text-muted-foreground h-4 w-4' />
+                  {t('models.dialogs.settings.defaultModelAPIIncludeAll.label')}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className='pt-1'>
+                <div className='flex items-center justify-between'>
+                  <p className='text-muted-foreground pr-4 text-sm'>{t('models.dialogs.settings.defaultModelAPIIncludeAll.description')}</p>
+                  <Switch
+                    id='default-model-api-include-all'
+                    checked={defaultModelAPIIncludeAll}
+                    onCheckedChange={setDefaultModelAPIIncludeAll}
                     disabled={updateModelSettings.isPending}
                   />
                 </div>

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -550,6 +550,7 @@ const MODEL_SETTINGS_QUERY = `
     systemModelSettings {
       fallbackToChannelsOnModelNotFound
       queryAllChannelModels
+      defaultModelAPIIncludeAll
     }
   }
 `;
@@ -615,11 +616,13 @@ const UPDATE_VIDEO_STORAGE_SETTINGS_MUTATION = `
 export interface ModelSettings {
   fallbackToChannelsOnModelNotFound: boolean;
   queryAllChannelModels: boolean;
+  defaultModelAPIIncludeAll: boolean;
 }
 
 export interface UpdateModelSettingsInput {
   fallbackToChannelsOnModelNotFound?: boolean;
   queryAllChannelModels?: boolean;
+  defaultModelAPIIncludeAll?: boolean;
 }
 
 export function useModelSettings() {

--- a/frontend/src/locales/en/models.json
+++ b/frontend/src/locales/en/models.json
@@ -103,6 +103,8 @@
   "models.dialogs.settings.fallbackToChannels.description": "When enabled, if a requested model is not found in model associations, the system will attempt to find enabled channels that support the requested model directly.",
   "models.dialogs.settings.queryAllChannelModels.label": "Query All Channel Models",
   "models.dialogs.settings.queryAllChannelModels.description": "When enabled, models API returns all models from enabled channels. When disabled, only models with explicit Model entity configuration will be returned.",
+  "models.dialogs.settings.defaultModelAPIIncludeAll.label": "Return full model info from /v1/models",
+  "models.dialogs.settings.defaultModelAPIIncludeAll.description": "When enabled, GET /v1/models returns the same extended metadata as ?include=all by default. When disabled, it returns basic fields unless include is explicitly requested.",
   "models.unassociated.title": "Unassociated Channels Detection",
   "models.unassociated.description": "Detect channels with models that are not associated with any model configuration",
   "models.unassociated.summary": "Found {{channelCount}} channels with {{modelCount}} unassociated models",

--- a/frontend/src/locales/zh-CN/models.json
+++ b/frontend/src/locales/zh-CN/models.json
@@ -103,6 +103,8 @@
   "models.dialogs.settings.fallbackToChannels.description": "启用后，如果请求的模型在模型关联中找不到，系统将尝试直接查找支持该请求模型的已启用渠道。",
   "models.dialogs.settings.queryAllChannelModels.label": "查询所有渠道模型",
   "models.dialogs.settings.queryAllChannelModels.description": "启用后，模型 API 将返回所有已启用渠道的模型。禁用后，仅返回具有显式模型实体配置的模型。",
+  "models.dialogs.settings.defaultModelAPIIncludeAll.label": "/v1/models 默认返回完整模型信息",
+  "models.dialogs.settings.defaultModelAPIIncludeAll.description": "启用后，GET /v1/models 默认返回与 ?include=all 相同的扩展元数据。禁用后，仅返回基础字段，除非显式指定 include。",
   "models.unassociated.title": "未关联渠道检测",
   "models.unassociated.description": "检测渠道中未与任何模型配置关联的模型",
   "models.unassociated.summary": "发现 {{channelCount}} 个渠道有 {{modelCount}} 个未关联的模型",

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -334,14 +334,14 @@ const (
 	openAIErrorParamModel         = "model"
 )
 
-func parseOpenAIModelInclude(includeParam string) (map[string]bool, bool) {
+func parseOpenAIModelInclude(includeParam string, defaultIncludeAll bool) (map[string]bool, bool) {
 	var (
 		include      map[string]bool
 		needFullData bool
 	)
 
 	if includeParam == "" {
-		return nil, false
+		return nil, defaultIncludeAll
 	}
 
 	if includeParam == "all" {
@@ -488,7 +488,7 @@ func (handlers *OpenAIHandlers) RetrieveModel(c *gin.Context) {
 		return
 	}
 
-	include, needFullData := parseOpenAIModelInclude(c.Query("include"))
+	include, needFullData := parseOpenAIModelInclude(c.Query("include"), false)
 
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
@@ -536,7 +536,7 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 
 	requestID, _ := contexts.GetRequestID(ctx)
 
-	include, needFullData := parseOpenAIModelInclude(c.Query("include"))
+	include, needFullData := parseOpenAIModelInclude(c.Query("include"), handlers.SystemService.ModelSettingsOrDefault(ctx).DefaultModelAPIIncludeAll)
 
 	var openaiModels []OpenAIModel
 	if needFullData {

--- a/internal/server/api/openai_retrieve_test.go
+++ b/internal/server/api/openai_retrieve_test.go
@@ -22,7 +22,7 @@ import (
 	openaitypes "github.com/looplj/axonhub/llm/transformer/openai"
 )
 
-func setupOpenAIRetrieveTest(t *testing.T) (*ent.Client, *biz.ChannelService, *gin.Engine, context.Context) {
+func setupOpenAIRetrieveTest(t *testing.T) (*ent.Client, *biz.ChannelService, *biz.SystemService, *gin.Engine, context.Context) {
 	t.Helper()
 
 	gin.SetMode(gin.TestMode)
@@ -42,8 +42,9 @@ func setupOpenAIRetrieveTest(t *testing.T) (*ent.Client, *biz.ChannelService, *g
 	})
 
 	handlers := &OpenAIHandlers{
-		ModelService: modelSvc,
-		EntClient:    client,
+		ModelService:  modelSvc,
+		SystemService: systemSvc,
+		EntClient:     client,
 	}
 
 	router := gin.New()
@@ -53,16 +54,17 @@ func setupOpenAIRetrieveTest(t *testing.T) (*ent.Client, *biz.ChannelService, *g
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
+	router.GET("/v1/models", handlers.ListModels)
 	router.GET("/v1/models/*model", handlers.RetrieveModel)
 
 	ctx := ent.NewContext(context.Background(), client)
 	ctx = authz.WithTestBypass(ctx)
 
-	return client, channelSvc, router, ctx
+	return client, channelSvc, systemSvc, router, ctx
 }
 
 func TestOpenAIHandlers_RetrieveModel_SupportsSlashModelIDs(t *testing.T) {
-	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+	client, channelSvc, _, router, ctx := setupOpenAIRetrieveTest(t)
 
 	createdAt := time.Unix(1712345678, 0)
 	ch, err := client.Channel.Create().
@@ -95,7 +97,7 @@ func TestOpenAIHandlers_RetrieveModel_SupportsSlashModelIDs(t *testing.T) {
 }
 
 func TestOpenAIHandlers_RetrieveModel_FallsBackToBasicWhenConfiguredMetadataMissing(t *testing.T) {
-	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+	client, channelSvc, _, router, ctx := setupOpenAIRetrieveTest(t)
 
 	createdAt := time.Unix(1712345688, 0)
 	ch, err := client.Channel.Create().
@@ -130,7 +132,7 @@ func TestOpenAIHandlers_RetrieveModel_FallsBackToBasicWhenConfiguredMetadataMiss
 }
 
 func TestOpenAIHandlers_RetrieveModel_ReturnsExtendedConfiguredModel(t *testing.T) {
-	client, channelSvc, router, ctx := setupOpenAIRetrieveTest(t)
+	client, channelSvc, _, router, ctx := setupOpenAIRetrieveTest(t)
 
 	channelCreatedAt := time.Unix(1712345698, 0)
 	ch, err := client.Channel.Create().
@@ -209,7 +211,7 @@ func TestOpenAIHandlers_RetrieveModel_ReturnsExtendedConfiguredModel(t *testing.
 }
 
 func TestOpenAIHandlers_RetrieveModel_ReturnsNotFound(t *testing.T) {
-	_, _, router, _ := setupOpenAIRetrieveTest(t)
+	_, _, _, router, _ := setupOpenAIRetrieveTest(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/models/missing-model", nil)
 	w := httptest.NewRecorder()
@@ -223,4 +225,144 @@ func TestOpenAIHandlers_RetrieveModel_ReturnsNotFound(t *testing.T) {
 	require.Equal(t, "invalid_request_error", got.Detail.Type)
 	require.Equal(t, "model", got.Detail.Param)
 	require.Contains(t, got.Detail.Message, "missing-model")
+}
+
+func TestOpenAIHandlers_ListModels_UsesBasicFieldsByDefault(t *testing.T) {
+	client, channelSvc, _, router, ctx := setupOpenAIRetrieveTest(t)
+
+	createdAt := time.Unix(1712345698, 0)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: ch}})
+
+	remark := "GPT-4.1 reasoning model"
+	_, err = client.Model.Create().
+		SetDeveloper("openai").
+		SetModelID("gpt-4.1").
+		SetName("GPT-4.1").
+		SetType(model.TypeChat).
+		SetGroup("gpt").
+		SetIcon("openai").
+		SetRemark(remark).
+		SetModelCard(&objects.ModelCard{
+			Vision:    true,
+			ToolCall:  true,
+			Reasoning: objects.ModelCardReasoning{Supported: true},
+			Limit:     objects.ModelCardLimit{Context: 200000, Output: 8192},
+			Cost:      objects.ModelCardCost{Input: 2, Output: 8, CacheRead: 0.5, CacheWrite: 1},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{
+				{
+					Type: "channel_model",
+					ChannelModel: &objects.ChannelModelAssociation{
+						ChannelID: ch.ID,
+						ModelID:   "gpt-4.1",
+					},
+				},
+			},
+		}).
+		SetStatus(model.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		Data []OpenAIModel `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got.Data, 1)
+	require.Equal(t, "gpt-4.1", got.Data[0].ID)
+	require.Empty(t, got.Data[0].Name)
+	require.Nil(t, got.Data[0].Capabilities)
+	require.Nil(t, got.Data[0].Pricing)
+}
+
+func TestOpenAIHandlers_ListModels_UsesExtendedFieldsWhenConfiguredAsDefault(t *testing.T) {
+	client, channelSvc, systemSvc, router, ctx := setupOpenAIRetrieveTest(t)
+
+	err := systemSvc.SetModelSettings(ctx, biz.SystemModelSettings{
+		FallbackToChannelsOnModelNotFound: true,
+		QueryAllChannelModels:             true,
+		DefaultModelAPIIncludeAll:         true,
+	})
+	require.NoError(t, err)
+
+	createdAt := time.Unix(1712345698, 0)
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: ch}})
+
+	remark := "GPT-4.1 reasoning model"
+	_, err = client.Model.Create().
+		SetDeveloper("openai").
+		SetModelID("gpt-4.1").
+		SetName("GPT-4.1").
+		SetType(model.TypeChat).
+		SetGroup("gpt").
+		SetIcon("openai").
+		SetRemark(remark).
+		SetModelCard(&objects.ModelCard{
+			Vision:    true,
+			ToolCall:  true,
+			Reasoning: objects.ModelCardReasoning{Supported: true},
+			Limit:     objects.ModelCardLimit{Context: 200000, Output: 8192},
+			Cost:      objects.ModelCardCost{Input: 2, Output: 8, CacheRead: 0.5, CacheWrite: 1},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{
+				{
+					Type: "channel_model",
+					ChannelModel: &objects.ChannelModelAssociation{
+						ChannelID: ch.ID,
+						ModelID:   "gpt-4.1",
+					},
+				},
+			},
+		}).
+		SetStatus(model.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		Data []OpenAIModel `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got.Data, 1)
+	require.Equal(t, "gpt-4.1", got.Data[0].ID)
+	require.Equal(t, "GPT-4.1", got.Data[0].Name)
+	require.Equal(t, remark, got.Data[0].Description)
+	require.NotNil(t, got.Data[0].Capabilities)
+	require.NotNil(t, got.Data[0].Pricing)
 }

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -216,6 +216,12 @@ type SystemModelSettings struct {
 	// When true, the models API will return all models supported by enabled channels.
 	// When false, only models that have explicit Model entity configuration will be returned.
 	QueryAllChannelModels bool `json:"query_all_channel_models"`
+
+	// DefaultModelAPIIncludeAll controls whether GET /v1/models returns extended model
+	// metadata by default when the include query parameter is omitted.
+	// When true, /v1/models behaves like /v1/models?include=all.
+	// When false, /v1/models returns only the basic compatibility fields by default.
+	DefaultModelAPIIncludeAll bool `json:"default_model_api_include_all"`
 }
 
 type SystemChannelSettings struct {

--- a/internal/server/biz/system_default.go
+++ b/internal/server/biz/system_default.go
@@ -29,6 +29,7 @@ var defaultRetryPolicy = RetryPolicy{
 var defaultModelSettings = SystemModelSettings{
 	FallbackToChannelsOnModelNotFound: true,
 	QueryAllChannelModels:             true,
+	DefaultModelAPIIncludeAll:         false,
 }
 
 var defaultChannelSetting = SystemChannelSettings{

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1414,6 +1414,7 @@ type ComplexityRoot struct {
 	}
 
 	SystemModelSettings struct {
+		DefaultModelAPIIncludeAll         func(childComplexity int) int
 		FallbackToChannelsOnModelNotFound func(childComplexity int) int
 		QueryAllChannelModels             func(childComplexity int) int
 	}
@@ -7945,6 +7946,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SystemModelSettingOnboarding.Onboarded(childComplexity), true
 
+	case "SystemModelSettings.defaultModelAPIIncludeAll":
+		if e.complexity.SystemModelSettings.DefaultModelAPIIncludeAll == nil {
+			break
+		}
+
+		return e.complexity.SystemModelSettings.DefaultModelAPIIncludeAll(childComplexity), true
 	case "SystemModelSettings.fallbackToChannelsOnModelNotFound":
 		if e.complexity.SystemModelSettings.FallbackToChannelsOnModelNotFound == nil {
 			break
@@ -36107,6 +36114,8 @@ func (ec *executionContext) fieldContext_Query_systemModelSettings(_ context.Con
 				return ec.fieldContext_SystemModelSettings_fallbackToChannelsOnModelNotFound(ctx, field)
 			case "queryAllChannelModels":
 				return ec.fieldContext_SystemModelSettings_queryAllChannelModels(ctx, field)
+			case "defaultModelAPIIncludeAll":
+				return ec.fieldContext_SystemModelSettings_defaultModelAPIIncludeAll(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SystemModelSettings", field.Name)
 		},
@@ -42718,6 +42727,35 @@ func (ec *executionContext) _SystemModelSettings_queryAllChannelModels(ctx conte
 }
 
 func (ec *executionContext) fieldContext_SystemModelSettings_queryAllChannelModels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SystemModelSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SystemModelSettings_defaultModelAPIIncludeAll(ctx context.Context, field graphql.CollectedField, obj *biz.SystemModelSettings) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SystemModelSettings_defaultModelAPIIncludeAll,
+		func(ctx context.Context) (any, error) {
+			return obj.DefaultModelAPIIncludeAll, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_SystemModelSettings_defaultModelAPIIncludeAll(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SystemModelSettings",
 		Field:      field,
@@ -69554,7 +69592,7 @@ func (ec *executionContext) unmarshalInputUpdateSystemModelSettingsInput(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"fallbackToChannelsOnModelNotFound", "queryAllChannelModels"}
+	fieldsInOrder := [...]string{"fallbackToChannelsOnModelNotFound", "queryAllChannelModels", "defaultModelAPIIncludeAll"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69575,6 +69613,13 @@ func (ec *executionContext) unmarshalInputUpdateSystemModelSettingsInput(ctx con
 				return it, err
 			}
 			it.QueryAllChannelModels = data
+		case "defaultModelAPIIncludeAll":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultModelAPIIncludeAll"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DefaultModelAPIIncludeAll = data
 		}
 	}
 
@@ -86547,6 +86592,11 @@ func (ec *executionContext) _SystemModelSettings(ctx context.Context, sel ast.Se
 			}
 		case "queryAllChannelModels":
 			out.Values[i] = ec._SystemModelSettings_queryAllChannelModels(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "defaultModelAPIIncludeAll":
+			out.Values[i] = ec._SystemModelSettings_defaultModelAPIIncludeAll(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/server/gql/system.graphql
+++ b/internal/server/gql/system.graphql
@@ -105,11 +105,13 @@ input UpdateRetryPolicyInput {
 type SystemModelSettings {
   fallbackToChannelsOnModelNotFound: Boolean!
   queryAllChannelModels: Boolean!
+  defaultModelAPIIncludeAll: Boolean!
 }
 
 input UpdateSystemModelSettingsInput {
   fallbackToChannelsOnModelNotFound: Boolean
   queryAllChannelModels: Boolean
+  defaultModelAPIIncludeAll: Boolean
 }
 
 input UpdateDefaultDataStorageInput {


### PR DESCRIPTION
## Summary
- add a new system model setting to control whether  returns basic info or full model metadata by default
- keep the default behavior backward-compatible:  still returns basic fields unless the setting is enabled
- expose the setting only in Models Settings and add targeted API handler coverage

## Testing
- go test ./internal/server/api -run 'TestOpenAIHandlers_(ListModels|RetrieveModel)|TestConvertModelToOpenAIExtended'

<img width="784" height="679" alt="image" src="https://github.com/user-attachments/assets/b8e1966f-48cc-4f2e-a402-bac8c82d3126" />

