### PR TITLE
fix(list_models): respect API key profile filtering in full model data mode

### DIFF
--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -556,23 +556,30 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 		return
 	}
 
+	if len(visibleModels) == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"object": "list",
+			"data":   []OpenAIModel{},
+		})
+
+		return
+	}
+
 	if !needFullData {
-		openaiModels = make([]OpenAIModel, 0, len(visibleModels))
-		for _, m := range visibleModels {
-			openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
-		}
+		openaiModels = lo.Map(visibleModels, func(m biz.ModelFacade, _ int) OpenAIModel {
+			return convertModelFacadeToOpenAIModel(m)
+		})
 	} else {
-		visibleIDs := make([]string, 0, len(visibleModels))
-		for _, m := range visibleModels {
-			visibleIDs = append(visibleIDs, m.ID)
-		}
+		visibleIDs := lo.Map(visibleModels, func(m biz.ModelFacade, _ int) string {
+			return m.ID
+		})
 
 		dbModels, err := handlers.EntClient.Model.Query().
 			Where(
 				model.StatusEQ(model.StatusEnabled),
 				model.ModelIDIn(visibleIDs...),
 			).
-				All(ctx)
+			All(ctx)
 		if err != nil {
 			handlers.writeOpenAIInternalError(c, requestID, err)
 			return
@@ -583,14 +590,13 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 			dbModelMap[m.ModelID] = m
 		}
 
-		openaiModels = make([]OpenAIModel, 0, len(visibleModels))
-		for _, m := range visibleModels {
+		openaiModels = lo.Map(visibleModels, func(m biz.ModelFacade, _ int) OpenAIModel {
 			if dbModel, ok := dbModelMap[m.ID]; ok {
-				openaiModels = append(openaiModels, convertModelToOpenAIExtended(dbModel, include))
-			} else {
-				openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
+				return convertModelToOpenAIExtended(dbModel, include)
 			}
-		}
+
+			return convertModelFacadeToOpenAIModel(m)
+		})
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -549,31 +549,47 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 	include, needFullData := parseOpenAIModelInclude(c.Query("include"), handlers.SystemService.ModelSettingsOrDefault(ctx).DefaultModelAPIIncludeAll)
 
 	var openaiModels []OpenAIModel
-	if needFullData {
-		// Query full model data from database with extended metadata
-		models, err := handlers.EntClient.Model.Query().
-			Where(model.StatusEQ(model.StatusEnabled)).
-			All(ctx)
-		if err != nil {
-			handlers.writeOpenAIInternalError(c, requestID, err)
-			return
-		}
 
-		openaiModels = make([]OpenAIModel, 0, len(models))
-		for _, m := range models {
-			openaiModels = append(openaiModels, convertModelToOpenAIExtended(m, include))
+	visibleModels, err := handlers.ModelService.ListEnabledModels(ctx)
+	if err != nil {
+		handlers.writeOpenAIInternalError(c, requestID, err)
+		return
+	}
+
+	if !needFullData {
+		openaiModels = make([]OpenAIModel, 0, len(visibleModels))
+		for _, m := range visibleModels {
+			openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
 		}
 	} else {
-		// Basic mode: only return basic fields (backward compatible)
-		models, err := handlers.ModelService.ListEnabledModels(ctx)
+		visibleIDs := make([]string, 0, len(visibleModels))
+		for _, m := range visibleModels {
+			visibleIDs = append(visibleIDs, m.ID)
+		}
+
+		dbModels, err := handlers.EntClient.Model.Query().
+			Where(
+				model.StatusEQ(model.StatusEnabled),
+				model.ModelIDIn(visibleIDs...),
+			).
+				All(ctx)
 		if err != nil {
 			handlers.writeOpenAIInternalError(c, requestID, err)
 			return
 		}
 
-		openaiModels = make([]OpenAIModel, 0, len(models))
-		for _, m := range models {
-			openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
+		dbModelMap := make(map[string]*ent.Model, len(dbModels))
+		for _, m := range dbModels {
+			dbModelMap[m.ModelID] = m
+		}
+
+		openaiModels = make([]OpenAIModel, 0, len(visibleModels))
+		for _, m := range visibleModels {
+			if dbModel, ok := dbModelMap[m.ID]; ok {
+				openaiModels = append(openaiModels, convertModelToOpenAIExtended(dbModel, include))
+			} else {
+				openaiModels = append(openaiModels, convertModelFacadeToOpenAIModel(m))
+			}
 		}
 	}
 

--- a/internal/server/api/openai_retrieve_test.go
+++ b/internal/server/api/openai_retrieve_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/enttest"
@@ -365,4 +366,314 @@ func TestOpenAIHandlers_ListModels_UsesExtendedFieldsWhenConfiguredAsDefault(t *
 	require.Equal(t, remark, got.Data[0].Description)
 	require.NotNil(t, got.Data[0].Capabilities)
 	require.NotNil(t, got.Data[0].Pricing)
+}
+
+func TestOpenAIHandlers_ListModels_ExtendedModeRespectsAPIKeyProfile(t *testing.T) {
+	client, channelSvc, systemSvc, _, ctx := setupOpenAIRetrieveTest(t)
+
+	err := systemSvc.SetModelSettings(ctx, biz.SystemModelSettings{
+		FallbackToChannelsOnModelNotFound: true,
+		QueryAllChannelModels:             true,
+		DefaultModelAPIIncludeAll:         true,
+	})
+	require.NoError(t, err)
+
+	createdAt := time.Unix(1712345698, 0)
+
+	openaiCh, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	anthropicCh, err := client.Channel.Create().
+		SetType(channel.TypeAnthropic).
+		SetName("Anthropic Channel").
+		SetBaseURL("https://api.anthropic.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"claude-3-opus-20240229"}).
+		SetDefaultTestModel("claude-3-opus-20240229").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: openaiCh}, {Channel: anthropicCh}})
+
+	_, err = client.Model.Create().
+		SetDeveloper("openai").
+		SetModelID("gpt-4.1").
+		SetName("GPT-4.1").
+		SetType(model.TypeChat).
+		SetGroup("gpt").
+		SetIcon("openai").
+		SetModelCard(&objects.ModelCard{
+			Vision:   true,
+			ToolCall: true,
+			Limit:    objects.ModelCardLimit{Context: 200000, Output: 8192},
+			Cost:     objects.ModelCardCost{Input: 2, Output: 8},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{{
+				Type: "channel_model",
+				ChannelModel: &objects.ChannelModelAssociation{
+					ChannelID: openaiCh.ID,
+					ModelID:   "gpt-4.1",
+				},
+			}},
+		}).
+		SetStatus(model.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Model.Create().
+		SetDeveloper("anthropic").
+		SetModelID("claude-3-opus-20240229").
+		SetName("Claude 3 Opus").
+		SetType(model.TypeChat).
+		SetGroup("claude").
+		SetIcon("anthropic").
+		SetModelCard(&objects.ModelCard{
+			Vision:   true,
+			ToolCall: true,
+			Limit:    objects.ModelCardLimit{Context: 200000, Output: 4096},
+			Cost:     objects.ModelCardCost{Input: 15, Output: 75},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{{
+				Type: "channel_model",
+				ChannelModel: &objects.ChannelModelAssociation{
+					ChannelID: anthropicCh.ID,
+					ModelID:   "claude-3-opus-20240229",
+				},
+			}},
+		}).
+		SetStatus(model.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	apiKey := &ent.APIKey{
+		ID:   99,
+		Name: "restricted-key",
+		Profiles: &objects.APIKeyProfiles{
+			ActiveProfile: "limited",
+			Profiles: []objects.APIKeyProfile{{
+				Name:     "limited",
+				ModelIDs: []string{"gpt-4.1"},
+			}},
+		},
+	}
+
+	restrictedRouter := gin.New()
+	restrictedRouter.Use(func(c *gin.Context) {
+		reqCtx := ent.NewContext(c.Request.Context(), client)
+		reqCtx = authz.WithTestBypass(reqCtx)
+		reqCtx = contexts.WithAPIKey(reqCtx, apiKey)
+		c.Request = c.Request.WithContext(reqCtx)
+		c.Next()
+	})
+
+	handlers := &OpenAIHandlers{
+		ModelService:  biz.NewModelService(biz.ModelServiceParams{
+			ChannelService: channelSvc,
+			SystemService:  systemSvc,
+			Ent:            client,
+		}),
+		SystemService: systemSvc,
+		EntClient:     client,
+	}
+	restrictedRouter.GET("/v1/models", handlers.ListModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	restrictedRouter.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		Data []OpenAIModel `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+
+	require.Len(t, got.Data, 1, "extended mode should only return models the API key has access to")
+	require.Equal(t, "gpt-4.1", got.Data[0].ID)
+	require.Equal(t, "GPT-4.1", got.Data[0].Name)
+	require.NotNil(t, got.Data[0].Capabilities)
+	require.NotNil(t, got.Data[0].Pricing)
+}
+
+func TestOpenAIHandlers_ListModels_ExtendedModeFallsBackToBasicForMissingDBModel(t *testing.T) {
+	client, channelSvc, systemSvc, _, ctx := setupOpenAIRetrieveTest(t)
+
+	err := systemSvc.SetModelSettings(ctx, biz.SystemModelSettings{
+		FallbackToChannelsOnModelNotFound: true,
+		QueryAllChannelModels:             true,
+		DefaultModelAPIIncludeAll:         true,
+	})
+	require.NoError(t, err)
+
+	createdAt := time.Unix(1712345698, 0)
+
+	openaiCh, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1", "gpt-4.1-mini"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: openaiCh}})
+
+	_, err = client.Model.Create().
+		SetDeveloper("openai").
+		SetModelID("gpt-4.1").
+		SetName("GPT-4.1").
+		SetType(model.TypeChat).
+		SetGroup("gpt").
+		SetIcon("openai").
+		SetModelCard(&objects.ModelCard{
+			Vision: true, ToolCall: true,
+			Limit: objects.ModelCardLimit{Context: 200000, Output: 8192},
+			Cost:  objects.ModelCardCost{Input: 2, Output: 8},
+		}).
+		SetSettings(&objects.ModelSettings{
+			Associations: []*objects.ModelAssociation{{
+				Type: "channel_model",
+				ChannelModel: &objects.ChannelModelAssociation{ChannelID: openaiCh.ID, ModelID: "gpt-4.1"},
+			}},
+		}).
+		SetStatus(model.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	apiKey := &ent.APIKey{
+		ID:   100,
+		Name: "fallback-test-key",
+		Profiles: &objects.APIKeyProfiles{
+			ActiveProfile: "limited",
+			Profiles: []objects.APIKeyProfile{{
+				Name:     "limited",
+				ModelIDs: []string{"gpt-4.1", "gpt-4.1-mini"},
+			}},
+		},
+	}
+
+	restrictedRouter := gin.New()
+	restrictedRouter.Use(func(c *gin.Context) {
+		reqCtx := ent.NewContext(c.Request.Context(), client)
+		reqCtx = authz.WithTestBypass(reqCtx)
+		reqCtx = contexts.WithAPIKey(reqCtx, apiKey)
+		c.Request = c.Request.WithContext(reqCtx)
+		c.Next()
+	})
+
+	handlers := &OpenAIHandlers{
+		ModelService:  biz.NewModelService(biz.ModelServiceParams{ChannelService: channelSvc, SystemService: systemSvc, Ent: client}),
+		SystemService: systemSvc,
+		EntClient:     client,
+	}
+	restrictedRouter.GET("/v1/models", handlers.ListModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	restrictedRouter.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		Data []OpenAIModel `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+
+	require.Len(t, got.Data, 2)
+
+	resultMap := make(map[string]OpenAIModel)
+	for _, m := range got.Data {
+		resultMap[m.ID] = m
+	}
+
+	gpt41, ok := resultMap["gpt-4.1"]
+	require.True(t, ok, "gpt-4.1 should be present")
+	require.NotNil(t, gpt41.Capabilities, "gpt-4.1 has a DB entry so should have extended fields")
+
+	gpt41mini, ok := resultMap["gpt-4.1-mini"]
+	require.True(t, ok, "gpt-4.1-mini should be present")
+	require.Nil(t, gpt41mini.Capabilities, "gpt-4.1-mini has no DB entry so should fall back to basic fields")
+}
+
+func TestOpenAIHandlers_ListModels_ExtendedModeWithZeroAllowedModelsReturnsEmpty(t *testing.T) {
+	client, channelSvc, systemSvc, _, ctx := setupOpenAIRetrieveTest(t)
+
+	err := systemSvc.SetModelSettings(ctx, biz.SystemModelSettings{
+		FallbackToChannelsOnModelNotFound: true,
+		QueryAllChannelModels:             true,
+		DefaultModelAPIIncludeAll:         true,
+	})
+	require.NoError(t, err)
+
+	createdAt := time.Unix(1712345698, 0)
+
+	openaiCh, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("OpenAI Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key"}).
+		SetSupportedModels([]string{"gpt-4.1"}).
+		SetDefaultTestModel("gpt-4.1").
+		SetStatus(channel.StatusEnabled).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelSvc.SetEnabledChannelsForTest([]*biz.Channel{{Channel: openaiCh}})
+
+	apiKey := &ent.APIKey{
+		ID:   101,
+		Name: "zero-models-key",
+		Profiles: &objects.APIKeyProfiles{
+			ActiveProfile: "none",
+			Profiles: []objects.APIKeyProfile{{
+				Name:     "none",
+				ModelIDs: []string{"nonexistent-model-xyz"},
+			}},
+		},
+	}
+
+	restrictedRouter := gin.New()
+	restrictedRouter.Use(func(c *gin.Context) {
+		reqCtx := ent.NewContext(c.Request.Context(), client)
+		reqCtx = authz.WithTestBypass(reqCtx)
+		reqCtx = contexts.WithAPIKey(reqCtx, apiKey)
+		c.Request = c.Request.WithContext(reqCtx)
+		c.Next()
+	})
+
+	handlers := &OpenAIHandlers{
+		ModelService:  biz.NewModelService(biz.ModelServiceParams{ChannelService: channelSvc, SystemService: systemSvc, Ent: client}),
+		SystemService: systemSvc,
+		EntClient:     client,
+	}
+	restrictedRouter.GET("/v1/models", handlers.ListModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	restrictedRouter.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got struct {
+		Data []OpenAIModel `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Empty(t, got.Data, "API key with no matching models should return empty list")
 }


### PR DESCRIPTION
## Purpose/Goal
Fix list models API key profile filtering when full model info setting is enabled.

## Summary
When `include=full` or `DefaultModelAPIIncludeAll=true`, the list_models endpoint was querying all enabled models from the database without respecting API key profile restrictions. This change ensures that API key profile visibility filtering is applied consistently in both basic and extended (full data) modes.

## What Changed
- **internal/server/api/openai.go**: Refactored ListModels handler to first fetch visible models via ModelService (which respects API key profiles), then conditionally enrich with database data based on needFullData flag
- **internal/server/api/openai_retrieve_test.go**: Added comprehensive test coverage:
  - TestOpenAIHandlers_ListModels_ExtendedModeRespectsAPIKeyProfile: Verifies extended mode only returns models the API key has access to
  - TestOpenAIHandlers_ListModels_ExtendedModeFallsBackToBasicForMissingDBModel: Verifies graceful fallback for channel-only models
  - TestOpenAIHandlers_ListModels_ExtendedModeWithZeroAllowedModelsReturnsEmpty: Verifies empty response when API key has no matching models

## Why This Matters
API key profile restrictions were being bypassed when users requested full model metadata. This fix ensures authorization boundaries are maintained regardless of the include parameter or server-side default settings.

## Spirit/Intent
Purpose/Goal: Maintain security invariants while providing rich model metadata. The fix preserves the existing authorization model (API key profiles) while enabling the extended model data feature. Users with restricted API keys should only see models they're authorized to access, whether in basic or extended mode.