### PR TITLE
opt: align codex trace header with latest codex cli

### DIFF
--- a/docs/en/api-reference/openai-api.md
+++ b/docs/en/api-reference/openai-api.md
@@ -59,8 +59,8 @@ AxonHub provides partial support for the OpenAI Responses API. This API offers a
 **Endpoints:**
 - `POST /v1/responses` - Generate a response
 
-**Limitations:**
-- ❌ `previous_response_id` is **not supported** - conversation history must be managed client-side
+**Capabilities:**
+- ✅ `previous_response_id` is supported for continued Responses conversations
 - ✅ Basic response generation is fully functional
 - ✅ Streaming responses are supported
 
@@ -84,9 +84,10 @@ client := openai.NewClient(
 
 ctx := context.Background()
 
-// Generate a response (previous_response_id not supported)
+// Generate a response (previous_response_id supported)
 params := responses.ResponseNewParams{
     Model: shared.ResponsesModel("gpt-4o"),
+    PreviousResponseID: openai.String("resp_prev_123"),
     Input: responses.ResponseNewParamsInputUnion{
         OfString: openai.String("Hello, how are you?"),
     },

--- a/docs/en/api-reference/openai-api.md
+++ b/docs/en/api-reference/openai-api.md
@@ -60,7 +60,7 @@ AxonHub provides partial support for the OpenAI Responses API. This API offers a
 - `POST /v1/responses` - Generate a response
 
 **Capabilities:**
-- ✅ `previous_response_id` is supported for continued Responses conversations
+- ✅ `previous_response_id` passthrough is supported for continued Responses conversations on the same upstream channel
 - ✅ Basic response generation is fully functional
 - ✅ Streaming responses are supported
 
@@ -84,7 +84,7 @@ client := openai.NewClient(
 
 ctx := context.Background()
 
-// Generate a response (previous_response_id supported)
+// Generate a response (previous_response_id passthrough on the same upstream channel)
 params := responses.ResponseNewParams{
     Model: shared.ResponsesModel("gpt-4o"),
     PreviousResponseID: openai.String("resp_prev_123"),

--- a/docs/zh/api-reference/openai-api.md
+++ b/docs/zh/api-reference/openai-api.md
@@ -60,7 +60,7 @@ AxonHub 提供对 OpenAI Responses API 的部分支持。该 API 为单轮交互
 - `POST /v1/responses` - 生成响应
 
 **能力：**
-- ✅ 支持 `previous_response_id`，可用于连续 Responses 对话复用
+- ✅ 支持 `previous_response_id` 透传，可用于同一上游 channel 上的连续 Responses 对话复用
 - ✅ 基本响应生成完全可用
 - ✅ 支持流式响应
 
@@ -84,7 +84,7 @@ client := openai.NewClient(
 
 ctx := context.Background()
 
-// 生成响应（支持 previous_response_id）
+// 生成响应（支持同一上游 channel 的 previous_response_id 透传）
 params := responses.ResponseNewParams{
     Model: shared.ResponsesModel("gpt-4o"),
     PreviousResponseID: openai.String("resp_prev_123"),

--- a/docs/zh/api-reference/openai-api.md
+++ b/docs/zh/api-reference/openai-api.md
@@ -59,8 +59,8 @@ AxonHub 提供对 OpenAI Responses API 的部分支持。该 API 为单轮交互
 **端点：**
 - `POST /v1/responses` - 生成响应
 
-**限制：**
-- ❌ **不支持** `previous_response_id` - 对话历史需要在客户端管理
+**能力：**
+- ✅ 支持 `previous_response_id`，可用于连续 Responses 对话复用
 - ✅ 基本响应生成完全可用
 - ✅ 支持流式响应
 
@@ -84,9 +84,10 @@ client := openai.NewClient(
 
 ctx := context.Background()
 
-// 生成响应（不支持 previous_response_id）
+// 生成响应（支持 previous_response_id）
 params := responses.ResponseNewParams{
     Model: shared.ResponsesModel("gpt-4o"),
+    PreviousResponseID: openai.String("resp_prev_123"),
     Input: responses.ResponseNewParamsInputUnion{
         OfString: openai.String("你好，最近怎么样？"),
     },

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/tracing"
 	"github.com/looplj/axonhub/llm/transformer/anthropic/claudecode"
+	"github.com/looplj/axonhub/llm/transformer/openai/codex"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
@@ -188,38 +188,18 @@ func tryExtractTraceIDFromClaudeCodeRequest(c *gin.Context, config tracing.Confi
 	return traceID, nil
 }
 
-const codexTraceHeader = "Session_id"
-const codexTurnMetadataHeader = "X-Codex-Turn-Metadata"
-
-type codexTurnMetadata struct {
-	SessionID string `json:"session_id"`
-}
-
 // tryExtractTraceIDFromCodexRequest extracts the trace ID from the Codex session header.
 func tryExtractTraceIDFromCodexRequest(c *gin.Context) string {
-	traceID := strings.TrimSpace(c.GetHeader(codexTraceHeader))
+	traceID := codex.GetSessionIDFromHeaders(c.Request.Header)
 	if traceID == "" {
-		turnMetadataRaw := strings.TrimSpace(c.GetHeader(codexTurnMetadataHeader))
-		if turnMetadataRaw == "" {
-			return ""
-		}
-
-		var turnMetadata codexTurnMetadata
-		if err := json.Unmarshal([]byte(turnMetadataRaw), &turnMetadata); err != nil {
-			return ""
-		}
-
-		traceID = strings.TrimSpace(turnMetadata.SessionID)
-		if traceID == "" {
-			return ""
-		}
-
-		log.Debug(c.Request.Context(), "Extracted trace ID from codex turn metadata", log.String("trace_id", traceID))
-
-		return traceID
+		return ""
 	}
 
-	log.Debug(c.Request.Context(), "Extracted trace ID from codex header", log.String("trace_id", traceID))
+	traceSource := "codex header"
+	if strings.TrimSpace(c.GetHeader(codex.SessionHeader)) == "" {
+		traceSource = "codex turn metadata"
+	}
+	log.Debug(c.Request.Context(), "Extracted trace ID from "+traceSource, log.String("trace_id", traceID))
 
 	return traceID
 }

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -188,12 +189,34 @@ func tryExtractTraceIDFromClaudeCodeRequest(c *gin.Context, config tracing.Confi
 }
 
 const codexTraceHeader = "Session_id"
+const codexTurnMetadataHeader = "X-Codex-Turn-Metadata"
+
+type codexTurnMetadata struct {
+	SessionID string `json:"session_id"`
+}
 
 // tryExtractTraceIDFromCodexRequest extracts the trace ID from the Codex session header.
 func tryExtractTraceIDFromCodexRequest(c *gin.Context) string {
 	traceID := strings.TrimSpace(c.GetHeader(codexTraceHeader))
 	if traceID == "" {
-		return ""
+		turnMetadataRaw := strings.TrimSpace(c.GetHeader(codexTurnMetadataHeader))
+		if turnMetadataRaw == "" {
+			return ""
+		}
+
+		var turnMetadata codexTurnMetadata
+		if err := json.Unmarshal([]byte(turnMetadataRaw), &turnMetadata); err != nil {
+			return ""
+		}
+
+		traceID = strings.TrimSpace(turnMetadata.SessionID)
+		if traceID == "" {
+			return ""
+		}
+
+		log.Debug(c.Request.Context(), "Extracted trace ID from codex turn metadata", log.String("trace_id", traceID))
+
+		return traceID
 	}
 
 	log.Debug(c.Request.Context(), "Extracted trace ID from codex header", log.String("trace_id", traceID))

--- a/internal/server/middleware/trace_test.go
+++ b/internal/server/middleware/trace_test.go
@@ -436,6 +436,201 @@ func TestWithTrace_CodexHeaderSetsTrace(t *testing.T) {
 	require.Equal(t, "codex-session-123", capturedSessionID)
 }
 
+func TestWithTrace_CodexTurnMetadataSetsTrace(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	config := tracing.Config{
+		TraceHeader:       "AH-Trace-Id",
+		CodexTraceEnabled: true,
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(func(c *gin.Context) {
+		ctx := authz.WithTestBypass(c.Request.Context())
+		ctx = ent.NewContext(ctx, client)
+		ctx = contexts.WithProjectID(ctx, testProject.ID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	var (
+		capturedTraceID   string
+		capturedSessionID string
+	)
+
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+
+		capturedTraceID = trace.TraceID
+
+		sessionID, ok := shared.GetSessionID(c.Request.Context())
+		require.True(t, ok)
+
+		capturedSessionID = sessionID
+
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte("{}")))
+	req.Header.Set("X-Codex-Turn-Metadata", `{"session_id":"codex-turn-session-123","turn_id":"turn-1"}`)
+
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "codex-turn-session-123", capturedTraceID)
+	require.Equal(t, "codex-turn-session-123", capturedSessionID)
+}
+
+func TestWithTrace_CodexHeaderHasPriorityOverTurnMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	config := tracing.Config{
+		TraceHeader:       "AH-Trace-Id",
+		CodexTraceEnabled: true,
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(func(c *gin.Context) {
+		ctx := authz.WithTestBypass(c.Request.Context())
+		ctx = ent.NewContext(ctx, client)
+		ctx = contexts.WithProjectID(ctx, testProject.ID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	var (
+		capturedTraceID   string
+		capturedSessionID string
+	)
+
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+
+		capturedTraceID = trace.TraceID
+
+		sessionID, ok := shared.GetSessionID(c.Request.Context())
+		require.True(t, ok)
+
+		capturedSessionID = sessionID
+
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Session_id", "codex-session-123")
+	req.Header.Set("X-Codex-Turn-Metadata", `{"session_id":"codex-turn-session-123","turn_id":"turn-1"}`)
+
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "codex-session-123", capturedTraceID)
+	require.Equal(t, "codex-session-123", capturedSessionID)
+}
+
+func TestWithTrace_CodexTurnMetadataInvalidOrMissingSessionDoesNotSetTrace(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	config := tracing.Config{
+		TraceHeader:       "AH-Trace-Id",
+		CodexTraceEnabled: true,
+	}
+
+	testCases := []struct {
+		name   string
+		header string
+	}{
+		{
+			name:   "invalid json",
+			header: `{"session_id":`,
+		},
+		{
+			name:   "missing session_id",
+			header: `{"turn_id":"turn-1"}`,
+		},
+		{
+			name:   "empty session_id",
+			header: `{"session_id":"   ","turn_id":"turn-1"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			router, client, traceService := setupTestTraceMiddleware(t)
+			defer client.Close()
+
+			ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+			ctx = ent.NewContext(ctx, client)
+
+			testProject, err := client.Project.Create().
+				SetName("test-project").
+				SetStatus(project.StatusActive).
+				Save(ctx)
+			require.NoError(t, err)
+
+			router.Use(func(c *gin.Context) {
+				ctx := authz.WithTestBypass(c.Request.Context())
+				ctx = ent.NewContext(ctx, client)
+				ctx = contexts.WithProjectID(ctx, testProject.ID)
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			})
+			router.Use(WithTrace(config, traceService))
+
+			var (
+				hasTrace   bool
+				hasSession bool
+			)
+
+			router.POST("/v1/chat/completions", func(c *gin.Context) {
+				_, hasTrace = contexts.GetTrace(c.Request.Context())
+				_, hasSession = shared.GetSessionID(c.Request.Context())
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte("{}")))
+			req.Header.Set("X-Codex-Turn-Metadata", tc.header)
+
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.False(t, hasTrace)
+			require.False(t, hasSession)
+		})
+	}
+}
+
 func TestWithTrace_CodexSessionMissingDoesNotSetTrace(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/llm/model.go
+++ b/llm/model.go
@@ -106,6 +106,9 @@ type Request struct {
 	// [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
 	PromptCacheKey *string `json:"prompt_cache_key,omitzero"`
 
+	// The unique ID of the previous response for multi-turn Responses API requests.
+	PreviousResponseID *string `json:"previous_response_id,omitempty"`
+
 	// A stable identifier used to help detect users of your application that may be
 	// violating OpenAI's usage policies. The IDs should be a string that uniquely
 	// identifies each user. We recommend hashing their username or email address, in
@@ -545,6 +548,9 @@ type Response struct {
 
 	// Model is the model used to generate the response.
 	Model string `json:"model"`
+
+	// The unique ID of the previous response for multi-turn Responses API responses.
+	PreviousResponseID *string `json:"previous_response_id,omitempty"`
 
 	// Usage is the unified token usage field for all request types (chat, embedding, rerank, image, video).
 	// For streaming chat requests, it will only be present in the last chunk when stream_options: {"include_usage": true} is set.

--- a/llm/transformer/openai/codex/codex_simulator_test.go
+++ b/llm/transformer/openai/codex/codex_simulator_test.go
@@ -86,6 +86,24 @@ func TestCodexOutbound_AllowsInboundIdentityOverrides(t *testing.T) {
 	assert.Contains(t, strings.ToLower(finalReq.Header.Get("User-Agent")), legacyCodexOriginator())
 }
 
+func TestCodexOutbound_PassthroughModernCodexHeaders(t *testing.T) {
+	ctx := context.Background()
+	sim := newCodexSimulator(t)
+	req := newCodexChatCompletionRequest(t)
+	req.Header.Set("X-Codex-Turn-Metadata", `{"session_id":"turn-session","turn_id":"turn-123"}`)
+	req.Header.Set("X-Codex-Window-Id", "window-123")
+	req.Header.Set("X-Client-Request-Id", "request-123")
+	req.Header.Set("X-Codex-Beta-Features", "js_repl")
+
+	finalReq, err := sim.Simulate(ctx, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"session_id":"turn-session","turn_id":"turn-123"}`, finalReq.Header.Get("X-Codex-Turn-Metadata"))
+	assert.Equal(t, "window-123", finalReq.Header.Get("X-Codex-Window-Id"))
+	assert.Equal(t, "request-123", finalReq.Header.Get("X-Client-Request-Id"))
+	assert.Equal(t, "js_repl", finalReq.Header.Get("X-Codex-Beta-Features"))
+}
+
 func TestCodexOutbound_SessionIDPrecedence(t *testing.T) {
 	t.Run("inbound Session_id header is used", func(t *testing.T) {
 		ctx := shared.WithSessionID(context.Background(), "context-session")
@@ -99,10 +117,34 @@ func TestCodexOutbound_SessionIDPrecedence(t *testing.T) {
 		assert.Equal(t, "header-session", finalReq.Header.Get("Session_id"))
 	})
 
+	t.Run("no inbound Session_id uses session_id from X-Codex-Turn-Metadata", func(t *testing.T) {
+		ctx := shared.WithSessionID(context.Background(), "context-session")
+		sim := newCodexSimulator(t)
+		req := newCodexChatCompletionRequest(t)
+		req.Header.Set("X-Codex-Turn-Metadata", `{"session_id":"turn-session","turn_id":"turn-123"}`)
+
+		finalReq, err := sim.Simulate(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "turn-session", finalReq.Header.Get("Session_id"))
+	})
+
 	t.Run("no inbound header but context has session uses context", func(t *testing.T) {
 		ctx := shared.WithSessionID(context.Background(), "context-session")
 		sim := newCodexSimulator(t)
 		req := newCodexChatCompletionRequest(t)
+
+		finalReq, err := sim.Simulate(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "context-session", finalReq.Header.Get("Session_id"))
+	})
+
+	t.Run("invalid X-Codex-Turn-Metadata falls back to context session", func(t *testing.T) {
+		ctx := shared.WithSessionID(context.Background(), "context-session")
+		sim := newCodexSimulator(t)
+		req := newCodexChatCompletionRequest(t)
+		req.Header.Set("X-Codex-Turn-Metadata", `{"session_id":`)
 
 		finalReq, err := sim.Simulate(ctx, req)
 		require.NoError(t, err)

--- a/llm/transformer/openai/codex/headers.go
+++ b/llm/transformer/openai/codex/headers.go
@@ -1,0 +1,52 @@
+package codex
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+const (
+	SessionHeader          = "Session_id"
+	TurnMetadataHeader     = "X-Codex-Turn-Metadata"
+	WindowIDHeader         = "X-Codex-Window-Id"
+	ClientRequestIDHeader  = "X-Client-Request-Id"
+	BetaFeaturesHeader     = "X-Codex-Beta-Features"
+)
+
+type TurnMetadata struct {
+	SessionID string `json:"session_id"`
+}
+
+var PassthroughHeaders = []string{
+	TurnMetadataHeader,
+	WindowIDHeader,
+	ClientRequestIDHeader,
+	BetaFeaturesHeader,
+}
+
+func ExtractSessionIDFromTurnMetadata(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var payload TurnMetadata
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(payload.SessionID)
+}
+
+func GetSessionIDFromHeaders(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+
+	sessionID := strings.TrimSpace(headers.Get(SessionHeader))
+	if sessionID != "" {
+		return sessionID
+	}
+
+	return ExtractSessionIDFromTurnMetadata(strings.TrimSpace(headers.Get(TurnMetadataHeader)))
+}

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -2,10 +2,8 @@ package codex
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -24,15 +22,7 @@ import (
 const (
 	codexBaseURL = "https://chatgpt.com/backend-api/codex#"
 	codexAPIURL  = "https://chatgpt.com/backend-api/codex/responses"
-	codexTurnMetadataHeader = "X-Codex-Turn-Metadata"
 )
-
-var codexPassthroughHeaders = []string{
-	codexTurnMetadataHeader,
-	"X-Codex-Window-Id",
-	"X-Client-Request-Id",
-	"X-Codex-Beta-Features",
-}
 
 // OutboundTransformer implements transformer.Outbound for Codex proxy.
 // It always talks to the Codex Responses upstream (SSE only) and adapts requests accordingly.
@@ -105,10 +95,10 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
 		rawHeaders = llmReq.RawRequest.Headers
-		rawSessionID = llmReq.RawRequest.Headers.Get("Session_id")
+		rawSessionID = llmReq.RawRequest.Headers.Get(SessionHeader)
 		rawOriginator = llmReq.RawRequest.Headers.Get("Originator")
 		rawUserAgent = llmReq.RawRequest.Headers.Get("User-Agent")
-		rawTurnMetadata = llmReq.RawRequest.Headers.Get(codexTurnMetadataHeader)
+		rawTurnMetadata = llmReq.RawRequest.Headers.Get(TurnMetadataHeader)
 	}
 
 	creds, err := t.tokens.Get(ctx)
@@ -177,21 +167,21 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		hreq.Headers.Set("User-Agent", rawUserAgent)
 	}
 
-	for _, header := range codexPassthroughHeaders {
+	for _, header := range PassthroughHeaders {
 		if value := rawHeaders.Get(header); value != "" {
 			hreq.Headers.Set(header, value)
 		}
 	}
 
 	if rawSessionID != "" {
-		hreq.Headers.Set("Session_id", rawSessionID)
-	} else if sessionID := extractSessionIDFromTurnMetadata(rawTurnMetadata); sessionID != "" {
-		hreq.Headers.Set("Session_id", sessionID)
-	} else if hreq.Headers.Get("Session_id") == "" {
+		hreq.Headers.Set(SessionHeader, rawSessionID)
+	} else if sessionID := ExtractSessionIDFromTurnMetadata(rawTurnMetadata); sessionID != "" {
+		hreq.Headers.Set(SessionHeader, sessionID)
+	} else if hreq.Headers.Get(SessionHeader) == "" {
 		if sessionID, ok := shared.GetSessionID(ctx); ok {
-			hreq.Headers.Set("Session_id", sessionID)
+			hreq.Headers.Set(SessionHeader, sessionID)
 		} else {
-			hreq.Headers.Set("Session_id", uuid.NewString())
+			hreq.Headers.Set(SessionHeader, uuid.NewString())
 		}
 	}
 
@@ -201,23 +191,6 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	return hreq, nil
 }
-
-func extractSessionIDFromTurnMetadata(raw string) string {
-	if raw == "" {
-		return ""
-	}
-
-	var payload struct {
-		SessionID string `json:"session_id"`
-	}
-
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return ""
-	}
-
-	return strings.TrimSpace(payload.SessionID)
-}
-
 func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
 	// Codex upstream returns Responses API response.
 	return t.responsesOutbound.TransformResponse(ctx, httpResp)

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -22,7 +23,15 @@ import (
 const (
 	codexBaseURL = "https://chatgpt.com/backend-api/codex#"
 	codexAPIURL  = "https://chatgpt.com/backend-api/codex/responses"
+	codexTurnMetadataHeader = "X-Codex-Turn-Metadata"
 )
+
+var codexPassthroughHeaders = []string{
+	codexTurnMetadataHeader,
+	"X-Codex-Window-Id",
+	"X-Client-Request-Id",
+	"X-Codex-Beta-Features",
+}
 
 // OutboundTransformer implements transformer.Outbound for Codex proxy.
 // It always talks to the Codex Responses upstream (SSE only) and adapts requests accordingly.
@@ -90,11 +99,15 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	rawSessionID := ""
 	rawOriginator := ""
 	rawUserAgent := ""
+	rawTurnMetadata := ""
+	var rawHeaders http.Header
 
 	if llmReq.RawRequest != nil && llmReq.RawRequest.Headers != nil {
+		rawHeaders = llmReq.RawRequest.Headers
 		rawSessionID = llmReq.RawRequest.Headers.Get("Session_id")
 		rawOriginator = llmReq.RawRequest.Headers.Get("Originator")
 		rawUserAgent = llmReq.RawRequest.Headers.Get("User-Agent")
+		rawTurnMetadata = llmReq.RawRequest.Headers.Get(codexTurnMetadataHeader)
 	}
 
 	creds, err := t.tokens.Get(ctx)
@@ -163,8 +176,16 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		hreq.Headers.Set("User-Agent", rawUserAgent)
 	}
 
+	for _, header := range codexPassthroughHeaders {
+		if value := rawHeaders.Get(header); value != "" {
+			hreq.Headers.Set(header, value)
+		}
+	}
+
 	if rawSessionID != "" {
 		hreq.Headers.Set("Session_id", rawSessionID)
+	} else if sessionID := extractSessionIDFromTurnMetadata(rawTurnMetadata); sessionID != "" {
+		hreq.Headers.Set("Session_id", sessionID)
 	} else if hreq.Headers.Get("Session_id") == "" {
 		if sessionID, ok := shared.GetSessionID(ctx); ok {
 			hreq.Headers.Set("Session_id", sessionID)
@@ -178,6 +199,22 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	}
 
 	return hreq, nil
+}
+
+func extractSessionIDFromTurnMetadata(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var payload struct {
+		SessionID string `json:"session_id"`
+	}
+
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ""
+	}
+
+	return payload.SessionID
 }
 func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
 	// Codex upstream returns Responses API response.

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -214,8 +215,9 @@ func extractSessionIDFromTurnMetadata(raw string) string {
 		return ""
 	}
 
-	return payload.SessionID
+	return strings.TrimSpace(payload.SessionID)
 }
+
 func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
 	// Codex upstream returns Responses API response.
 	return t.responsesOutbound.TransformResponse(ctx, httpResp)

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -15,10 +15,11 @@ import (
 // streamAggregator holds the state for aggregating stream chunks.
 type streamAggregator struct {
 	// Response metadata
-	responseID string
-	model      string
-	createdAt  int64
-	status     string
+	responseID         string
+	model              string
+	createdAt          int64
+	status             string
+	previousResponseID *string
 
 	// Output items - keyed by output_index.
 	// Some streams may (unexpectedly) reuse output_index for multiple items, so we store a slice.
@@ -207,6 +208,7 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			a.responseID = ev.Response.ID
 			a.model = ev.Response.Model
 			a.createdAt = ev.Response.CreatedAt
+			a.previousResponseID = ev.Response.PreviousResponseID
 
 			if ev.Response.Usage != nil {
 				a.usage = ev.Response.Usage
@@ -444,8 +446,11 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 
 	case StreamEventTypeResponseCompleted:
 		a.status = "completed"
-		if ev.Response != nil && ev.Response.Usage != nil {
-			a.usage = ev.Response.Usage
+		if ev.Response != nil {
+			a.previousResponseID = ev.Response.PreviousResponseID
+			if ev.Response.Usage != nil {
+				a.usage = ev.Response.Usage
+			}
 		}
 
 	case StreamEventTypeResponseFailed:
@@ -571,12 +576,13 @@ func (a *streamAggregator) buildResponse() *Response {
 	}
 
 	return &Response{
-		Object:    "response",
-		ID:        a.responseID,
-		Model:     a.model,
-		CreatedAt: a.createdAt,
-		Status:    lo.ToPtr(a.status),
-		Output:    output,
-		Usage:     a.usage,
+		Object:             "response",
+		ID:                 a.responseID,
+		Model:              a.model,
+		CreatedAt:          a.createdAt,
+		Status:             lo.ToPtr(a.status),
+		Output:             output,
+		Usage:              a.usage,
+		PreviousResponseID: a.previousResponseID,
 	}
 }

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -259,6 +259,52 @@ func TestAggregateStreamChunks_BasicEvents(t *testing.T) {
 	require.Equal(t, int64(5), meta.Usage.CompletionTokens)
 }
 
+func TestAggregateStreamChunks_PreservesPreviousResponseID(t *testing.T) {
+	chunks := []*httpclient.StreamEvent{
+		{
+			Type: "response.created",
+			Data: []byte(`{
+				"type": "response.created",
+				"sequence_number": 0,
+				"response": {
+					"id": "resp_test_prev",
+					"object": "response",
+					"created_at": 1700000000,
+					"model": "gpt-5.4",
+					"status": "in_progress",
+					"previous_response_id": "resp_prev_123",
+					"output": []
+				}
+			}`),
+		},
+		{
+			Type: "response.completed",
+			Data: []byte(`{
+				"type": "response.completed",
+				"sequence_number": 1,
+				"response": {
+					"id": "resp_test_prev",
+					"object": "response",
+					"created_at": 1700000000,
+					"model": "gpt-5.4",
+					"status": "completed",
+					"previous_response_id": "resp_prev_123",
+					"output": []
+				}
+			}`),
+		},
+	}
+
+	resultBytes, _, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+
+	var resp Response
+	err = json.Unmarshal(resultBytes, &resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp.PreviousResponseID)
+	require.Equal(t, "resp_prev_123", *resp.PreviousResponseID)
+}
+
 func TestAggregateStreamChunks_SkipsInvalidJSON(t *testing.T) {
 	chunks := []*httpclient.StreamEvent{
 		{

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -178,6 +178,7 @@ func convertToLLMRequest(req *Request) (*llm.Request, error) {
 		ServiceTier:         req.ServiceTier,
 		ParallelToolCalls:   req.ParallelToolCalls,
 		PromptCacheKey:      req.PromptCacheKey,
+		PreviousResponseID:  req.PreviousResponseID,
 		TransformerMetadata: map[string]any{},
 		TransformOptions:    llm.TransformOptions{},
 	}
@@ -759,12 +760,13 @@ func convertToolsToLLM(tools []Tool) ([]llm.Tool, error) {
 // convertToResponsesAPIResponse converts llm.Response to Responses API Response.
 func convertToResponsesAPIResponse(chatResp *llm.Response) *Response {
 	resp := &Response{
-		Object:    "response",
-		ID:        chatResp.ID,
-		Model:     chatResp.Model,
-		CreatedAt: chatResp.Created,
-		Output:    make([]Item, 0),
-		Status:    lo.ToPtr("completed"),
+		Object:             "response",
+		ID:                 chatResp.ID,
+		Model:              chatResp.Model,
+		CreatedAt:          chatResp.Created,
+		Output:             make([]Item, 0),
+		Status:             lo.ToPtr("completed"),
+		PreviousResponseID: chatResp.PreviousResponseID,
 	}
 
 	// Convert usage

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -417,6 +417,21 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 				require.Equal(t, []string{"file_search_call.results", "reasoning.encrypted_content"}, v.([]string))
 			},
 		},
+		{
+			name: "request with previous_response_id",
+			httpReq: &httpclient.Request{
+				Body: []byte(`{
+					"model": "gpt-5.4",
+					"previous_response_id": "resp_prev_123",
+					"input": "Continue"
+				}`),
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *llm.Request) {
+				require.NotNil(t, result.PreviousResponseID)
+				require.Equal(t, "resp_prev_123", *result.PreviousResponseID)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -611,6 +626,37 @@ func TestInboundTransformer_TransformResponse(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, resp.Status)
 				require.Equal(t, "incomplete", *resp.Status)
+			},
+		},
+		{
+			name: "response with previous_response_id",
+			chatResp: &llm.Response{
+				ID:                 "chatcmpl-prev",
+				Object:             "chat.completion",
+				Created:            1677652288,
+				Model:              "gpt-5.4",
+				PreviousResponseID: lo.ToPtr("resp_prev_123"),
+				Choices: []llm.Choice{
+					{
+						Index: 0,
+						Message: &llm.Message{
+							Role: "assistant",
+							Content: llm.MessageContent{
+								Content: lo.ToPtr("continued"),
+							},
+						},
+						FinishReason: lo.ToPtr("stop"),
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *httpclient.Response) {
+				var resp Response
+
+				err := json.Unmarshal(result.Body, &resp)
+				require.NoError(t, err)
+				require.NotNil(t, resp.PreviousResponseID)
+				require.Equal(t, "resp_prev_123", *resp.PreviousResponseID)
 			},
 		},
 	}

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -179,6 +179,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		StreamOptions:        convertStreamOptions(llmReq.StreamOptions, llmReq.TransformerMetadata),
 		Reasoning:            convertReasoning(llmReq),
 		PromptCacheKey:       llmReq.PromptCacheKey,
+		PreviousResponseID:   llmReq.PreviousResponseID,
 		Include:              xmap.GetStringSlice(llmReq.TransformerMetadata, "include"),
 		MaxToolCalls:         xmap.GetInt64Ptr(llmReq.TransformerMetadata, "max_tool_calls"),
 		PromptCacheRetention: xmap.GetStringPtr(llmReq.TransformerMetadata, "prompt_cache_retention"),
@@ -286,11 +287,12 @@ func (t *OutboundTransformer) transformStandardResponse(
 	}
 
 	llmResp := &llm.Response{
-		Object:  "chat.completion",
-		ID:      resp.ID,
-		Model:   resp.Model,
-		Created: resp.CreatedAt,
-		Choices: make([]llm.Choice, 0),
+		Object:             "chat.completion",
+		ID:                 resp.ID,
+		Model:              resp.Model,
+		Created:            resp.CreatedAt,
+		PreviousResponseID: resp.PreviousResponseID,
+		Choices:            make([]llm.Choice, 0),
 	}
 
 	// Convert usage if present

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -41,11 +41,12 @@ type responsesOutboundStream struct {
 
 // outboundStreamState holds the state for a streaming session.
 type outboundStreamState struct {
-	responseID    string
-	responseModel string
-	usage         *llm.Usage
-	created       int64
-	scope         shared.TransportScope
+	responseID         string
+	responseModel      string
+	previousResponseID *string
+	usage              *llm.Usage
+	created            int64
+	scope              shared.TransportScope
 
 	// Content accumulation
 	textContent      strings.Builder
@@ -134,10 +135,11 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 
 	// Build base response
 	resp := &llm.Response{
-		Object:  "chat.completion.chunk",
-		ID:      s.state.responseID,
-		Model:   s.state.responseModel,
-		Created: s.state.created,
+		Object:             "chat.completion.chunk",
+		ID:                 s.state.responseID,
+		Model:              s.state.responseModel,
+		Created:            s.state.created,
+		PreviousResponseID: s.state.previousResponseID,
 	}
 
 	//nolint:exhaustive //Only process events we care about.
@@ -147,10 +149,12 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			s.state.responseID = streamEvent.Response.ID
 			s.state.responseModel = streamEvent.Response.Model
 			s.state.created = streamEvent.Response.CreatedAt
+			s.state.previousResponseID = streamEvent.Response.PreviousResponseID
 
 			resp.ID = s.state.responseID
 			resp.Model = s.state.responseModel
 			resp.Created = s.state.created
+			resp.PreviousResponseID = s.state.previousResponseID
 
 			if streamEvent.Response.Usage != nil {
 				s.state.usage = streamEvent.Response.Usage.ToUsage()
@@ -173,6 +177,7 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			s.state.responseID = streamEvent.Response.ID
 			s.state.responseModel = streamEvent.Response.Model
 			s.state.created = streamEvent.Response.CreatedAt
+			s.state.previousResponseID = streamEvent.Response.PreviousResponseID
 
 			if streamEvent.Response.Usage != nil {
 				s.state.usage = streamEvent.Response.Usage.ToUsage()
@@ -417,6 +422,11 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 
 	case StreamEventTypeResponseCompleted:
 		// Response completed - emit two events: one with finish_reason, one with usage
+		if streamEvent.Response != nil {
+			s.state.previousResponseID = streamEvent.Response.PreviousResponseID
+			resp.PreviousResponseID = s.state.previousResponseID
+		}
+
 		finishReason := "stop"
 		if len(s.state.toolCalls) > 0 {
 			finishReason = "tool_calls"
@@ -435,12 +445,13 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		if streamEvent.Response != nil && streamEvent.Response.Usage != nil {
 			s.state.usage = streamEvent.Response.Usage.ToUsage()
 			usageResp := &llm.Response{
-				Object:  "chat.completion.chunk",
-				ID:      s.state.responseID,
-				Model:   s.state.responseModel,
-				Created: s.state.created,
-				Choices: []llm.Choice{},
-				Usage:   s.state.usage,
+				Object:             "chat.completion.chunk",
+				ID:                 s.state.responseID,
+				Model:              s.state.responseModel,
+				Created:            s.state.created,
+				PreviousResponseID: s.state.previousResponseID,
+				Choices:            []llm.Choice{},
+				Usage:              s.state.usage,
 			}
 
 			s.enqueue(resp)

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1,12 +1,14 @@
 package responses
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
@@ -128,4 +130,60 @@ func TestOutboundTransformer_StreamTransformation_ErrorEvent(t *testing.T) {
 	_, err = streams.All(transformedStream)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Something went wrong")
+}
+
+func TestOutboundTransformer_TransformStream_PreservesPreviousResponseID(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	events := []*httpclient.StreamEvent{
+		{
+			Type: "response.created",
+			Data: []byte(`{
+				"type":"response.created",
+				"response":{
+					"id":"resp_stream_prev",
+					"object":"response",
+					"created_at":1700000000,
+					"model":"gpt-5.4",
+					"status":"in_progress",
+					"previous_response_id":"resp_prev_123",
+					"output":[]
+				}
+			}`),
+		},
+		{
+			Type: "response.completed",
+			Data: []byte(`{
+				"type":"response.completed",
+				"response":{
+					"id":"resp_stream_prev",
+					"object":"response",
+					"created_at":1700000000,
+					"model":"gpt-5.4",
+					"status":"completed",
+					"previous_response_id":"resp_prev_123",
+					"output":[],
+					"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}
+				}
+			}`),
+		},
+	}
+
+	stream, err := trans.TransformStream(context.Background(), streams.SliceStream(events))
+	require.NoError(t, err)
+
+	actual, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Len(t, actual, 4)
+
+	require.NotNil(t, actual[0].PreviousResponseID)
+	require.Equal(t, "resp_prev_123", *actual[0].PreviousResponseID)
+
+	require.NotNil(t, actual[1].PreviousResponseID)
+	require.Equal(t, "resp_prev_123", *actual[1].PreviousResponseID)
+
+	require.NotNil(t, actual[2].PreviousResponseID)
+	require.Equal(t, "resp_prev_123", *actual[2].PreviousResponseID)
+	require.Equal(t, llm.DoneResponse, actual[3])
 }

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -678,6 +678,30 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 				require.Equal(t, []string{"file_search_call.results", "reasoning.encrypted_content"}, req.Include)
 			},
 		},
+		{
+			name: "request with previous_response_id",
+			chatReq: &llm.Request{
+				Model:              "gpt-5.4",
+				PreviousResponseID: lo.ToPtr("resp_prev_123"),
+				Messages: []llm.Message{
+					{
+						Role: "user",
+						Content: llm.MessageContent{
+							Content: lo.ToPtr("Continue"),
+						},
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *httpclient.Request, chatReq *llm.Request) {
+				var req Request
+
+				err := json.Unmarshal(result.Body, &req)
+				require.NoError(t, err)
+				require.NotNil(t, req.PreviousResponseID)
+				require.Equal(t, "resp_prev_123", *req.PreviousResponseID)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -869,6 +893,39 @@ func TestOutboundTransformer_TransformResponse(t *testing.T) {
 				require.NotNil(t, result.Choices[0].Message)
 				require.NotNil(t, result.Choices[0].Message.ReasoningSignature)
 				require.Equal(t, "encrypted_data_here", *result.Choices[0].Message.ReasoningSignature)
+			},
+		},
+		{
+			name: "response with previous_response_id",
+			httpResp: &httpclient.Response{
+				StatusCode: http.StatusOK,
+				Body: []byte(`{
+					"id": "resp_456",
+					"object": "response",
+					"created_at": 1759161016,
+					"status": "completed",
+					"model": "gpt-5.4",
+					"previous_response_id": "resp_prev_123",
+					"output": [
+						{
+							"id": "msg_456",
+							"type": "message",
+							"status": "completed",
+							"content": [
+								{
+									"type": "output_text",
+									"text": "Continued response"
+								}
+							],
+							"role": "assistant"
+						}
+					]
+				}`),
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *llm.Response) {
+				require.NotNil(t, result.PreviousResponseID)
+				require.Equal(t, "resp_prev_123", *result.PreviousResponseID)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- align Codex cache/session semantics with the current Codex client headers
- preserve modern Codex identity headers and pass through Codex-specific request metadata
- support `previous_response_id` passthrough for the Responses API path
<img width="445" height="920" alt="image" src="https://github.com/user-attachments/assets/1e73f4c9-a46a-43be-95f7-3a0ae61273b7" />


## Why
Recent Codex clients send cache/session context through `X-Codex-Turn-Metadata.session_id` and related Codex headers instead of relying only on legacy `Session_id`. Without honoring these fields, downstream requests can lose conversation/cache continuity and always report `cache_tokens = 0`.

## Changes
- trace middleware: accept `X-Codex-Turn-Metadata.session_id` as trace/session source while keeping `Session_id` precedence
- codex outbound: pass through
  - `X-Codex-Turn-Metadata`
  - `X-Codex-Window-Id`
  - `X-Client-Request-Id`
  - `X-Codex-Beta-Features`
- responses inbound/outbound: preserve `previous_response_id`
- docs: document `previous_response_id` support
- tests: add coverage for new Codex and Responses compatibility paths

## Verification
- `go test ./internal/server/middleware -run 'TestWithTrace_Codex(HeaderSetsTrace|TurnMetadataSetsTrace|HeaderHasPriorityOverTurnMetadata|TurnMetadataInvalidOrMissingSessionDoesNotSetTrace|SessionMissingDoesNotSetTrace)' -count=1`
- `cd llm && go test ./transformer/openai/codex -run 'TestCodexOutbound_(PassthroughModernCodexHeaders|SessionIDPrecedence|MinimalIdentityHeaders|AllowsInboundIdentityOverrides)' -count=1`
- `cd llm && go test ./transformer/openai/responses -run 'TestInboundTransformer_TransformRequest|TestInboundTransformer_TransformResponse|TestOutboundTransformer_TransformRequest|TestOutboundTransformer_TransformResponse' -count=1`