### PR TITLE
chore(i18n): 补充 StepFun 开发者名称翻译

### DIFF
--- a/frontend/src/locales/en/models.json
+++ b/frontend/src/locales/en/models.json
@@ -174,6 +174,7 @@
   "models.developers.mistral": "Mistral",
   "models.developers.moonshot": "Moonshot",
   "models.developers.openai": "OpenAI",
+  "models.developers.stepfun": "StepFun",
   "models.developers.xai": "xAI",
   "models.developers.xiaomi": "Xiaomi",
   "models.developers.zai": "Z.ai",

--- a/frontend/src/locales/zh-CN/models.json
+++ b/frontend/src/locales/zh-CN/models.json
@@ -174,6 +174,7 @@
   "models.developers.mistral": "Mistral",
   "models.developers.moonshot": "月之暗面",
   "models.developers.openai": "OpenAI",
+  "models.developers.stepfun": "阶跃星辰",
   "models.developers.xai": "xAI",
   "models.developers.xiaomi": "小米",
   "models.developers.zai": "智谱",


### PR DESCRIPTION
## 摘要
- 为英文模型语言包补充缺失的 StepFun 开发者名称
- 为简体中文模型语言包补充缺失的 StepFun 开发者名称

## 备注
- 另外请将更新后的 `frontend/src/features/models/data/providers.json` 同步到 `unstable` 分支，因为之前新增的 `kwaipilot` 模型列表也需要一并同步，避免 developers 数据源不一致。