### PR TITLE
fix: normalize storage keys and unify configured model routing

### DIFF
--- a/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-mapping-dialog.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 // 扩展 schema 以包含模型映射的校验规则
-const createModelMappingFormSchema = (supportedModels: string[]) =>
+const createModelMappingFormSchema = () =>
   z.object({
     extraModelPrefix: z.string().optional(),
     modelMappings: z
@@ -45,15 +45,6 @@ const createModelMappingFormSchema = (supportedModels: string[]) =>
         },
         {
           message: 'Each original model can only be mapped once',
-        }
-      )
-      .refine(
-        (mappings) => {
-          // 检查所有目标模型是否在支持的模型列表中
-          return mappings.every((m) => supportedModels.includes(m.to));
-        },
-        {
-          message: 'Target model must be in supported models',
         }
       ),
     autoTrimedModelPrefixes: z.array(z.string()).optional(),
@@ -100,7 +91,7 @@ export function ChannelsModelMappingDialog({ open, onOpenChange, currentRow }: P
 
   const prefixSuggestions = useMemo(() => extractAllPrefixes(currentRow.supportedModels), [currentRow.supportedModels]);
 
-  const modelMappingFormSchema = createModelMappingFormSchema(currentRow.supportedModels);
+  const modelMappingFormSchema = createModelMappingFormSchema();
 
   const form = useForm<z.infer<typeof modelMappingFormSchema>>({
     resolver: zodResolver(modelMappingFormSchema),
@@ -181,11 +172,6 @@ export function ChannelsModelMappingDialog({ open, onOpenChange, currentRow }: P
     if (!normalized.from || !normalized.to) {
       return t('channels.dialogs.settings.modelMapping.validationRequired', {
         defaultValue: 'Both alias and target model are required',
-      });
-    }
-    if (!currentRow.supportedModels.includes(normalized.to)) {
-      return t('channels.dialogs.settings.modelMapping.targetInvalid', {
-        defaultValue: 'Target model must be in supported models',
       });
     }
     const isDuplicateFrom = modelMappings.some((mapping, idx) => idx !== skipIndex && mapping.from === normalized.from);

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -372,7 +373,7 @@ func (svc *ChannelService) ListModels(ctx context.Context, input ListModelsInput
 			// Add model mappings if requested
 			if input.IncludeMapping && ch.Settings != nil {
 				for _, mapping := range ch.Settings.ModelMappings {
-					if mapping.From != "" && mapping.To != "" {
+					if strings.TrimSpace(mapping.From) != "" && strings.TrimSpace(mapping.To) != "" {
 						setModelStatus(modelMap, mapping.From, ch.Status)
 					}
 				}

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -3,7 +3,6 @@ package biz
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -373,8 +372,7 @@ func (svc *ChannelService) ListModels(ctx context.Context, input ListModelsInput
 			// Add model mappings if requested
 			if input.IncludeMapping && ch.Settings != nil {
 				for _, mapping := range ch.Settings.ModelMappings {
-					// Only add the mapping if the target model is supported
-					if slices.Contains(ch.SupportedModels, mapping.To) {
+					if mapping.From != "" && mapping.To != "" {
 						setModelStatus(modelMap, mapping.From, ch.Status)
 					}
 				}

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -886,18 +885,19 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 
 	// 4. Model mappings
 	for _, mapping := range ch.Settings.ModelMappings {
-		// Only add if the target model is supported
-		if slices.Contains(ch.SupportedModels, mapping.To) {
-			if _, exists := entries[mapping.From]; !exists {
-				entries[mapping.From] = ChannelModelEntry{
-					RequestModel: mapping.From,
-					ActualModel:  mapping.To,
-					Source:       "mapping",
-				}
-				// When hideMappedModels is enabled, remove mapped models from the entries
-				if ch.Settings.HideMappedModels {
-					delete(entries, mapping.To)
-				}
+		if strings.TrimSpace(mapping.From) == "" || strings.TrimSpace(mapping.To) == "" {
+			continue
+		}
+
+		if _, exists := entries[mapping.From]; !exists {
+			entries[mapping.From] = ChannelModelEntry{
+				RequestModel: mapping.From,
+				ActualModel:  mapping.To,
+				Source:       "mapping",
+			}
+			// When hideMappedModels is enabled, remove mapped models from the entries
+			if ch.Settings.HideMappedModels {
+				delete(entries, mapping.To)
 			}
 		}
 	}

--- a/internal/server/biz/channel_llm_test.go
+++ b/internal/server/biz/channel_llm_test.go
@@ -293,7 +293,7 @@ func TestChannel_GetModelEntries_HideMappedModels(t *testing.T) {
 			shouldNotContain: []string{"gpt-4"},
 		},
 		{
-			name: "HideMappedModels=true with mapping to unsupported model does not hide original",
+			name: "HideMappedModels=true with mapping to unsupported model still exposes alias",
 			channel: &Channel{
 				Channel: &ent.Channel{
 					Name:            "Test Channel",
@@ -313,8 +313,13 @@ func TestChannel_GetModelEntries_HideMappedModels(t *testing.T) {
 					ActualModel:  "gpt-4",
 					Source:       "mapping",
 				},
+				"invalid-alias": {
+					RequestModel: "invalid-alias",
+					ActualModel:  "claude-3",
+					Source:       "mapping",
+				},
 			},
-			shouldNotContain: []string{"gpt-4", "invalid-alias", "claude-3"},
+			shouldNotContain: []string{"gpt-4", "claude-3"},
 		},
 		{
 			name: "HideMappedModels=true with no mappings shows all original models",

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -518,19 +518,23 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			return "", fmt.Errorf("failed to get file system: %w", err)
 		}
 
+		returnKey := key
+		fsKey := key
+
 		if ds.Type == datastorage.TypeFs {
-			key = filepath.FromSlash(key)
-			err = fs.MkdirAll(filepath.Dir(key), 0o777)
+			fsKey = filepath.FromSlash(key)
+			err = fs.MkdirAll(filepath.Dir(fsKey), 0o777)
 			if err != nil {
-				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if ds.Type == datastorage.TypeWebdav {
 			// For WebDAV, remove leading slash to avoid 405 error on some servers (e.g., Synology)
-			key = strings.TrimPrefix(key, "/")
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
 
-			err = s.mkdirAll(fs, filepath.Dir(key))
+			err = s.mkdirAll(fs, filepath.Dir(fsKey))
 			if err != nil {
-				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		}
 
@@ -538,23 +542,17 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			// For S3 with PathStyle enabled, remove leading slash from key
 			// to avoid InvalidArgument error from S3 compatible storage services
 			if isS3PathStyle(ds) {
-				key = strings.TrimPrefix(key, "/")
+				returnKey = strings.TrimPrefix(returnKey, "/")
+				fsKey = strings.TrimPrefix(fsKey, "/")
 			}
-
-			f, err := fs.Create(key)
-			if err != nil {
-				return "", fmt.Errorf("failed to create file: %w, key: %s", err, key)
-			}
-
-			_ = f.Close()
 		}
 
 		// Write data to file
-		if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
-			return "", fmt.Errorf("failed to write file: %w, key: %s", err, key)
+		if err := afero.WriteFile(fs, fsKey, data, 0o777); err != nil {
+			return "", fmt.Errorf("failed to write file: %w, key: %s", err, fsKey)
 		}
 
-		return key, nil
+		return returnKey, nil
 	default:
 		return "", fmt.Errorf("unsupported storage type: %s", ds.Type)
 	}
@@ -573,33 +571,38 @@ func (s *DataStorageService) SaveDataFromReader(ctx context.Context, ds *ent.Dat
 			return "", 0, fmt.Errorf("failed to get file system: %w", err)
 		}
 
+		returnKey := key
+		fsKey := key
+
 		if ds.Type == datastorage.TypeFs {
-			key = filepath.FromSlash(key)
-			if err := fs.MkdirAll(filepath.Dir(key), 0o777); err != nil {
-				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+			fsKey = filepath.FromSlash(key)
+			if err := fs.MkdirAll(filepath.Dir(fsKey), 0o777); err != nil {
+				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if ds.Type == datastorage.TypeWebdav {
 			// For WebDAV, remove leading slash to avoid 405 error on some servers (e.g., Synology)
-			key = strings.TrimPrefix(key, "/")
-			if err := s.mkdirAll(fs, filepath.Dir(key)); err != nil {
-				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, key)
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
+			if err := s.mkdirAll(fs, filepath.Dir(fsKey)); err != nil {
+				return "", 0, fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
 		} else if isS3PathStyle(ds) {
-			key = strings.TrimPrefix(key, "/")
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
 		}
 
-		f, err := fs.Create(key)
+		f, err := fs.Create(fsKey)
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, key)
+			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, fsKey)
 		}
 		defer f.Close()
 
 		n, err := io.Copy(f, r)
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to write file: %w, key: %s", err, key)
+			return "", 0, fmt.Errorf("failed to write file: %w, key: %s", err, fsKey)
 		}
 
-		return key, n, nil
+		return returnKey, n, nil
 	default:
 		return "", 0, fmt.Errorf("unsupported storage type: %s", ds.Type)
 	}

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -536,15 +536,11 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			if err != nil {
 				return "", fmt.Errorf("failed to create directory: %w, key: %s", err, fsKey)
 			}
-		}
-
-		if ds.Type != datastorage.TypeFs {
+		} else if isS3PathStyle(ds) {
 			// For S3 with PathStyle enabled, remove leading slash from key
 			// to avoid InvalidArgument error from S3 compatible storage services
-			if isS3PathStyle(ds) {
-				returnKey = strings.TrimPrefix(returnKey, "/")
-				fsKey = strings.TrimPrefix(fsKey, "/")
-			}
+			returnKey = strings.TrimPrefix(returnKey, "/")
+			fsKey = strings.TrimPrefix(fsKey, "/")
 		}
 
 		// Write data to file

--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -575,13 +575,18 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		allowedModelIDs = profile.ModelIDs
 	}
 
+	settings := svc.systemService.ModelSettingsOrDefault(ctx)
+
 	// Query configured Model entities (used in both modes)
-	configuredModels, err := svc.queryConfiguredModelFacades(ctx, allowedModelIDs, channels)
+	configuredModels, err := svc.queryConfiguredModelFacades(
+		ctx,
+		allowedModelIDs,
+		channels,
+		settings.FallbackToChannelsOnModelNotFound,
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	settings := svc.systemService.ModelSettingsOrDefault(ctx)
 	if !settings.QueryAllChannelModels {
 		return configuredModels, nil
 	}
@@ -628,7 +633,12 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 
 // queryConfiguredModelFacades queries enabled Model entities and returns them as ModelFacades
 // filtered by allowed model IDs and channel associations.
-func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, allowedModelIDs []string, channels []*Channel) ([]ModelFacade, error) {
+func (svc *ModelService) queryConfiguredModelFacades(
+	ctx context.Context,
+	allowedModelIDs []string,
+	channels []*Channel,
+	allowFallback bool,
+) ([]ModelFacade, error) {
 	query := svc.entFromContext(ctx).
 		Model.
 		Query().
@@ -642,26 +652,49 @@ func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, allowe
 		return nil, fmt.Errorf("failed to list configured models: %w", err)
 	}
 
-	var models []ModelFacade
+	models := make([]ModelFacade, 0, len(enabledModels))
 
-	for _, m := range enabledModels {
-		if m.Settings == nil {
+	for _, configuredModel := range enabledModels {
+		if !svc.isConfiguredModelRoutable(configuredModel, channels, allowFallback) {
 			continue
 		}
 
-		associations := MatchConnections(m.Settings.Associations, channels)
-		if len(associations) > 0 {
-			models = append(models, ModelFacade{
-				ID:          m.ModelID,
-				DisplayName: m.ModelID,
-				CreatedAt:   m.CreatedAt,
-				Created:     m.CreatedAt.Unix(),
-				OwnedBy:     "configured",
-			})
-		}
+		models = append(models, ModelFacade{
+			ID:          configuredModel.ModelID,
+			DisplayName: configuredModel.ModelID,
+			CreatedAt:   configuredModel.CreatedAt,
+			Created:     configuredModel.CreatedAt.Unix(),
+			OwnedBy:     "configured",
+		})
 	}
 
 	return models, nil
+}
+
+func (svc *ModelService) isConfiguredModelRoutable(configuredModel *ent.Model, channels []*Channel, allowFallback bool) bool {
+	if configuredModel == nil {
+		return false
+	}
+
+	if configuredModel.Settings != nil && len(configuredModel.Settings.Associations) > 0 {
+		associations := MatchConnections(configuredModel.Settings.Associations, channels)
+		if len(associations) > 0 {
+			return true
+		}
+	}
+
+	if !allowFallback {
+		return false
+	}
+
+	for _, ch := range channels {
+		entries := ch.GetModelEntries()
+		if _, ok := entries[configuredModel.ModelID]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // CountAssociatedChannels counts the number of unique channels associated with the given model associations.

--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -652,10 +652,19 @@ func (svc *ModelService) queryConfiguredModelFacades(
 		return nil, fmt.Errorf("failed to list configured models: %w", err)
 	}
 
+	channelEntries := make(map[string]struct{})
+	if allowFallback {
+		for _, ch := range channels {
+			for modelID := range ch.GetModelEntries() {
+				channelEntries[modelID] = struct{}{}
+			}
+		}
+	}
+
 	models := make([]ModelFacade, 0, len(enabledModels))
 
 	for _, configuredModel := range enabledModels {
-		if !svc.isConfiguredModelRoutable(configuredModel, channels, allowFallback) {
+		if !svc.isConfiguredModelRoutable(configuredModel, channels, allowFallback, channelEntries) {
 			continue
 		}
 
@@ -671,7 +680,12 @@ func (svc *ModelService) queryConfiguredModelFacades(
 	return models, nil
 }
 
-func (svc *ModelService) isConfiguredModelRoutable(configuredModel *ent.Model, channels []*Channel, allowFallback bool) bool {
+func (svc *ModelService) isConfiguredModelRoutable(
+	configuredModel *ent.Model,
+	channels []*Channel,
+	allowFallback bool,
+	channelEntries map[string]struct{},
+) bool {
 	if configuredModel == nil {
 		return false
 	}
@@ -687,14 +701,8 @@ func (svc *ModelService) isConfiguredModelRoutable(configuredModel *ent.Model, c
 		return false
 	}
 
-	for _, ch := range channels {
-		entries := ch.GetModelEntries()
-		if _, ok := entries[configuredModel.ModelID]; ok {
-			return true
-		}
-	}
-
-	return false
+	_, ok := channelEntries[configuredModel.ModelID]
+	return ok
 }
 
 // CountAssociatedChannels counts the number of unique channels associated with the given model associations.

--- a/internal/server/biz/model_test.go
+++ b/internal/server/biz/model_test.go
@@ -601,7 +601,7 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 		require.False(t, resultMap["gpt-4-disabled"], "Disabled channel model should not be included")
 	})
 
-	t.Run("mapping to unsupported model should be ignored", func(t *testing.T) {
+	t.Run("mapping to unsupported model should still be included", func(t *testing.T) {
 		// Create channel with invalid mapping
 		_, err := client.Channel.Create().
 			SetType(channel.TypeOpenai).
@@ -645,7 +645,7 @@ func TestModelService_ListEnabledModels(t *testing.T) {
 
 		require.True(t, resultMap["gpt-4"], "Valid model should be included")
 		require.True(t, resultMap["gpt-4-latest"], "Valid mapping should be included")
-		require.False(t, resultMap["invalid-mapping"], "Invalid mapping should not be included")
+		require.True(t, resultMap["invalid-mapping"], "Configured mapping alias should be included")
 	})
 
 	t.Run("auto-trimmed models", func(t *testing.T) {

--- a/internal/server/gql/model.resolvers.go
+++ b/internal/server/gql/model.resolvers.go
@@ -123,6 +123,15 @@ func (r *queryResolver) FetchModels(ctx context.Context, input biz.FetchModelsIn
 // When QueryAllChannelModels is true, returns all models from channels.
 // When false, returns only configured models (models with explicit Model entity configuration).
 func (r *queryResolver) QueryModels(ctx context.Context, input QueryModelsInput) ([]*biz.ModelIdentityWithStatus, error) {
+	// Convert channel status to model status
+	var modelStatusIn []model.Status
+
+	if len(input.StatusIn) > 0 {
+		for _, status := range input.StatusIn {
+			modelStatusIn = append(modelStatusIn, model.Status(status.String()))
+		}
+	}
+
 	// Check the QueryAllChannelModels setting
 	settings := r.systemService.ModelSettingsOrDefault(ctx)
 
@@ -135,25 +144,37 @@ func (r *queryResolver) QueryModels(ctx context.Context, input QueryModelsInput)
 			IncludeAllChannelModels: lo.FromPtrOr(input.IncludeAllChannelModels, false),
 		}
 
-		// Return all models from channels
-		models, err := r.channelService.ListModels(ctx, bizInput)
+		channelModels, err := r.channelService.ListModels(ctx, bizInput)
 		if err != nil {
 			return nil, err
 		}
 
-		return models, nil
+		configuredModels, err := r.modelService.ListModels(ctx, modelStatusIn)
+		if err != nil {
+			return nil, err
+		}
+
+		merged := make([]*biz.ModelIdentityWithStatus, 0, len(channelModels)+len(configuredModels))
+		seen := make(map[string]struct{}, len(channelModels)+len(configuredModels))
+
+		for _, item := range configuredModels {
+			merged = append(merged, item)
+			seen[item.ID] = struct{}{}
+		}
+
+		for _, item := range channelModels {
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+
+			merged = append(merged, item)
+			seen[item.ID] = struct{}{}
+		}
+
+		return merged, nil
 	}
 
 	// Return only configured models
-	// Convert channel status to model status
-	var modelStatusIn []model.Status
-
-	if len(input.StatusIn) > 0 {
-		for _, status := range input.StatusIn {
-			modelStatusIn = append(modelStatusIn, model.Status(status.String()))
-		}
-	}
-
 	models, err := r.modelService.ListModels(ctx, modelStatusIn)
 	if err != nil {
 		return nil, err

--- a/internal/server/orchestrator/candidates.go
+++ b/internal/server/orchestrator/candidates.go
@@ -87,11 +87,6 @@ func (s *DefaultSelector) Select(ctx context.Context, req *llm.Request) ([]*Chan
 			return nil, fmt.Errorf("%w: %q", biz.ErrInvalidModel, req.Model)
 		}
 
-		log.Warn(ctx, "failed to select configured model candidates",
-			log.String("request_model", req.Model),
-			log.Cause(err),
-		)
-
 		return nil, fmt.Errorf("%w: %q", err, req.Model)
 	}
 

--- a/internal/server/orchestrator/candidates.go
+++ b/internal/server/orchestrator/candidates.go
@@ -87,6 +87,11 @@ func (s *DefaultSelector) Select(ctx context.Context, req *llm.Request) ([]*Chan
 			return nil, fmt.Errorf("%w: %q", biz.ErrInvalidModel, req.Model)
 		}
 
+		log.Warn(ctx, "failed to select configured model candidates",
+			log.String("request_model", req.Model),
+			log.Cause(err),
+		)
+
 		return nil, fmt.Errorf("%w: %q", err, req.Model)
 	}
 
@@ -127,12 +132,22 @@ func (s *DefaultSelector) selectChannelCadidates(ctx context.Context, req *llm.R
 func (s *DefaultSelector) selectModelCandidates(ctx context.Context, req *llm.Request) ([]*ChannelModelsCandidate, error) {
 	model, err := s.ModelService.GetModelByModelID(ctx, req.Model, model.StatusEnabled)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("failed to query AxonHub Model: %w", err)
 	}
+
+	settings := s.SystemService.ModelSettingsOrDefault(ctx)
+	allowFallback := settings.FallbackToChannelsOnModelNotFound
 
 	if model.Settings == nil || len(model.Settings.Associations) == 0 {
 		if log.DebugEnabled(ctx) {
 			log.Debug(ctx, "model has no associations", log.String("model", req.Model))
+		}
+
+		if allowFallback {
+			return s.selectChannelCadidates(ctx, req)
 		}
 
 		return []*ChannelModelsCandidate{}, nil
@@ -153,6 +168,10 @@ func (s *DefaultSelector) selectModelCandidates(ctx context.Context, req *llm.Re
 
 	candidates := filterResolvedCandidatesForRequest(ctx, req, resolvedCandidates)
 	if len(candidates) == 0 {
+		if allowFallback {
+			return s.selectChannelCadidates(ctx, req)
+		}
+
 		if log.DebugEnabled(ctx) {
 			log.Debug(ctx, "no candidates matched request conditions",
 				log.String("model", req.Model),


### PR DESCRIPTION
This PR replaces #1340 and is rebuilt on top of `release/v0.9.x` as requested.

### What changed
- keep storage keys slash-separated across fs/webdav/s3 path-style handling
- remove redundant pre-create I/O in `SaveData`
- allow channel model mappings when `from/to` are non-empty instead of requiring target membership in `supportedModels`
- merge configured models with channel models in `QueryModels`, with configured models taking priority
- allow configured-model routing to fall back to channel selection when `FallbackToChannelsOnModelNotFound` is enabled
- silence noisy configured-model fallback behavior by returning clean not-found flow to the selector

### Validation
- `go test ./internal/server/biz -run 'TestChannel_GetModelEntries_HideMappedModels|TestModelService_ListEnabledModels' -count=1`
- `go test ./internal/server/orchestrator -run 'TestChatCompletionOrchestrator_Process_MinuteQuotaExceeded' -count=1 -v`
- `go test ./internal/server/gql -run '^$' -count=1`
