### PR TITLE
fix(pipeline): prevent channels from getting stuck in processing status

### DIFF
--- a/llm/pipeline/middleware_test.go
+++ b/llm/pipeline/middleware_test.go
@@ -720,3 +720,38 @@ func (f *failingExecutor) Do(ctx context.Context, request *httpclient.Request) (
 func (f *failingExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	return nil, errors.New("executor stream error")
 }
+
+func TestMiddleware_RawRequest_Error_CleanupMiddlewares(t *testing.T) {
+	ctx := context.Background()
+	callOrder := []string{}
+
+	m1 := newTrackingMiddleware("M1", &callOrder)
+	m2 := newTrackingMiddleware("M2", &callOrder)
+	m2.shouldFailOnRawRequest = true
+	m3 := newTrackingMiddleware("M3", &callOrder)
+
+	exec := &testExecutor{}
+	factory := NewFactory(exec)
+
+	p := factory.Pipeline(
+		&testInbound{},
+		&testOutbound{},
+		WithMiddlewares(m1, m2, m3),
+	)
+
+	request := &httpclient.Request{}
+	result, err := p.Process(ctx, request)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "raw request middleware error")
+
+	require.True(t, m1.outboundRequestCalled)
+	require.True(t, m2.outboundRequestCalled)
+	require.False(t, m3.outboundRequestCalled)
+
+	require.True(t, m1.outboundRawErrorCalled,
+		"already-executed middleware must receive OnOutboundRawError for cleanup")
+	require.True(t, m2.outboundRawErrorCalled)
+	require.True(t, m3.outboundRawErrorCalled)
+}

--- a/llm/pipeline/middleware_test.go
+++ b/llm/pipeline/middleware_test.go
@@ -753,5 +753,6 @@ func TestMiddleware_RawRequest_Error_CleanupMiddlewares(t *testing.T) {
 	require.True(t, m1.outboundRawErrorCalled,
 		"already-executed middleware must receive OnOutboundRawError for cleanup")
 	require.True(t, m2.outboundRawErrorCalled)
-	require.True(t, m3.outboundRawErrorCalled)
+	require.True(t, m3.outboundRawErrorCalled,
+		"unexecuted middleware must receive OnOutboundRawError for unconditional cleanup")
 }

--- a/llm/pipeline/non_streaming.go
+++ b/llm/pipeline/non_streaming.go
@@ -32,6 +32,8 @@ func (p *pipeline) notStream(
 	// Apply raw response middlewares
 	httpResp, err = p.applyRawResponseMiddlewares(ctx, httpResp)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply raw response middlewares: %w", err)
 	}
 
@@ -41,16 +43,22 @@ func (p *pipeline) notStream(
 
 	llmResp, err := p.Outbound.TransformResponse(ctx, httpResp)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to transform response: %w", err)
 	}
 
 	// Apply LLM response middlewares
 	llmResp, err = p.applyLlmResponseMiddlewares(ctx, llmResp)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply llm response middlewares: %w", err)
 	}
 
 	if p.emptyResponseDetection && !hasResponseContent(llmResp) {
+		p.applyRawErrorResponseMiddlewares(ctx, ErrEmptyResponse)
+
 		return nil, ErrEmptyResponse
 	}
 
@@ -58,12 +66,16 @@ func (p *pipeline) notStream(
 
 	finalResp, err := p.Inbound.TransformResponse(ctx, llmResp)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to transform final response: %w", err)
 	}
 
 	// Apply inbound raw response middlewares after final response transformation
 	finalResp, err = p.applyInboundRawResponseMiddlewares(ctx, finalResp)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply inbound raw response middlewares: %w", err)
 	}
 

--- a/llm/pipeline/pipeline.go
+++ b/llm/pipeline/pipeline.go
@@ -353,6 +353,8 @@ func (p *pipeline) processRequest(ctx context.Context, request *llm.Request) (*R
 	// Apply raw request middlewares
 	httpReq, err = p.applyRawRequestMiddlewares(ctx, httpReq)
 	if err != nil {
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply raw request middlewares: %w", err)
 	}
 

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -64,6 +64,8 @@ func (p *pipeline) checkEmptyResponse(
 	}
 
 	if err := llmStream.Err(); err != nil {
+		llmStream.Close()
+
 		return nil, err
 	}
 
@@ -146,8 +148,10 @@ func (p *pipeline) stream(
 
 	// Check for empty response if detection is enabled
 	if p.emptyResponseDetection {
+		rawLlmStream := llmStream
 		llmStream, err = p.checkEmptyResponse(ctx, llmStream)
 		if err != nil {
+			rawLlmStream.Close()
 			p.applyRawErrorResponseMiddlewares(ctx, err)
 
 			return nil, err

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -95,8 +95,12 @@ func (p *pipeline) stream(
 	}
 
 	// Apply raw stream middlewares
+	rawStream := outboundStream
 	outboundStream, err = p.applyRawStreamMiddlewares(ctx, outboundStream)
 	if err != nil {
+		rawStream.Close()
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply raw stream middlewares: %w", err)
 	}
 
@@ -115,13 +119,21 @@ func (p *pipeline) stream(
 
 	llmStream, err := p.Outbound.TransformStream(ctx, outboundStream)
 	if err != nil {
+		outboundStream.Close()
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		slog.ErrorContext(ctx, "Failed to transform streaming request", slog.Any("error", err))
 		return nil, err
 	}
 
+	rawLlmStream := llmStream
+
 	// Apply LLM stream middlewares
 	llmStream, err = p.applyLlmStreamMiddlewares(ctx, llmStream)
 	if err != nil {
+		rawLlmStream.Close()
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply llm stream middlewares: %w", err)
 	}
 
@@ -136,18 +148,28 @@ func (p *pipeline) stream(
 	if p.emptyResponseDetection {
 		llmStream, err = p.checkEmptyResponse(ctx, llmStream)
 		if err != nil {
+			p.applyRawErrorResponseMiddlewares(ctx, err)
+
 			return nil, err
 		}
 	}
 
 	inboundStream, err := p.Inbound.TransformStream(ctx, llmStream)
 	if err != nil {
+		llmStream.Close()
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		slog.ErrorContext(ctx, "Failed to transform streaming request", slog.Any("error", err))
 		return nil, err
 	}
 
+	rawInboundStream := inboundStream
+
 	inboundStream, err = p.applyInboundRawStreamMiddlewares(ctx, inboundStream)
 	if err != nil {
+		rawInboundStream.Close()
+		p.applyRawErrorResponseMiddlewares(ctx, err)
+
 		return nil, fmt.Errorf("failed to apply inbound raw stream middlewares: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Requests can get permanently stuck in "processing" status, causing the system to failover to a different channel without giving the first one a chance to complete.

Introduced by #1503 (per-channel concurrency queue + admission control).

## Bug Behavior

- Requests appear stuck in "processing" status and never transition to completed/failed
- System immediately failovers to a different channel
- User sees: channel A stuck saying processing, request handled by channel B
- Concurrency of 15 should not trigger this, but hard-mode queueing (QueueSize > 0) can when the queue is at capacity

## Root Cause

When `applyRawRequestMiddlewares` fails partway through (e.g. `withChannelLimiter` returns `ChannelQueueError` after `persistRequestExecution` has already run), the pipeline returns the error without calling `applyRawErrorResponseMiddlewares`. This means `persistRequestExecution.OnOutboundRawError` is never invoked, leaving the request execution stuck in "processing" forever.

Before #1503, no middleware after `persistRequestExecution` could fail in `OnOutboundRawRequest`, so this was a latent bug. The new `withChannelLimiter` middleware (positioned after `persistRequestExecution`) can return `ChannelQueueError`, which now triggers it.

The same latent bug existed in `notStream` and `stream` for non-executor error paths (e.g. TransformResponse failure, empty response detection).

## Key Changes

- `pipeline.go`: Call `applyRawErrorResponseMiddlewares` when `applyRawRequestMiddlewares` fails
- `non_streaming.go`: Add cleanup calls on all non-executor error paths (raw response, transform, LLM response, empty response, inbound transform, inbound raw response)
- `stream.go`: Add cleanup calls on all non-executor error paths + save original stream references before wrapping to prevent nil-pointer panics when closing on error. Also fix stream leak in `checkEmptyResponse` when `llmStream.Err()` returns non-nil.
- `middleware_test.go`: Regression test verifying already-executed middlewares receive `OnOutboundRawError` when a later middleware fails

## Risks

All `OnOutboundRawError` handlers are idempotent (nil checks, sync.Once guards), so calling them after a later middleware fails is safe.

### Known limitation (P2, pre-existing)

If `applyRawStreamMiddlewares` iterates multiple wrapping middlewares and a later one fails after an earlier one has already wrapped the stream, only the innermost (pre-wrap) stream is closed. Intermediate wrapped streams from successfully-run middlewares are not cleaned up. This is rare (requires ≥2 raw stream middlewares where one fails mid-chain) and pre-existing — not introduced by this PR. A proper fix would require tracking intermediate streams in the middleware application loop, which is a separate refactor.