### PR TITLE
fix(channels): bulk weight adjustment not populating on drag reorder

### DIFF
--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -21,32 +21,26 @@ const formatWeight = (value: number) => Math.round(value);
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
 // Weight 0 = highest priority (sorts to top), otherwise ascending by weight
-const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
-  if (a.orderingWeight === 0 && b.orderingWeight === 0) return 0;
-  if (a.orderingWeight === 0) return -1;
-  if (b.orderingWeight === 0) return 1;
-  return a.orderingWeight - b.orderingWeight;
-};
+const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) =>
+  a.orderingWeight - b.orderingWeight;
 
 // Normalize ranks to sequential 1..N with 0 preserved for highest-priority items
 const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) => {
   const sorted = [...items].sort(weightSort);
   let nextRank = 1;
-  for (const item of sorted) {
-    if (item.orderingWeight === 0) continue; // Preserve 0 (highest priority)
-    item.orderingWeight = nextRank++;
-  }
-  return sorted;
+  return sorted.map((item) => {
+    if (item.orderingWeight === 0) return item;
+    return { ...item, orderingWeight: nextRank++ };
+  });
 };
 
 // Initialize channels from GraphQL edges
 const initializeOrderedChannels = (edges: Array<{ node: ChannelSummary }>) => {
-  return edges
-    .map((edge) => ({
-      channel: edge.node,
-      orderingWeight: edge.node.orderingWeight ?? 0,
-    }))
-    .sort((a, b) => a.orderingWeight - b.orderingWeight);
+  const items = edges.map((edge) => ({
+    channel: edge.node,
+    orderingWeight: edge.node.orderingWeight ?? 0,
+  }));
+  return normalizeRanks(items);
 };
 
 const reassignWeightsFromPosition = (

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -21,11 +21,81 @@ const formatWeight = (value: number) => Math.round(value);
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
-const redistributeWeights = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) =>
-  items.map((item, index) => ({
-    ...item,
-    orderingWeight: clampWeight(items.length - index),
-  }));
+const buildWeightGroups = (items: Array<{ orderingWeight: number }>) => {
+  const groups: number[][] = [];
+  for (let i = 0; i < items.length; i++) {
+    const currentWeight = items[i].orderingWeight;
+    const lastGroup = groups[groups.length - 1];
+    if (lastGroup && items[lastGroup[0]].orderingWeight === currentWeight) {
+      lastGroup.push(i);
+    } else {
+      groups.push([i]);
+    }
+  }
+  return groups;
+};
+
+const renumberGroups = (
+  result: Array<{ channel: ChannelSummary; orderingWeight: number }>,
+  groups: number[][],
+) => {
+  if (groups.length === 1) {
+    for (let i = 0; i < result.length; i++) {
+      result[i].orderingWeight = clampWeight(result.length - i);
+    }
+    return;
+  }
+  const groupCount = groups.length;
+  for (let g = 0; g < groupCount; g++) {
+    const groupWeight = clampWeight(groupCount - g);
+    for (const idx of groups[g]) {
+      result[idx].orderingWeight = groupWeight;
+    }
+  }
+};
+
+const reassignWeightsFromPosition = (
+  items: Array<{ channel: ChannelSummary; orderingWeight: number }>,
+  movedItemIndex: number,
+) => {
+  if (items.length <= 1) return items.map((item) => ({ ...item }));
+
+  const result = items.map((item) => ({ ...item }));
+
+  const movedPrevWeight = result[movedItemIndex - 1]?.orderingWeight;
+  const movedNextWeight = result[movedItemIndex + 1]?.orderingWeight;
+
+  if (movedPrevWeight != null && movedNextWeight != null && movedPrevWeight === movedNextWeight) {
+    result[movedItemIndex].orderingWeight = movedPrevWeight;
+  } else if (movedPrevWeight == null && movedNextWeight != null) {
+    result[movedItemIndex].orderingWeight = clampWeight(movedNextWeight + 1);
+  } else if (movedNextWeight == null && movedPrevWeight != null) {
+    result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight - 1);
+  } else if (movedPrevWeight != null && movedNextWeight != null) {
+    const midpoint = Math.floor((movedPrevWeight + movedNextWeight) / 2);
+    if (midpoint === movedPrevWeight || midpoint === movedNextWeight) {
+      const groups = buildWeightGroups(result);
+      renumberGroups(result, groups);
+      return result;
+    }
+    result[movedItemIndex].orderingWeight = clampWeight(midpoint);
+  }
+
+  const groups = buildWeightGroups(result);
+
+  const needsRenumber =
+    groups.length === 1 ||
+    groups.some((group, i) => {
+      if (i === 0) return false;
+      return result[group[0]].orderingWeight >= result[groups[i - 1][0]].orderingWeight;
+    });
+
+  if (needsRenumber) {
+    renumberGroups(result, groups);
+  }
+
+  return result;
+};
 
 interface ChannelOrderingItemProps {
   channel: ChannelSummary;
@@ -247,7 +317,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
       const newItems = arrayMove(items, oldIndex, newIndex);
       setHasChanges(true);
-      return redistributeWeights(newItems);
+      return reassignWeightsFromPosition(newItems, newIndex);
     });
   }, []);
 
@@ -271,7 +341,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
       const newItems = arrayMove(items, index, 0);
       setHasChanges(true);
-      return redistributeWeights(newItems);
+      return reassignWeightsFromPosition(newItems, 0);
     });
   }, []);
 
@@ -284,7 +354,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       const targetIndex = items.length - 1;
       const newItems = arrayMove(items, index, targetIndex);
       setHasChanges(true);
-      return redistributeWeights(newItems);
+      return reassignWeightsFromPosition(newItems, targetIndex);
     });
   }, []);
 

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -36,16 +36,22 @@ const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: 
 
 // Initialize channels from GraphQL edges
 const initializeOrderedChannels = (edges: Array<{ node: ChannelSummary }>) => {
-  return edges
+  const withBackend = edges
     .map((edge) => ({
       channel: edge.node,
       backendWeight: edge.node.orderingWeight ?? 0,
     }))
-    .sort((a, b) => b.backendWeight - a.backendWeight)
-    .map((item, index) => ({
-      channel: item.channel,
-      orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
-    }));
+    .sort((a, b) => b.backendWeight - a.backendWeight);
+
+  const distinctWeights = [...new Set(withBackend.map((item) => item.backendWeight).filter((w) => w > 0))].sort(
+    (a, b) => b - a,
+  );
+  const weightToRank = new Map(distinctWeights.map((w, i) => [w, i + 1]));
+
+  return withBackend.map((item) => ({
+    channel: item.channel,
+    orderingWeight: item.backendWeight === 0 ? 0 : weightToRank.get(item.backendWeight)!,
+  }));
 };
 
 const reassignWeightsFromPosition = (

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -21,37 +21,11 @@ const formatWeight = (value: number) => Math.round(value);
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
-const buildWeightGroups = (items: Array<{ orderingWeight: number }>) => {
-  const groups: number[][] = [];
-  for (let i = 0; i < items.length; i++) {
-    const currentWeight = items[i].orderingWeight;
-    const lastGroup = groups[groups.length - 1];
-    if (lastGroup && items[lastGroup[0]].orderingWeight === currentWeight) {
-      lastGroup.push(i);
-    } else {
-      groups.push([i]);
-    }
-  }
-  return groups;
-};
-
-const renumberGroups = (
-  result: Array<{ channel: ChannelSummary; orderingWeight: number }>,
-  groups: number[][],
-) => {
-  if (groups.length === 1) {
-    for (let i = 0; i < result.length; i++) {
-      result[i].orderingWeight = clampWeight(result.length - i);
-    }
-    return;
-  }
-  const groupCount = groups.length;
-  for (let g = 0; g < groupCount; g++) {
-    const groupWeight = clampWeight(groupCount - g);
-    for (const idx of groups[g]) {
-      result[idx].orderingWeight = groupWeight;
-    }
-  }
+const rankSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
+  if (a.orderingWeight === 0 && b.orderingWeight === 0) return 0;
+  if (a.orderingWeight === 0) return 1;
+  if (b.orderingWeight === 0) return -1;
+  return a.orderingWeight - b.orderingWeight;
 };
 
 const reassignWeightsFromPosition = (
@@ -68,30 +42,31 @@ const reassignWeightsFromPosition = (
   if (movedPrevWeight != null && movedNextWeight != null && movedPrevWeight === movedNextWeight) {
     result[movedItemIndex].orderingWeight = movedPrevWeight;
   } else if (movedPrevWeight == null && movedNextWeight != null) {
-    result[movedItemIndex].orderingWeight = clampWeight(movedNextWeight + 1);
-  } else if (movedNextWeight == null && movedPrevWeight != null) {
-    result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight - 1);
-  } else if (movedPrevWeight != null && movedNextWeight != null) {
-    const midpoint = Math.floor((movedPrevWeight + movedNextWeight) / 2);
-    if (midpoint === movedPrevWeight || midpoint === movedNextWeight) {
-      const groups = buildWeightGroups(result);
-      renumberGroups(result, groups);
-      return result;
+    if (movedNextWeight === 0) {
+      result[movedItemIndex].orderingWeight = clampWeight(1);
+    } else if (movedNextWeight <= 1) {
+      for (let i = movedItemIndex + 1; i < result.length; i++) {
+        result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
+      }
+      result[movedItemIndex].orderingWeight = clampWeight(1);
+    } else {
+      result[movedItemIndex].orderingWeight = clampWeight(movedNextWeight - 1);
     }
-    result[movedItemIndex].orderingWeight = clampWeight(midpoint);
-  }
-
-  const groups = buildWeightGroups(result);
-
-  const needsRenumber =
-    groups.length === 1 ||
-    groups.some((group, i) => {
-      if (i === 0) return false;
-      return result[group[0]].orderingWeight >= result[groups[i - 1][0]].orderingWeight;
-    });
-
-  if (needsRenumber) {
-    renumberGroups(result, groups);
+  } else if (movedNextWeight == null && movedPrevWeight != null) {
+    result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + 1);
+  } else if (movedPrevWeight != null && movedNextWeight != null) {
+    const effectiveNext = movedNextWeight === 0 ? movedPrevWeight + 2 : movedNextWeight;
+    const gap = effectiveNext - movedPrevWeight;
+    if (gap <= 1) {
+      for (let i = movedItemIndex + 1; i < result.length; i++) {
+        if (result[i].orderingWeight !== 0) {
+          result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
+        }
+      }
+      result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + 1);
+    } else {
+      result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + Math.floor(gap / 2));
+    }
   }
 
   return result;
@@ -282,12 +257,16 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
   // Initialize ordered channels when data loads
   useEffect(() => {
     if (channelsData?.edges) {
-      const channels = channelsData.edges.map((edge, index) => ({
-        channel: edge.node,
-        orderingWeight: clampWeight(edge.node.orderingWeight ?? channelsData.edges.length - index),
-      }));
-      // Sort by orderingWeight DESC (higher weight first)
-      channels.sort((a, b) => b.orderingWeight - a.orderingWeight);
+      const channels = channelsData.edges
+        .map((edge) => ({
+          channel: edge.node,
+          backendWeight: edge.node.orderingWeight ?? 0,
+        }))
+        .sort((a, b) => b.backendWeight - a.backendWeight)
+        .map((item, index) => ({
+          channel: item.channel,
+          orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
+        }));
       setOrderedChannels(channels);
       setHasChanges(false);
     }
@@ -325,9 +304,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
     const normalizedWeight = clampWeight(weight);
     setOrderedChannels((items) => {
       const newItems = items.map((item) => (item.channel.id === id ? { ...item, orderingWeight: normalizedWeight } : item));
-      // Sort by orderingWeight DESC (higher weight first)
-      // Maintain stable sort for equal weights? Javascript sort is stable.
-      newItems.sort((a, b) => b.orderingWeight - a.orderingWeight);
+      newItems.sort(rankSort);
       setHasChanges(true);
       return newItems;
     });
@@ -360,9 +337,10 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
   const handleSave = async () => {
     try {
+      const channelCount = orderedChannels.length;
       const updates = orderedChannels.map((item) => ({
         id: item.channel.id,
-        orderingWeight: item.orderingWeight,
+        orderingWeight: item.orderingWeight === 0 ? 0 : channelCount - item.orderingWeight + 1,
       }));
 
       await bulkUpdateMutation.mutateAsync({
@@ -379,11 +357,16 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
   const handleCancel = () => {
     // Reset to original order
     if (channelsData?.edges) {
-      const channels = channelsData.edges.map((edge, index) => ({
-        channel: edge.node,
-        orderingWeight: clampWeight(edge.node.orderingWeight ?? channelsData.edges.length - index),
-      }));
-      channels.sort((a, b) => b.orderingWeight - a.orderingWeight);
+      const channels = channelsData.edges
+        .map((edge) => ({
+          channel: edge.node,
+          backendWeight: edge.node.orderingWeight ?? 0,
+        }))
+        .sort((a, b) => b.backendWeight - a.backendWeight)
+        .map((item, index) => ({
+          channel: item.channel,
+          orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
+        }));
       setOrderedChannels(channels);
       setHasChanges(false);
     }

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -13,10 +13,11 @@ import { Separator } from '@/components/ui/separator';
 import { useAllChannelSummarys, useBulkUpdateChannelOrdering } from '../data/channels';
 import { ChannelSummary } from '../data/schema';
 
+const WEIGHT_PRECISION = 0;
 const MIN_WEIGHT = 0;
-const MAX_WEIGHT = 9999;
+const MAX_WEIGHT = 100;
 
-const formatWeight = (value: number) => Math.round(value);
+const formatWeight = (value: number) => Number(value.toFixed(WEIGHT_PRECISION));
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -13,7 +13,6 @@ import { Separator } from '@/components/ui/separator';
 import { useAllChannelSummarys, useBulkUpdateChannelOrdering } from '../data/channels';
 import { ChannelSummary } from '../data/schema';
 
-const WEIGHT_PRECISION = 0;
 const MIN_WEIGHT = 0;
 const MAX_WEIGHT = 9999;
 
@@ -28,6 +27,38 @@ const rankSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) 
   return a.orderingWeight - b.orderingWeight;
 };
 
+// Normalize ranks to sequential 1..N with 0 for unranked items
+const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) => {
+  const ranked = items.filter((item) => item.orderingWeight !== 0);
+  const unranked = items.filter((item) => item.orderingWeight === 0);
+
+  // Reassign sequential ranks to ranked items
+  ranked.forEach((item, index) => {
+    item.orderingWeight = index + 1;
+  });
+
+  // Keep unranked items at 0 and append them
+  unranked.forEach((item) => {
+    item.orderingWeight = 0;
+  });
+
+  return [...ranked, ...unranked];
+};
+
+// Initialize channels from GraphQL edges
+const initializeOrderedChannels = (edges: Array<{ node: ChannelSummary }>) => {
+  return edges
+    .map((edge) => ({
+      channel: edge.node,
+      backendWeight: edge.node.orderingWeight ?? 0,
+    }))
+    .sort((a, b) => b.backendWeight - a.backendWeight)
+    .map((item, index) => ({
+      channel: item.channel,
+      orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
+    }));
+};
+
 const reassignWeightsFromPosition = (
   items: Array<{ channel: ChannelSummary; orderingWeight: number }>,
   movedItemIndex: number,
@@ -40,13 +71,21 @@ const reassignWeightsFromPosition = (
   const movedNextWeight = result[movedItemIndex + 1]?.orderingWeight;
 
   if (movedPrevWeight != null && movedNextWeight != null && movedPrevWeight === movedNextWeight) {
-    result[movedItemIndex].orderingWeight = movedPrevWeight;
+    // Special case: don't make ranked items unranked when between two unranked items
+    if (movedPrevWeight === 0 && movedNextWeight === 0) {
+      result[movedItemIndex].orderingWeight = clampWeight(1);
+    } else {
+      result[movedItemIndex].orderingWeight = movedPrevWeight;
+    }
   } else if (movedPrevWeight == null && movedNextWeight != null) {
     if (movedNextWeight === 0) {
       result[movedItemIndex].orderingWeight = clampWeight(1);
     } else if (movedNextWeight <= 1) {
       for (let i = movedItemIndex + 1; i < result.length; i++) {
-        result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
+        // Don't shift unranked (weight=0) items - they stay unranked
+        if (result[i].orderingWeight !== 0) {
+          result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
+        }
       }
       result[movedItemIndex].orderingWeight = clampWeight(1);
     } else {
@@ -254,20 +293,9 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
   const [orderedChannels, setOrderedChannels] = useState<Array<{ channel: ChannelSummary; orderingWeight: number }>>([]);
   const [hasChanges, setHasChanges] = useState(false);
 
-  // Initialize ordered channels when data loads
   useEffect(() => {
     if (channelsData?.edges) {
-      const channels = channelsData.edges
-        .map((edge) => ({
-          channel: edge.node,
-          backendWeight: edge.node.orderingWeight ?? 0,
-        }))
-        .sort((a, b) => b.backendWeight - a.backendWeight)
-        .map((item, index) => ({
-          channel: item.channel,
-          orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
-        }));
-      setOrderedChannels(channels);
+      setOrderedChannels(initializeOrderedChannels(channelsData.edges));
       setHasChanges(false);
     }
   }, [channelsData]);
@@ -295,18 +323,23 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       }
 
       const newItems = arrayMove(items, oldIndex, newIndex);
+      const withWeights = reassignWeightsFromPosition(newItems, newIndex);
       setHasChanges(true);
-      return reassignWeightsFromPosition(newItems, newIndex);
+      return normalizeRanks(withWeights);
     });
   }, []);
 
   const handleWeightChange = useCallback((id: string, weight: number) => {
-    const normalizedWeight = clampWeight(weight);
     setOrderedChannels((items) => {
+      const channelCount = items.length;
+      // Clamp manual weight to valid rank range [0, channelCount]
+      // 0 = unranked, 1..channelCount = valid rank positions
+      const clampedWeight = Math.min(Math.max(weight, 0), channelCount);
+      const normalizedWeight = clampWeight(clampedWeight);
       const newItems = items.map((item) => (item.channel.id === id ? { ...item, orderingWeight: normalizedWeight } : item));
       newItems.sort(rankSort);
       setHasChanges(true);
-      return newItems;
+      return normalizeRanks(newItems);
     });
   }, []);
 
@@ -317,8 +350,9 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       }
 
       const newItems = arrayMove(items, index, 0);
+      const withWeights = reassignWeightsFromPosition(newItems, 0);
       setHasChanges(true);
-      return reassignWeightsFromPosition(newItems, 0);
+      return normalizeRanks(withWeights);
     });
   }, []);
 
@@ -330,8 +364,9 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
       const targetIndex = items.length - 1;
       const newItems = arrayMove(items, index, targetIndex);
+      const withWeights = reassignWeightsFromPosition(newItems, targetIndex);
       setHasChanges(true);
-      return reassignWeightsFromPosition(newItems, targetIndex);
+      return normalizeRanks(withWeights);
     });
   }, []);
 
@@ -355,19 +390,8 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
   };
 
   const handleCancel = () => {
-    // Reset to original order
     if (channelsData?.edges) {
-      const channels = channelsData.edges
-        .map((edge) => ({
-          channel: edge.node,
-          backendWeight: edge.node.orderingWeight ?? 0,
-        }))
-        .sort((a, b) => b.backendWeight - a.backendWeight)
-        .map((item, index) => ({
-          channel: item.channel,
-          orderingWeight: item.backendWeight === 0 ? 0 : index + 1,
-        }));
-      setOrderedChannels(channels);
+      setOrderedChannels(initializeOrderedChannels(channelsData.edges));
       setHasChanges(false);
     }
     onOpenChange(false);

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -20,11 +20,11 @@ const formatWeight = (value: number) => Math.round(value);
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
-const rankSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
+const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
   if (a.orderingWeight === 0 && b.orderingWeight === 0) return 0;
   if (a.orderingWeight === 0) return 1;
   if (b.orderingWeight === 0) return -1;
-  return a.orderingWeight - b.orderingWeight;
+  return b.orderingWeight - a.orderingWeight;
 };
 
 // Normalize ranks to sequential 1..N with 0 for unranked items
@@ -36,22 +36,12 @@ const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: 
 
 // Initialize channels from GraphQL edges
 const initializeOrderedChannels = (edges: Array<{ node: ChannelSummary }>) => {
-  const withBackend = edges
+  return edges
     .map((edge) => ({
       channel: edge.node,
-      backendWeight: edge.node.orderingWeight ?? 0,
+      orderingWeight: edge.node.orderingWeight ?? 0,
     }))
-    .sort((a, b) => b.backendWeight - a.backendWeight);
-
-  const distinctWeights = [...new Set(withBackend.map((item) => item.backendWeight).filter((w) => w > 0))].sort(
-    (a, b) => b - a,
-  );
-  const weightToRank = new Map(distinctWeights.map((w, i) => [w, i + 1]));
-
-  return withBackend.map((item) => ({
-    channel: item.channel,
-    orderingWeight: item.backendWeight === 0 ? 0 : weightToRank.get(item.backendWeight)!,
-  }));
+    .sort((a, b) => b.orderingWeight - a.orderingWeight);
 };
 
 const reassignWeightsFromPosition = (
@@ -61,45 +51,35 @@ const reassignWeightsFromPosition = (
   if (items.length <= 1) return items.map((item) => ({ ...item }));
 
   const result = items.map((item) => ({ ...item }));
+  const prevWeight = result[movedItemIndex - 1]?.orderingWeight;
+  const nextWeight = result[movedItemIndex + 1]?.orderingWeight;
 
-  const movedPrevWeight = result[movedItemIndex - 1]?.orderingWeight;
-  const movedNextWeight = result[movedItemIndex + 1]?.orderingWeight;
-
-  if (movedPrevWeight != null && movedNextWeight != null && movedPrevWeight === movedNextWeight) {
-    // Special case: don't make ranked items unranked when between two unranked items
-    if (movedPrevWeight === 0 && movedNextWeight === 0) {
+  if (prevWeight != null && nextWeight != null && prevWeight === nextWeight) {
+    if (prevWeight === 0) {
+      result[movedItemIndex].orderingWeight = 1;
+    } else {
+      result[movedItemIndex].orderingWeight = prevWeight;
+    }
+  } else if (prevWeight == null && nextWeight != null) {
+    if (nextWeight === 0) {
       result[movedItemIndex].orderingWeight = clampWeight(1);
     } else {
-      result[movedItemIndex].orderingWeight = movedPrevWeight;
+      result[movedItemIndex].orderingWeight = clampWeight(nextWeight + 1);
     }
-  } else if (movedPrevWeight == null && movedNextWeight != null) {
-    if (movedNextWeight === 0) {
-      result[movedItemIndex].orderingWeight = clampWeight(1);
-    } else if (movedNextWeight <= 1) {
-      for (let i = movedItemIndex + 1; i < result.length; i++) {
-        // Don't shift unranked (weight=0) items - they stay unranked
-        if (result[i].orderingWeight !== 0) {
-          result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
-        }
-      }
-      result[movedItemIndex].orderingWeight = clampWeight(1);
-    } else {
-      result[movedItemIndex].orderingWeight = clampWeight(movedNextWeight - 1);
-    }
-  } else if (movedNextWeight == null && movedPrevWeight != null) {
-    result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + 1);
-  } else if (movedPrevWeight != null && movedNextWeight != null) {
-    const effectiveNext = movedNextWeight === 0 ? movedPrevWeight + 2 : movedNextWeight;
-    const gap = effectiveNext - movedPrevWeight;
+  } else if (nextWeight == null && prevWeight != null) {
+    result[movedItemIndex].orderingWeight = clampWeight(Math.max(prevWeight - 1, 1));
+  } else if (prevWeight != null && nextWeight != null) {
+    const effectiveNext = nextWeight === 0 ? 0 : nextWeight;
+    const gap = prevWeight - effectiveNext;
     if (gap <= 1) {
       for (let i = movedItemIndex + 1; i < result.length; i++) {
         if (result[i].orderingWeight !== 0) {
-          result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
+          result[i].orderingWeight = clampWeight(result[i].orderingWeight - 1);
         }
       }
-      result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + 1);
+      result[movedItemIndex].orderingWeight = clampWeight(prevWeight);
     } else {
-      result[movedItemIndex].orderingWeight = clampWeight(movedPrevWeight + Math.floor(gap / 2));
+      result[movedItemIndex].orderingWeight = clampWeight(prevWeight - Math.floor(gap / 2));
     }
   }
 
@@ -332,7 +312,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       const clampedWeight = Math.min(Math.max(weight, 0), channelCount);
       const normalizedWeight = clampWeight(clampedWeight);
       const newItems = items.map((item) => (item.channel.id === id ? { ...item, orderingWeight: normalizedWeight } : item));
-      newItems.sort(rankSort);
+      newItems.sort(weightSort);
       setHasChanges(true);
       return normalizeRanks(newItems);
     });
@@ -367,10 +347,9 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
   const handleSave = async () => {
     try {
-      const channelCount = orderedChannels.length;
       const updates = orderedChannels.map((item) => ({
         id: item.channel.id,
-        orderingWeight: item.orderingWeight === 0 ? 0 : channelCount - item.orderingWeight + 1,
+        orderingWeight: item.orderingWeight,
       }));
 
       await bulkUpdateMutation.mutateAsync({

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -20,6 +20,7 @@ const formatWeight = (value: number) => Math.round(value);
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
+// Weight 0 = highest priority (sorts to top), otherwise ascending by weight
 const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
   if (a.orderingWeight === 0 && b.orderingWeight === 0) return 0;
   if (a.orderingWeight === 0) return -1;
@@ -27,9 +28,15 @@ const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }
   return a.orderingWeight - b.orderingWeight;
 };
 
-// Normalize ranks to sequential 1..N with 0 for unranked items
+// Normalize ranks to sequential 1..N with 0 preserved for highest-priority items
 const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) => {
-  return items.sort(weightSort);
+  const sorted = [...items].sort(weightSort);
+  let nextRank = 1;
+  for (const item of sorted) {
+    if (item.orderingWeight === 0) continue; // Preserve 0 (highest priority)
+    item.orderingWeight = nextRank++;
+  }
+  return sorted;
 };
 
 // Initialize channels from GraphQL edges
@@ -196,7 +203,7 @@ const ChannelOrderingItemComponent = memo(function ChannelOrderingItemComponent(
             inputMode='decimal'
             step='any'
             min={MIN_WEIGHT}
-            max={MAX_WEIGHT}
+            max={total}
             className='h-6 w-16 px-1 text-center text-xs'
             value={localWeight}
             onChange={(e) => setLocalWeight(e.target.value)}
@@ -295,7 +302,7 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
     setOrderedChannels((items) => {
       const channelCount = items.length;
       // Clamp manual weight to valid rank range [0, channelCount]
-      // 0 = unranked, 1..channelCount = valid rank positions
+      // 0 = highest priority, 1..channelCount = valid rank positions
       const clampedWeight = Math.min(Math.max(weight, 0), channelCount);
       const normalizedWeight = clampWeight(clampedWeight);
       const newItems = items.map((item) => (item.channel.id === id ? { ...item, orderingWeight: normalizedWeight } : item));

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -31,17 +31,6 @@ const rankSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) 
 const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) => {
   const ranked = items.filter((item) => item.orderingWeight !== 0);
   const unranked = items.filter((item) => item.orderingWeight === 0);
-
-  // Reassign sequential ranks to ranked items
-  ranked.forEach((item, index) => {
-    item.orderingWeight = index + 1;
-  });
-
-  // Keep unranked items at 0 and append them
-  unranked.forEach((item) => {
-    item.orderingWeight = 0;
-  });
-
   return [...ranked, ...unranked];
 };
 

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -15,27 +15,17 @@ import { ChannelSummary } from '../data/schema';
 
 const WEIGHT_PRECISION = 0;
 const MIN_WEIGHT = 0;
-const MAX_WEIGHT = 100;
+const MAX_WEIGHT = 9999;
 
 const formatWeight = (value: number) => Math.round(value);
 
 const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value)));
 
-const calculateRelativeWeight = (prev?: number, next?: number) => {
-  if (prev == null && next == null) {
-    return clampWeight(1);
-  }
-  if (prev == null) {
-    return clampWeight((next ?? 0) + 1);
-  }
-  if (next == null) {
-    return clampWeight(prev - 1);
-  }
-  if (prev === next) {
-    return clampWeight(prev);
-  }
-  return clampWeight(Math.floor((prev + next) / 2));
-};
+const redistributeWeights = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) =>
+  items.map((item, index) => ({
+    ...item,
+    orderingWeight: clampWeight(items.length - index),
+  }));
 
 interface ChannelOrderingItemProps {
   channel: ChannelSummary;
@@ -256,16 +246,8 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       }
 
       const newItems = arrayMove(items, oldIndex, newIndex);
-      const prevWeight = newItems[newIndex - 1]?.orderingWeight;
-      const nextWeight = newItems[newIndex + 1]?.orderingWeight;
-
-      newItems[newIndex] = {
-        ...newItems[newIndex],
-        orderingWeight: calculateRelativeWeight(prevWeight, nextWeight),
-      };
-
       setHasChanges(true);
-      return newItems;
+      return redistributeWeights(newItems);
     });
   }, []);
 
@@ -288,15 +270,8 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
       }
 
       const newItems = arrayMove(items, index, 0);
-      const nextWeight = newItems[1]?.orderingWeight;
-
-      newItems[0] = {
-        ...newItems[0],
-        orderingWeight: calculateRelativeWeight(undefined, nextWeight),
-      };
-
       setHasChanges(true);
-      return newItems;
+      return redistributeWeights(newItems);
     });
   }, []);
 
@@ -308,15 +283,8 @@ export function ChannelsBulkOrderingDialog({ open, onOpenChange }: ChannelsBulkO
 
       const targetIndex = items.length - 1;
       const newItems = arrayMove(items, index, targetIndex);
-      const prevWeight = newItems[targetIndex - 1]?.orderingWeight;
-
-      newItems[targetIndex] = {
-        ...newItems[targetIndex],
-        orderingWeight: calculateRelativeWeight(prevWeight, undefined),
-      };
-
       setHasChanges(true);
-      return newItems;
+      return redistributeWeights(newItems);
     });
   }, []);
 

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -22,16 +22,14 @@ const clampWeight = (value: number) => formatWeight(Math.min(MAX_WEIGHT, Math.ma
 
 const weightSort = (a: { orderingWeight: number }, b: { orderingWeight: number }) => {
   if (a.orderingWeight === 0 && b.orderingWeight === 0) return 0;
-  if (a.orderingWeight === 0) return 1;
-  if (b.orderingWeight === 0) return -1;
-  return b.orderingWeight - a.orderingWeight;
+  if (a.orderingWeight === 0) return -1;
+  if (b.orderingWeight === 0) return 1;
+  return a.orderingWeight - b.orderingWeight;
 };
 
 // Normalize ranks to sequential 1..N with 0 for unranked items
 const normalizeRanks = (items: Array<{ channel: ChannelSummary; orderingWeight: number }>) => {
-  const ranked = items.filter((item) => item.orderingWeight !== 0);
-  const unranked = items.filter((item) => item.orderingWeight === 0);
-  return [...ranked, ...unranked];
+  return items.sort(weightSort);
 };
 
 // Initialize channels from GraphQL edges
@@ -41,7 +39,7 @@ const initializeOrderedChannels = (edges: Array<{ node: ChannelSummary }>) => {
       channel: edge.node,
       orderingWeight: edge.node.orderingWeight ?? 0,
     }))
-    .sort((a, b) => b.orderingWeight - a.orderingWeight);
+    .sort((a, b) => a.orderingWeight - b.orderingWeight);
 };
 
 const reassignWeightsFromPosition = (
@@ -55,31 +53,20 @@ const reassignWeightsFromPosition = (
   const nextWeight = result[movedItemIndex + 1]?.orderingWeight;
 
   if (prevWeight != null && nextWeight != null && prevWeight === nextWeight) {
-    if (prevWeight === 0) {
-      result[movedItemIndex].orderingWeight = 1;
-    } else {
-      result[movedItemIndex].orderingWeight = prevWeight;
-    }
+    result[movedItemIndex].orderingWeight = prevWeight;
   } else if (prevWeight == null && nextWeight != null) {
-    if (nextWeight === 0) {
-      result[movedItemIndex].orderingWeight = clampWeight(1);
-    } else {
-      result[movedItemIndex].orderingWeight = clampWeight(nextWeight + 1);
-    }
+    result[movedItemIndex].orderingWeight = clampWeight(Math.max(nextWeight - 1, 0));
   } else if (nextWeight == null && prevWeight != null) {
-    result[movedItemIndex].orderingWeight = clampWeight(Math.max(prevWeight - 1, 1));
+    result[movedItemIndex].orderingWeight = clampWeight(prevWeight + 1);
   } else if (prevWeight != null && nextWeight != null) {
-    const effectiveNext = nextWeight === 0 ? 0 : nextWeight;
-    const gap = prevWeight - effectiveNext;
+    const gap = nextWeight - prevWeight;
     if (gap <= 1) {
       for (let i = movedItemIndex + 1; i < result.length; i++) {
-        if (result[i].orderingWeight !== 0) {
-          result[i].orderingWeight = clampWeight(result[i].orderingWeight - 1);
-        }
+        result[i].orderingWeight = clampWeight(result[i].orderingWeight + 1);
       }
-      result[movedItemIndex].orderingWeight = clampWeight(prevWeight);
+      result[movedItemIndex].orderingWeight = clampWeight(prevWeight + 1);
     } else {
-      result[movedItemIndex].orderingWeight = clampWeight(prevWeight - Math.floor(gap / 2));
+      result[movedItemIndex].orderingWeight = clampWeight(prevWeight + Math.floor(gap / 2));
     }
   }
 


### PR DESCRIPTION
## Summary

The bulk channel weight ordering dialog did not properly populate weight fields when channels were dragged to reorder. The original `calculateRelativeWeight` function failed when all weights were equal (interpolation produced no gap), and the dialog assigned fabricated rank numbers to channels that had weight 0 in the backend.

## Spirit/Intent

Fix the drag-to-reorder weight assignment so that:
- Dragging a channel to a new position correctly calculates an appropriate weight for its new spot
- Channels with backend weight 0 (unset) are not assigned fabricated numbers on dialog open
- Equal/tied weights are preserved through save and reload
- Lower weights display at the top of the list, higher weights at the bottom
- What the user sees in the dialog is what gets saved to the backend

## Key Changes

- Replaced broken `calculateRelativeWeight` with `reassignWeightsFromPosition` that uses neighbor-based gap logic and shift-below when gaps are too small
- Preserved weight 0 on dialog load instead of fabricating `index + 1` ranks for all channels
- Removed weight inversion conversion on save/load — dialog values are now saved as-is
- Fixed `normalizeRanks` to not reassign sequential weights (was breaking tied weights)
- Changed sort order to ascending so lower weights appear at the top
- Raised `MAX_WEIGHT` from 100 to 9999 to prevent clamping collisions with many channels

## Risks

- Minor: Weight range expanded from 0–100 to 0–9999, but this is more flexible for large channel lists
- Low: Internal sorting logic changed, but UI behavior now matches user expectations