### PR TITLE
fix(transformer): nil safety and arithmetic overflow fixes

### DIFF
--- a/llm/transformer/anthropic/usage.go
+++ b/llm/transformer/anthropic/usage.go
@@ -102,7 +102,7 @@ func convertToAnthropicUsage(llmUsage *llm.Usage) *Usage {
 			Ephemeral5mInputTokens: llmUsage.PromptTokensDetails.WriteCached5MinTokens,
 			Ephemeral1hInputTokens: llmUsage.PromptTokensDetails.WriteCached1HourTokens,
 		}
-		usage.InputTokens -= (usage.CacheReadInputTokens + usage.CacheCreationInputTokens)
+		usage.InputTokens = max(0, usage.InputTokens - usage.CacheReadInputTokens - usage.CacheCreationInputTokens)
 	}
 
 	// Note: Anthropic doesn't have a direct equivalent for reasoning tokens in their current API

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -507,7 +507,7 @@ func convertToGeminiUsage(chatUsage *llm.Usage) *UsageMetadata {
 
 	if chatUsage.CompletionTokensDetails != nil {
 		usage.ThoughtsTokenCount = chatUsage.CompletionTokensDetails.ReasoningTokens
-		usage.CandidatesTokenCount = chatUsage.CompletionTokens - usage.ThoughtsTokenCount
+		usage.CandidatesTokenCount = max(0, chatUsage.CompletionTokens - usage.ThoughtsTokenCount)
 	}
 
 	if len(chatUsage.CompletionModalityTokenDetails) > 0 {

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -148,17 +148,20 @@ func (m Message) ToLLMMessage() llm.Message {
 
 	// Convert ToolCalls
 	if m.ToolCalls != nil {
-		msg.ToolCalls = lo.Map(m.ToolCalls, func(tc ToolCall, _ int) llm.ToolCall {
-			return tc.ToLLMToolCall()
-		})
+		msg.ToolCalls = make([]llm.ToolCall, len(m.ToolCalls))
+		for i, tc := range m.ToolCalls {
+			msg.ToolCalls[i] = tc.ToLLMToolCall()
 
-		firstThoughtSignature := lo.FindOrElse(msg.ToolCalls, llm.ToolCall{}, func(tc llm.ToolCall) bool {
-			raw, ok := tc.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string)
-			return ok && raw != ""
-		})
-
-		if raw, ok := firstThoughtSignature.TransformerMetadata[TransformerMetadataKeyGoogleThoughtSignature].(string); ok {
-			msg.ReasoningSignature = lo.ToPtr(raw)
+			// Extract ReasoningSignature once from the first tool call that carries it.
+			if msg.ReasoningSignature == nil {
+				extraContent := tc.ExtraContent
+				if extraContent == nil && tc.ExtraFields != nil {
+					extraContent = tc.ExtraFields.ExtraContent
+				}
+				if extraContent != nil && extraContent.Google != nil && extraContent.Google.ThoughtSignature != "" {
+					msg.ReasoningSignature = lo.ToPtr(extraContent.Google.ThoughtSignature)
+				}
+			}
 		}
 	}
 

--- a/llm/transformer/openai/responses/usage.go
+++ b/llm/transformer/openai/responses/usage.go
@@ -17,6 +17,9 @@ type Usage struct {
 }
 
 func (u *Usage) ToUsage() *llm.Usage {
+	if u == nil {
+		return nil
+	}
 	return &llm.Usage{
 		PromptTokens:     u.InputTokens,
 		CompletionTokens: u.OutputTokens,


### PR DESCRIPTION
## Problem

Several transformers have crash-prone patterns:
- Nil pointer dereference when optional response fields are missing
- Usage token subtraction can produce negative values causing downstream errors
- Outbound conversion can accidentally overwrite existing fields

## Fix

- Add nil checks before accessing optional transformer fields
- Clamp usage subtraction results to zero (no negative token counts)
- Preserve existing fields during outbound conversion

## Scope

Transformer files affected by F-D39/40/41/42/43 only.

### Files changed

| File | Fix |
|------|-----|
| `llm/transformer/openai/responses/usage.go` | F-D39: nil guard on `Usage.ToUsage()` |
| `llm/transformer/gemini/convert.go` | F-D40: `max(0, ...)` on candidates token count |
| `llm/transformer/openai/inbound_convert.go` | F-D41/42: rewrite ToolCalls loop to prevent field overwrite + add nested nil checks |
| `llm/transformer/anthropic/usage.go` | F-D43: `max(0, ...)` on input token subtraction |