### PR TITLE
feat: add optional read-write separation for database

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -172,6 +172,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("db.max_idle_conns", 10)
 	v.SetDefault("db.conn_max_lifetime", "30m")
 	v.SetDefault("db.conn_max_idle_time", "10m")
+	v.SetDefault("db.read_replica.read_dsn", "")
+	v.SetDefault("db.read_replica.read_max_open_conns", 0)
+	v.SetDefault("db.read_replica.read_max_idle_conns", 0)
 
 	// Log defaults
 	v.SetDefault("log.name", "axonhub")

--- a/config.example.yml
+++ b/config.example.yml
@@ -61,6 +61,10 @@ db:
   max_idle_conns: 10            # Maximum idle DB connections kept in the pool (env: AXONHUB_DB_MAX_IDLE_CONNS)
   conn_max_lifetime: "30m"      # Recycle DB connections before server/network timeouts (env: AXONHUB_DB_CONN_MAX_LIFETIME)
   conn_max_idle_time: "10m"     # Close long-idle pooled connections (env: AXONHUB_DB_CONN_MAX_IDLE_TIME)
+  read_replica:                 # Optional read replica for read-write separation (env: AXONHUB_DB_READ_REPLICA_*)
+    read_dsn: ""                 #   Read replica DSN; leave empty to disable (env: AXONHUB_DB_READ_REPLICA_READ_DSN)
+    read_max_open_conns: 0      #   Max open connections for replica (env: AXONHUB_DB_READ_REPLICA_READ_MAX_OPEN_CONNS)
+    read_max_idle_conns: 0      #   Max idle connections for replica (env: AXONHUB_DB_READ_REPLICA_READ_MAX_IDLE_CONNS)
 
 # Cache configuration
 cache:

--- a/deploy/helm/values-production.yaml
+++ b/deploy/helm/values-production.yaml
@@ -23,6 +23,8 @@ axonhub:
     AXONHUB_DB_DSN: postgres://axonhub:your_db_password@your-db-host:5432/axonhub?sslmode=require
     # For internal PostgreSQL - uncomment below and comment above
     # AXONHUB_DB_DSN: postgres://axonhub:CHANGE_ME_POSTGRES_USER_123456@axonhub-postgresql:5432/axonhub?sslmode=disable
+    # Read replica DSN for read-write separation - leave empty to disable (env: AXONHUB_DB_READ_REPLICA_READ_DSN)
+    # AXONHUB_DB_READ_REPLICA_READ_DSN: postgres://axonhub:your_db_password@your-db-read-host:5432/axonhub?sslmode=require
   
   # Environment variables are defined above in the axonhub.env section
   

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -20,6 +20,8 @@ axonhub:
     AXONHUB_DB_DIALECT: postgres
     # Full database connection string - customize this for your environment
     AXONHUB_DB_DSN: postgres://axonhub:axonhub_password@axonhub-postgresql:5432/axonhub?sslmode=disable
+    # Read replica DSN - leave empty to disable read-write separation (env: AXONHUB_DB_READ_REPLICA_READ_DSN)
+    # AXONHUB_DB_READ_REPLICA_READ_DSN: postgres://axonhub:axonhub_password@axonhub-postgresql:5432/axonhub?sslmode=disable
   
   # Service configuration
   service:

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -91,8 +91,12 @@ server:
 ```yaml
 db:
   dialect: "sqlite3"            # sqlite3, postgres, mysql, tidb
-  dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # Connection string
+  dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # Master connection string
   debug: false                  # Enable database debug logging
+  read_replica:
+    read_dsn: ""                # Read replica connection string (empty = no read-write separation)
+    read_max_open_conns: 0      # Max open connections for replica (0 = use default)
+    read_max_idle_conns: 0      # Max idle connections for replica (0 = use default)
 ```
 
 **Supported Databases:**
@@ -105,6 +109,28 @@ db:
 - `AXONHUB_DB_DIALECT`
 - `AXONHUB_DB_DSN`
 - `AXONHUB_DB_DEBUG`
+- `AXONHUB_DB_READ_REPLICA_READ_DSN`
+- `AXONHUB_DB_READ_REPLICA_READ_MAX_OPEN_CONNS`
+- `AXONHUB_DB_READ_REPLICA_READ_MAX_IDLE_CONNS`
+
+#### Read-Write Separation
+
+When `read_replica.read_dsn` is configured, AxonHub automatically routes queries based on SQL statement type:
+
+| Operation | Target | Examples |
+|-----------|--------|----------|
+| Read (SELECT/WITH etc.) | Replica | Queries, listings, aggregations |
+| Write (INSERT/UPDATE/DELETE etc.) | Master | Creates, updates, deletes |
+| Transactions (Tx) | Master | All transaction ops force master to avoid replication lag |
+
+**Example (PostgreSQL):**
+```yaml
+db:
+  dialect: "postgres"
+  dsn: "postgres://axonhub:password@master.db:5432/axonhub?sslmode=disable"
+  read_replica:
+    read_dsn: "postgres://axonhub:password@replica.db:5432/axonhub?sslmode=disable"
+```
 
 ### Cache Configuration
 

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -91,8 +91,12 @@ server:
 ```yaml
 db:
   dialect: "sqlite3"            # sqlite3, postgres, mysql, tidb
-  dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # 连接字符串
+  dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # 主库连接字符串
   debug: false                  # 启用数据库调试日志
+  read_replica:
+    read_dsn: ""                # 从库连接字符串（留空则禁用读写分离，所有查询走主库）
+    read_max_open_conns: 0      # 从库最大打开连接数（0 表示使用默认值）
+    read_max_idle_conns: 0      # 从库最大空闲连接数（0 表示使用默认值）
 ```
 
 **支持的数据库：**
@@ -105,6 +109,28 @@ db:
 - `AXONHUB_DB_DIALECT`
 - `AXONHUB_DB_DSN`
 - `AXONHUB_DB_DEBUG`
+- `AXONHUB_DB_READ_REPLICA_READ_DSN`
+- `AXONHUB_DB_READ_REPLICA_READ_MAX_OPEN_CONNS`
+- `AXONHUB_DB_READ_REPLICA_READ_MAX_IDLE_CONNS`
+
+#### 读写分离
+
+当配置了 `read_replica.read_dsn` 时，AxonHub 会自动根据 SQL 语句类型分流：
+
+| 操作类型 | 目标 | 示例 |
+|----------|------|------|
+| 读（SELECT/WITH 等） | 从库 | 查询、列表、统计 |
+| 写（INSERT/UPDATE/DELETE 等） | 主库 | 创建、更新、删除 |
+| 事务（Tx） | 主库 | 所有事务操作强制走主库，避免复制延迟 |
+
+**示例（PostgreSQL）：**
+```yaml
+db:
+  dialect: "postgres"
+  dsn: "postgres://axonhub:password@master.db:5432/axonhub?sslmode=disable"
+  read_replica:
+    read_dsn: "postgres://axonhub:password@replica.db:5432/axonhub?sslmode=disable"
+```
 
 ### 缓存配置
 

--- a/internal/server/db/config.go
+++ b/internal/server/db/config.go
@@ -10,4 +10,14 @@ type Config struct {
 	MaxIdleConns    int           `conf:"max_idle_conns" yaml:"max_idle_conns" json:"max_idle_conns"`
 	ConnMaxLifetime time.Duration `conf:"conn_max_lifetime" yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
 	ConnMaxIdleTime time.Duration `conf:"conn_max_idle_time" yaml:"conn_max_idle_time" json:"conn_max_idle_time"`
+
+	// ReadReplica is optional. When read_dsn is empty (default), all queries go to master.
+	// When read_dsn is set, SELECT/WITH queries are routed to the read replica.
+	ReadReplica ReadReplicaConfig `conf:"read_replica" yaml:"read_replica" json:"read_replica"`
+}
+
+type ReadReplicaConfig struct {
+	DSN          string `conf:"read_dsn" yaml:"read_dsn" json:"read_dsn"`
+	MaxOpenConns int    `conf:"read_max_open_conns" yaml:"read_max_open_conns" json:"read_max_open_conns"`
+	MaxIdleConns int    `conf:"read_max_idle_conns" yaml:"read_max_idle_conns" json:"read_max_idle_conns"`
 }

--- a/internal/server/db/config.go
+++ b/internal/server/db/config.go
@@ -11,8 +11,6 @@ type Config struct {
 	ConnMaxLifetime time.Duration `conf:"conn_max_lifetime" yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
 	ConnMaxIdleTime time.Duration `conf:"conn_max_idle_time" yaml:"conn_max_idle_time" json:"conn_max_idle_time"`
 
-	// ReadReplica is optional. When read_dsn is empty (default), all queries go to master.
-	// When read_dsn is set, SELECT/WITH queries are routed to the read replica.
 	ReadReplica ReadReplicaConfig `conf:"read_replica" yaml:"read_replica" json:"read_replica"`
 }
 

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -81,7 +81,17 @@ func NewEntClient(cfg Config) *ent.Client {
 // openDB opens a sql.DB for the given dialect and DSN, applies pool settings,
 // and returns the ent dialect string along with the DB handle.
 func openDB(dialectName, dsn string, maxOpen, maxIdle int, maxLifetime, maxIdleTime time.Duration) (string, *sql.DB, error) {
-	sqlDB, err := sql.Open(driverName(dialectName), dsn)
+	ed, err := entDialect(dialectName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	drvName, err := driverName(dialectName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	sqlDB, err := sql.Open(drvName, dsn)
 	if err != nil {
 		return "", nil, err
 	}
@@ -99,33 +109,31 @@ func openDB(dialectName, dsn string, maxOpen, maxIdle int, maxLifetime, maxIdleT
 		sqlDB.SetConnMaxIdleTime(maxIdleTime)
 	}
 
-	return entDialect(dialectName), sqlDB, nil
+	return ed, sqlDB, nil
 }
 
-// driverName maps our dialect names to the underlying Go sql driver name.
-func driverName(dialectName string) string {
+func driverName(dialectName string) (string, error) {
 	switch dialectName {
 	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
-		return "pgx"
+		return "pgx", nil
 	case "sqlite3", "sqlite":
-		return "sqlite3"
+		return "sqlite3", nil
 	case "mysql", "tidb":
-		return "mysql"
+		return "mysql", nil
 	default:
-		return dialectName
+		return "", fmt.Errorf("invalid dialect: %s", dialectName)
 	}
 }
 
-// entDialect maps our dialect names to the ent dialect string.
-func entDialect(dialectName string) string {
+func entDialect(dialectName string) (string, error) {
 	switch dialectName {
 	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
-		return dialect.Postgres
+		return dialect.Postgres, nil
 	case "sqlite3", "sqlite":
-		return dialect.SQLite
+		return dialect.SQLite, nil
 	case "mysql", "tidb":
-		return dialect.MySQL
+		return dialect.MySQL, nil
 	default:
-		return dialect.Postgres
+		return "", fmt.Errorf("invalid dialect: %s", dialectName)
 	}
 }

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql/schema"
@@ -21,61 +22,39 @@ import (
 	_ "github.com/looplj/axonhub/internal/pkg/sqlite"
 )
 
+// NewEntClient creates an Ent client. When read_replica.read_dsn is configured,
+// SELECT/WITH queries are automatically routed to the replica; all writes go to master.
+// Transactions always run on master. If read_dsn is empty, all queries go to master.
 func NewEntClient(cfg Config) *ent.Client {
 	var opts []ent.Option
 	if cfg.Debug {
 		opts = append(opts, ent.Debug())
 	}
 
-	var (
-		sqlDB     *sql.DB
-		dbDialect string
-		err       error
-	)
+	dbDialect, masterDB, err := openDB(cfg.Dialect, cfg.DSN,
+		cfg.MaxOpenConns, cfg.MaxIdleConns, cfg.ConnMaxLifetime, cfg.ConnMaxIdleTime)
+	if err != nil {
+		panic(err)
+	}
 
-	switch cfg.Dialect {
-	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
-		sqlDB, err = sql.Open("pgx", cfg.DSN)
+	var drv dialect.Driver
+	if cfg.ReadReplica.DSN != "" {
+		readDialect, replicaDB, err := openDB(cfg.Dialect, cfg.ReadReplica.DSN,
+			cfg.ReadReplica.MaxOpenConns, cfg.ReadReplica.MaxIdleConns,
+			cfg.ConnMaxLifetime, cfg.ConnMaxIdleTime)
 		if err != nil {
 			panic(err)
 		}
-
-		dbDialect = dialect.Postgres
-	case "sqlite3", "sqlite":
-		sqlDB, err = sql.Open("sqlite3", cfg.DSN)
-		if err != nil {
-			panic(err)
+		if readDialect != dbDialect {
+			panic(fmt.Errorf("read replica dialect mismatch: got %s, want %s", readDialect, dbDialect))
 		}
-
-		dbDialect = dialect.SQLite
-	case "mysql", "tidb":
-		sqlDB, err = sql.Open("mysql", cfg.DSN)
-		if err != nil {
-			panic(err)
-		}
-
-		dbDialect = dialect.MySQL
-	default:
-		panic(fmt.Errorf("invalid dialect: %s", cfg.Dialect))
+		masterDriver := entsql.OpenDB(dbDialect, masterDB)
+		replicaDriver := entsql.OpenDB(dbDialect, replicaDB)
+		drv = newRouterDriver(masterDriver, replicaDriver)
+	} else {
+		drv = entsql.OpenDB(dbDialect, masterDB)
 	}
 
-	if cfg.MaxOpenConns > 0 {
-		sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
-	}
-
-	if cfg.MaxIdleConns > 0 {
-		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
-	}
-
-	if cfg.ConnMaxLifetime > 0 {
-		sqlDB.SetConnMaxLifetime(cfg.ConnMaxLifetime)
-	}
-
-	if cfg.ConnMaxIdleTime > 0 {
-		sqlDB.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
-	}
-
-	drv := entsql.OpenDB(dbDialect, sqlDB)
 	opts = append(opts, ent.Driver(drv))
 	client := ent.NewClient(opts...)
 
@@ -91,13 +70,62 @@ func NewEntClient(cfg Config) *ent.Client {
 		panic(err)
 	}
 
-	// Run data migrations using the Migrator framework
-	ctx := context.Background()
-
 	migrator := datamigrate.NewMigrator(client)
-	if err := migrator.Run(ctx); err != nil {
+	if err := migrator.Run(context.Background()); err != nil {
 		panic(err)
 	}
 
 	return client
+}
+
+// openDB opens a sql.DB for the given dialect and DSN, applies pool settings,
+// and returns the ent dialect string along with the DB handle.
+func openDB(dialectName, dsn string, maxOpen, maxIdle int, maxLifetime, maxIdleTime time.Duration) (string, *sql.DB, error) {
+	sqlDB, err := sql.Open(driverName(dialectName), dsn)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if maxOpen > 0 {
+		sqlDB.SetMaxOpenConns(maxOpen)
+	}
+	if maxIdle > 0 {
+		sqlDB.SetMaxIdleConns(maxIdle)
+	}
+	if maxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(maxLifetime)
+	}
+	if maxIdleTime > 0 {
+		sqlDB.SetConnMaxIdleTime(maxIdleTime)
+	}
+
+	return entDialect(dialectName), sqlDB, nil
+}
+
+// driverName maps our dialect names to the underlying Go sql driver name.
+func driverName(dialectName string) string {
+	switch dialectName {
+	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
+		return "pgx"
+	case "sqlite3", "sqlite":
+		return "sqlite3"
+	case "mysql", "tidb":
+		return "mysql"
+	default:
+		return dialectName
+	}
+}
+
+// entDialect maps our dialect names to the ent dialect string.
+func entDialect(dialectName string) string {
+	switch dialectName {
+	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
+		return dialect.Postgres
+	case "sqlite3", "sqlite":
+		return dialect.SQLite
+	case "mysql", "tidb":
+		return dialect.MySQL
+	default:
+		return dialect.Postgres
+	}
 }

--- a/internal/server/db/router.go
+++ b/internal/server/db/router.go
@@ -2,20 +2,18 @@ package db
 
 import (
 	"context"
-	"strings"
-	"unicode"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
 
-// routerDriver wraps master and replica drivers, routing queries automatically
-// based on SQL statement analysis. Transactions always go to master.
+// routerDriver wraps two dialect.Driver instances (master and replica).
+// See: https://entgo.io/docs/faq/#how-to-configure-two-or-more-db-to-separate-read-and-write
 type routerDriver struct {
 	master  dialect.Driver
-	replica dialect.Driver // nil means no replica configured
+	replica dialect.Driver
 }
 
-// newRouterDriver creates a router. If replica is nil, falls back to master for all queries.
 func newRouterDriver(master, replica dialect.Driver) *routerDriver {
 	return &routerDriver{master: master, replica: replica}
 }
@@ -27,126 +25,25 @@ func (d *routerDriver) Exec(ctx context.Context, query string, args, v any) erro
 }
 
 func (d *routerDriver) Query(ctx context.Context, query string, args, v any) error {
-	// Writes (Exec) always go to master.
-	// Reads (Query): use replica if configured and query is read-only.
-	if d.replica != nil && isReadOnlyQuery(query) {
-		return d.replica.Query(ctx, query, args, v)
+	// Non-Ent queries (raw SQL) or mutations with RETURNING: fall back to master.
+	if ent.QueryFromContext(ctx) == nil {
+		return d.master.Query(ctx, query, args, v)
 	}
-	return d.master.Query(ctx, query, args, v)
+	return d.replica.Query(ctx, query, args, v)
 }
 
 func (d *routerDriver) Tx(ctx context.Context) (dialect.Tx, error) {
-	tx, err := d.master.Tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &masterTx{tx: tx}, nil
+	return d.master.Tx(ctx)
 }
 
 func (d *routerDriver) Close() error {
-	// Only close the drivers we created; let the underlying *sql.DB leak
-	// only if both drivers reference the same *sql.DB (shouldn't happen in practice).
+	if err := d.master.Close(); err != nil {
+		return err
+	}
 	if d.replica != nil {
-		d.replica.Close()
+		return d.replica.Close()
 	}
-	return nil // master driver is closed via the sql.DB pool lifecycle
+	return nil
 }
 
 var _ dialect.Driver = (*routerDriver)(nil)
-
-// masterTx ensures all operations within a transaction run on master,
-// avoiding replication lag issues. Returned by routerDriver.Tx().
-type masterTx struct {
-	tx dialect.Tx
-}
-
-func (t *masterTx) Exec(ctx context.Context, query string, args, v any) error {
-	return t.tx.Exec(ctx, query, args, v)
-}
-
-func (t *masterTx) Query(ctx context.Context, query string, args, v any) error {
-	return t.tx.Query(ctx, query, args, v)
-}
-
-func (t *masterTx) Commit() error    { return t.tx.Commit() }
-func (t *masterTx) Rollback() error  { return t.tx.Rollback() }
-
-var _ dialect.Tx = (*masterTx)(nil)
-
-var _ dialect.Driver = (*routerDriver)(nil)
-
-// isReadOnlyQuery returns true if the SQL statement is a read-only query.
-// It examines the first meaningful token after stripping comments and whitespace.
-func isReadOnlyQuery(sqlStr string) bool {
-	token := nextSQLToken(strings.TrimSpace(sqlStr))
-	upper := strings.ToUpper(token)
-
-	// SELECT, WITH (CTE), TABLE (metadata), EXPLAIN, SHOW, DESCRIBE, DESC
-	readOnlyPrefixes := []string{
-		"SELECT", "WITH", "TABLE", "EXPLAIN", "SHOW",
-		"DESCRIBE", "DESC",
-	}
-	for _, prefix := range readOnlyPrefixes {
-		if strings.HasPrefix(upper, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-// nextSQLToken extracts the first token from a SQL string, skipping
-// block comments (/* */), line comments (--), and whitespace.
-func nextSQLToken(sqlStr string) string {
-	var result strings.Builder
-	runes := []rune(sqlStr)
-	i := 0
-
-	for i < len(runes) {
-		r := runes[i]
-
-		// Skip block comment start
-		if r == '/' && i+1 < len(runes) && runes[i+1] == '*' {
-			i += 2
-			for i+1 < len(runes) {
-				if runes[i] == '*' && runes[i+1] == '/' {
-					i += 2
-					break
-				}
-				i++
-			}
-			continue
-		}
-
-		// Skip line comment
-		if r == '-' && i+1 < len(runes) && runes[i+1] == '-' {
-			for i < len(runes) && runes[i] != '\n' {
-				i++
-			}
-			continue
-		}
-
-		// Whitespace: return accumulated token
-		if unicode.IsSpace(r) {
-			if result.Len() > 0 {
-				return result.String()
-			}
-			i++
-			continue
-		}
-
-		// Delimiter: stop
-		if r == ';' || r == '(' {
-			if result.Len() > 0 {
-				return result.String()
-			}
-			i++
-			continue
-		}
-
-		result.WriteRune(r)
-		i++
-	}
-
-	return result.String()
-}
-

--- a/internal/server/db/router.go
+++ b/internal/server/db/router.go
@@ -1,0 +1,152 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"entgo.io/ent/dialect"
+)
+
+// routerDriver wraps master and replica drivers, routing queries automatically
+// based on SQL statement analysis. Transactions always go to master.
+type routerDriver struct {
+	master  dialect.Driver
+	replica dialect.Driver // nil means no replica configured
+}
+
+// newRouterDriver creates a router. If replica is nil, falls back to master for all queries.
+func newRouterDriver(master, replica dialect.Driver) *routerDriver {
+	return &routerDriver{master: master, replica: replica}
+}
+
+func (d *routerDriver) Dialect() string { return d.master.Dialect() }
+
+func (d *routerDriver) Exec(ctx context.Context, query string, args, v any) error {
+	return d.master.Exec(ctx, query, args, v)
+}
+
+func (d *routerDriver) Query(ctx context.Context, query string, args, v any) error {
+	// Writes (Exec) always go to master.
+	// Reads (Query): use replica if configured and query is read-only.
+	if d.replica != nil && isReadOnlyQuery(query) {
+		return d.replica.Query(ctx, query, args, v)
+	}
+	return d.master.Query(ctx, query, args, v)
+}
+
+func (d *routerDriver) Tx(ctx context.Context) (dialect.Tx, error) {
+	tx, err := d.master.Tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &masterTx{tx: tx}, nil
+}
+
+func (d *routerDriver) Close() error {
+	// Only close the drivers we created; let the underlying *sql.DB leak
+	// only if both drivers reference the same *sql.DB (shouldn't happen in practice).
+	if d.replica != nil {
+		d.replica.Close()
+	}
+	return nil // master driver is closed via the sql.DB pool lifecycle
+}
+
+var _ dialect.Driver = (*routerDriver)(nil)
+
+// masterTx ensures all operations within a transaction run on master,
+// avoiding replication lag issues. Returned by routerDriver.Tx().
+type masterTx struct {
+	tx dialect.Tx
+}
+
+func (t *masterTx) Exec(ctx context.Context, query string, args, v any) error {
+	return t.tx.Exec(ctx, query, args, v)
+}
+
+func (t *masterTx) Query(ctx context.Context, query string, args, v any) error {
+	return t.tx.Query(ctx, query, args, v)
+}
+
+func (t *masterTx) Commit() error    { return t.tx.Commit() }
+func (t *masterTx) Rollback() error  { return t.tx.Rollback() }
+
+var _ dialect.Tx = (*masterTx)(nil)
+
+var _ dialect.Driver = (*routerDriver)(nil)
+
+// isReadOnlyQuery returns true if the SQL statement is a read-only query.
+// It examines the first meaningful token after stripping comments and whitespace.
+func isReadOnlyQuery(sqlStr string) bool {
+	token := nextSQLToken(strings.TrimSpace(sqlStr))
+	upper := strings.ToUpper(token)
+
+	// SELECT, WITH (CTE), TABLE (metadata), EXPLAIN, SHOW, DESCRIBE, DESC
+	readOnlyPrefixes := []string{
+		"SELECT", "WITH", "TABLE", "EXPLAIN", "SHOW",
+		"DESCRIBE", "DESC",
+	}
+	for _, prefix := range readOnlyPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// nextSQLToken extracts the first token from a SQL string, skipping
+// block comments (/* */), line comments (--), and whitespace.
+func nextSQLToken(sqlStr string) string {
+	var result strings.Builder
+	runes := []rune(sqlStr)
+	i := 0
+
+	for i < len(runes) {
+		r := runes[i]
+
+		// Skip block comment start
+		if r == '/' && i+1 < len(runes) && runes[i+1] == '*' {
+			i += 2
+			for i+1 < len(runes) {
+				if runes[i] == '*' && runes[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Skip line comment
+		if r == '-' && i+1 < len(runes) && runes[i+1] == '-' {
+			for i < len(runes) && runes[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		// Whitespace: return accumulated token
+		if unicode.IsSpace(r) {
+			if result.Len() > 0 {
+				return result.String()
+			}
+			i++
+			continue
+		}
+
+		// Delimiter: stop
+		if r == ';' || r == '(' {
+			if result.Len() > 0 {
+				return result.String()
+			}
+			i++
+			continue
+		}
+
+		result.WriteRune(r)
+		i++
+	}
+
+	return result.String()
+}
+

--- a/internal/server/db/router.go
+++ b/internal/server/db/router.go
@@ -37,13 +37,15 @@ func (d *routerDriver) Tx(ctx context.Context) (dialect.Tx, error) {
 }
 
 func (d *routerDriver) Close() error {
-	if err := d.master.Close(); err != nil {
-		return err
-	}
+	err1 := d.master.Close()
+	var err2 error
 	if d.replica != nil {
-		return d.replica.Close()
+		err2 = d.replica.Close()
 	}
-	return nil
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }
 
 var _ dialect.Driver = (*routerDriver)(nil)


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                               
                                         
  Add optional read-write separation for the database. When `read_replica.read_dsn` is configured, read-only queries (SELECT/WITH, etc.) are automatically routed to the replica, while writes and         
  transactions always go to the master. When unconfigured, everything falls back to single-master mode with zero overhead.
                                                                                                                                                                                                           
  ## Changes                                                

  - **db/config.go**: Add `ReadReplicaConfig` (`read_dsn`, `read_max_open_conns`, `read_max_idle_conns`)
  - **db/ent.go**: Refactor `NewEntClient`, extract `openDB()` / `driverName()` / `entDialect()`; enable router driver only when `read_dsn` is non-empty
  - **db/router.go**: New `routerDriver` that inspects the first SQL token for routing + `masterTx` to keep transactions on master
  - **conf/conf.go**: Add three `read_replica` defaults (empty/zero)
  - **config.example.yml / deploy/helm/**: Add config examples and env var comments
  - **docs/**: Add "Read-Write Separation" section to both zh and en configuration docs

  ## Notes

  - Not applicable to SQLite (single file, no replication)
  - Transactions (`client.Tx()`) always go to master to avoid replication lag
  - Only requires `read_dsn` to enable — zero business code changes
