### PR TITLE
fix(dashboard): align token stats by API key/channel/model with totals

### DIFF
--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -342,35 +342,32 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context, timeWindow *stri
 
 	var results []tokenStats
 
-	// Database-level aggregation with JOIN
+	// Aggregate directly on usage_logs.api_key_id. Joining to requests is unnecessary
+	// (the column is already on usage_logs) and breaks once the requests table is
+	// pruned by GC retention while usage_logs are still kept.
 	err := r.client.UsageLog.Query().
+		Where(usagelog.APIKeyIDNotNil()).
 		Modify(func(s *sql.Selector) {
-			// Join to requests table to get api_key_id
-			requestTable := sql.Table(request.Table)
-			s.Join(requestTable).On(
-				s.C(usagelog.FieldRequestID),
-				requestTable.C(request.FieldID),
-			)
-
-			// Filter: only requests with non-null api_key_id
-			s.Where(sql.NotNull(requestTable.C(request.FieldAPIKeyID)))
-
-			// Apply time window filter when provided
 			if applyFilter {
 				s.Where(sql.GTE(s.C(usagelog.FieldCreatedAt), since))
 			}
 
-			// Group by api_key_id
-			s.GroupBy(requestTable.C(request.FieldAPIKeyID))
+			s.GroupBy(s.C(usagelog.FieldAPIKeyID))
 
-			// Select aggregations
 			s.Select(
-				sql.As(requestTable.C(request.FieldAPIKeyID), "api_key_id"),
-				sql.As(sql.Sum(s.C(usagelog.FieldPromptTokens)), "input_tokens"),
-				sql.As(sql.Sum(s.C(usagelog.FieldCompletionTokens)), "output_tokens"),
+				s.C(usagelog.FieldAPIKeyID),
+				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptTokens)), "input_tokens"),
+				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionTokens)), "output_tokens"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionReasoningTokens)), "reasoning_tokens"),
 			)
+
+			// Order by billable total (input + output). Reasoning is already inside
+			// completion_tokens, so adding it would double-count.
+			s.OrderBy(sql.Desc(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
+				s.C(usagelog.FieldPromptTokens),
+				s.C(usagelog.FieldCompletionTokens))))
+			s.Limit(10)
 		}).
 		Scan(ctx, &results)
 	if err != nil {
@@ -379,18 +376,6 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context, timeWindow *stri
 
 	if len(results) == 0 {
 		return []*TokenStatsByAPIKey{}, nil
-	}
-
-	// Sort by total tokens (descending) and limit to top 3
-	sort.Slice(results, func(i, j int) bool {
-		totalI := results[i].InputTokens + results[i].OutputTokens + results[i].ReasoningTokens
-		totalJ := results[j].InputTokens + results[j].OutputTokens + results[j].ReasoningTokens
-
-		return totalI > totalJ
-	})
-
-	if len(results) > 3 {
-		results = results[:3]
 	}
 
 	// Extract API key IDs
@@ -416,7 +401,7 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context, timeWindow *stri
 
 	for _, result := range results {
 		if ak, exists := apiKeyMap[result.APIKeyID]; exists {
-			totalTokens := result.InputTokens + result.OutputTokens + result.ReasoningTokens
+			totalTokens := result.InputTokens + result.OutputTokens
 
 			response = append(response, &TokenStatsByAPIKey{
 				APIKeyID:        objects.GUID{Type: "APIKey", ID: result.APIKeyID},
@@ -1500,10 +1485,11 @@ func (r *queryResolver) TokenStatsByChannel(ctx context.Context, timeWindow *str
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionReasoningTokens)), "reasoning_tokens"),
 			)
 
-			s.OrderBy(sql.Desc(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
+			// Order by billable total (input + output). Reasoning is already inside
+			// completion_tokens, so adding it would double-count.
+			s.OrderBy(sql.Desc(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
 				s.C(usagelog.FieldPromptTokens),
-				s.C(usagelog.FieldCompletionTokens),
-				s.C(usagelog.FieldCompletionReasoningTokens))))
+				s.C(usagelog.FieldCompletionTokens))))
 			s.Limit(10)
 		}).
 		Scan(ctx, &results)
@@ -1512,7 +1498,7 @@ func (r *queryResolver) TokenStatsByChannel(ctx context.Context, timeWindow *str
 	}
 
 	return lo.Map(results, func(item channelTokenStats, _ int) *TokenStatsByChannel {
-		totalTokens := item.InputTokens + item.OutputTokens + item.ReasoningTokens
+		totalTokens := item.InputTokens + item.OutputTokens
 
 		return &TokenStatsByChannel{
 			ChannelName:     item.ChannelName,
@@ -1558,10 +1544,11 @@ func (r *queryResolver) TokenStatsByModel(ctx context.Context, timeWindow *strin
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionReasoningTokens)), "reasoning_tokens"),
 			)
 
-			s.OrderBy(sql.Desc(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
+			// Order by billable total (input + output). Reasoning is already inside
+			// completion_tokens, so adding it would double-count.
+			s.OrderBy(sql.Desc(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
 				s.C(usagelog.FieldPromptTokens),
-				s.C(usagelog.FieldCompletionTokens),
-				s.C(usagelog.FieldCompletionReasoningTokens))))
+				s.C(usagelog.FieldCompletionTokens))))
 			s.Limit(10)
 		}).
 		Scan(ctx, &results)
@@ -1570,7 +1557,7 @@ func (r *queryResolver) TokenStatsByModel(ctx context.Context, timeWindow *strin
 	}
 
 	return lo.Map(results, func(item modelTokenStats, _ int) *TokenStatsByModel {
-		totalTokens := item.InputTokens + item.OutputTokens + item.ReasoningTokens
+		totalTokens := item.InputTokens + item.OutputTokens
 
 		return &TokenStatsByModel{
 			ModelID:         item.ModelID,

--- a/internal/server/gql/dashboard.resolvers.go
+++ b/internal/server/gql/dashboard.resolvers.go
@@ -355,7 +355,7 @@ func (r *queryResolver) TokenStatsByAPIKey(ctx context.Context, timeWindow *stri
 			s.GroupBy(s.C(usagelog.FieldAPIKeyID))
 
 			s.Select(
-				s.C(usagelog.FieldAPIKeyID),
+				sql.As(s.C(usagelog.FieldAPIKeyID), "api_key_id"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptTokens)), "input_tokens"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionTokens)), "output_tokens"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),

--- a/internal/server/gql/dashboard_helpers.go
+++ b/internal/server/gql/dashboard_helpers.go
@@ -217,10 +217,12 @@ func (r *queryResolver) getTopModelsForAPIKeys(ctx context.Context, apiKeyIDs []
 			sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionTokens)), "output_tokens"),
 			sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptCachedTokens)), "cached_tokens"),
 			sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldCompletionReasoningTokens)), "reasoning_tokens"),
-			sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
+			// Order by billable total (input + output). Reasoning is already inside
+			// completion_tokens, so adding it would double-count and bias the
+			// per-API-key top-N model ranking toward reasoning-heavy models.
+			sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0) + COALESCE(SUM(%s), 0)",
 				s.C(usagelog.FieldPromptTokens),
-				s.C(usagelog.FieldCompletionTokens),
-				s.C(usagelog.FieldCompletionReasoningTokens)), "total_tokens"),
+				s.C(usagelog.FieldCompletionTokens)), "total_tokens"),
 		).GroupBy(s.C(usagelog.FieldAPIKeyID), s.C(usagelog.FieldModelID)).
 			OrderBy(sql.Desc("total_tokens"))
 	}).Scan(ctx, &allResults)


### PR DESCRIPTION
## Summary

- `tokenStatsByAPIKey` joined `usage_logs` to `requests` only to read `api_key_id`, but `usage_logs.api_key_id` is the same column. Once the `requests` table is pruned by GC retention while usage_logs are still kept, the dashboard's by-API-key panel silently zeroes out while the all-time totals stay non-zero. Aggregate directly on `usage_logs.api_key_id` (mirroring `requestStatsByAPIKey` / `costStatsByAPIKey`), and bump the per-key limit from 3 → 10 to match the other by-X resolvers and the chart's existing `slice(0, 10)`.
- Fix `totalTokens` in by-API-key, by-channel and by-model from `input + output + reasoning` to `input + output`. Reasoning tokens are already a subset of `completion_tokens`, so the previous formula double-counted them and made the per-row total drift above the all-time stats card on reasoning-heavy traffic. The matching `ORDER BY` formulas are simplified the same way.

## Test plan

- [ ] On a DB where `requests` has been pruned but `usage_logs` is retained, confirm "Tokens by API key" panel populates and the sum matches "All token stats" / API-Keys page totals.
- [ ] On reasoning-heavy traffic, confirm the by-key/channel/model `totalTokens` no longer exceeds the input+output total.
- [ ] On an account with >3 active keys, confirm up to 10 keys now appear in the chart.