### PR TITLE
Fix channel prefix handling for model names

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -857,7 +857,7 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 			continue
 		}
 
-		fullPrefix := prefix + "/"
+		fullPrefix := strings.TrimSuffix(prefix, "/") + "/"
 
 		// Determine if any supported model already carries this prefix.
 		// When true: forward direction (trim prefix from model names).
@@ -873,7 +873,7 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 		for _, model := range ch.SupportedModels {
 			if hasPrefix {
 				// Forward: model has the prefix, expose trimmed version
-				if after, ok := strings.CutPrefix(model, fullPrefix); ok {
+				if after, ok := strings.CutPrefix(model, fullPrefix); ok && after != "" {
 					if _, exists := entries[after]; !exists {
 						entries[after] = ChannelModelEntry{
 							RequestModel: after,

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -857,14 +857,37 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 			continue
 		}
 
-		prefix += "/"
+		fullPrefix := prefix + "/"
+
+		// Determine if any supported model already carries this prefix.
+		// When true: forward direction (trim prefix from model names).
+		// When false: reverse direction (add prefix to model names).
+		hasPrefix := false
 		for _, model := range ch.SupportedModels {
-			// Only process models that have the prefix
-			if after, ok := strings.CutPrefix(model, prefix); ok {
-				trimmedModel := after
-				if _, exists := entries[trimmedModel]; !exists {
-					entries[trimmedModel] = ChannelModelEntry{
-						RequestModel: trimmedModel,
+			if strings.HasPrefix(model, fullPrefix) {
+				hasPrefix = true
+				break
+			}
+		}
+
+		for _, model := range ch.SupportedModels {
+			if hasPrefix {
+				// Forward: model has the prefix, expose trimmed version
+				if after, ok := strings.CutPrefix(model, fullPrefix); ok {
+					if _, exists := entries[after]; !exists {
+						entries[after] = ChannelModelEntry{
+							RequestModel: after,
+							ActualModel:  model,
+							Source:       "auto_trim",
+						}
+					}
+				}
+			} else {
+				// Reverse: no models carry the prefix, expose prefixed version
+				prefixedModel := fullPrefix + model
+				if _, exists := entries[prefixedModel]; !exists {
+					entries[prefixedModel] = ChannelModelEntry{
+						RequestModel: prefixedModel,
 						ActualModel:  model,
 						Source:       "auto_trim",
 					}

--- a/internal/server/biz/channel_llm_test.go
+++ b/internal/server/biz/channel_llm_test.go
@@ -411,8 +411,8 @@ func TestChannel_ChooseModel_AutoTrimedModelPrefixes(t *testing.T) {
 				},
 			},
 			inputModel:    "deepseek-ai/DeepSeek-V3.2",
-			expectedModel: "",
-			expectError:   true,
+			expectedModel: "DeepSeek-V3.2",
+			expectError:   false,
 		},
 		{
 			name: "request trimmed, channel supports prefixed",


### PR DESCRIPTION
Fixes #1361

Was only handling the prefix trim case. But some channels like Nebius have models without the prefix, so we need to add it. Now the code checks which direction is needed and handles both. Verified with the test case.