### PR TITLE
Don't mark completed streams as cancelled

### DIFF
--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -633,9 +633,15 @@ func (s *RequestService) UpdateRequestExecutionStatus(
 }
 
 // UpdateRequestExecutionStatusFromError updates request execution status based on error type and sets error message.
-func (s *RequestService) UpdateRequestExecutionStatusFromError(ctx context.Context, executionID int, rawErr error) error {
+// If streamCompleted is true and the error is a context cancellation, the execution is not marked as cancelled
+// (the client disconnected after the stream finished).
+func (s *RequestService) UpdateRequestExecutionStatusFromError(ctx context.Context, executionID int, rawErr error, streamCompleted bool) error {
 	status := requestexecution.StatusFailed
 	if errors.Is(rawErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		if streamCompleted {
+			return nil
+		}
+
 		status = requestexecution.StatusCanceled
 	}
 
@@ -858,8 +864,14 @@ func (s *RequestService) UpdateRequestStatus(ctx context.Context, requestID int,
 }
 
 // UpdateRequestStatusFromError updates request status based on error type: canceled if context canceled, otherwise failed.
-func (s *RequestService) UpdateRequestStatusFromError(ctx context.Context, requestID int, rawErr error) error {
+// If streamCompleted is true and the error is a context cancellation, the request is not marked as cancelled
+// (the client disconnected after the stream finished).
+func (s *RequestService) UpdateRequestStatusFromError(ctx context.Context, requestID int, rawErr error, streamCompleted bool) error {
 	if errors.Is(rawErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		if streamCompleted {
+			return nil
+		}
+
 		return s.UpdateRequestStatus(ctx, requestID, request.StatusCanceled)
 	}
 

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -140,7 +140,7 @@ func (ts *InboundPersistentStream) Close() error {
 				errToReport = ctxErr
 			}
 
-			if err := ts.requestService.UpdateRequestStatusFromError(persistCtx, ts.request.ID, errToReport); err != nil {
+			if err := ts.requestService.UpdateRequestStatusFromError(persistCtx, ts.request.ID, errToReport, ts.state.StreamCompleted); err != nil {
 				log.Warn(persistCtx, "Failed to update request status from error", log.Cause(err))
 			}
 		}

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -249,6 +249,7 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 				persistCtx,
 				requestExec.ID,
 				err,
+				outbound.StreamCompleted(),
 			); updateErr != nil {
 				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(updateErr))
 			}
@@ -260,6 +261,7 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 				persistCtx,
 				request.ID,
 				err,
+				outbound.StreamCompleted(),
 			); updateErr != nil {
 				log.Warn(persistCtx, "Failed to update request status from error", log.Cause(updateErr))
 			}

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -126,7 +126,7 @@ func (ts *OutboundPersistentStream) Close() error {
 		}
 
 		if ts.requestExec != nil {
-			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport); err != nil {
+			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport, ts.state.StreamCompleted); err != nil {
 				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
 			}
 		}
@@ -311,6 +311,11 @@ func (p *PersistentOutboundTransformer) GetCurrentModelID() string {
 // GetRequestedModel returns the originally requested model ID.
 func (p *PersistentOutboundTransformer) GetRequestedModel() string {
 	return p.state.OriginalModel
+}
+
+// StreamCompleted returns true if the stream received a terminal event.
+func (p *PersistentOutboundTransformer) StreamCompleted() bool {
+	return p.state.StreamCompleted
 }
 
 // HasMoreChannels returns true if there are more candidates available for retry.


### PR DESCRIPTION
Fixes #1402

When clients disconnect after the stream finishes, we were still marking those requests as cancelled. This was cluttering the request logs with spurious entries. Now we track if the stream completed and skip the cancellation status if it did.