### PR TITLE
Draft: Add OpenAI cache identity support

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -149,6 +149,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.openai_cache_identity.extra_session_body_fields", []string{})
 	v.SetDefault("server.openai_cache_identity.derive_from_conversation_anchor", true)
 	v.SetDefault("server.openai_cache_identity.anchor_max_bytes", 32768)
+	v.SetDefault("server.openai_cache_identity.trusted_prompt_cache_key_hosts", []string{})
 
 	// Dashboard defaults
 	v.SetDefault("server.dashboard.all_time_token_stats_soft_ttl", "1h")

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -143,6 +143,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.trace.claude_code_trace_enabled", false)
 	v.SetDefault("server.trace.codex_trace_enabled", false)
 
+	// OpenAI cache identity defaults
+	v.SetDefault("server.openai_cache_identity.enabled", true)
+	v.SetDefault("server.openai_cache_identity.extra_session_headers", []string{})
+	v.SetDefault("server.openai_cache_identity.extra_session_body_fields", []string{})
+	v.SetDefault("server.openai_cache_identity.derive_from_conversation_anchor", true)
+	v.SetDefault("server.openai_cache_identity.anchor_max_bytes", 32768)
+
 	// Dashboard defaults
 	v.SetDefault("server.dashboard.all_time_token_stats_soft_ttl", "1h")
 	v.SetDefault("server.dashboard.all_time_token_stats_hard_ttl", "24h")

--- a/internal/server/api/aisdk.go
+++ b/internal/server/api/aisdk.go
@@ -47,6 +47,7 @@ func NewAiSDKHandlers(params AiSdkHandlersParams) *AiSDKHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver: not needed for AISDK
 			),
 			StreamWriter: WriteJSONStream,
 		},

--- a/internal/server/api/anthropic.go
+++ b/internal/server/api/anthropic.go
@@ -52,6 +52,7 @@ func NewAnthropicHandlers(params AnthropicHandlersParams) *AnthropicHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver: not needed for Anthropic
 			),
 		},
 		ChannelService: params.ChannelService,

--- a/internal/server/api/doubao.go
+++ b/internal/server/api/doubao.go
@@ -56,7 +56,7 @@ func NewDoubaoHandlers(params DoubaoHandlersParams) *DoubaoHandlers {
 			params.QuotaService,
 			params.PromptProtectionRuleService,
 			params.LiveStreamRegistry,
-				nil, // cacheIdentityResolver
+			nil, // cacheIdentityResolver
 		),
 		InboundTransformer: inbound,
 	}

--- a/internal/server/api/doubao.go
+++ b/internal/server/api/doubao.go
@@ -56,6 +56,7 @@ func NewDoubaoHandlers(params DoubaoHandlersParams) *DoubaoHandlers {
 			params.QuotaService,
 			params.PromptProtectionRuleService,
 			params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver
 		),
 		InboundTransformer: inbound,
 	}

--- a/internal/server/api/gemini.go
+++ b/internal/server/api/gemini.go
@@ -52,6 +52,7 @@ func NewGeminiHandlers(params GeminiHandlersParams) *GeminiHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver
 			),
 		),
 		ChannelService: params.ChannelService,

--- a/internal/server/api/jina.go
+++ b/internal/server/api/jina.go
@@ -41,6 +41,7 @@ func NewJinaHandlers(params JinaHandlersParams) *JinaHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver
 			),
 		},
 		EmbeddingHandlers: &ChatCompletionHandlers{
@@ -56,6 +57,7 @@ func NewJinaHandlers(params JinaHandlersParams) *JinaHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver
 			),
 		},
 	}

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -16,6 +16,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/model"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/cacheidentity"
 	"github.com/looplj/axonhub/internal/server/orchestrator"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -39,6 +40,7 @@ type OpenAIHandlersParams struct {
 	HttpClient                  *httpclient.HttpClient
 	LiveStreamRegistry          *biz.LiveStreamRegistry
 	Client                      *ent.Client
+	CacheIdentityResolver       *cacheidentity.Resolver
 }
 
 type OpenAIHandlers struct {
@@ -75,6 +77,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		ResponseCompletionHandlers: &ChatCompletionHandlers{
@@ -90,6 +93,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		CompactHandlers: &ChatCompletionHandlers{
@@ -105,6 +109,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		EmbeddingHandlers: &ChatCompletionHandlers{
@@ -120,6 +125,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		ImageGenerationHandlers: &ChatCompletionHandlers{
@@ -135,6 +141,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		ImageEditHandlers: &ChatCompletionHandlers{
@@ -150,6 +157,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		ImageVariationHandlers: &ChatCompletionHandlers{
@@ -165,6 +173,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		VideoHandlers: &ChatCompletionHandlers{
@@ -180,6 +189,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.QuotaService,
 				params.PromptProtectionRuleService,
 				params.LiveStreamRegistry,
+				params.CacheIdentityResolver,
 			),
 		},
 		VideoInboundTransformer: videoInbound,

--- a/internal/server/api/playground.go
+++ b/internal/server/api/playground.go
@@ -65,6 +65,7 @@ func NewPlaygroundHandlers(params PlaygroundHandlersParams) *PlaygroundHandlers 
 			params.QuotaService,
 			params.PromptProtectionRuleService,
 			params.LiveStreamRegistry,
+				nil, // cacheIdentityResolver
 		),
 	}
 }

--- a/internal/server/cacheidentity/anchor.go
+++ b/internal/server/cacheidentity/anchor.go
@@ -43,14 +43,14 @@ func DeriveAnchor(messages []llm.Message, projectID int, apiKeyID int, maxBytes 
 		case "system", "developer":
 			if seenUser {
 				// system/developer after first user → stop
-				break
+				goto done
 			}
 
 			parts = append(parts, canonicalizeMessage(msg))
 		case "user":
 			if seenUser {
 				// second user message → stop
-				break
+				goto done
 			}
 
 			parts = append(parts, canonicalizeMessage(msg))

--- a/internal/server/cacheidentity/anchor.go
+++ b/internal/server/cacheidentity/anchor.go
@@ -1,0 +1,197 @@
+package cacheidentity
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+const (
+	anchorVersion   = "ah:anchor:v1"
+	defaultMaxBytes = 32768
+)
+
+// DeriveAnchor computes a deterministic conversation-anchor digest from
+// the leading stable portion of the message list.
+//
+// The stable prefix is defined as: all contiguous system/developer messages
+// followed by the first user message. The hash stops before the first
+// assistant, tool-call, or tool-result message.
+//
+// The hash is namespaced by project and API key to prevent cross-tenant
+// collisions.
+func DeriveAnchor(messages []llm.Message, projectID int, apiKeyID int, maxBytes int) string {
+	if len(messages) == 0 {
+		return ""
+	}
+
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+
+	// Extract leading stable prefix.
+	var parts []string
+	seenUser := false
+
+	for _, msg := range messages {
+		role := strings.ToLower(msg.Role)
+
+		switch role {
+		case "system", "developer":
+			if seenUser {
+				// system/developer after first user → stop
+				break
+			}
+
+			parts = append(parts, canonicalizeMessage(msg))
+		case "user":
+			if seenUser {
+				// second user message → stop
+				break
+			}
+
+			parts = append(parts, canonicalizeMessage(msg))
+			seenUser = true
+		default:
+			// assistant, tool, function, etc. → stop
+			goto done
+		}
+	}
+
+done:
+	if len(parts) == 0 {
+		return ""
+	}
+
+	canonical := strings.Join(parts, "\n---\n")
+
+	// Apply byte limit.
+	if len(canonical) > maxBytes {
+		canonical = canonical[:maxBytes]
+	}
+
+	// Build namespaced hash input.
+	input := fmt.Sprintf("%s:%d:%d:%s", anchorVersion, projectID, apiKeyID, canonical)
+
+	hash := sha256.Sum256([]byte(input))
+
+	return fmt.Sprintf("%s:%x", anchorVersion, hash)
+}
+
+// canonicalizeMessage produces a stable string representation of a message
+// for hashing. It normalizes whitespace (CRLF → LF) and emits stable
+// descriptors for binary/inline parts so multimodal identity is preserved.
+func canonicalizeMessage(msg llm.Message) string {
+	var sb strings.Builder
+	sb.WriteString(msg.Role)
+	sb.WriteByte(':')
+
+	// Plain text content.
+	if msg.Content.Content != nil {
+		text := normalizeLineEndings(*msg.Content.Content)
+		sb.WriteString(text)
+
+		return sb.String()
+	}
+
+	// Multi-part content.
+	for i, part := range msg.Content.MultipleContent {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+
+		switch part.Type {
+		case "text":
+			if part.Text != nil {
+				sb.WriteString(normalizeLineEndings(*part.Text))
+			}
+		case "image_url":
+			if part.ImageURL != nil {
+				sb.WriteString("[image_url:")
+				sb.WriteString(canonicalizeURL(part.ImageURL.URL))
+				sb.WriteByte(']')
+			}
+		case "video_url":
+			if part.VideoURL != nil {
+				sb.WriteString("[video_url:")
+				sb.WriteString(canonicalizeURL(part.VideoURL.URL))
+				sb.WriteByte(']')
+			}
+		case "document":
+			if part.Document != nil {
+				sb.WriteString("[document:")
+				sb.WriteString(part.Document.MIMEType)
+				sb.WriteByte(':')
+				sb.WriteString(canonicalizeURL(part.Document.URL))
+				sb.WriteByte(']')
+			}
+		case "input_audio":
+			if part.InputAudio != nil {
+				// Compute a stable digest of the audio data so two
+				// requests with different audio payloads but the same
+				// text produce distinct anchors.
+				sb.WriteString("[input_audio:")
+				sb.WriteString(part.InputAudio.Format)
+				sb.WriteByte(':')
+				sb.WriteString(hashInlineData(part.InputAudio.Data))
+				sb.WriteByte(']')
+			}
+		case "compaction", "compaction_summary":
+			// Skip entirely — these are encrypted/ephemeral.
+			continue
+		default:
+			sb.WriteString("[")
+			sb.WriteString(part.Type)
+			sb.WriteString("]")
+		}
+	}
+
+	return sb.String()
+}
+
+// canonicalizeURL produces a stable identifier for a URL. For remote URLs
+// the URL itself is the stable identity. For data: URLs (inline base64),
+// the binary content is hashed to produce a stable, short descriptor
+// that distinguishes different inline payloads.
+func canonicalizeURL(u string) string {
+	if !strings.HasPrefix(u, "data:") {
+		// Remote URL — already a stable external identifier.
+		return u
+	}
+
+	// data:<mediatype>;base64,<data>
+	// Hash the binary content for a stable, comparable descriptor.
+	idx := strings.Index(u, ",")
+	if idx < 0 {
+		return hashInlineData(u)
+	}
+
+	mediaType := u[5:idx] // between "data:" and ","
+	b64Data := u[idx+1:]
+
+	return fmt.Sprintf("%s:%s", strings.TrimSuffix(mediaType, ";base64"), hashInlineData(b64Data))
+}
+
+// hashInlineData computes a truncated SHA-256 hex digest of base64-encoded
+// binary data. It decodes first to produce a stable hash regardless of
+// whitespace or line-break differences in the base64 encoding.
+func hashInlineData(b64 string) string {
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		// Fallback: hash the raw base64 string if decode fails.
+		h := sha256.Sum256([]byte(b64))
+		return fmt.Sprintf("sha256:%x", h[:16])
+	}
+
+	h := sha256.Sum256(decoded)
+
+	return fmt.Sprintf("sha256:%x", h[:16])
+}
+
+// normalizeLineEndings replaces CRLF with LF for stable hashing.
+func normalizeLineEndings(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}

--- a/internal/server/cacheidentity/channel_policy.go
+++ b/internal/server/cacheidentity/channel_policy.go
@@ -27,8 +27,8 @@ func ChannelAllowsPromptCacheKey(channelType channel.Type, baseURL string) bool 
 // isOfficialOpenAIHost checks if the base URL points to api.openai.com.
 func isOfficialOpenAIHost(baseURL string) bool {
 	if baseURL == "" {
-		// Empty base URL typically means "use default", which is api.openai.com.
-		return true
+		// Default-deny: only explicit official OpenAI hosts are allowlisted.
+		return false
 	}
 
 	parsed, err := url.Parse(baseURL)

--- a/internal/server/cacheidentity/channel_policy.go
+++ b/internal/server/cacheidentity/channel_policy.go
@@ -1,0 +1,42 @@
+package cacheidentity
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/looplj/axonhub/internal/ent/channel"
+)
+
+// ChannelAllowsPromptCacheKey determines whether a channel should receive
+// the prompt_cache_key field in outbound requests.
+//
+// V1 policy: only allow official OpenAI-backed channels with the canonical
+// api.openai.com host. Third-party OpenAI-compatible proxies are denied
+// to prevent 502 regressions (PR #1426).
+func ChannelAllowsPromptCacheKey(channelType channel.Type, baseURL string) bool {
+	switch channelType {
+	case channel.TypeOpenai, channel.TypeOpenaiResponses:
+		return isOfficialOpenAIHost(baseURL)
+	default:
+		// All other channel types (codex, gemini_openai, deepseek, openrouter,
+		// nanogpt, etc.) do not receive prompt_cache_key on the wire.
+		return false
+	}
+}
+
+// isOfficialOpenAIHost checks if the base URL points to api.openai.com.
+func isOfficialOpenAIHost(baseURL string) bool {
+	if baseURL == "" {
+		// Empty base URL typically means "use default", which is api.openai.com.
+		return true
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+
+	return host == "api.openai.com"
+}

--- a/internal/server/cacheidentity/channel_policy.go
+++ b/internal/server/cacheidentity/channel_policy.go
@@ -10,13 +10,13 @@ import (
 // ChannelAllowsPromptCacheKey determines whether a channel should receive
 // the prompt_cache_key field in outbound requests.
 //
-// V1 policy: only allow official OpenAI-backed channels with the canonical
-// api.openai.com host. Third-party OpenAI-compatible proxies are denied
-// to prevent 502 regressions (PR #1426).
-func ChannelAllowsPromptCacheKey(channelType channel.Type, baseURL string) bool {
+// Policy: allow official OpenAI-backed channels with api.openai.com or any
+// explicitly configured trusted proxy host. Third-party OpenAI-compatible
+// proxies are denied by default to prevent 502 regressions (PR #1426).
+func ChannelAllowsPromptCacheKey(channelType channel.Type, baseURL string, trustedHosts []string) bool {
 	switch channelType {
 	case channel.TypeOpenai, channel.TypeOpenaiResponses:
-		return isOfficialOpenAIHost(baseURL)
+		return isTrustedOpenAIHost(baseURL, trustedHosts)
 	default:
 		// All other channel types (codex, gemini_openai, deepseek, openrouter,
 		// nanogpt, etc.) do not receive prompt_cache_key on the wire.
@@ -24,10 +24,12 @@ func ChannelAllowsPromptCacheKey(channelType channel.Type, baseURL string) bool 
 	}
 }
 
-// isOfficialOpenAIHost checks if the base URL points to api.openai.com.
-func isOfficialOpenAIHost(baseURL string) bool {
+// isTrustedOpenAIHost checks if the base URL points to api.openai.com or
+// any configured trusted proxy host. Matching is case-insensitive and
+// ignores scheme, port, and path.
+func isTrustedOpenAIHost(baseURL string, trustedHosts []string) bool {
 	if baseURL == "" {
-		// Default-deny: only explicit official OpenAI hosts are allowlisted.
+		// Default-deny: only explicit hosts are allowlisted.
 		return false
 	}
 
@@ -38,5 +40,17 @@ func isOfficialOpenAIHost(baseURL string) bool {
 
 	host := strings.ToLower(parsed.Hostname())
 
-	return host == "api.openai.com"
+	// Official OpenAI is always trusted.
+	if host == "api.openai.com" {
+		return true
+	}
+
+	// Check configured trusted proxy hosts.
+	for _, trusted := range trustedHosts {
+		if strings.EqualFold(host, trusted) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/server/cacheidentity/channel_policy_test.go
+++ b/internal/server/cacheidentity/channel_policy_test.go
@@ -3,6 +3,8 @@ package cacheidentity
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/looplj/axonhub/internal/ent/channel"
 )
 
@@ -10,10 +12,11 @@ func TestChannelAllowsPromptCacheKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		chType    channel.Type
-		baseURL   string
-		wantAllow bool
+		name         string
+		chType       channel.Type
+		baseURL      string
+		trustedHosts []string
+		wantAllow    bool
 	}{
 		{
 			name:      "official openai host allowed",
@@ -34,16 +37,65 @@ func TestChannelAllowsPromptCacheKey(t *testing.T) {
 			wantAllow: false,
 		},
 		{
-			name:      "third party host denied",
+			name:      "third party host denied with no trusted list",
 			chType:    channel.TypeOpenai,
 			baseURL:   "https://openrouter.ai/api/v1",
 			wantAllow: false,
 		},
 		{
-			name:      "non openai channel denied",
+			name:      "non openai channel denied even with trusted host",
 			chType:    channel.TypeOpenrouter,
 			baseURL:   "https://api.openai.com/v1",
 			wantAllow: false,
+		},
+		{
+			name:         "trusted proxy allowed",
+			chType:       channel.TypeOpenai,
+			baseURL:      "https://ai-hub.miguocomics.co/v1",
+			trustedHosts: []string{"ai-hub.miguocomics.co"},
+			wantAllow:    true,
+		},
+		{
+			name:         "trusted proxy case insensitive",
+			chType:       channel.TypeOpenai,
+			baseURL:      "https://ai-hub.miguocomics.co/v1",
+			trustedHosts: []string{"AI-Hub.MiguoComics.CO"},
+			wantAllow:    true,
+		},
+		{
+			name:         "untrusted proxy denied even with other trusted hosts",
+			chType:       channel.TypeOpenai,
+			baseURL:      "https://unknown-proxy.example.com/v1",
+			trustedHosts: []string{"ai-hub.miguocomics.co"},
+			wantAllow:    false,
+		},
+		{
+			name:         "official openai always trusted even without trusted list",
+			chType:       channel.TypeOpenai,
+			baseURL:      "https://api.openai.com/v1",
+			trustedHosts: nil,
+			wantAllow:    true,
+		},
+		{
+			name:         "non openai channel denied even with matching trusted host",
+			chType:       channel.TypeGeminiOpenai,
+			baseURL:      "https://ai-hub.miguocomics.co/v1",
+			trustedHosts: []string{"ai-hub.miguocomics.co"},
+			wantAllow:    false,
+		},
+		{
+			name:         "openai responses channel with trusted proxy",
+			chType:       channel.TypeOpenaiResponses,
+			baseURL:      "https://ai-hub.miguocomics.co/v1",
+			trustedHosts: []string{"ai-hub.miguocomics.co"},
+			wantAllow:    true,
+		},
+		{
+			name:         "multiple trusted hosts second match",
+			chType:       channel.TypeOpenai,
+			baseURL:      "https://proxy-b.internal/v1",
+			trustedHosts: []string{"proxy-a.internal", "proxy-b.internal"},
+			wantAllow:    true,
 		},
 	}
 
@@ -51,10 +103,8 @@ func TestChannelAllowsPromptCacheKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := ChannelAllowsPromptCacheKey(tc.chType, tc.baseURL)
-			if got != tc.wantAllow {
-				t.Fatalf("ChannelAllowsPromptCacheKey(%q, %q) = %v, want %v", tc.chType, tc.baseURL, got, tc.wantAllow)
-			}
+			got := ChannelAllowsPromptCacheKey(tc.chType, tc.baseURL, tc.trustedHosts)
+			require.Equal(t, tc.wantAllow, got)
 		})
 	}
 }

--- a/internal/server/cacheidentity/channel_policy_test.go
+++ b/internal/server/cacheidentity/channel_policy_test.go
@@ -1,0 +1,60 @@
+package cacheidentity
+
+import (
+	"testing"
+
+	"github.com/looplj/axonhub/internal/ent/channel"
+)
+
+func TestChannelAllowsPromptCacheKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		chType    channel.Type
+		baseURL   string
+		wantAllow bool
+	}{
+		{
+			name:      "official openai host allowed",
+			chType:    channel.TypeOpenai,
+			baseURL:   "https://api.openai.com/v1",
+			wantAllow: true,
+		},
+		{
+			name:      "responses official openai host allowed",
+			chType:    channel.TypeOpenaiResponses,
+			baseURL:   "https://api.openai.com/v1",
+			wantAllow: true,
+		},
+		{
+			name:      "empty base url denied",
+			chType:    channel.TypeOpenai,
+			baseURL:   "",
+			wantAllow: false,
+		},
+		{
+			name:      "third party host denied",
+			chType:    channel.TypeOpenai,
+			baseURL:   "https://openrouter.ai/api/v1",
+			wantAllow: false,
+		},
+		{
+			name:      "non openai channel denied",
+			chType:    channel.TypeOpenrouter,
+			baseURL:   "https://api.openai.com/v1",
+			wantAllow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ChannelAllowsPromptCacheKey(tc.chType, tc.baseURL)
+			if got != tc.wantAllow {
+				t.Fatalf("ChannelAllowsPromptCacheKey(%q, %q) = %v, want %v", tc.chType, tc.baseURL, got, tc.wantAllow)
+			}
+		})
+	}
+}

--- a/internal/server/cacheidentity/config.go
+++ b/internal/server/cacheidentity/config.go
@@ -9,4 +9,5 @@ type Config struct {
 	ExtraSessionBodyFields       []string `conf:"extra_session_body_fields" yaml:"extra_session_body_fields" json:"extra_session_body_fields"`
 	DeriveFromConversationAnchor bool     `conf:"derive_from_conversation_anchor" yaml:"derive_from_conversation_anchor" json:"derive_from_conversation_anchor"`
 	AnchorMaxBytes               int      `conf:"anchor_max_bytes" yaml:"anchor_max_bytes" json:"anchor_max_bytes"`
+	TrustedPromptCacheKeyHosts   []string `conf:"trusted_prompt_cache_key_hosts" yaml:"trusted_prompt_cache_key_hosts" json:"trusted_prompt_cache_key_hosts"`
 }

--- a/internal/server/cacheidentity/config.go
+++ b/internal/server/cacheidentity/config.go
@@ -1,0 +1,12 @@
+package cacheidentity
+
+// Config holds cache identity resolution settings. This mirrors
+// server.OpenAICacheIdentity but lives in this package to avoid an
+// import cycle between internal/server and internal/server/cacheidentity.
+type Config struct {
+	Enabled                      bool     `conf:"enabled" yaml:"enabled" json:"enabled"`
+	ExtraSessionHeaders          []string `conf:"extra_session_headers" yaml:"extra_session_headers" json:"extra_session_headers"`
+	ExtraSessionBodyFields       []string `conf:"extra_session_body_fields" yaml:"extra_session_body_fields" json:"extra_session_body_fields"`
+	DeriveFromConversationAnchor bool     `conf:"derive_from_conversation_anchor" yaml:"derive_from_conversation_anchor" json:"derive_from_conversation_anchor"`
+	AnchorMaxBytes               int      `conf:"anchor_max_bytes" yaml:"anchor_max_bytes" json:"anchor_max_bytes"`
+}

--- a/internal/server/cacheidentity/resolver.go
+++ b/internal/server/cacheidentity/resolver.go
@@ -1,0 +1,308 @@
+package cacheidentity
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/looplj/axonhub/internal/contexts"
+	"github.com/looplj/axonhub/internal/log"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/anthropic/claudecode"
+	"github.com/looplj/axonhub/llm/transformer/openai/codex"
+	"github.com/looplj/axonhub/llm/transformer/shared"
+)
+
+// Source classifies how the cache identity was resolved.
+const (
+	SourceNone               = "none"
+	SourceClientProvided     = "client_provided"
+	SourceSessionHeader      = "session_header"
+	SourceSessionBodyField   = "session_body_field"
+	SourceThreadIdentity     = "thread_identity"
+	SourceConversationAnchor = "conversation_anchor"
+)
+
+// TransformerMetadata keys used to propagate resolved identity through the pipeline.
+const (
+	MetaResolvedSessionID       = "resolved_session_id"
+	MetaResolvedPromptCacheKey  = "resolved_prompt_cache_key"
+	MetaResolvedCacheSource     = "resolved_prompt_cache_source"
+	MetaAllowPromptCacheKeyEmit = "allow_prompt_cache_key_emit"
+)
+
+// Result holds the output of an identity resolution pass.
+type Result struct {
+	SessionID      string
+	PromptCacheKey string
+	Source         string
+}
+
+// Resolver derives stable session IDs and prompt cache keys from a
+// combination of inbound headers, body fields, thread context, and
+// conversation-anchor hashing.
+type Resolver struct {
+	config       Config
+	threadHeader string // from tracing config, e.g. "AH-Thread-Id"
+}
+
+// NewResolver creates a resolver with the given configuration.
+func NewResolver(config Config, threadHeader string) *Resolver {
+	if threadHeader == "" {
+		threadHeader = "AH-Thread-Id"
+	}
+
+	return &Resolver{
+		config:       config,
+		threadHeader: threadHeader,
+	}
+}
+
+// Resolve runs the full resolution precedence and returns the result.
+// It reads from:
+//   - headers on llmReq.RawRequest
+//   - body fields on llmReq.RawRequest
+//   - thread context via contexts.GetThread
+//   - conversation anchor from llmReq.Messages
+func (r *Resolver) Resolve(ctx context.Context, llmReq *llm.Request) Result {
+	if !r.config.Enabled || llmReq == nil {
+		return Result{Source: SourceNone}
+	}
+
+	// 1. If client already provided a non-empty prompt_cache_key, preserve it.
+	if pck := ptrString(llmReq.PromptCacheKey); pck != "" {
+		return Result{
+			PromptCacheKey: pck,
+			Source:         SourceClientProvided,
+		}
+	}
+
+	// 2. Try to resolve a stable session identity from headers/body.
+	sessionID, source := r.resolveSessionIdentity(ctx, llmReq)
+
+	// 3. If we have a session identity, use it as both session and cache key.
+	if sessionID != "" {
+		return Result{
+			SessionID:      sessionID,
+			PromptCacheKey: sessionID,
+			Source:         source,
+		}
+	}
+
+	// 4. Try thread identity from context.
+	if thread, ok := contexts.GetThread(ctx); ok && thread != nil && thread.ThreadID != "" {
+		return Result{
+			SessionID:      thread.ThreadID,
+			PromptCacheKey: thread.ThreadID,
+			Source:         SourceThreadIdentity,
+		}
+	}
+
+	// 5. Derive conversation-anchor fingerprint if enabled.
+	if r.config.DeriveFromConversationAnchor && len(llmReq.Messages) > 0 {
+		projectID, _ := contexts.GetProjectID(ctx)
+		apiKeyID := getAPIKeyID(ctx)
+
+		anchor := DeriveAnchor(llmReq.Messages, projectID, apiKeyID, r.config.AnchorMaxBytes)
+		if anchor != "" {
+			return Result{
+				PromptCacheKey: anchor,
+				Source:         SourceConversationAnchor,
+			}
+		}
+	}
+
+	return Result{Source: SourceNone}
+}
+
+// resolveSessionIdentity checks built-in and configured header/body sources.
+func (r *Resolver) resolveSessionIdentity(ctx context.Context, llmReq *llm.Request) (string, string) {
+	var headers http.Header
+	var rawBody []byte
+
+	if llmReq.RawRequest != nil {
+		headers = llmReq.RawRequest.Headers
+		rawBody = llmReq.RawRequest.Body
+	}
+
+	// --- Header-based candidates ---
+
+	// Built-in: Codex Session_id header.
+	if sid := codex.GetSessionIDFromHeaders(headers); sid != "" {
+		return sid, SourceSessionHeader
+	}
+
+	// Built-in: configured thread header (e.g. AH-Thread-Id).
+	if headers != nil {
+		if v := strings.TrimSpace(headers.Get(r.threadHeader)); v != "" {
+			return v, SourceSessionHeader
+		}
+
+		// Built-in: Conversation_id header.
+		if v := strings.TrimSpace(headers.Get("Conversation_id")); v != "" {
+			return v, SourceSessionHeader
+		}
+	}
+
+	// Configured extra session headers.
+	for _, h := range r.config.ExtraSessionHeaders {
+		if headers != nil {
+			if v := strings.TrimSpace(headers.Get(h)); v != "" {
+				if log.DebugEnabled(ctx) {
+					log.Debug(ctx, "resolved session from extra header",
+						log.String("header", h),
+						log.String("source", SourceSessionHeader),
+					)
+				}
+
+				return v, SourceSessionHeader
+			}
+		}
+	}
+
+	// --- Body-based candidates ---
+	if len(rawBody) > 0 {
+		// Built-in body fields.
+		for _, field := range []string{"metadata.session_id", "metadata.conversation_id"} {
+			if v := gjson.GetBytes(rawBody, field); v.Exists() && strings.TrimSpace(v.String()) != "" {
+				return strings.TrimSpace(v.String()), SourceSessionBodyField
+			}
+		}
+
+		// Configured extra session body fields.
+		for _, field := range r.config.ExtraSessionBodyFields {
+			if v := gjson.GetBytes(rawBody, field); v.Exists() && strings.TrimSpace(v.String()) != "" {
+				if log.DebugEnabled(ctx) {
+					log.Debug(ctx, "resolved session from extra body field",
+						log.String("field", field),
+						log.String("source", SourceSessionBodyField),
+					)
+				}
+
+				return strings.TrimSpace(v.String()), SourceSessionBodyField
+			}
+		}
+	}
+
+	// Also check Claude Code metadata.user_id for session_id if present.
+	// Claude Code encodes session identity in user_id using either:
+	//   - v2 JSON: {"device_id":"...","session_id":"...","account_uuid":"..."}
+	//   - Legacy:  user_<64hex>_account__session_<uuid>
+	// Reuse the canonical parser to handle both formats correctly.
+	if len(rawBody) > 0 {
+		if v := gjson.GetBytes(rawBody, "metadata.user_id"); v.Exists() {
+			if uid := claudecode.ParseUserID(v.String()); uid != nil && uid.SessionID != "" {
+				return uid.SessionID, SourceSessionBodyField
+			}
+		}
+	}
+
+	return "", ""
+}
+
+// StoreOnRequest writes resolved identity into TransformerMetadata.
+func StoreOnRequest(llmReq *llm.Request, result Result) {
+	if llmReq.TransformerMetadata == nil {
+		llmReq.TransformerMetadata = map[string]any{}
+	}
+
+	if result.SessionID != "" {
+		llmReq.TransformerMetadata[MetaResolvedSessionID] = result.SessionID
+	}
+
+	if result.PromptCacheKey != "" {
+		llmReq.TransformerMetadata[MetaResolvedPromptCacheKey] = result.PromptCacheKey
+	}
+
+	llmReq.TransformerMetadata[MetaResolvedCacheSource] = result.Source
+}
+
+// GetResolvedSessionID reads the resolved session ID from TransformerMetadata.
+func GetResolvedSessionID(llmReq *llm.Request) string {
+	if llmReq == nil || llmReq.TransformerMetadata == nil {
+		return ""
+	}
+
+	v, _ := llmReq.TransformerMetadata[MetaResolvedSessionID].(string)
+
+	return v
+}
+
+// GetResolvedPromptCacheKey reads the resolved prompt cache key from TransformerMetadata.
+func GetResolvedPromptCacheKey(llmReq *llm.Request) string {
+	if llmReq == nil || llmReq.TransformerMetadata == nil {
+		return ""
+	}
+
+	v, _ := llmReq.TransformerMetadata[MetaResolvedPromptCacheKey].(string)
+
+	return v
+}
+
+// GetResolvedCacheSource reads the source classification from TransformerMetadata.
+func GetResolvedCacheSource(llmReq *llm.Request) string {
+	if llmReq == nil || llmReq.TransformerMetadata == nil {
+		return SourceNone
+	}
+
+	v, _ := llmReq.TransformerMetadata[MetaResolvedCacheSource].(string)
+	if v == "" {
+		return SourceNone
+	}
+
+	return v
+}
+
+func ptrString(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
+}
+
+func getAPIKeyID(ctx context.Context) int {
+	key, ok := contexts.GetAPIKey(ctx)
+	if !ok || key == nil {
+		return 0
+	}
+
+	return key.ID
+}
+
+// IsPromptCacheKeyEmitAllowed checks the TransformerMetadata flag.
+func IsPromptCacheKeyEmitAllowed(meta map[string]any) bool {
+	if meta == nil {
+		return false
+	}
+
+	v, ok := meta[MetaAllowPromptCacheKeyEmit].(bool)
+
+	return ok && v
+}
+
+// SetPromptCacheKeyEmitAllowed sets the TransformerMetadata flag.
+func SetPromptCacheKeyEmitAllowed(llmReq *llm.Request, allowed bool) {
+	if llmReq.TransformerMetadata == nil {
+		llmReq.TransformerMetadata = map[string]any{}
+	}
+
+	llmReq.TransformerMetadata[MetaAllowPromptCacheKeyEmit] = allowed
+}
+
+// InjectSessionIDToContext stores the resolved session ID into the context
+// via shared.WithSessionID if not already present.
+func InjectSessionIDToContext(ctx context.Context, result Result) context.Context {
+	if result.SessionID == "" {
+		return ctx
+	}
+
+	// Don't overwrite if the trace middleware already set a session-scoped value.
+	if _, ok := shared.GetSessionID(ctx); ok {
+		return ctx
+	}
+
+	return shared.WithSessionID(ctx, result.SessionID)
+}

--- a/internal/server/cacheidentity/resolver.go
+++ b/internal/server/cacheidentity/resolver.go
@@ -60,6 +60,13 @@ func NewResolver(config Config, threadHeader string) *Resolver {
 	}
 }
 
+// TrustedHosts returns the configured trusted proxy hostnames for
+// prompt_cache_key emission. This is used by the orchestrator to
+// thread the list into outbound gating without exposing the full config.
+func (r *Resolver) TrustedHosts() []string {
+	return r.config.TrustedPromptCacheKeyHosts
+}
+
 // Resolve runs the full resolution precedence and returns the result.
 // It reads from:
 //   - headers on llmReq.RawRequest
@@ -134,6 +141,12 @@ func (r *Resolver) resolveSessionIdentity(ctx context.Context, llmReq *llm.Reque
 		return sid, SourceSessionHeader
 	}
 
+	// Built-in: OpenCode X-Session-Affinity header.
+	if headers != nil {
+		if v := strings.TrimSpace(headers.Get("X-Session-Affinity")); v != "" {
+			return v, SourceSessionHeader
+		}
+	}
 	// Built-in: configured thread header (e.g. AH-Thread-Id).
 	if headers != nil {
 		if v := strings.TrimSpace(headers.Get(r.threadHeader)); v != "" {

--- a/internal/server/cacheidentity/resolver_test.go
+++ b/internal/server/cacheidentity/resolver_test.go
@@ -1,0 +1,120 @@
+package cacheidentity
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestResolver_XSessionAffinity(t *testing.T) {
+	resolver := NewResolver(Config{Enabled: true}, "")
+
+	ctx := context.Background()
+	req := &llm.Request{
+		Model: "gpt-4o",
+		RawRequest: &httpclient.Request{
+			Headers: http.Header{
+				"X-Session-Affinity": []string{"opencode-session-abc123"},
+			},
+		},
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	result := resolver.Resolve(ctx, req)
+
+	require.Equal(t, "opencode-session-abc123", result.SessionID)
+	require.Equal(t, "opencode-session-abc123", result.PromptCacheKey)
+	require.Equal(t, SourceSessionHeader, result.Source)
+}
+
+func TestResolver_CodexSessionTakesPrecedenceOverSessionAffinity(t *testing.T) {
+	resolver := NewResolver(Config{Enabled: true}, "")
+
+	ctx := context.Background()
+	req := &llm.Request{
+		Model: "gpt-4o",
+		RawRequest: &httpclient.Request{
+			Headers: http.Header{
+				"Session_id":         []string{"codex-session-xyz"},
+				"X-Session-Affinity": []string{"opencode-session-abc"},
+			},
+		},
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	result := resolver.Resolve(ctx, req)
+
+	require.Equal(t, "codex-session-xyz", result.SessionID)
+	require.Equal(t, SourceSessionHeader, result.Source)
+}
+
+func TestResolver_ClientProvidedTakesPrecedenceOverAll(t *testing.T) {
+	resolver := NewResolver(Config{Enabled: true}, "")
+
+	ctx := context.Background()
+	req := &llm.Request{
+		Model:          "gpt-4o",
+		PromptCacheKey: lo.ToPtr("client-key-explicit"),
+		RawRequest: &httpclient.Request{
+			Headers: http.Header{
+				"X-Session-Affinity": []string{"opencode-session-abc"},
+			},
+		},
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	result := resolver.Resolve(ctx, req)
+
+	require.Equal(t, "client-key-explicit", result.PromptCacheKey)
+	require.Empty(t, result.SessionID)
+	require.Equal(t, SourceClientProvided, result.Source)
+}
+
+func TestResolver_DisabledReturnsNone(t *testing.T) {
+	resolver := NewResolver(Config{Enabled: false}, "")
+
+	ctx := context.Background()
+	req := &llm.Request{
+		Model: "gpt-4o",
+		RawRequest: &httpclient.Request{
+			Headers: http.Header{
+				"X-Session-Affinity": []string{"opencode-session-abc"},
+			},
+		},
+	}
+
+	result := resolver.Resolve(ctx, req)
+
+	require.Equal(t, SourceNone, result.Source)
+	require.Empty(t, result.SessionID)
+	require.Empty(t, result.PromptCacheKey)
+}
+
+func TestResolver_TrustedHosts(t *testing.T) {
+	resolver := NewResolver(Config{
+		Enabled:                    true,
+		TrustedPromptCacheKeyHosts: []string{"ai-hub.example.com", "proxy.internal"},
+	}, "")
+
+	hosts := resolver.TrustedHosts()
+	require.Equal(t, []string{"ai-hub.example.com", "proxy.internal"}, hosts)
+}
+
+func TestResolver_TrustedHostsEmptyDefault(t *testing.T) {
+	resolver := NewResolver(Config{Enabled: true}, "")
+
+	hosts := resolver.TrustedHosts()
+	require.Empty(t, hosts)
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -40,8 +40,11 @@ type OpenAICacheIdentity struct {
 	Enabled bool `conf:"enabled" yaml:"enabled" json:"enabled"`
 
 	// ExtraSessionHeaders lists additional HTTP headers to inspect for
-	// stable session identifiers beyond the built-in candidates
-	// (Session_id, X-Codex-Turn-Metadata, AH-Thread-Id, Conversation_id).
+	// stable session identifiers beyond the built-in candidates:
+	//   - Session_id (Codex direct header)
+	//   - X-Codex-Turn-Metadata (session_id extracted via codex.GetSessionIDFromHeaders)
+	//   - AH-Thread-Id (configurable thread header)
+	//   - Conversation_id
 	ExtraSessionHeaders []string `conf:"extra_session_headers" yaml:"extra_session_headers" json:"extra_session_headers"`
 
 	// ExtraSessionBodyFields lists additional JSON body fields (gjson paths)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -43,6 +43,7 @@ type OpenAICacheIdentity struct {
 	// stable session identifiers beyond the built-in candidates:
 	//   - Session_id (Codex direct header)
 	//   - X-Codex-Turn-Metadata (session_id extracted via codex.GetSessionIDFromHeaders)
+	//   - X-Session-Affinity (OpenCode session header)
 	//   - AH-Thread-Id (configurable thread header)
 	//   - Conversation_id
 	ExtraSessionHeaders []string `conf:"extra_session_headers" yaml:"extra_session_headers" json:"extra_session_headers"`
@@ -63,6 +64,13 @@ type OpenAICacheIdentity struct {
 	// uniqueness for long system prompts at a negligible CPU cost.
 	// Default: 32768.
 	AnchorMaxBytes int `conf:"anchor_max_bytes" yaml:"anchor_max_bytes" json:"anchor_max_bytes"`
+
+	// TrustedPromptCacheKeyHosts lists additional hostnames that are trusted
+	// to receive derived prompt_cache_key values. Official api.openai.com is
+	// always trusted regardless of this list. Host matching is case-insensitive
+	// and ignores scheme, port, and path.
+	// Default: [] (empty — only api.openai.com trusted).
+	TrustedPromptCacheKeyHosts []string `conf:"trusted_prompt_cache_key_hosts" yaml:"trusted_prompt_cache_key_hosts" json:"trusted_prompt_cache_key_hosts"`
 }
 
 // Dashboard holds configuration for the dashboard cache settings.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -26,6 +26,40 @@ type Config struct {
 	DisableSSLVerify bool `conf:"disable_ssl_verify" yaml:"disable_ssl_verify" json:"disable_ssl_verify"`
 	CORS             CORS `conf:"cors" yaml:"cors" json:"cors"`
 	API              API  `conf:"api" yaml:"api" json:"api"`
+
+	OpenAICacheIdentity OpenAICacheIdentity `conf:"openai_cache_identity" yaml:"openai_cache_identity" json:"openai_cache_identity"`
+}
+
+// OpenAICacheIdentity configures upstream-native cache identity resolution
+// for OpenAI-compatible traffic. When enabled, AxonHub derives stable
+// session IDs and prompt cache keys for clients that do not send explicit
+// session identifiers.
+type OpenAICacheIdentity struct {
+	// Enabled controls whether cache identity resolution runs.
+	// Default: true.
+	Enabled bool `conf:"enabled" yaml:"enabled" json:"enabled"`
+
+	// ExtraSessionHeaders lists additional HTTP headers to inspect for
+	// stable session identifiers beyond the built-in candidates
+	// (Session_id, X-Codex-Turn-Metadata, AH-Thread-Id, Conversation_id).
+	ExtraSessionHeaders []string `conf:"extra_session_headers" yaml:"extra_session_headers" json:"extra_session_headers"`
+
+	// ExtraSessionBodyFields lists additional JSON body fields (gjson paths)
+	// to inspect for stable session identifiers beyond the built-in candidates
+	// (metadata.session_id, metadata.conversation_id).
+	ExtraSessionBodyFields []string `conf:"extra_session_body_fields" yaml:"extra_session_body_fields" json:"extra_session_body_fields"`
+
+	// DeriveFromConversationAnchor controls whether a deterministic
+	// conversation-anchor fingerprint is derived when no explicit session
+	// identity is available.
+	// Default: true.
+	DeriveFromConversationAnchor bool `conf:"derive_from_conversation_anchor" yaml:"derive_from_conversation_anchor" json:"derive_from_conversation_anchor"`
+
+	// AnchorMaxBytes is the maximum number of bytes of the canonicalized
+	// anchor content fed to the hash function. Larger values improve
+	// uniqueness for long system prompts at a negligible CPU cost.
+	// Default: 32768.
+	AnchorMaxBytes int `conf:"anchor_max_bytes" yaml:"anchor_max_bytes" json:"anchor_max_bytes"`
 }
 
 // Dashboard holds configuration for the dashboard cache settings.

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -77,7 +77,13 @@ func tryGetTraceIDFromBody(c *gin.Context, config tracing.Config) (string, error
 // gets or creates the corresponding trace entity in the database.
 func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		traceID := getTraceIDFromHeader(c, config)
+		var traceID string
+		sessionScoped := false // only session-scoped sources should seed shared.WithSessionID
+
+		traceID = getTraceIDFromHeader(c, config)
+		// Trace-header and extra-trace-header sources are request-scoped,
+		// NOT suitable for cache identity (they change every turn).
+
 		if traceID == "" && config.ClaudeCodeTraceEnabled {
 			var err error
 
@@ -86,10 +92,17 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 				AbortWithError(c, http.StatusBadRequest, err)
 				return
 			}
+
+			if traceID != "" {
+				sessionScoped = true
+			}
 		}
 
 		if traceID == "" && config.CodexTraceEnabled {
 			traceID = tryExtractTraceIDFromCodexRequest(c)
+			if traceID != "" {
+				sessionScoped = true
+			}
 		}
 
 		if traceID == "" && len(config.ExtraTraceBodyFields) > 0 {
@@ -100,6 +113,7 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 				AbortWithError(c, http.StatusBadRequest, err)
 				return
 			}
+			// Extra trace body fields are trace-scoped, not session-scoped.
 		}
 
 		if traceID == "" {
@@ -139,8 +153,13 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 
 		ctx := contexts.WithTrace(c.Request.Context(), trace)
 
-		// Set session ID in context if available, to let the provider use it for cache if needed.
-		ctx = shared.WithSessionID(ctx, traceID)
+		// Only set session ID for session-scoped sources (Codex, Claude Code).
+		// Trace-header sources (AH-Trace-Id, extra_trace_headers, extra_trace_body_fields)
+		// are per-request and must NOT seed cache identity to avoid breaking cache
+		// continuity across turns.
+		if sessionScoped {
+			ctx = shared.WithSessionID(ctx, traceID)
+		}
 
 		c.Request = c.Request.WithContext(ctx)
 

--- a/internal/server/orchestrator/cache_identity.go
+++ b/internal/server/orchestrator/cache_identity.go
@@ -36,10 +36,10 @@ func (m *cacheIdentityMiddleware) OnInboundLlmRequest(ctx context.Context, llmRe
 	// Store resolved values on TransformerMetadata for later use.
 	cacheidentity.StoreOnRequest(llmRequest, result)
 
-	// Inject session ID into context so downstream components can access it.
-	// This does NOT overwrite a session ID already set by the trace middleware
-	// (e.g., from Codex Session_id header).
-	ctx = cacheidentity.InjectSessionIDToContext(ctx, result)
+	// Note: Session ID is stored on TransformerMetadata above. Context-level
+	// injection happens later in applyCacheIdentityGating, which correctly
+	// returns the updated context. We cannot inject here because
+	// OnInboundLlmRequest does not return context.
 
 	if log.DebugEnabled(ctx) {
 		redactedKey := result.PromptCacheKey

--- a/internal/server/orchestrator/cache_identity.go
+++ b/internal/server/orchestrator/cache_identity.go
@@ -1,0 +1,59 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/looplj/axonhub/internal/log"
+	"github.com/looplj/axonhub/internal/server/cacheidentity"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/pipeline"
+)
+
+// cacheIdentityMiddleware resolves stable session IDs and prompt cache keys
+// on the inbound path. It runs before candidate selection so the resolved
+// identity survives channel retries.
+type cacheIdentityMiddleware struct {
+	pipeline.DummyMiddleware
+
+	resolver *cacheidentity.Resolver
+}
+
+func enrichCacheIdentity(resolver *cacheidentity.Resolver) pipeline.Middleware {
+	return &cacheIdentityMiddleware{resolver: resolver}
+}
+
+func (m *cacheIdentityMiddleware) Name() string {
+	return "cache-identity"
+}
+
+func (m *cacheIdentityMiddleware) OnInboundLlmRequest(ctx context.Context, llmRequest *llm.Request) (*llm.Request, error) {
+	if m.resolver == nil {
+		return llmRequest, nil
+	}
+
+	result := m.resolver.Resolve(ctx, llmRequest)
+
+	// Store resolved values on TransformerMetadata for later use.
+	cacheidentity.StoreOnRequest(llmRequest, result)
+
+	// Inject session ID into context so downstream components can access it.
+	// This does NOT overwrite a session ID already set by the trace middleware
+	// (e.g., from Codex Session_id header).
+	ctx = cacheidentity.InjectSessionIDToContext(ctx, result)
+
+	if log.DebugEnabled(ctx) {
+		redactedKey := result.PromptCacheKey
+		if len(redactedKey) > 16 {
+			redactedKey = redactedKey[:16] + "..."
+		}
+
+		log.Debug(ctx, "cache identity resolved",
+			log.String("source", result.Source),
+			log.String("cache_key_preview", redactedKey),
+			log.Bool("session_injected", result.SessionID != ""),
+			log.Bool("cache_key_injected", result.PromptCacheKey != ""),
+		)
+	}
+
+	return llmRequest, nil
+}

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -54,6 +54,12 @@ func NewChatCompletionOrchestrator(
 	circuitBreakerLoadBalancer := NewLoadBalancer(systemService, channelService,
 		NewWeightStrategy(), NewModelAwareCircuitBreakerStrategy(modelCircuitBreaker), rateLimitStrategy)
 
+	// Extract trusted hosts from resolver config (or empty if resolver is nil).
+	var trustedHosts []string
+	if cacheIdentityResolver != nil {
+		trustedHosts = cacheIdentityResolver.TrustedHosts()
+	}
+
 	return &ChatCompletionOrchestrator{
 		Inbound:            inbound,
 		RequestService:     requestService,
@@ -68,7 +74,8 @@ func NewChatCompletionOrchestrator(
 			cc.StripBillingHeaderCCH(),
 			stream.EnsureUsage(),
 		},
-		cacheIdentityResolver: cacheIdentityResolver,
+		cacheIdentityResolver:      cacheIdentityResolver,
+		trustedCacheKeyHosts:       trustedHosts,
 		PipelineFactory:            pipeline.NewFactory(httpClient),
 		ModelMapper:                NewModelMapper(),
 		channelSelector:            defaultSelector,
@@ -118,6 +125,10 @@ type ChatCompletionOrchestrator struct {
 	// cacheIdentityResolver resolves stable session IDs and prompt cache keys.
 	// May be nil if the feature is disabled.
 	cacheIdentityResolver *cacheidentity.Resolver
+
+	// trustedCacheKeyHosts is the list of trusted proxy hostnames for
+	// prompt_cache_key emission. Extracted from resolver config at construction.
+	trustedCacheKeyHosts []string
 }
 
 func (processor *ChatCompletionOrchestrator) WithChannelSelector(selector CandidateSelector) *ChatCompletionOrchestrator {
@@ -214,7 +225,7 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 	// Add global middlewares
 	middlewares = append(middlewares, processor.Middlewares...)
 
-	inbound, outbound := NewPersistentTransformers(state, processor.Inbound)
+	inbound, outbound := NewPersistentTransformers(state, processor.Inbound, processor.trustedCacheKeyHosts)
 
 	// Add inbound middlewares (executed after inbound.TransformRequest)
 	// Cache identity resolution runs first so the resolved identity

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/pkg/xcontext"
 	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/cacheidentity"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/pipeline/cc"
@@ -29,6 +30,7 @@ func NewChatCompletionOrchestrator(
 	quotaService *biz.QuotaService,
 	promptProtectionRuleService *biz.PromptProtectionRuleService,
 	liveStreamRegistry *biz.LiveStreamRegistry,
+	cacheIdentityResolver *cacheidentity.Resolver,
 ) *ChatCompletionOrchestrator {
 	connectionTracker := NewDefaultConnectionTracker(256)
 	rateLimitTracker := NewChannelRequestTracker()
@@ -66,6 +68,7 @@ func NewChatCompletionOrchestrator(
 			cc.StripBillingHeaderCCH(),
 			stream.EnsureUsage(),
 		},
+		cacheIdentityResolver: cacheIdentityResolver,
 		PipelineFactory:            pipeline.NewFactory(httpClient),
 		ModelMapper:                NewModelMapper(),
 		channelSelector:            defaultSelector,
@@ -111,6 +114,10 @@ type ChatCompletionOrchestrator struct {
 	// proxy is the proxy configuration for testing
 	// If set, it will override the channel's default proxy configuration
 	proxy *httpclient.ProxyConfig
+
+	// cacheIdentityResolver resolves stable session IDs and prompt cache keys.
+	// May be nil if the feature is disabled.
+	cacheIdentityResolver *cacheidentity.Resolver
 }
 
 func (processor *ChatCompletionOrchestrator) WithChannelSelector(selector CandidateSelector) *ChatCompletionOrchestrator {
@@ -210,6 +217,12 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 	inbound, outbound := NewPersistentTransformers(state, processor.Inbound)
 
 	// Add inbound middlewares (executed after inbound.TransformRequest)
+	// Cache identity resolution runs first so the resolved identity
+	// survives channel retries and is available to all downstream steps.
+	if processor.cacheIdentityResolver != nil {
+		middlewares = append(middlewares, enrichCacheIdentity(processor.cacheIdentityResolver))
+	}
+
 	middlewares = append(middlewares,
 		enforceQuota(inbound, processor.QuotaService),
 		checkApiKeyModelAccess(inbound),

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -310,8 +310,9 @@ var errSkipCandidateByCircuitBreaker = errors.New("skip candidate by circuit bre
 
 // PersistentOutboundTransformer wraps an outbound transformer with shared persistence state.
 type PersistentOutboundTransformer struct {
-	wrapped transformer.Outbound
-	state   *PersistenceState
+	wrapped              transformer.Outbound
+	state                *PersistenceState
+	trustedCacheKeyHosts []string
 }
 
 // APIFormat returns the API format of the transformer.
@@ -430,7 +431,7 @@ func (p *PersistentOutboundTransformer) applyCacheIdentityGating(
 	}
 
 	ch := candidate.Channel
-	allowed := cacheidentity.ChannelAllowsPromptCacheKey(ch.Type, ch.BaseURL)
+	allowed := cacheidentity.ChannelAllowsPromptCacheKey(ch.Type, ch.BaseURL, p.trustedCacheKeyHosts)
 
 	if allowed {
 		// Inject resolved prompt_cache_key if the request doesn't already have one.
@@ -452,6 +453,14 @@ func (p *PersistentOutboundTransformer) applyCacheIdentityGating(
 		}
 
 		cacheidentity.SetPromptCacheKeyEmitAllowed(&cloned, false)
+
+		if log.DebugEnabled(ctx) {
+			log.Debug(ctx, "prompt_cache_key emission denied",
+				log.String("channel", ch.Name),
+				log.String("host", ch.BaseURL),
+				log.String("source", source),
+			)
+		}
 	}
 
 	return ctx, &cloned

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/pkg/xcontext"
 	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/cacheidentity"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
@@ -349,6 +352,12 @@ func (p *PersistentOutboundTransformer) TransformRequest(ctx context.Context, ll
 	llmRequest = applyTransformOptions(llmRequest, candidate.Channel.Settings)
 	llmRequest = filterResponseCustomToolMessagesForNonResponsesOutbound(llmRequest, p.wrapped.APIFormat())
 
+	// --- Cache identity gating per channel ---
+	// Apply the resolved cache identity based on whether this channel allows
+	// prompt_cache_key emission. This runs per-attempt so retries/channel
+	// switches don't leak identity to incompatible upstreams.
+	ctx, llmRequest = p.applyCacheIdentityGating(ctx, llmRequest, candidate)
+
 	return p.wrapped.TransformRequest(ctx, llmRequest)
 }
 
@@ -384,6 +393,68 @@ func containsResponseCustomToolMessages(messages []llm.Message) bool {
 	}
 
 	return false
+}
+
+// applyCacheIdentityGating applies channel-aware cache identity policy.
+// It injects the resolved session ID into the context and sets or clears
+// PromptCacheKey on a shallow clone of the request so retries/channel
+// switches do not leak or lose identity fields across attempts.
+func (p *PersistentOutboundTransformer) applyCacheIdentityGating(
+	ctx context.Context,
+	llmRequest *llm.Request,
+	candidate *ChannelModelsCandidate,
+) (context.Context, *llm.Request) {
+	if candidate == nil || candidate.Channel == nil {
+		return ctx, llmRequest
+	}
+
+	// Inject resolved session ID into context if not already present.
+	if sessionID := cacheidentity.GetResolvedSessionID(llmRequest); sessionID != "" {
+		if _, ok := shared.GetSessionID(ctx); !ok {
+			ctx = shared.WithSessionID(ctx, sessionID)
+		}
+	}
+
+	// Shallow-clone the request to isolate per-attempt mutations.
+	// The clone shares slices/maps with the original (Messages, etc.)
+	// but PromptCacheKey and TransformerMetadata are replaced so
+	// mutations don't bleed across retries or channel switches.
+	cloned := *llmRequest
+	if llmRequest.TransformerMetadata != nil {
+		meta := make(map[string]any, len(llmRequest.TransformerMetadata))
+		for k, v := range llmRequest.TransformerMetadata {
+			meta[k] = v
+		}
+
+		cloned.TransformerMetadata = meta
+	}
+
+	ch := candidate.Channel
+	allowed := cacheidentity.ChannelAllowsPromptCacheKey(ch.Type, ch.BaseURL)
+
+	if allowed {
+		// Inject resolved prompt_cache_key if the request doesn't already have one.
+		if lo.FromPtr(cloned.PromptCacheKey) == "" {
+			if pck := cacheidentity.GetResolvedPromptCacheKey(&cloned); pck != "" {
+				cloned.PromptCacheKey = lo.ToPtr(pck)
+			}
+		}
+
+		// Set the metadata flag so the Responses outbound fallback is allowed.
+		cacheidentity.SetPromptCacheKeyEmitAllowed(&cloned, true)
+	} else {
+		// Deny: clear any resolved prompt_cache_key to prevent it from leaking
+		// to the outbound serializer. Preserve client-provided values: if the
+		// source was "client_provided" the client explicitly wants it.
+		source := cacheidentity.GetResolvedCacheSource(&cloned)
+		if source != cacheidentity.SourceClientProvided {
+			cloned.PromptCacheKey = nil
+		}
+
+		cacheidentity.SetPromptCacheKeyEmitAllowed(&cloned, false)
+	}
+
+	return ctx, &cloned
 }
 
 func (p *PersistentOutboundTransformer) TransformResponse(ctx context.Context, response *httpclient.Response) (*llm.Response, error) {

--- a/internal/server/orchestrator/transformer.go
+++ b/internal/server/orchestrator/transformer.go
@@ -10,12 +10,13 @@ var (
 )
 
 // NewPersistentTransformers creates enhanced persistent transformers with pre-constructed state.
-func NewPersistentTransformers(state *PersistenceState, wrapped transformer.Inbound) (*PersistentInboundTransformer, *PersistentOutboundTransformer) {
+func NewPersistentTransformers(state *PersistenceState, wrapped transformer.Inbound, trustedCacheKeyHosts []string) (*PersistentInboundTransformer, *PersistentOutboundTransformer) {
 	return &PersistentInboundTransformer{
 			wrapped: wrapped,
 			state:   state,
 		}, &PersistentOutboundTransformer{
-			wrapped: nil, // Will be set when channel is selected
-			state:   state,
+			wrapped:              nil, // Will be set when channel is selected
+			state:                state,
+			trustedCacheKeyHosts: trustedCacheKeyHosts,
 		}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/looplj/axonhub/internal/server/api"
 	"github.com/looplj/axonhub/internal/server/backup"
 	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/cacheidentity"
 	"github.com/looplj/axonhub/internal/server/dependencies"
 	"github.com/looplj/axonhub/internal/server/gc"
 	"github.com/looplj/axonhub/internal/server/gql"
@@ -92,6 +93,20 @@ func Run(opts ...fx.Option) {
 			dependencies.Module,
 			biz.Module,
 			orchestrator.Module,
+			fx.Provide(func(cfg Config) *cacheidentity.Resolver {
+				ci := cfg.OpenAICacheIdentity
+				if !ci.Enabled {
+					return nil
+				}
+
+				return cacheidentity.NewResolver(cacheidentity.Config{
+					Enabled:                      ci.Enabled,
+					ExtraSessionHeaders:          ci.ExtraSessionHeaders,
+					ExtraSessionBodyFields:       ci.ExtraSessionBodyFields,
+					DeriveFromConversationAnchor: ci.DeriveFromConversationAnchor,
+					AnchorMaxBytes:               ci.AnchorMaxBytes,
+				}, cfg.Trace.ThreadHeader)
+			}),
 			backup.Module,
 			video_storage.Module,
 			api.Module,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,7 @@ func Run(opts ...fx.Option) {
 					ExtraSessionBodyFields:       ci.ExtraSessionBodyFields,
 					DeriveFromConversationAnchor: ci.DeriveFromConversationAnchor,
 					AnchorMaxBytes:               ci.AnchorMaxBytes,
+					TrustedPromptCacheKeyHosts:   ci.TrustedPromptCacheKeyHosts,
 				}, cfg.Trace.ThreadHeader)
 			}),
 			backup.Module,

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -187,8 +187,14 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	}
 
 	if lo.FromPtr(payload.PromptCacheKey) == "" {
-		if sessionID, ok := shared.GetSessionID(ctx); ok {
-			payload.PromptCacheKey = lo.ToPtr(sessionID)
+		// Only fall back to session ID as prompt_cache_key when explicitly
+		// allowed by the orchestrator's channel gating. This prevents the
+		// shared Responses transformer from leaking cache keys to third-party
+		// OpenAI-compatible proxies that reject unknown fields.
+		if isPromptCacheKeyFallbackAllowed(llmReq.TransformerMetadata) {
+			if sessionID, ok := shared.GetSessionID(ctx); ok {
+				payload.PromptCacheKey = lo.ToPtr(sessionID)
+			}
 		}
 	}
 
@@ -345,4 +351,24 @@ func (t *OutboundTransformer) transformStandardResponse(
 	}
 
 	return llmResp, nil
+}
+
+// isPromptCacheKeyFallbackAllowed checks the TransformerMetadata flag that
+// controls whether GetSessionID should be used as a prompt_cache_key fallback.
+// The flag is set by the orchestrator's channel-aware cache identity gating.
+//
+// Default-deny: if the flag is absent or not explicitly true, fallback is
+// disallowed. This prevents accidental cache-key leakage to third-party
+// proxies when a caller forgets to set the flag.
+func isPromptCacheKeyFallbackAllowed(meta map[string]any) bool {
+	if meta == nil {
+		return false
+	}
+
+	v, ok := meta["allow_prompt_cache_key_emit"].(bool)
+	if !ok {
+		return false
+	}
+
+	return v
 }

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -739,6 +739,11 @@ func TestOutboundTransformer_TransformRequest_UsesSharedSessionIDAsPromptCacheKe
 				},
 			},
 		},
+		// Explicitly allow fallback — the orchestrator's channel gating
+		// sets this flag for official OpenAI channels.
+		TransformerMetadata: map[string]any{
+			"allow_prompt_cache_key_emit": true,
+		},
 	}
 
 	httpReq, err := transformer.TransformRequest(ctx, req)
@@ -749,6 +754,34 @@ func TestOutboundTransformer_TransformRequest_UsesSharedSessionIDAsPromptCacheKe
 	require.NoError(t, err)
 	require.NotNil(t, payload.PromptCacheKey)
 	require.Equal(t, "shared-session-123", *payload.PromptCacheKey)
+}
+
+func TestOutboundTransformer_TransformRequest_DeniesPromptCacheKeyFallbackByDefault(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	ctx := shared.WithSessionID(context.Background(), "shared-session-123")
+
+	req := &llm.Request{
+		Model: "gpt-5.4",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("Hello"),
+				},
+			},
+		},
+		// No TransformerMetadata → flag is absent → default-deny.
+	}
+
+	httpReq, err := transformer.TransformRequest(ctx, req)
+	require.NoError(t, err)
+
+	var payload Request
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+	require.Nil(t, payload.PromptCacheKey, "prompt_cache_key should not be set when allow flag is absent (default-deny)")
 }
 
 func TestOutboundTransformer_TransformResponse(t *testing.T) {


### PR DESCRIPTION
## Why
Codex gets very high prompt-cache hit rates because it sends a stable session identity that AxonHub can forward upstream. Other OpenAI-compatible clients like OpenCode or Hermes Agent typically do not, so identical multi-turn conversations end up looking unrelated to upstream OpenAI caching.

This PR adds a schema-free cache identity layer for OpenAI traffic so AxonHub can derive a stable `prompt_cache_key` when the client does not provide one, while still avoiding the proxy regressions we previously saw when unknown fields were forwarded to third-party OpenAI-compatible backends.

## What changed
### 1. Root-level cache identity resolution
A new `internal/server/cacheidentity` package resolves stable cache identity from inbound requests using this precedence:
1. client-provided non-empty `prompt_cache_key`
2. stable session/conversation identity from built-in or configured headers/body fields
3. AxonHub thread identity
4. deterministic conversation-anchor hash

The resolved values are stored in `TransformerMetadata` so they survive channel selection and retries without adding DB fields or schema changes.

### 2. Conversation-anchor fallback with multimodal normalization
When no explicit stable session identity exists, AxonHub now derives a deterministic anchor from the leading stable conversation prefix:
- contiguous `system` / `developer` messages
- followed by the first `user` message
- stops before assistant/tool turns

The anchor normalizes multimodal input so different inline payloads do not collapse to the same cache key:
- remote URLs stay as-is
- inline `data:` URLs are hashed
- input audio is hashed from decoded base64 data
- document parts include MIME type plus normalized URL/hash
- compaction content is skipped as ephemeral

The final anchor is namespaced by project + API key and emitted as `ah:anchor:v1:<sha256>`.

### 3. Inbound middleware for cache identity enrichment
A new `OnInboundLlmRequest` middleware resolves cache identity once on the inbound side, after AxonHub has access to both:
- parsed `llm.Request.Messages`
- inbound raw headers/body through `PersistentInboundTransformer`

This keeps the resolution logic in the root module and avoids pushing root-level config/context concerns into `llm/`.

### 4. Explicit trace/session propagation
`internal/server/middleware/trace.go` now only seeds `shared.WithSessionID(...)` for session-scoped sources:
- Codex session identity
- Claude Code session identity

It no longer treats trace-scoped sources such as `AH-Trace-Id`, `extra_trace_headers`, or `extra_trace_body_fields` as session identity for caching.

This preserves tracing behavior while intentionally stopping per-request trace IDs from poisoning cache continuity across turns.

### 5. Per-channel `prompt_cache_key` gating
The outbound path now applies cache identity per attempt, after the actual candidate channel is selected.

Behavior:
- clone the request for the attempt
- inject session identity into context when needed
- only emit `prompt_cache_key` for official OpenAI-backed channels
- clear the field for third-party OpenAI-compatible proxies

Current allowlist:
- `openai`
- `openai_responses`
- only when the normalized host is `api.openai.com`

Everything else remains deny-by-default, including custom OpenAI-compatible proxies.

### 6. Responses fallback is now default-deny
The shared Responses outbound transformer previously allowed `shared.GetSessionID(ctx) -> prompt_cache_key` fallback too broadly.

This PR changes that contract so fallback only happens when the orchestrator explicitly sets `allow_prompt_cache_key_emit = true`. If the flag is absent, fallback is denied.

That prevents accidental cache-key leakage to incompatible upstream proxies.

## Safety / compatibility notes
- no DB schema changes
- no `effective_*` fields added
- no dual-write or “safety net” emission path
- `prompt_cache_key` forwarding stays restricted to official OpenAI upstreams
- `AH-Trace-Id` no longer acts as cache identity; this is intentional

## Key implementation files
- `internal/server/cacheidentity/resolver.go`
- `internal/server/cacheidentity/anchor.go`
- `internal/server/middleware/trace.go`
- `internal/server/orchestrator/cache_identity.go`
- `internal/server/orchestrator/outbound.go`
- `llm/transformer/openai/responses/outbound.go`

## Testing
### Build / vet
- `go build ./...` (root)
- `go build ./...` (`llm/` module)
- `go vet ./internal/server/cacheidentity/... ./internal/server/orchestrator/... ./internal/server/middleware/...`

### Tests
- `go test ./transformer/openai/responses/...`
- `go test ./internal/server/cacheidentity/... ./internal/server/orchestrator/... ./internal/server/middleware/...`

### Covered behavior
- explicit allow flag required for Responses `GetSessionID -> prompt_cache_key` fallback
- default-deny behavior when the flag is absent
- request cloning prevents cache-key leakage across retries/channel switches
- Claude Code `metadata.user_id` parsing uses the canonical parser
- multimodal anchor normalization distinguishes different inline payloads

## Reviewer guide
If you want the shortest review path, start with:
1. `internal/server/cacheidentity/resolver.go`
2. `internal/server/cacheidentity/anchor.go`
3. `internal/server/middleware/trace.go`
4. `internal/server/orchestrator/outbound.go`
5. `llm/transformer/openai/responses/outbound.go`
