### PR TITLE
fix(redis): add connection pool configuration options

### DIFF
--- a/internal/pkg/xredis/client.go
+++ b/internal/pkg/xredis/client.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -110,6 +111,50 @@ func newRedisOptions(cfg Config) (*redis.Options, error) {
 	// Ensure TLSInsecureSkipVerify is not silently set without TLS
 	if opts.TLSConfig == nil && cfg.TLSInsecureSkipVerify {
 		return nil, errors.New("tls_insecure_skip_verify requires TLS to be enabled (tls=true or rediss://)")
+	}
+
+	// Apply sensible defaults for pool and timeout if not configured
+	if opts.PoolSize == 0 {
+		opts.PoolSize = cfg.PoolSize
+		if opts.PoolSize == 0 {
+			opts.PoolSize = 50
+		}
+	}
+	if opts.MinIdleConns == 0 {
+		opts.MinIdleConns = cfg.MinIdleConns
+		if opts.MinIdleConns == 0 {
+			opts.MinIdleConns = 10
+		}
+	}
+	if opts.DialTimeout == 0 {
+		opts.DialTimeout = cfg.DialTimeout
+		if opts.DialTimeout == 0 {
+			opts.DialTimeout = 5 * time.Second
+		}
+	}
+	if opts.ReadTimeout == 0 {
+		opts.ReadTimeout = cfg.ReadTimeout
+		if opts.ReadTimeout == 0 {
+			opts.ReadTimeout = 3 * time.Second
+		}
+	}
+	if opts.WriteTimeout == 0 {
+		opts.WriteTimeout = cfg.WriteTimeout
+		if opts.WriteTimeout == 0 {
+			opts.WriteTimeout = 3 * time.Second
+		}
+	}
+	if opts.PoolTimeout == 0 {
+		opts.PoolTimeout = cfg.PoolTimeout
+		if opts.PoolTimeout == 0 {
+			opts.PoolTimeout = 4 * time.Second
+		}
+	}
+	if opts.MaxRetries == 0 {
+		opts.MaxRetries = cfg.MaxRetries
+		if opts.MaxRetries == 0 {
+			opts.MaxRetries = 3
+		}
 	}
 
 	return opts, nil

--- a/internal/pkg/xredis/config.go
+++ b/internal/pkg/xredis/config.go
@@ -13,4 +13,11 @@ type Config struct {
 	TLS                   bool          `conf:"tls" yaml:"tls" json:"tls"`
 	TLSInsecureSkipVerify bool          `conf:"tls_insecure_skip_verify" yaml:"tls_insecure_skip_verify" json:"tls_insecure_skip_verify"`
 	Expiration            time.Duration `conf:"expiration" yaml:"expiration" json:"expiration"`
+	PoolSize              int           `conf:"pool_size" yaml:"pool_size" json:"pool_size"`
+	MinIdleConns          int           `conf:"min_idle_conns" yaml:"min_idle_conns" json:"min_idle_conns"`
+	DialTimeout           time.Duration `conf:"dial_timeout" yaml:"dial_timeout" json:"dial_timeout"`
+	ReadTimeout           time.Duration `conf:"read_timeout" yaml:"read_timeout" json:"read_timeout"`
+	WriteTimeout          time.Duration `conf:"write_timeout" yaml:"write_timeout" json:"write_timeout"`
+	PoolTimeout           time.Duration `conf:"pool_timeout" yaml:"pool_timeout" json:"pool_timeout"`
+	MaxRetries            int           `conf:"max_retries" yaml:"max_retries" json:"max_retries"`
 }


### PR DESCRIPTION
## Problem

Redis Config only has basic fields (Addr, Password, DB). Under high load,
the default Go-redis pool settings (10 idle conns, no pool timeout) can
lead to connection exhaustion.

## Fix

Add pool configuration fields to `internal/pkg/xredis/config.go`:
- `PoolSize` (default: 50)
- `MinIdleConns` (default: 10)
- `DialTimeout` (default: 5s)
- `ReadTimeout` (default: 3s)
- `WriteTimeout` (default: 3s)
- `PoolTimeout` (default: 4s)
- `MaxRetries` (default: 3)

Applied in `newRedisOptions()` with fallback defaults.

## Scope

`internal/pkg/xredis/config.go` + `internal/pkg/xredis/client.go`