### PR TITLE
fix(models): resolve vision capability from modalities when explicit field is absent

### DIFF
--- a/frontend/src/features/models/components/models-action-dialog.tsx
+++ b/frontend/src/features/models/components/models-action-dialog.tsx
@@ -22,7 +22,7 @@ import { useModels } from '../context/models-context';
 import { DEVELOPER_IDS, DEVELOPER_ICONS } from '../data/constants';
 import { useCreateModel, useUpdateModel } from '../data/models';
 import { useDevelopersData } from '../data/providers';
-import { type Provider, type ProviderModel } from '../data/providers.schema';
+import { type Provider, type ProviderModel, resolveVision } from '../data/providers.schema';
 import { CreateModelInput, createModelInputSchema, UpdateModelInput, ModelCard, ModelType, modelTypeSchema, updateModelInputSchema } from '../data/schema';
 
 function isDeveloper(provider: string) {
@@ -191,7 +191,7 @@ export function ModelsActionDialog() {
             input: selectedModel.modalities?.input || [],
             output: selectedModel.modalities?.output || [],
           },
-          vision: selectedModel.vision,
+          vision: resolveVision(selectedModel),
           cost: {
             input: selectedModel.cost?.input || 0,
             output: selectedModel.cost?.output || 0,

--- a/frontend/src/features/models/components/models-batch-create-dialog.tsx
+++ b/frontend/src/features/models/components/models-batch-create-dialog.tsx
@@ -13,7 +13,7 @@ import { useModels } from '../context/models-context';
 import { DEVELOPER_IDS, DEVELOPER_ICONS } from '../data/constants';
 import { useBulkCreateModels } from '../data/models';
 import { useDevelopersData } from '../data/providers';
-import { type Provider, type ProviderModel } from '../data/providers.schema';
+import { type Provider, type ProviderModel, resolveVision } from '../data/providers.schema';
 import { CreateModelInput, ModelCard, ModelType, modelTypeSchema } from '../data/schema';
 
 interface ModelRow {
@@ -158,7 +158,7 @@ export function ModelsBatchCreateDialog() {
                 input: selectedModel.modalities?.input || [],
                 output: selectedModel.modalities?.output || [],
               },
-              vision: selectedModel.attachment || false,
+              vision: resolveVision(selectedModel),
               cost: {
                 input: selectedModel.cost?.input || 0,
                 output: selectedModel.cost?.output || 0,

--- a/frontend/src/features/models/data/providers.schema.ts
+++ b/frontend/src/features/models/data/providers.schema.ts
@@ -70,3 +70,8 @@ export const providersDataSchema = z.object({
 export type ProviderModel = z.infer<typeof providerModelSchema>;
 export type Provider = z.infer<typeof providerSchema>;
 export type ProvidersData = z.infer<typeof providersDataSchema>;
+
+export function resolveVision(model: ProviderModel): boolean {
+  if (model.vision !== undefined) return model.vision;
+  return !!model.modalities?.input?.includes('image');
+}


### PR DESCRIPTION
## Summary
Fix vision capability resolution for models that have image modality but lack explicit vision field. This ensures consistent vision detection across the codebase.

## Spirit/Intent
Enable automatic vision capability detection from input modalities when explicit vision field is missing, preventing models with image support from being incorrectly marked as non-vision.

## Key Changes
- Added `resolveVision` helper in providers.schema.ts that checks explicit vision field first, then falls back to checking if 'image' is in input modalities
- Updated models-action-dialog.tsx to use `resolveVision` instead of direct vision field access
- Updated models-batch-create-dialog.tsx to use `resolveVision` instead of attachment-based fallback

## Risks
Low risk - backward compatible change that preserves explicit vision field when present, only adds fallback behavior when absent.