### PR TITLE
feat: add Meta developer and Llama models support

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -15,6 +15,7 @@ export const DEVELOPER_IDS = [
   'xai',
   'bytedance',
   'stepfun',
+  'meta',
 ];
 
 export const DEVELOPER_ICONS: Record<string, string> = {
@@ -34,4 +35,5 @@ export const DEVELOPER_ICONS: Record<string, string> = {
   nvidia: 'Nvidia',
   bytedance: 'Doubao',
   stepfun: 'Stepfun',
+  meta: 'Meta',
 };

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -14184,6 +14184,149 @@
           "family": "kat-coder"
         }
       ]
+    },
+    "meta": {
+      "id": "meta",
+      "api": "https://api.llama.com/compat/v1/",
+      "name": "Meta",
+      "doc": "https://llama.developer.meta.com/docs/models",
+      "display_name": "Meta",
+      "models": [
+        {
+          "id": "llama-4-scout-17b-16e-instruct-fp8",
+          "name": "Llama-4-Scout-17B-16E-Instruct-FP8",
+          "family": "llama",
+          "attachment": true,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-08",
+          "release_date": "2025-04-05",
+          "last_updated": "2025-04-05",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama-4-Scout-17B-16E-Instruct-FP8",
+          "type": "chat"
+        },
+        {
+          "id": "llama-4-maverick-17b-128e-instruct-fp8",
+          "name": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+          "family": "llama",
+          "attachment": true,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2024-08",
+          "release_date": "2025-04-05",
+          "last_updated": "2025-04-05",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+          "type": "chat"
+        },
+        {
+          "id": "llama-3.3-70b-instruct",
+          "name": "Llama-3.3-70B-Instruct",
+          "family": "llama",
+          "attachment": true,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2023-12",
+          "release_date": "2024-12-06",
+          "last_updated": "2024-12-06",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama-3.3-70B-Instruct",
+          "type": "chat"
+        },
+        {
+          "id": "llama-3.3-8b-instruct",
+          "name": "Llama-3.3-8B-Instruct",
+          "family": "llama",
+          "attachment": true,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": true,
+          "temperature": true,
+          "knowledge": "2023-12",
+          "release_date": "2024-12-06",
+          "last_updated": "2024-12-06",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "display_name": "Llama-3.3-8B-Instruct",
+          "type": "chat"
+        }
+      ]
     }
   }
 }

--- a/frontend/src/locales/en/models.json
+++ b/frontend/src/locales/en/models.json
@@ -170,6 +170,7 @@
   "models.developers.deepseek": "DeepSeek",
   "models.developers.google": "Google",
   "models.developers.kwaipilot": "KwaiPilot",
+  "models.developers.meta": "Meta",
   "models.developers.minimax": "MiniMax",
   "models.developers.mistral": "Mistral",
   "models.developers.moonshot": "Moonshot",

--- a/frontend/src/locales/zh-CN/models.json
+++ b/frontend/src/locales/zh-CN/models.json
@@ -170,6 +170,7 @@
   "models.developers.deepseek": "深度求索",
   "models.developers.google": "Google",
   "models.developers.kwaipilot": "快手",
+  "models.developers.meta": "Meta",
   "models.developers.minimax": "稀宇科技",
   "models.developers.mistral": "Mistral",
   "models.developers.moonshot": "月之暗面",

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -285,6 +285,26 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
+	// Map llama channel's llama models to meta developer
+	if (allowedIds.includes("meta") && data.providers.llama) {
+		const llamaProvider = data.providers.llama;
+		const llamaModels = (llamaProvider.models || []).filter((m) =>
+			m.id?.toLowerCase().startsWith("llama"),
+		);
+		if (llamaModels.length > 0) {
+			filtered.meta = {
+				...llamaProvider,
+				id: "meta",
+				name: "Meta",
+				display_name: "Meta",
+				models: llamaModels,
+			};
+			console.log(
+				`Mapped ${llamaModels.length} llama models to meta developer`,
+			);
+		}
+	}
+
 	// Map doubao channel's doubao models to bytedance developer
 	if (allowedIds.includes("bytedance") && data.providers.doubao) {
 		const doubaoProvider = data.providers.doubao;


### PR DESCRIPTION
## Purpose/Goal
Adding Meta and their Llama models to the supported "add model" developer list.

## Summary
This change adds Meta as a supported model developer with 4 Llama models:
- Llama-4-Scout-17B-16E-Instruct-FP8
- Llama-4-Maverick-17B-128E-Instruct-FP8
- Llama-3.3-70B-Instruct
- Llama-3.3-8B-Instruct

The Meta provider data was generated by running `scripts/sync/sync-model-developers.js`, which fetches from the upstream [ThinkInAIXYZ/PublicProviderConf](https://github.com/ThinkInAIXYZ/PublicProviderConf) and maps the `llama` channel to the `meta` developer. Only the Meta-specific additions were retained; unrelated sync drift (model updates to other providers) was excluded to keep this PR scoped to the Meta addition.

## What Changed
- Added `meta` to `DEVELOPER_IDS` and `DEVELOPER_ICONS` in `constants.ts`
- Added Meta provider with 4 Llama models to `providers.json` (via sync script)
- Added localization strings for Meta in English and Chinese
- Updated sync script to map upstream `llama` channel models to `meta` developer

## Spirit/Intent
This enables users to access Meta's Llama models through the AxonHub interface, expanding the range of available open-weight models. The integration follows the existing pattern used for other developers like ByteDance, ensuring consistency in how model providers are registered and displayed.