### PR TITLE
fix: unwrap DebugDriver layer in Driver() to fix perf analysis in debug model

### DIFF
--- a/internal/ent/driver.go
+++ b/internal/ent/driver.go
@@ -1,9 +1,20 @@
 package ent
 
-import "entgo.io/ent/dialect"
+import (
+	"entgo.io/ent/dialect"
+)
 
 // Driver returns the underlying dialect.Driver.
 // This is useful for executing raw SQL queries when needed.
+// It automatically unwraps any dialect.DebugDriver layers
+// to return the actual driver (e.g., *sql.Driver).
 func (c *Client) Driver() dialect.Driver {
-	return c.config.driver
+	drv := c.config.driver
+	for {
+		if dd, ok := drv.(*dialect.DebugDriver); ok {
+			drv = dd.Driver
+			continue
+		}
+		return drv
+	}
 }


### PR DESCRIPTION
Root cause: When Ent is in debug mode, the driver is wrapped as `dialect.DebugDriver`. In `channel_performance_helpers.go:202`:

```go
dbDriver := r.client.Driver()

sqlDB, ok := dbDriver.(*sql.Driver)

if !ok {

return nil, fmt.Errorf("failed to get underlying SQL driver")

}
```

Before the modification, `Driver()` directly returned `c.config.driver`, but in debug mode, it got `*dialect.DebugDriver`, causing the type assertion to fail.

fix: In the `Driver()` method, loop through and unpack the `DebugDriver` layer until you get the underlying `*sql.Driver`, consistent with the existing patterns in `channel_probe.go` and `dashboard.resolvers.go`.