### PR TITLE
fix(xiaomi): map models provided mimo token plan as xiaomi models

### DIFF
--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12747,7 +12747,7 @@
             "cache_read": 0.02
           },
           "limit": {
-            "context": 256000,
+            "context": 1000000,
             "output": 128000
           },
           "display_name": "MiMo-V2.5",

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12667,6 +12667,104 @@
       "display_name": "Xiaomi",
       "models": [
         {
+          "id": "mimo-v2.5-pro",
+          "name": "MiMo-V2.5-Pro",
+          "family": "mimo",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "interleaved": {
+            "field": "reasoning_content"
+          },
+          "temperature": true,
+          "knowledge": "2024-12",
+          "release_date": "2026-04-22",
+          "last_updated": "2026-04-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 1,
+            "output": 4,
+            "cache_read": 0.2
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "display_name": "MiMo-V2.5-Pro",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          }
+        },
+        {
+          "id": "mimo-v2.5",
+          "name": "MiMo-V2.5",
+          "family": "mimo",
+          "attachment": false,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "interleaved": {
+            "field": "reasoning_content"
+          },
+          "temperature": true,
+          "knowledge": "2024-12",
+          "release_date": "2026-04-22",
+          "last_updated": "2026-04-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0.2,
+            "output": 0.8,
+            "cache_read": 0.02
+          },
+          "limit": {
+            "context": 256000,
+            "output": 128000
+          },
+          "display_name": "MiMo-V2.5",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          }
+        },
+        {
           "id": "mimo-v2-omni",
           "name": "MiMo-V2-Omni",
           "family": "mimo",

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12669,8 +12669,8 @@
         {
           "id": "mimo-v2.5-pro",
           "name": "MiMo-V2.5-Pro",
-          "family": "mimo",
-          "attachment": false,
+          "family": "mimo-v2.5-pro",
+          "attachment": true,
           "reasoning": {
             "supported": true,
             "default": true
@@ -12693,9 +12693,9 @@
           },
           "open_weights": true,
           "cost": {
-            "input": 1,
-            "output": 4,
-            "cache_read": 0.2
+            "input": 0,
+            "output": 0,
+            "cache_read": 0
           },
           "limit": {
             "context": 1000000,
@@ -12718,8 +12718,8 @@
         {
           "id": "mimo-v2.5",
           "name": "MiMo-V2.5",
-          "family": "mimo",
-          "attachment": false,
+          "family": "mimo-v2.5",
+          "attachment": true,
           "reasoning": {
             "supported": true,
             "default": true
@@ -12734,7 +12734,11 @@
           "last_updated": "2026-04-22",
           "modalities": {
             "input": [
-              "text"
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
             ],
             "output": [
               "text"
@@ -12742,9 +12746,9 @@
           },
           "open_weights": true,
           "cost": {
-            "input": 0.2,
-            "output": 0.8,
-            "cache_read": 0.02
+            "input": 0,
+            "output": 0,
+            "cache_read": 0
           },
           "limit": {
             "context": 1000000,
@@ -12795,9 +12799,9 @@
           },
           "open_weights": true,
           "cost": {
-            "input": 0.4,
-            "output": 2,
-            "cache_read": 0.08
+            "input": 0,
+            "output": 0,
+            "cache_read": 0
           },
           "limit": {
             "context": 256000,
@@ -12816,6 +12820,37 @@
               ]
             }
           }
+        },
+        {
+          "id": "mimo-v2-tts",
+          "name": "MiMo-V2-TTS",
+          "family": "mimo",
+          "attachment": false,
+          "reasoning": {
+            "supported": false
+          },
+          "tool_call": false,
+          "release_date": "2026-03-18",
+          "last_updated": "2026-03-18",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "limit": {
+            "context": 8000,
+            "output": 16000
+          },
+          "display_name": "MiMo-V2-TTS",
+          "type": "chat"
         },
         {
           "id": "mimo-v2-pro",
@@ -12844,9 +12879,9 @@
           },
           "open_weights": true,
           "cost": {
-            "input": 1,
-            "output": 3,
-            "cache_read": 0.2
+            "input": 0,
+            "output": 0,
+            "cache_read": 0
           },
           "limit": {
             "context": 1000000,

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -12799,15 +12799,64 @@
           },
           "open_weights": true,
           "cost": {
-            "input": 0,
-            "output": 0,
-            "cache_read": 0
+            "input": 0.4,
+            "output": 2,
+            "cache_read": 0.08
           },
           "limit": {
             "context": 256000,
             "output": 128000
           },
           "display_name": "MiMo-V2-Omni",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          }
+        },
+        {
+          "id": "mimo-v2-pro",
+          "name": "MiMo-V2-Pro",
+          "family": "mimo",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "tool_call": true,
+          "interleaved": {
+            "field": "reasoning_content"
+          },
+          "temperature": true,
+          "knowledge": "2024-12",
+          "release_date": "2026-03-18",
+          "last_updated": "2026-03-18",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "cost": {
+            "input": 1,
+            "output": 3,
+            "cache_read": 0.2
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "display_name": "MiMo-V2-Pro",
           "type": "chat",
           "extra_capabilities": {
             "reasoning": {
@@ -12851,55 +12900,6 @@
           },
           "display_name": "MiMo-V2-TTS",
           "type": "chat"
-        },
-        {
-          "id": "mimo-v2-pro",
-          "name": "MiMo-V2-Pro",
-          "family": "mimo",
-          "attachment": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "tool_call": true,
-          "interleaved": {
-            "field": "reasoning_content"
-          },
-          "temperature": true,
-          "knowledge": "2024-12",
-          "release_date": "2026-03-18",
-          "last_updated": "2026-03-18",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "open_weights": true,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cache_read": 0
-          },
-          "limit": {
-            "context": 1000000,
-            "output": 128000
-          },
-          "display_name": "MiMo-V2-Pro",
-          "type": "chat",
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thinking_blocks"
-              ]
-            }
-          }
         },
         {
           "id": "mimo-v2-flash",

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -325,6 +325,51 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
+	// Merge xiaomi-token-plan-* providers into xiaomi developer
+	if (allowedIds.includes("xiaomi")) {
+		const xiaomiTokenPlanKeys = [
+			"xiaomi-token-plan-cn",
+		];
+		const mergedModels = new Map();
+		let baseProvider = filtered.xiaomi || data.providers.xiaomi || null;
+
+		for (const key of xiaomiTokenPlanKeys) {
+			const provider = data.providers[key];
+			if (!provider) continue;
+			const models = Array.isArray(provider.models) ? provider.models : [];
+			for (const model of models) {
+				if (!mergedModels.has(model.id)) {
+					mergedModels.set(model.id, deepClone(model));
+				}
+			}
+		}
+
+		// Also include models already on the xiaomi provider
+		if (baseProvider) {
+			const existingModels = Array.isArray(baseProvider.models)
+				? baseProvider.models
+				: [];
+			for (const model of existingModels) {
+				if (!mergedModels.has(model.id)) {
+					mergedModels.set(model.id, deepClone(model));
+				}
+			}
+		}
+
+		if (mergedModels.size > 0) {
+			filtered.xiaomi = {
+				...(baseProvider || {}),
+				id: "xiaomi",
+				name: "Xiaomi",
+				display_name: "Xiaomi",
+				models: Array.from(mergedModels.values()),
+			};
+			console.log(
+				`Merged ${mergedModels.size} models from xiaomi-token-plan-* into xiaomi developer`,
+			);
+		}
+	}
+
 	if (allowedIds.includes(KWAIPILOT_DEVELOPER_ID)) {
 		const kwaipilotProvider = buildKWAIPilotProvider(data);
 		if (kwaipilotProvider) {

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -329,27 +329,24 @@ function filterProviders(data, allowedIds) {
 	if (allowedIds.includes("xiaomi")) {
 		const xiaomiTokenPlanKeys = [
 			"xiaomi-token-plan-cn",
+			"xiaomi-token-plan-sgp",
+			"xiaomi-token-plan-ams",
 		];
 		const mergedModels = new Map();
-		let baseProvider = filtered.xiaomi || data.providers.xiaomi || null;
+		const baseProvider = filtered.xiaomi || data.providers.xiaomi || null;
 
-		for (const key of xiaomiTokenPlanKeys) {
-			const provider = data.providers[key];
-			if (!provider) continue;
-			const models = Array.isArray(provider.models) ? provider.models : [];
-			for (const model of models) {
-				if (!mergedModels.has(model.id)) {
-					mergedModels.set(model.id, deepClone(model));
-				}
+		// Process base provider first so its real pricing takes precedence
+		if (baseProvider) {
+			for (const model of baseProvider.models || []) {
+				mergedModels.set(model.id, deepClone(model));
 			}
 		}
 
-		// Also include models already on the xiaomi provider
-		if (baseProvider) {
-			const existingModels = Array.isArray(baseProvider.models)
-				? baseProvider.models
-				: [];
-			for (const model of existingModels) {
+		// Add token-plan models only for IDs not already present
+		for (const key of xiaomiTokenPlanKeys) {
+			const provider = data.providers[key];
+			if (!provider) continue;
+			for (const model of provider.models || []) {
 				if (!mergedModels.has(model.id)) {
 					mergedModels.set(model.id, deepClone(model));
 				}


### PR DESCRIPTION
https://github.com/looplj/axonhub/pull/1499

the upsteam do have these mimo v2.5 models, but them exist in mimo-token-plan-cn so I add a mapping from it

