### PR TITLE
feat(models): add drag-and-drop sorting for model associations

### DIFF
--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -3,6 +3,11 @@ import { z } from 'zod';
 import { useForm, useFieldArray, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { IconPlus, IconTrash, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
 import { useQueryModels } from '@/gql/models';
 import { useTranslation } from 'react-i18next';
 import { extractNumberIDAsNumber } from '@/lib/utils';
@@ -234,6 +239,17 @@ export function ModelsAssociationDialog() {
 
   const isOpen = open === 'association';
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
   useEffect(() => {
     if (isOpen) {
       fetchModels({
@@ -425,9 +441,8 @@ export function ModelsAssociationDialog() {
 
   useEffect(() => {
     if (isOpen && currentRow) {
-      const associations = currentRow.settings?.associations || [];
-      form.reset({
-        associations: associations.map((assoc) => {
+      const associations = (currentRow.settings?.associations || [])
+        .map((assoc) => {
           const exclude = assoc.regex?.exclude?.[0] || assoc.modelId?.exclude?.[0];
           const promptTokensCondition = readPromptTokensCondition(assoc.when);
           return {
@@ -446,7 +461,10 @@ export function ModelsAssociationDialog() {
             excludeChannelIds: exclude?.channelIds || [],
             excludeChannelTags: exclude?.channelTags || [],
           };
-        }),
+        })
+        .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+      form.reset({
+        associations,
       });
     }
   }, [isOpen, currentRow, form]);
@@ -606,14 +624,9 @@ export function ModelsAssociationDialog() {
   const handleAddAssociation = useCallback(() => {
     if (fields.length >= 10) return;
 
-    // Get the priority of the last rule (highest priority)
-    const currentAssociations = form.getValues('associations') || [];
-    const lastPriority =
-      currentAssociations.length > 0 ? Math.max(...currentAssociations.map((a) => a.priority ?? 0)) : 0;
-
     append({
       type: 'channel_model',
-      priority: lastPriority,
+      priority: fields.length,
       disabled: false,
       whenEnabled: false,
       whenCondition: DEFAULT_WHEN_CONDITION,
@@ -625,7 +638,41 @@ export function ModelsAssociationDialog() {
       excludeChannelIds: [],
       excludeChannelTags: [],
     });
-  }, [append, fields.length, form]);
+  }, [append, fields.length]);
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      const currentAssociations = [...form.getValues('associations')];
+      currentAssociations.splice(index, 1);
+      currentAssociations.forEach((assoc, idx) => {
+        assoc.priority = idx;
+      });
+      form.setValue('associations', currentAssociations, { shouldDirty: true });
+    },
+    [form]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = fields.findIndex((f) => f.id === active.id);
+      const newIndex = fields.findIndex((f) => f.id === over.id);
+
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const currentAssociations = [...form.getValues('associations')];
+      const movedAssociations = arrayMove(currentAssociations, oldIndex, newIndex);
+
+      movedAssociations.forEach((assoc, idx) => {
+        assoc.priority = idx;
+      });
+
+      form.setValue('associations', movedAssociations, { shouldDirty: true });
+    },
+    [fields, form]
+  );
 
   // Filter connections by channel name
   const filteredConnections = useMemo(() => {
@@ -663,25 +710,23 @@ export function ModelsAssociationDialog() {
                     </div>
                   )}
 
-                  {fields
-                    .map((field, index) => ({ field, index }))
-                    .sort((a, b) => {
-                      const priorityA = form.getValues(`associations.${a.index}.priority`) ?? 0;
-                      const priorityB = form.getValues(`associations.${b.index}.priority`) ?? 0;
-                      return priorityA - priorityB;
-                    })
-                    .map(({ field, index }) => (
-                      <AssociationRow
-                        key={field.id}
-                        index={index}
-                        form={form}
-                        channelOptions={channelOptions}
-                        allModelOptions={allModelOptions}
-                        allTags={allTags}
-                        onRemove={() => remove(index)}
-                        portalContainer={dialogContentRef.current}
-                      />
-                    ))}
+                  <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                    <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+                      {fields.map((field, index) => (
+                        <AssociationRow
+                          key={field.id}
+                          id={field.id}
+                          index={index}
+                          form={form}
+                          channelOptions={channelOptions}
+                          allModelOptions={allModelOptions}
+                          allTags={allTags}
+                          onRemove={() => handleRemove(index)}
+                          portalContainer={dialogContentRef.current}
+                        />
+                      ))}
+                    </SortableContext>
+                  </DndContext>
                 </form>
               </Form>
             </div>
@@ -847,6 +892,7 @@ function buildAssociationWhen(enabled?: boolean, value?: FilterBuilderGroupListV
 }
 
 interface AssociationRowProps {
+  id: string;
   index: number;
   form: ReturnType<typeof useForm<AssociationFormData>>;
   channelOptions: { value: number; label: string; allModelEntries: Array<{ requestModel: string; actualModel: string; source: string }> }[];
@@ -856,8 +902,15 @@ interface AssociationRowProps {
   portalContainer: HTMLElement | null;
 }
 
-function AssociationRow({ index, form, channelOptions, allModelOptions, allTags, onRemove, portalContainer }: AssociationRowProps) {
+function AssociationRow({ id, index, form, channelOptions, allModelOptions, allTags, onRemove, portalContainer }: AssociationRowProps) {
   const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
 
   const type = form.watch(`associations.${index}.type`);
   const channelId = form.watch(`associations.${index}.channelId`);
@@ -933,7 +986,11 @@ function AssociationRow({ index, form, channelOptions, allModelOptions, allTags,
   }, [channelId, channelOptions, allModelOptions, showModel, type]);
 
   return (
-    <div className={`flex flex-col gap-3 rounded-lg border p-3 ${disabled ? 'opacity-50' : ''}`}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex flex-col gap-3 rounded-lg border p-3 ${disabled ? 'opacity-50' : ''} ${isDragging ? 'ring-primary/20 relative z-50 shadow-xl ring-2' : ''}`}
+    >
       <div className='grid grid-cols-[2.5rem_4rem_1fr_2.5rem] sm:grid-cols-[2.25rem_3rem_14rem_1fr_2.25rem] items-center gap-2'>
         {/* Enable/Disable Switch */}
         <div className='flex items-center justify-center'>
@@ -944,27 +1001,17 @@ function AssociationRow({ index, form, channelOptions, allModelOptions, allTags,
           />
         </div>
 
-        {/* Priority Input */}
-        <FormField
-          control={form.control}
-          name={`associations.${index}.priority`}
-          render={({ field }) => (
-            <FormItem className='min-w-0 gap-0'>
-              <FormControl>
-                <Input
-                  type='number'
-                  min={0}
-                  max={10}
-                  {...field}
-                  value={field.value ?? 0}
-                  onChange={(e) => field.onChange(Math.max(0, Math.min(10, Number(e.target.value) || 0)))}
-                  className='h-10 sm:h-9 text-center [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:hidden [&::-webkit-inner-spin-button]:appearance-none'
-                  placeholder='0'
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
+        {/* Drag Handle + Priority Display */}
+        <div className='flex items-center justify-center gap-1'>
+          <div
+            className='text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing flex items-center justify-center p-1'
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className='h-4 w-4' />
+          </div>
+          <span className='text-muted-foreground text-xs w-4 text-center'>{index + 1}</span>
+        </div>
 
         {/* Type Select */}
         <FormField

--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -4,8 +4,7 @@ import { useForm, useFieldArray, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { IconPlus, IconTrash, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
-import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { useSortable } from '@dnd-kit/sortable';
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical } from 'lucide-react';
 import { useQueryModels } from '@/gql/models';
@@ -289,10 +288,20 @@ export function ModelsAssociationDialog() {
     },
   });
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, move, remove } = useFieldArray({
     control: form.control,
     name: 'associations',
   });
+
+  const syncAssociationPriorities = useCallback(() => {
+    const currentAssociations = form.getValues('associations');
+
+    currentAssociations.forEach((association, index) => {
+      if (association.priority !== index) {
+        form.setValue(`associations.${index}.priority`, index, { shouldDirty: true });
+      }
+    });
+  }, [form]);
 
   // Watch associations for debounced preview - useWatch triggers re-renders
   const watchedAssociations = useWatch({
@@ -641,15 +650,15 @@ export function ModelsAssociationDialog() {
   }, [append, fields.length]);
 
   const handleRemove = useCallback(
-    (index: number) => {
-      const currentAssociations = [...form.getValues('associations')];
-      currentAssociations.splice(index, 1);
-      currentAssociations.forEach((assoc, idx) => {
-        assoc.priority = idx;
-      });
-      form.setValue('associations', currentAssociations, { shouldDirty: true });
+    (id: string) => {
+      const index = fields.findIndex((field) => field.id === id);
+
+      if (index === -1) return;
+
+      remove(index);
+      syncAssociationPriorities();
     },
-    [form]
+    [fields, remove, syncAssociationPriorities]
   );
 
   const handleDragEnd = useCallback(
@@ -662,16 +671,10 @@ export function ModelsAssociationDialog() {
 
       if (oldIndex === -1 || newIndex === -1) return;
 
-      const currentAssociations = [...form.getValues('associations')];
-      const movedAssociations = arrayMove(currentAssociations, oldIndex, newIndex);
-
-      movedAssociations.forEach((assoc, idx) => {
-        assoc.priority = idx;
-      });
-
-      form.setValue('associations', movedAssociations, { shouldDirty: true });
+      move(oldIndex, newIndex);
+      syncAssociationPriorities();
     },
-    [fields, form]
+    [fields, move, syncAssociationPriorities]
   );
 
   // Filter connections by channel name
@@ -721,7 +724,7 @@ export function ModelsAssociationDialog() {
                           channelOptions={channelOptions}
                           allModelOptions={allModelOptions}
                           allTags={allTags}
-                          onRemove={() => handleRemove(index)}
+                          onRemove={() => handleRemove(field.id)}
                           portalContainer={dialogContentRef.current}
                         />
                       ))}


### PR DESCRIPTION
## Summary
Replace the priority number input with dnd-kit drag-and-drop sorting in the model association dialog. This improves UX by allowing users to reorder association rules intuitively instead of manually entering priority values.

## Changes
- Use `@dnd-kit/core`, `@dnd-kit/sortable` for drag-and-drop (already in `package.json`)
- Add drag handle with `GripVertical` icon to each association row
- Auto-sync `priority` values on drag, add, and remove operations
- Keep existing preview and submit logic unchanged
- Fix initialization sort to ensure loaded associations are always ordered by priority

## Testing
- Verified TypeScript compilation passes (`pnpm tsc --noEmit`)
- Tested drag-and-drop reordering in the model association dialog
- Confirmed priority values are correctly updated after drag/add/remove