### PR TITLE
feat: add MiMo v2.5 model metadata to xiaomi provider

### DIFF
--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12670,7 +12670,7 @@
           "id": "mimo-v2.5-pro",
           "name": "MiMo-V2.5-Pro",
           "family": "mimo",
-          "attachment": false,
+          "attachment": true,
           "reasoning": {
             "supported": true,
             "default": true

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12747,7 +12747,7 @@
             "cache_read": 0.02
           },
           "limit": {
-            "context": 256000,
+            "context": 1000000,
             "output": 128000
           },
           "display_name": "MiMo-V2.5",

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12667,6 +12667,104 @@
       "display_name": "Xiaomi",
       "models": [
         {
+          "id": "mimo-v2.5-pro",
+          "name": "MiMo-V2.5-Pro",
+          "family": "mimo",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "interleaved": {
+            "field": "reasoning_content"
+          },
+          "temperature": true,
+          "knowledge": "2024-12",
+          "release_date": "2026-04-22",
+          "last_updated": "2026-04-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 1,
+            "output": 4,
+            "cache_read": 0.2
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "display_name": "MiMo-V2.5-Pro",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          }
+        },
+        {
+          "id": "mimo-v2.5",
+          "name": "MiMo-V2.5",
+          "family": "mimo",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "interleaved": {
+            "field": "reasoning_content"
+          },
+          "temperature": true,
+          "knowledge": "2024-12",
+          "release_date": "2026-04-22",
+          "last_updated": "2026-04-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0.2,
+            "output": 0.8,
+            "cache_read": 0.02
+          },
+          "limit": {
+            "context": 256000,
+            "output": 128000
+          },
+          "display_name": "MiMo-V2.5",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          }
+        },
+        {
           "id": "mimo-v2-omni",
           "name": "MiMo-V2-Omni",
           "family": "mimo",


### PR DESCRIPTION
## Summary
- Add mimo-v2.5-pro model metadata (1M context, 128K output, reasoning support)
- Add mimo-v2.5 model metadata (1M context, 128K output, reasoning support)
- Both models released 2026-04-22 with knowledge cutoff 2024-12