### PR TITLE
fix(bailian): strip response_format and sanitize tool arguments

### DIFF
--- a/llm/transformer/bailian/outbound.go
+++ b/llm/transformer/bailian/outbound.go
@@ -2,6 +2,7 @@ package bailian
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -60,8 +61,36 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 // TransformRequest applies Bailian-specific request normalization before delegating to OpenAI-compatible transformer.
 func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
 	llmReq = mergeConsecutiveToolCallMessages(llmReq)
+	llmReq = sanitizeForBailian(llmReq)
 
 	return t.Outbound.TransformRequest(ctx, llmReq)
+}
+
+// sanitizeForBailian removes unsupported fields and fixes format issues for Bailian API compatibility.
+func sanitizeForBailian(req *llm.Request) *llm.Request {
+	if req == nil {
+		return nil
+	}
+
+	if req.ResponseFormat != nil {
+		req.ResponseFormat = nil
+	}
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].ToolCalls {
+			args := req.Messages[i].ToolCalls[j].Function.Arguments
+			if args == "" {
+				req.Messages[i].ToolCalls[j].Function.Arguments = "{}"
+				continue
+			}
+			if !json.Valid([]byte(args)) {
+				wrapped, _ := json.Marshal(args)
+				req.Messages[i].ToolCalls[j].Function.Arguments = string(wrapped)
+			}
+		}
+	}
+
+	return req
 }
 
 func mergeConsecutiveToolCallMessages(req *llm.Request) *llm.Request {

--- a/llm/transformer/bailian/sanitize_test.go
+++ b/llm/transformer/bailian/sanitize_test.go
@@ -1,0 +1,106 @@
+package bailian
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestSanitizeForBailian_StripResponseFormat(t *testing.T) {
+	req := &llm.Request{
+		ResponseFormat: &llm.ResponseFormat{
+			Type: "json_object",
+		},
+		Messages: []llm.Message{},
+	}
+
+	result := sanitizeForBailian(req)
+
+	if result.ResponseFormat != nil {
+		t.Errorf("expected ResponseFormat to be nil, got %+v", result.ResponseFormat)
+	}
+}
+
+func TestSanitizeForBailian_EmptyArguments(t *testing.T) {
+	args := ""
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						Function: llm.FunctionCall{
+							Name:      "test_func",
+							Arguments: args,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := sanitizeForBailian(req)
+
+	expected := "{}"
+	if result.Messages[0].ToolCalls[0].Function.Arguments != expected {
+		t.Errorf("expected empty arguments to become %q, got %q", expected, result.Messages[0].ToolCalls[0].Function.Arguments)
+	}
+}
+
+func TestSanitizeForBailian_NonJSONArguments(t *testing.T) {
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						Function: llm.FunctionCall{
+							Name:      "test_func",
+							Arguments: "not json at all",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := sanitizeForBailian(req)
+
+	args := result.Messages[0].ToolCalls[0].Function.Arguments
+	if !json.Valid([]byte(args)) {
+		t.Errorf("expected arguments to be valid JSON, got %q", args)
+	}
+}
+
+func TestSanitizeForBailian_ValidJSONArgumentsUnchanged(t *testing.T) {
+	original := `{"key": "value"}`
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						Function: llm.FunctionCall{
+							Name:      "test_func",
+							Arguments: original,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := sanitizeForBailian(req)
+
+	if result.Messages[0].ToolCalls[0].Function.Arguments != original {
+		t.Errorf("expected valid JSON arguments to be unchanged, got %q", result.Messages[0].ToolCalls[0].Function.Arguments)
+	}
+}
+
+func TestSanitizeForBailian_NilRequest(t *testing.T) {
+	result := sanitizeForBailian(nil)
+	if result != nil {
+		t.Errorf("expected nil result for nil request")
+	}
+}


### PR DESCRIPTION
## Problem

Bailian (百炼) API:
1. Does not support the `response_format` parameter — forwarding it causes errors
2. Requires tool call arguments to be valid JSON — malformed arguments cause API failures

## Fix

- Strip `response_format` from outgoing requests to Bailian
- Sanitize tool call arguments to ensure valid JSON before forwarding
- Add unit tests for sanitization logic

## Scope

`llm/transformer/bailian/outbound.go` + new test file