### PR TITLE
fix(anthropic): accept xhigh effort level for Claude Opus 4.7

### DIFF
--- a/llm/transformer/anthropic/inbound.go
+++ b/llm/transformer/anthropic/inbound.go
@@ -89,10 +89,10 @@ func (t *InboundTransformer) TransformRequest(ctx context.Context, httpReq *http
 			// output_config is optional for adaptive thinking (defaults to "high" effort upstream)
 			if anthropicReq.OutputConfig != nil && anthropicReq.OutputConfig.Effort != "" {
 				switch anthropicReq.OutputConfig.Effort {
-				case "low", "medium", "high", "max":
+				case "low", "medium", "high", "xhigh", "max":
 					// valid
 				default:
-					return nil, fmt.Errorf("%w: output_config.effort must be one of: low, medium, high, max", transformer.ErrInvalidRequest)
+					return nil, fmt.Errorf("%w: output_config.effort must be one of: low, medium, high, xhigh, max", transformer.ErrInvalidRequest)
 				}
 			}
 		default:

--- a/llm/transformer/anthropic/inbound_test.go
+++ b/llm/transformer/anthropic/inbound_test.go
@@ -588,6 +588,25 @@ func TestInboundTransformer_TransformRequest_ThinkingValidation(t *testing.T) {
 		require.Nil(t, got.ReasoningBudget)
 	})
 
+	t.Run("thinking adaptive with xhigh effort is accepted", func(t *testing.T) {
+		req := mkReq(`{
+			"model": "claude-opus-4-7",
+			"max_tokens": 1024,
+			"messages": [{"role": "user", "content": "Hello"}],
+			"thinking": {"type": "adaptive"},
+			"output_config": {"effort": "xhigh"}
+		}`)
+
+		got, err := transformer.TransformRequest(t.Context(), req)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.NotNil(t, got.TransformerMetadata)
+		require.Equal(t, "adaptive", got.TransformerMetadata[TransformerMetadataKeyThinkingType])
+		require.Equal(t, "xhigh", got.TransformerMetadata[TransformerMetadataKeyOutputConfigEffort])
+		require.Equal(t, "xhigh", got.ReasoningEffort)
+		require.Nil(t, got.ReasoningBudget)
+	})
+
 	t.Run("invalid thinking.type is rejected", func(t *testing.T) {
 		req := mkReq(`{
 			"model": "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
## Summary

Claude Opus 4.7 introduces a new `xhigh` effort level (between `high` and `max`), and Claude Code sets `xhigh` as the **default** for Opus 4.7. Clients upgrading to 4.7 immediately hit:

```
400 invalid_request_error: invalid request: output_config.effort must be one of: low, medium, high, max
```

The inbound validator at `llm/transformer/anthropic/inbound.go:92` is the only place missing `xhigh`. Internally, `xhigh` is already a first-class value:

- `llm/transformer/anthropic/thinking.go:34` — `"xhigh": 30000` in `defaultReasoningEffortMapping`
- `llm/transformer/anthropic/inbound_convert.go:328-331` — comment notes `max` maps to `xhigh` for downstream transformers; `xhigh` itself passes through as `ReasoningEffort`

So this is a one-case-label oversight rather than a real protocol gap.

## Change

- `llm/transformer/anthropic/inbound.go`: add `"xhigh"` to the valid-effort switch
- `llm/transformer/anthropic/inbound_test.go`: add regression test covering `output_config.effort=xhigh` on `claude-opus-4-7`

## Reference

- https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
- https://code.claude.com/docs/en/model-config#adjust-effort-level (see capability flag `xhigh_effort`)

## Test plan

- [x] `llm/transformer/anthropic` unit tests pass locally (trivially — the new `xhigh` branch reuses the same code path as `high`)
- [ ] CI green