### PR TITLE
Display userQuery per trace/thread entry

### DIFF
--- a/frontend/src/features/threads/components/threads-columns.tsx
+++ b/frontend/src/features/threads/components/threads-columns.tsx
@@ -53,10 +53,10 @@ export function useThreadsColumns(): ColumnDef<Thread>[] {
       enableSorting: false,
     },
     {
-      accessorKey: 'firstUserQuery',
-      header: ({ column }) => <DataTableColumnHeader column={column} title={t('threads.columns.firstUserQuery')} />,
+      accessorKey: 'userQuery',
+      header: ({ column }) => <DataTableColumnHeader column={column} title={t('threads.columns.userQuery')} />,
       cell: ({ row }) => {
-        const query = row.getValue('firstUserQuery') as string | null | undefined;
+        const query = row.getValue('userQuery') as string | null | undefined;
         return (
           <div className='max-w-96 truncate text-xs' title={query || ''}>
             {query || '-'}

--- a/frontend/src/features/threads/components/trace-card.tsx
+++ b/frontend/src/features/threads/components/trace-card.tsx
@@ -51,11 +51,11 @@ export function TraceCard({ trace, onViewTrace, index }: TraceCardProps) {
           {/* Chat Messages */}
           <div className='space-y-4 pt-1'>
             {/* User Query */}
-            {trace.firstUserQuery && (
+            {trace.userQuery && (
               <div className='flex items-start justify-end gap-2.5'>
                 <div className='flex max-w-[85%] flex-col items-end gap-1'>
                   <div className='relative rounded-2xl rounded-tr-sm bg-gradient-to-br from-primary to-primary/90 px-4 py-2.5 text-primary-foreground shadow-sm'>
-                    <p className='text-sm leading-relaxed'>{trace.firstUserQuery}</p>
+                    <p className='text-sm leading-relaxed'>{trace.userQuery}</p>
                   </div>
                 </div>
                 <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted ring-2 ring-background'>

--- a/frontend/src/features/threads/data/schema.ts
+++ b/frontend/src/features/threads/data/schema.ts
@@ -24,7 +24,7 @@ export const threadSchema = z.object({
   updatedAt: z.coerce.date(),
   project: projectSchema,
   tracesSummary: threadTracesSummarySchema,
-  firstUserQuery: z.string().nullable().optional(),
+  userQuery: z.string().nullable().optional(),
   usageMetadata: usageMetadataSchema,
 });
 

--- a/frontend/src/features/threads/data/threads.ts
+++ b/frontend/src/features/threads/data/threads.ts
@@ -43,7 +43,7 @@ function buildThreadsQuery() {
             tracesSummary: traces(first: 1) {
               totalCount
             }
-            firstUserQuery
+            userQuery: firstUserQuery
           }
           cursor
         }
@@ -106,7 +106,7 @@ function buildThreadDetailQuery() {
                 requests(where: { status: completed }) {
                   totalCount
                 }
-                firstUserQuery
+                userQuery: firstUserQuery
                 firstText
               }
               cursor

--- a/frontend/src/features/traces/components/traces-columns.tsx
+++ b/frontend/src/features/traces/components/traces-columns.tsx
@@ -50,11 +50,11 @@ export function useTracesColumns(): ColumnDef<Trace>[] {
     //   },
     // },
     {
-      accessorKey: 'firstUserQuery',
+      accessorKey: 'userQuery',
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('traces.columns.userQuery')} />,
       enableSorting: false,
       cell: ({ row }) => {
-        const query = row.getValue('firstUserQuery') as string | null | undefined;
+        const query = row.getValue('userQuery') as string | null | undefined;
         return (
           <div className='max-w-64 truncate text-xs' title={query || ''}>
             {query || '-'}

--- a/frontend/src/features/traces/data/schema.ts
+++ b/frontend/src/features/traces/data/schema.ts
@@ -23,7 +23,7 @@ export const traceSchema = z.object({
   updatedAt: z.coerce.date(),
   thread: threadSchema,
   requests: traceRequestsSummarySchema,
-  firstUserQuery: z.string().nullable().optional(),
+  userQuery: z.string().nullable().optional(),
   firstText: z.string().nullable().optional(),
 });
 

--- a/frontend/src/features/traces/data/traces.ts
+++ b/frontend/src/features/traces/data/traces.ts
@@ -19,7 +19,7 @@ function buildTracesQuery() {
           node {
             id
             traceID
-            firstUserQuery
+            userQuery: firstUserQuery
             createdAt
             updatedAt
             thread {

--- a/frontend/src/locales/en/threads.json
+++ b/frontend/src/locales/en/threads.json
@@ -6,7 +6,7 @@
   "threads.columns.project": "Project",
   "threads.columns.unknownProject": "Unknown Project",
   "threads.columns.traceCount": "Trace Count",
-  "threads.columns.firstUserQuery": "User Query",
+  "threads.columns.userQuery": "User Query",
   "threads.columns.details": "Details",
   "threads.actions.viewDetails": "View Details",
   "threads.detail.title": "Thread Details",

--- a/frontend/src/locales/zh-CN/threads.json
+++ b/frontend/src/locales/zh-CN/threads.json
@@ -6,7 +6,7 @@
   "threads.columns.project": "项目",
   "threads.columns.unknownProject": "未知项目",
   "threads.columns.traceCount": "追踪数量",
-  "threads.columns.firstUserQuery": "用户查询",
+  "threads.columns.userQuery": "用户查询",
   "threads.columns.details": "详情",
   "threads.actions.viewDetails": "查看详情",
   "threads.detail.title": "线程详情",

--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -212,15 +212,11 @@ func (s *Segment) FirstUserQuery() *string {
 	// Prefer the latest user query in the current segment.
 	// The first request of a trace may carry prior thread context as prefix,
 	// so the current turn's user prompt is typically the last user_query span.
-	var latestQuery *string
-	for _, span := range s.RequestSpans {
+	for i := len(s.RequestSpans) - 1; i >= 0; i-- {
+		span := s.RequestSpans[i]
 		if span.Type == "user_query" && span.Value != nil && span.Value.UserQuery != nil {
-			latestQuery = lo.ToPtr(span.Value.UserQuery.Text)
+			return lo.ToPtr(span.Value.UserQuery.Text)
 		}
-	}
-
-	if latestQuery != nil {
-		return latestQuery
 	}
 
 	// If not found in current segment, search in children

--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -209,11 +209,18 @@ func (s *Segment) FirstUserQuery() *string {
 		return nil
 	}
 
-	// Search in request spans first
+	// Prefer the latest user query in the current segment.
+	// The first request of a trace may carry prior thread context as prefix,
+	// so the current turn's user prompt is typically the last user_query span.
+	var latestQuery *string
 	for _, span := range s.RequestSpans {
 		if span.Type == "user_query" && span.Value != nil && span.Value.UserQuery != nil {
-			return lo.ToPtr(span.Value.UserQuery.Text)
+			latestQuery = lo.ToPtr(span.Value.UserQuery.Text)
 		}
+	}
+
+	if latestQuery != nil {
+		return latestQuery
 	}
 
 	// If not found in current segment, search in children

--- a/internal/server/biz/trace_test.go
+++ b/internal/server/biz/trace_test.go
@@ -83,6 +83,34 @@ func countSpansByType(spans []Span, spanType string) int {
 	return count
 }
 
+func TestSegment_FirstUserQueryPrefersLatestQueryInCurrentSegment(t *testing.T) {
+	segment := &Segment{
+		RequestSpans: []Span{
+			{
+				Type: "user_query",
+				Value: &SpanValue{
+					UserQuery: &SpanUserQuery{Text: "What is Go?"},
+				},
+			},
+			{
+				Type: "text",
+				Value: &SpanValue{
+					Text: &SpanText{Text: "Go is a programming language."},
+				},
+			},
+			{
+				Type: "user_query",
+				Value: &SpanValue{
+					UserQuery: &SpanUserQuery{Text: "Tell me about goroutines."},
+				},
+			},
+		},
+	}
+
+	require.NotNil(t, segment.FirstUserQuery())
+	require.Equal(t, "Tell me about goroutines.", *segment.FirstUserQuery())
+}
+
 func TestRequestService_LoadersReturnEmptyJSONAndSlices(t *testing.T) {
 	traceService, client := setupTestTraceService(t, nil)
 	defer client.Close()

--- a/internal/server/biz/trace_test.go
+++ b/internal/server/biz/trace_test.go
@@ -111,6 +111,38 @@ func TestSegment_FirstUserQueryPrefersLatestQueryInCurrentSegment(t *testing.T) 
 	require.Equal(t, "Tell me about goroutines.", *segment.FirstUserQuery())
 }
 
+func TestSegment_FirstUserQueryFallsBackToChildrenLatestQuery(t *testing.T) {
+	segment := &Segment{
+		Children: []*Segment{
+			{
+				RequestSpans: []Span{
+					{
+						Type: "user_query",
+						Value: &SpanValue{
+							UserQuery: &SpanUserQuery{Text: "What is Go?"},
+						},
+					},
+					{
+						Type: "text",
+						Value: &SpanValue{
+							Text: &SpanText{Text: "Go is a programming language."},
+						},
+					},
+					{
+						Type: "user_query",
+						Value: &SpanValue{
+							UserQuery: &SpanUserQuery{Text: "Tell me about goroutines."},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NotNil(t, segment.FirstUserQuery())
+	require.Equal(t, "Tell me about goroutines.", *segment.FirstUserQuery())
+}
+
 func TestRequestService_LoadersReturnEmptyJSONAndSlices(t *testing.T) {
 	traceService, client := setupTestTraceService(t, nil)
 	defer client.Close()


### PR DESCRIPTION
TL;DR: `firstUserQuery` was a bad UI label. In threads it suggested first-ever history, but we want the prompt shown for the current trace/row.

Why:
- thread views are a list of trace rows, so each row should show that trace’s current prompt
- `firstUserQuery` was misleading for both traces and threads
- `userQuery` is clearer and matches the actual span semantics better

Fix:
- keep the backend GraphQL field for compatibility
- alias it to `userQuery` in the frontend
- update trace/thread tables + cards to use the clearer name

Backend note: the trace resolver now returns the latest user query for the current trace segment, which fixes the multi-message thread case.



Before: 

[Thread]
<img width="594" height="788" alt="image" src="https://github.com/user-attachments/assets/66db3546-8adb-42d2-8e25-d6feaa734b73" />

[Trace]
<img width="732" height="226" alt="image" src="https://github.com/user-attachments/assets/9f5ab00a-bebd-44be-a2fa-aadf140b33d9" />

