### PR TITLE
fix(playground): only show thinking in last assistant message

### DIFF
--- a/frontend/src/features/playground/index.tsx
+++ b/frontend/src/features/playground/index.tsx
@@ -420,7 +420,7 @@ export default function Playground() {
                               }
                               if (part.type === 'reasoning') {
                                 return (
-                                  <Reasoning key={index} isStreaming={status === 'streaming'}>
+                                  <Reasoning key={index} isStreaming={isLastAssistant && status === 'streaming'}>
                                     <ReasoningTrigger />
                                     <ReasoningContent>{part.text}</ReasoningContent>
                                   </Reasoning>

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -278,6 +278,7 @@
   "channels.dialogs.fields.apiFormat.formats.anthropic/messages": "Anthropic (Messages)",
   "channels.dialogs.fields.apiFormat.formats.gemini/contents": "Gemini (Contents)",
   "channels.dialogs.fields.apiFormat.kimiCoding.label": "Kimi Coding (api.kimi.com)",
+  "channels.dialogs.fields.apiFormat.formats.ollama/chat": "Ollama (Chat)",
   "channels.dialogs.fields.provider.label": "Provider",
   "channels.dialogs.fields.baseURL.label": "Base URL",
   "channels.dialogs.fields.baseURL.placeholder": "https://api.openai.com/v1",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -275,6 +275,7 @@
   "channels.dialogs.fields.apiFormat.formats.openai/responses": "OpenAI (Responses)",
   "channels.dialogs.fields.apiFormat.formats.anthropic/messages": "Anthropic (Messages)",
   "channels.dialogs.fields.apiFormat.formats.gemini/contents": "Gemini (Contents)",
+  "channels.dialogs.fields.apiFormat.formats.ollama/chat": "Ollama (Chat)",
   "channels.dialogs.fields.provider.label": "服务商",
   "channels.dialogs.fields.baseURL.label": "Base URL",
   "channels.dialogs.fields.baseURL.placeholder": "https://api.openai.com/v1",


### PR DESCRIPTION
Previously, reasoning (thinking) blocks were displayed for all assistant
messages in the conversation history. Now they only appear for the most
recent assistant response, matching expected behavior.