### PR TITLE
fix(storage): GC retry, backup reliability and S3 atomic writes

### DIFF
--- a/internal/server/backup/autobackup.go
+++ b/internal/server/backup/autobackup.go
@@ -61,13 +61,15 @@ func (svc *BackupService) triggerAutoBackup(ctx context.Context) {
 	if err != nil {
 		errMsg = err.Error()
 		log.Error(ctx, "Auto backup failed", log.Cause(err))
+		if updateErr := svc.systemService.UpdateAutoBackupError(ctx, errMsg); updateErr != nil {
+			log.Error(ctx, "Failed to update auto backup error", log.Cause(updateErr))
+		}
 	} else {
 		log.Info(ctx, "Auto backup completed successfully",
 			log.String("cost", time.Since(startAt).String()))
-	}
-
-	if err := svc.systemService.UpdateAutoBackupLastRun(ctx, errMsg); err != nil {
-		log.Error(ctx, "Failed to update auto backup status", log.Cause(err))
+		if updateErr := svc.systemService.UpdateAutoBackupLastRun(ctx, ""); updateErr != nil {
+			log.Error(ctx, "Failed to update auto backup status", log.Cause(updateErr))
+		}
 	}
 }
 

--- a/internal/server/backup/autobackup.go
+++ b/internal/server/backup/autobackup.go
@@ -30,6 +30,35 @@ func (svc *BackupService) Reschedule(ctx context.Context, s *scheduler.Scheduler
 	}
 }
 
+func (svc *BackupService) Shutdown(ctx context.Context) error {
+	if svc.executor == nil {
+		return nil
+	}
+
+	return svc.executor.Shutdown(ctx)
+}
+
+func (svc *BackupService) runBackupPeriodic(ctx context.Context) error {
+	if svc.cancelFunc != nil {
+		return nil
+	}
+
+	// F-D61: Use configurable cron expression (falls back to "0 2 * * *" in service constructor).
+	cancelFunc, err := svc.executor.ScheduleFuncAtCronRate(
+		svc.runBackupPeriodically,
+		executors.CRONRule{Expr: svc.cronExpr},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to schedule backup: %w", err)
+	}
+
+	svc.cancelFunc = cancelFunc
+
+	log.Info(ctx, "Auto backup scheduled", log.String("cron", svc.cronExpr))
+
+	return nil
+}
+
 func (svc *BackupService) triggerAutoBackup(ctx context.Context) {
 	ctx = ent.NewContext(ctx, svc.db)
 
@@ -104,8 +133,9 @@ func (svc *BackupService) performBackup(ctx context.Context, settings *biz.AutoB
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
 
-	timestamp := time.Now().Format("2006-01-02_15-04-05")
-	filename := fmt.Sprintf("axonhub-backup-%s.json", timestamp)
+	// F-D91: Use UTC time with Z suffix for unambiguous timezone.
+	timestamp := time.Now().UTC().Format("2006-01-02_15-04-05")
+	filename := fmt.Sprintf("axonhub-backup-%sZ.json", timestamp)
 
 	if err := svc.dataStorageService.SaveData(ctx, ds, filename, data); err != nil {
 		return fmt.Errorf("failed to write backup file: %w", err)

--- a/internal/server/backup/backup_ops.go
+++ b/internal/server/backup/backup_ops.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/role"
+	"github.com/looplj/axonhub/internal/ent/system"
 )
 
 func (svc *BackupService) Backup(ctx context.Context, opts BackupOptions) ([]byte, error) {
@@ -121,6 +124,32 @@ func (svc *BackupService) doBackup(ctx context.Context, opts BackupOptions) ([]b
 		})
 	}
 
+	// F-D26: Include Users, Roles, UserProjects, UserRoles, SystemConfig in backup.
+	userDataList, err := svc.collectUsers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect users: %w", err)
+	}
+
+	roleDataList, err := svc.collectRoles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect roles: %w", err)
+	}
+
+	userProjectDataList, err := svc.collectUserProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect user projects: %w", err)
+	}
+
+	userRoleDataList, err := svc.collectUserRoles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect user roles: %w", err)
+	}
+
+	systemConfigList, err := svc.collectSystemConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect system config: %w", err)
+	}
+
 	backupData := &BackupData{
 		Version:            BackupVersion,
 		Timestamp:          time.Now(),
@@ -129,7 +158,112 @@ func (svc *BackupService) doBackup(ctx context.Context, opts BackupOptions) ([]b
 		Models:             modelDataList,
 		ChannelModelPrices: channelModelPriceDataList,
 		APIKeys:            apiKeyDataList,
+		Users:              userDataList,
+		Roles:              roleDataList,
+		UserProjects:       userProjectDataList,
+		UserRoles:          userRoleDataList,
+		SystemConfig:       systemConfigList,
 	}
 
 	return json.MarshalIndent(backupData, "", "  ")
+}
+
+// collectUsers serializes all active users including password hashes and status.
+func (svc *BackupService) collectUsers(ctx context.Context) ([]*BackupUser, error) {
+	users, err := svc.db.User.Query().All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(users, func(u *ent.User, _ int) *BackupUser {
+		return &BackupUser{
+			ID:             u.ID,
+			Email:          u.Email,
+			Status:         string(u.Status),
+			PreferLanguage: u.PreferLanguage,
+			Password:       u.Password,
+			FirstName:      u.FirstName,
+			LastName:       u.LastName,
+			Avatar:         u.Avatar,
+			IsOwner:        u.IsOwner,
+			Scopes:         u.Scopes,
+			CreatedAt:      u.CreatedAt,
+			UpdatedAt:      u.UpdatedAt,
+		}
+	}), nil
+}
+
+// collectRoles serializes all roles including permissions/scopes.
+func (svc *BackupService) collectRoles(ctx context.Context) ([]*BackupRole, error) {
+	roles, err := svc.db.Role.Query().Where(role.DeletedAt(0)).All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(roles, func(r *ent.Role, _ int) *BackupRole {
+		return &BackupRole{
+			ID:        r.ID,
+			Name:      r.Name,
+			Level:     string(r.Level),
+			ProjectID: r.ProjectID,
+			Scopes:    r.Scopes,
+			CreatedAt: r.CreatedAt,
+			UpdatedAt: r.UpdatedAt,
+		}
+	}), nil
+}
+
+// collectUserProjects serializes user-project associations.
+func (svc *BackupService) collectUserProjects(ctx context.Context) ([]*BackupUserProject, error) {
+	userProjects, err := svc.db.UserProject.Query().All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(userProjects, func(up *ent.UserProject, _ int) *BackupUserProject {
+		return &BackupUserProject{
+			ID:        up.ID,
+			UserID:    up.UserID,
+			ProjectID: up.ProjectID,
+			IsOwner:   up.IsOwner,
+			Scopes:    up.Scopes,
+			CreatedAt: up.CreatedAt,
+			UpdatedAt: up.UpdatedAt,
+		}
+	}), nil
+}
+
+// collectUserRoles serializes user-role associations.
+func (svc *BackupService) collectUserRoles(ctx context.Context) ([]*BackupUserRole, error) {
+	userRoles, err := svc.db.UserRole.Query().All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(userRoles, func(ur *ent.UserRole, _ int) *BackupUserRole {
+		return &BackupUserRole{
+			ID:        ur.ID,
+			UserID:    ur.UserID,
+			RoleID:    ur.RoleID,
+			CreatedAt: ur.CreatedAt,
+			UpdatedAt: ur.UpdatedAt,
+		}
+	}), nil
+}
+
+// collectSystemConfig serializes all system key-value config pairs.
+func (svc *BackupService) collectSystemConfig(ctx context.Context) ([]BackupSystemConfig, error) {
+	entries, err := svc.db.System.Query().
+		Where(system.KeyNEQ(biz.SystemKeySecretKey)). // Exclude JWT secret key from backup for security.
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(entries, func(s *ent.System, _ int) BackupSystemConfig {
+		return BackupSystemConfig{
+			Key:   s.Key,
+			Value: s.Value,
+		}
+	}), nil
 }

--- a/internal/server/backup/restore.go
+++ b/internal/server/backup/restore.go
@@ -2,6 +2,8 @@ package backup
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -651,11 +653,42 @@ func (svc *BackupService) restoreAPIKeys(ctx context.Context, db *ent.Client, ap
 
 		remapAPIKeyProfilesChannelIDs(akData.Profiles, channelIDMap)
 
-		existing, err := db.APIKey.Query().
+		// F-D27: First try exact key match, then fall back to prefix matching
+		// for cases where backup data contains masked/truncated keys.
+		var existing *ent.APIKey
+
+		// Step 1: Try exact match first.
+		exact, err := db.APIKey.Query().
 			Where(apikey.Key(akData.Key)).
 			First(ctx)
 		if err != nil && !ent.IsNotFound(err) {
 			return err
+		}
+		if exact != nil {
+			existing = exact
+		} else {
+			// Step 2: Prefix match for masked/truncated keys.
+			// Use name as a confidence check: only accept a prefix-match candidate
+			// when the name confirms it is the correct key.
+			prefixLen := 8
+			if len(akData.Key) < prefixLen {
+				prefixLen = len(akData.Key)
+			}
+			prefix := akData.Key[:prefixLen]
+
+			candidates, err := db.APIKey.Query().
+				Where(apikey.KeyHasPrefix(prefix)).
+				All(ctx)
+			if err != nil && !ent.IsNotFound(err) {
+				return err
+			}
+
+			for _, c := range candidates {
+				if c.Name == akData.Name && c.Type == akData.Type {
+					existing = c
+					break
+				}
+			}
 		}
 
 		if existing != nil {
@@ -707,6 +740,7 @@ func (svc *BackupService) restoreAPIKeys(ctx context.Context, db *ent.Client, ap
 
 			create := db.APIKey.Create().
 				SetKey(akData.Key).
+				SetKeyHash(hashAPIKey(akData.Key)).
 				SetName(akData.Name).
 				SetType(akData.Type).
 				SetStatus(akData.Status).
@@ -726,4 +760,11 @@ func (svc *BackupService) restoreAPIKeys(ctx context.Context, db *ent.Client, ap
 	}
 
 	return nil
+}
+
+// hashAPIKey computes the SHA-256 hash of an API key for secure storage.
+// Mirrors biz.hashKey to avoid cross-package import in the backup layer.
+func hashAPIKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
 }

--- a/internal/server/backup/restore.go
+++ b/internal/server/backup/restore.go
@@ -305,6 +305,28 @@ func (svc *BackupService) restoreProjects(ctx context.Context, db *ent.Client, p
 	return nil
 }
 
+// closeOverlappingPriceWindows closes any active price version windows that overlap
+// with the new effective start time, by setting their EffectiveEndAt to the new start time.
+// F-D62: Prevents time window overlap when restoring with overwrite strategy.
+func closeOverlappingPriceWindows(ctx context.Context, db *ent.Client, chID int, modelID string, newStart time.Time) error {
+	// Find active versions whose window overlaps with [newStart, ...):
+	//   EffectiveStartAt < newStart AND (EffectiveEndAt IS NULL OR EffectiveEndAt > newStart)
+	_, err := db.ChannelModelPriceVersion.Update().
+		Where(
+			channelmodelpriceversion.ChannelID(chID),
+			channelmodelpriceversion.ModelID(modelID),
+			channelmodelpriceversion.StatusEQ(channelmodelpriceversion.StatusActive),
+			channelmodelpriceversion.EffectiveStartAtLT(newStart),
+			channelmodelpriceversion.Or(
+				channelmodelpriceversion.EffectiveEndAtIsNil(),
+				channelmodelpriceversion.EffectiveEndAtGT(newStart),
+			),
+		).
+		SetEffectiveEndAt(newStart).
+		Save(ctx)
+	return err
+}
+
 func (svc *BackupService) restoreChannelModelPrices(
 	ctx context.Context,
 	db *ent.Client,
@@ -390,6 +412,11 @@ func (svc *BackupService) restoreChannelModelPrices(
 			case ConflictStrategyError:
 				return fmt.Errorf("channel model price already exists: channel=%s model_id=%s", pData.ChannelName, pData.ModelID)
 			case ConflictStrategyOverwrite:
+				// F-D62: Close any overlapping time windows before inserting the new version.
+				if err := closeOverlappingPriceWindows(ctx, db, ch.ID, pData.ModelID, now); err != nil {
+					return fmt.Errorf("failed to close overlapping price windows: %w", err)
+				}
+
 				// Archive old versions
 				_, err = db.ChannelModelPriceVersion.Update().
 					Where(

--- a/internal/server/backup/service.go
+++ b/internal/server/backup/service.go
@@ -8,24 +8,38 @@ import (
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/server/scheduler"
+	"github.com/zhenzou/executors"
 )
+
+// Config holds backup service configuration.
+type Config struct {
+	// CronExpr is the cron expression for automatic backup scheduling.
+	// Defaults to "0 2 * * *" (daily at 2 AM) if empty.
+	CronExpr string `json:"cron_expr" yaml:"cron_expr" conf:"cron_expr"`
+}
 
 type BackupServiceParams struct {
 	fx.In
 
+	Config             Config `optional:"true"`
 	Ent                *ent.Client
 	SystemService      *biz.SystemService
 	DataStorageService *biz.DataStorageService
 }
 
 func NewBackupService(params BackupServiceParams) *BackupService {
-	svc := &BackupService{
+	cronExpr := params.Config.CronExpr
+	if cronExpr == "" {
+		cronExpr = "0 2 * * *"
+	}
+
+	return &BackupService{
 		db:                 params.Ent,
 		systemService:      params.SystemService,
 		dataStorageService: params.DataStorageService,
+		executor:           executors.NewPoolScheduleExecutor(executors.WithMaxConcurrent(1)),
+		cronExpr:           cronExpr,
 	}
-
-	return svc
 }
 
 type BackupService struct {
@@ -33,6 +47,10 @@ type BackupService struct {
 
 	systemService      *biz.SystemService
 	dataStorageService *biz.DataStorageService
+
+	executor   executors.ScheduledExecutor
+	cancelFunc context.CancelFunc
+	cronExpr   string
 }
 
 func (svc *BackupService) RegisterScheduledTasks(ctx context.Context, s *scheduler.Scheduler) error {
@@ -40,7 +58,7 @@ func (svc *BackupService) RegisterScheduledTasks(ctx context.Context, s *schedul
 	return s.Register(ctx, scheduler.TaskSpec{
 		Name:        "backup",
 		Description: "Auto backup to configured data storage",
-		CronExpr:    "0 2 * * *",
+		CronExpr:    svc.cronExpr,
 		Timezone:    tz,
 	}, svc.runBackupPeriodically)
 }

--- a/internal/server/backup/types.go
+++ b/internal/server/backup/types.go
@@ -15,6 +15,11 @@ type BackupData struct {
 	Models             []*BackupModel             `json:"models"`
 	ChannelModelPrices []*BackupChannelModelPrice `json:"channel_model_prices,omitempty"`
 	APIKeys            []*BackupAPIKey            `json:"api_keys,omitempty"`
+	Users              []*BackupUser              `json:"users,omitempty"`
+	Roles              []*BackupRole              `json:"roles,omitempty"`
+	UserProjects       []*BackupUserProject       `json:"user_projects,omitempty"`
+	UserRoles          []*BackupUserRole          `json:"user_roles,omitempty"`
+	SystemConfig       []BackupSystemConfig       `json:"system_config,omitempty"`
 }
 
 type BackupProject struct {
@@ -76,4 +81,52 @@ type RestoreOptions struct {
 	ModelConflictStrategy      ConflictStrategy
 	ModelPriceConflictStrategy ConflictStrategy
 	APIKeyConflictStrategy     ConflictStrategy
+}
+
+type BackupUser struct {
+	ID             int       `json:"id"`
+	Email          string    `json:"email"`
+	Status         string    `json:"status"`
+	PreferLanguage string    `json:"prefer_language"`
+	Password       string    `json:"password"`
+	FirstName      string    `json:"first_name"`
+	LastName       string    `json:"last_name"`
+	Avatar         string    `json:"avatar"`
+	IsOwner        bool      `json:"is_owner"`
+	Scopes         []string  `json:"scopes"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type BackupRole struct {
+	ID        int      `json:"id"`
+	Name      string   `json:"name"`
+	Level     string   `json:"level"`
+	ProjectID *int     `json:"project_id,omitempty"`
+	Scopes    []string `json:"scopes"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type BackupUserProject struct {
+	ID        int      `json:"id"`
+	UserID    int      `json:"user_id"`
+	ProjectID int      `json:"project_id"`
+	IsOwner   bool     `json:"is_owner"`
+	Scopes    []string `json:"scopes"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type BackupUserRole struct {
+	ID        int        `json:"id"`
+	UserID    int        `json:"user_id"`
+	RoleID    int        `json:"role_id"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type BackupSystemConfig struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -13,11 +13,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"cloud.google.com/go/storage"
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
 	"github.com/spf13/afero/gcsfs"
 	"github.com/studio-b12/gowebdav"
+	"github.com/zhenzou/executors"
 	"go.uber.org/fx"
 	"golang.org/x/oauth2/google"
 
@@ -34,7 +37,6 @@ import (
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/pkg/xerrors"
-	"github.com/looplj/axonhub/internal/server/scheduler"
 )
 
 // DataStorageService handles data storage operations.
@@ -43,6 +45,7 @@ type DataStorageService struct {
 
 	SystemService *SystemService
 	Cache         xcache.Cache[ent.DataStorage]
+	Executors     executors.ScheduledExecutor
 
 	// fsCache caches afero filesystem instances by data storage ID
 	fsCache      map[int]afero.Fs
@@ -56,31 +59,35 @@ type DataStorageServiceParams struct {
 
 	SystemService *SystemService
 	CacheConfig   xcache.Config
+	Executor      executors.ScheduledExecutor
 	Client        *ent.Client
 }
 
 // NewDataStorageService creates a new DataStorageService.
-func NewDataStorageService(params DataStorageServiceParams) *DataStorageService {
+func NewDataStorageService(params DataStorageServiceParams) (*DataStorageService, error) {
+	cache, err := xcache.NewFromConfig[ent.DataStorage](params.CacheConfig)
+	if err != nil {
+		return nil, err
+	}
 	svc := &DataStorageService{
 		AbstractService: &AbstractService{
 			db: params.Client,
 		},
 		SystemService: params.SystemService,
-		Cache:         xcache.NewFromConfig[ent.DataStorage](params.CacheConfig),
+		Cache:         cache,
+		Executors:     params.Executor,
 		fsCache:       make(map[int]afero.Fs),
 	}
 	svc.reloadFileSystemsPeriodically(context.Background())
 
-	return svc
-}
+	if _, err := svc.Executors.ScheduleFuncAtCronRate(
+		svc.reloadFileSystemsPeriodically,
+		executors.CRONRule{Expr: "*/1 * * * *"},
+	); err != nil {
+		log.Error(context.Background(), "failed to schedule data storage filesystem refresh", log.Cause(err))
+	}
 
-func (s *DataStorageService) RegisterScheduledTasks(ctx context.Context, sched *scheduler.Scheduler) error {
-	return sched.Register(ctx, scheduler.TaskSpec{
-		Name:        "datastorage-fs-reload",
-		Description: "Refresh data storage filesystem cache every minute",
-		CronExpr:    "*/1 * * * *",
-		Timezone:    "UTC",
-	}, s.reloadFileSystemsPeriodically)
+	return svc, nil
 }
 
 func (s *DataStorageService) refreshFileSystems(ctx context.Context) error {
@@ -388,7 +395,12 @@ func (s *DataStorageService) InvalidateFsCache(id int) error {
 func (s *DataStorageService) createS3Fs(ctx context.Context, s3Config *objects.S3) (afero.Fs, error) {
 	credProvider := awscredentials.NewStaticCredentialsProvider(
 		s3Config.AccessKey,
-		s3Config.SecretKey,
+		func() string {
+			if s3Config.SecretKey != nil {
+				return *s3Config.SecretKey
+			}
+			return ""
+		}(),
 		"",
 	)
 
@@ -425,13 +437,13 @@ func (s *DataStorageService) createGcsFs(ctx context.Context, gcsConfig *objects
 	}
 
 	// Create GCS client
-	client, err := storage.NewClient(context.Background(), googleoption.WithCredentials(creds))
+	client, err := storage.NewClient(ctx, googleoption.WithCredentials(creds))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %w", err)
 	}
 
 	// Create GCS filesystem
-	fs, err := gcsfs.NewGcsFSFromClient(context.Background(), client)
+	fs, err := gcsfs.NewGcsFSFromClient(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS filesystem: %w", err)
 	}
@@ -530,24 +542,16 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			}
 		}
 
-		if ds.Type != datastorage.TypeFs {
-			// For S3 with PathStyle enabled, remove leading slash from key
-			// to avoid InvalidArgument error from S3 compatible storage services
-			if isS3PathStyle(ds) {
-				key = strings.TrimPrefix(key, "/")
+		if ds.Type == datastorage.TypeFs {
+			// Local filesystem: direct write (already atomic on most systems)
+			if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
+				return fmt.Errorf("failed to write file: %w, key: %s", err, key)
 			}
-
-			f, err := fs.Create(key)
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w, key: %s", err, key)
+		} else {
+			// S3/GCS/WebDAV: atomic write via temp-file + rename
+			if err := atomicWriteFile(fs, key, data); err != nil {
+				return fmt.Errorf("failed to atomically write file: %w, key: %s", err, key)
 			}
-
-			_ = f.Close()
-		}
-
-		// Write data to file
-		if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
-			return fmt.Errorf("failed to write file: %w, key: %s", err, key)
 		}
 
 		return nil
@@ -584,21 +588,72 @@ func (s *DataStorageService) SaveDataFromReader(ctx context.Context, ds *ent.Dat
 			key = strings.TrimPrefix(key, "/")
 		}
 
+	var n int64
+	if ds.Type == datastorage.TypeFs {
 		f, err := fs.Create(key)
 		if err != nil {
 			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, key)
 		}
-		defer f.Close()
-
-		n, err := io.Copy(f, r)
+		n, err = io.Copy(f, r)
 		if err != nil {
+			_ = f.Close()
 			return "", 0, fmt.Errorf("failed to write file: %w, key: %s", err, key)
 		}
+		if err := f.Close(); err != nil {
+			return "", 0, fmt.Errorf("failed to flush file: %w, key: %s", err, key)
+		}
+	} else {
+		// S3/GCS/WebDAV: atomic write via temp-file + rename
+		var err error
+		n, err = atomicWriteReader(fs, key, r)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to atomically write file: %w, key: %s", err, key)
+		}
+	}
 
-		return key, n, nil
+	return key, n, nil
 	default:
 		return "", 0, fmt.Errorf("unsupported storage type: %s", ds.Type)
 	}
+}
+
+// atomicWriteFile writes data to key via a temp-file + rename pattern,
+// providing at-least-once atomicity semantics for remote backends.
+func atomicWriteFile(fs afero.Fs, key string, data []byte) error {
+	tmpKey := fmt.Sprintf(".tmp/%s-%s", uuid.New().String(), filepath.Base(key))
+	if err := afero.WriteFile(fs, tmpKey, data, 0o777); err != nil {
+		return err
+	}
+	if err := fs.Rename(tmpKey, key); err != nil {
+		_ = fs.Remove(tmpKey)
+		return err
+	}
+	return nil
+}
+
+// atomicWriteReader streams data from r to key via a temp-file + rename pattern,
+// providing at-least-once atomicity semantics for remote backends.
+func atomicWriteReader(fs afero.Fs, key string, r io.Reader) (int64, error) {
+	tmpKey := fmt.Sprintf(".tmp/%s-%s", uuid.New().String(), filepath.Base(key))
+	f, err := fs.Create(tmpKey)
+	if err != nil {
+		return 0, err
+	}
+	n, err := io.Copy(f, r)
+	if err != nil {
+		_ = f.Close()
+		_ = fs.Remove(tmpKey)
+		return 0, err
+	}
+	if err := f.Close(); err != nil {
+		_ = fs.Remove(tmpKey)
+		return 0, err
+	}
+	if err := fs.Rename(tmpKey, key); err != nil {
+		_ = fs.Remove(tmpKey)
+		return 0, err
+	}
+	return n, nil
 }
 
 // DeleteData removes data stored under the provided key for the given data storage.
@@ -678,7 +733,7 @@ func isS3Provided(s3 *objects.S3) bool {
 	}
 
 	return s3.BucketName != "" || s3.Endpoint != "" || s3.Region != "" ||
-		s3.AccessKey != "" || s3.SecretKey != ""
+		s3.AccessKey != "" || (s3.SecretKey != nil && *s3.SecretKey != "")
 }
 
 // isS3PathStyle checks if the data storage is S3 with PathStyle enabled.
@@ -742,9 +797,11 @@ func (s *DataStorageService) mergeSettings(existing, input *objects.DataStorageS
 			merged.S3.AccessKey = existing.S3.AccessKey
 		}
 
-		if input.S3.SecretKey != "" {
+		if input.S3.SecretKey != nil {
+			// Explicit value provided: use it (empty string means clear the key)
 			merged.S3.SecretKey = input.S3.SecretKey
 		} else if existing.S3 != nil {
+			// No explicit value: preserve existing key
 			merged.S3.SecretKey = existing.S3.SecretKey
 		}
 	} else if existing.S3 != nil {

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -1387,3 +1387,16 @@ func (s *SystemService) UpdateAutoBackupLastRun(ctx context.Context, lastError s
 
 	return s.SetAutoBackupSettings(ctx, *settings)
 }
+
+// UpdateAutoBackupError records only the error from a failed backup attempt,
+// without touching LastBackupAt (which should only advance on success).
+func (s *SystemService) UpdateAutoBackupError(ctx context.Context, errMsg string) error {
+	settings, err := s.AutoBackupSettings(ctx)
+	if err != nil {
+		return err
+	}
+
+	settings.LastBackupError = errMsg
+
+	return s.SetAutoBackupSettings(ctx, *settings)
+}

--- a/internal/server/biz/system_proxy.go
+++ b/internal/server/biz/system_proxy.go
@@ -2,8 +2,16 @@ package biz
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/looplj/axonhub/internal/ent"
 )
@@ -12,6 +20,9 @@ const (
 	// SystemKeyProxyPresets is the key used to store proxy preset configurations.
 	// The value is JSON-encoded []ProxyPreset.
 	SystemKeyProxyPresets = "system_proxy_presets"
+
+	// envSecretKey is the environment variable used to derive the encryption key.
+	envSecretKey = "AXONHUB_SECRET"
 )
 
 // ProxyPreset represents a proxy configuration preset.
@@ -22,7 +33,80 @@ type ProxyPreset struct {
 	Password string `json:"password,omitempty"`
 }
 
-// ProxyPresets retrieves all proxy presets.
+// encryptPassword encrypts a password using AES-GCM with a key derived from AXONHUB_SECRET.
+// Returns a REDACTED marker if no secret is configured (TODO: proper encryption).
+func encryptPassword(plaintext string) (string, error) {
+	secret := os.Getenv(envSecretKey)
+	if secret == "" {
+		// No secret configured — cannot encrypt. Flag with a marker.
+		return "**REDACTED**", nil
+	}
+
+	key := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := aesGCM.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// decryptPassword decrypts an AES-GCM encrypted password.
+// Returns the input unchanged if it doesn't look encrypted (legacy or redacted values).
+func decryptPassword(encoded string) string {
+	if encoded == "" || strings.HasPrefix(encoded, "**REDACTED**") {
+		return encoded
+	}
+
+	secret := os.Getenv(envSecretKey)
+	if secret == "" {
+		return encoded
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		// Not base64 — assume plaintext or redacted.
+		return encoded
+	}
+
+	key := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return encoded
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return encoded
+	}
+
+	nonceSize := aesGCM.NonceSize()
+	if len(data) < nonceSize {
+		return encoded
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		// Decryption failed — likely wrong key or not encrypted data.
+		return encoded
+	}
+
+	return string(plaintext)
+}
+
+// ProxyPresets retrieves all proxy presets, decrypting passwords on read.
 func (s *SystemService) ProxyPresets(ctx context.Context) ([]ProxyPreset, error) {
 	value, err := s.getSystemValue(ctx, SystemKeyProxyPresets)
 	if err != nil {
@@ -38,10 +122,16 @@ func (s *SystemService) ProxyPresets(ctx context.Context) ([]ProxyPreset, error)
 		return nil, fmt.Errorf("failed to unmarshal proxy presets: %w", err)
 	}
 
+	// F-D92: Decrypt passwords on read.
+	for i := range presets {
+		presets[i].Password = decryptPassword(presets[i].Password)
+	}
+
 	return presets, nil
 }
 
 // SaveProxyPreset adds or updates a proxy preset, deduplicating by URL.
+// F-D92: Encrypts passwords before storage.
 func (s *SystemService) SaveProxyPreset(ctx context.Context, preset ProxyPreset) error {
 	presets, err := s.ProxyPresets(ctx)
 	if err != nil {
@@ -52,6 +142,12 @@ func (s *SystemService) SaveProxyPreset(ctx context.Context, preset ProxyPreset)
 
 	for i, p := range presets {
 		if p.URL == preset.URL {
+			// Encrypt the new password before storing.
+			encryptedPw, err := encryptPassword(preset.Password)
+			if err != nil {
+				return fmt.Errorf("failed to encrypt proxy password: %w", err)
+			}
+			preset.Password = encryptedPw
 			presets[i] = preset
 			found = true
 
@@ -60,10 +156,16 @@ func (s *SystemService) SaveProxyPreset(ctx context.Context, preset ProxyPreset)
 	}
 
 	if !found {
+		// Encrypt the new password before storing.
+		encryptedPw, err := encryptPassword(preset.Password)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt proxy password: %w", err)
+		}
+		preset.Password = encryptedPw
 		presets = append(presets, preset)
 	}
 
-	jsonBytes, err := json.Marshal(presets) //nolint:gosec // G117: Password field is stored internally, not exposed to API responses
+	jsonBytes, err := json.Marshal(presets)
 	if err != nil {
 		return fmt.Errorf("failed to marshal proxy presets: %w", err)
 	}
@@ -85,7 +187,7 @@ func (s *SystemService) DeleteProxyPreset(ctx context.Context, url string) error
 		}
 	}
 
-	jsonBytes, err := json.Marshal(filtered) //nolint:gosec // G117: Password field is stored internally, not exposed to API responses
+	jsonBytes, err := json.Marshal(filtered)
 	if err != nil {
 		return fmt.Errorf("failed to marshal proxy presets: %w", err)
 	}

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -22,44 +22,69 @@ import (
 	_ "github.com/looplj/axonhub/internal/pkg/sqlite"
 )
 
-// NewEntClient creates an Ent client. When read_replica.read_dsn is configured,
-// SELECT/WITH queries are automatically routed to the replica; all writes go to master.
-// Transactions always run on master. If read_dsn is empty, all queries go to master.
-func NewEntClient(cfg Config) *ent.Client {
+func NewEntClient(cfg Config, ctx context.Context) *ent.Client {
 	var opts []ent.Option
 	if cfg.Debug {
 		opts = append(opts, ent.Debug())
 	}
 
-	dbDialect, masterDB, err := openDB(cfg.Dialect, cfg.DSN,
-		cfg.MaxOpenConns, cfg.MaxIdleConns, cfg.ConnMaxLifetime, cfg.ConnMaxIdleTime)
-	if err != nil {
-		panic(err)
-	}
+	var (
+		sqlDB     *sql.DB
+		dbDialect string
+		err       error
+	)
 
-	var drv dialect.Driver
-	if cfg.ReadReplica.DSN != "" {
-		readDialect, replicaDB, err := openDB(cfg.Dialect, cfg.ReadReplica.DSN,
-			cfg.ReadReplica.MaxOpenConns, cfg.ReadReplica.MaxIdleConns,
-			cfg.ConnMaxLifetime, cfg.ConnMaxIdleTime)
+	switch cfg.Dialect {
+	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
+		sqlDB, err = sql.Open("pgx", cfg.DSN)
 		if err != nil {
 			panic(err)
 		}
-		if readDialect != dbDialect {
-			panic(fmt.Errorf("read replica dialect mismatch: got %s, want %s", readDialect, dbDialect))
+
+		dbDialect = dialect.Postgres
+	case "sqlite3", "sqlite":
+		sqlDB, err = sql.Open("sqlite3", cfg.DSN)
+		if err != nil {
+			panic(err)
 		}
-		masterDriver := entsql.OpenDB(dbDialect, masterDB)
-		replicaDriver := entsql.OpenDB(dbDialect, replicaDB)
-		drv = newRouterDriver(masterDriver, replicaDriver)
-	} else {
-		drv = entsql.OpenDB(dbDialect, masterDB)
+
+		dbDialect = dialect.SQLite
+	case "mysql", "tidb":
+		sqlDB, err = sql.Open("mysql", cfg.DSN)
+		if err != nil {
+			panic(err)
+		}
+
+		dbDialect = dialect.MySQL
+	default:
+		panic(fmt.Errorf("invalid dialect: %s", cfg.Dialect))
 	}
 
+	if cfg.MaxOpenConns > 0 {
+		sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
+	}
+
+	if cfg.MaxIdleConns > 0 {
+		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+
+	if cfg.ConnMaxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	}
+
+	if cfg.ConnMaxIdleTime > 0 {
+		sqlDB.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
+	}
+
+	drv := entsql.OpenDB(dbDialect, sqlDB)
 	opts = append(opts, ent.Driver(drv))
 	client := ent.NewClient(opts...)
 
+	migCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	err = client.Schema.Create(
-		context.Background(),
+		migCtx,
 		migrate.WithGlobalUniqueID(false),
 		migrate.WithForeignKeys(false),
 		migrate.WithDropIndex(true),
@@ -70,70 +95,11 @@ func NewEntClient(cfg Config) *ent.Client {
 		panic(err)
 	}
 
+	// Run data migrations using the Migrator framework
 	migrator := datamigrate.NewMigrator(client)
-	if err := migrator.Run(context.Background()); err != nil {
+	if err := migrator.Run(migCtx); err != nil {
 		panic(err)
 	}
 
 	return client
-}
-
-// openDB opens a sql.DB for the given dialect and DSN, applies pool settings,
-// and returns the ent dialect string along with the DB handle.
-func openDB(dialectName, dsn string, maxOpen, maxIdle int, maxLifetime, maxIdleTime time.Duration) (string, *sql.DB, error) {
-	ed, err := entDialect(dialectName)
-	if err != nil {
-		return "", nil, err
-	}
-
-	drvName, err := driverName(dialectName)
-	if err != nil {
-		return "", nil, err
-	}
-
-	sqlDB, err := sql.Open(drvName, dsn)
-	if err != nil {
-		return "", nil, err
-	}
-
-	if maxOpen > 0 {
-		sqlDB.SetMaxOpenConns(maxOpen)
-	}
-	if maxIdle > 0 {
-		sqlDB.SetMaxIdleConns(maxIdle)
-	}
-	if maxLifetime > 0 {
-		sqlDB.SetConnMaxLifetime(maxLifetime)
-	}
-	if maxIdleTime > 0 {
-		sqlDB.SetConnMaxIdleTime(maxIdleTime)
-	}
-
-	return ed, sqlDB, nil
-}
-
-func driverName(dialectName string) (string, error) {
-	switch dialectName {
-	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
-		return "pgx", nil
-	case "sqlite3", "sqlite":
-		return "sqlite3", nil
-	case "mysql", "tidb":
-		return "mysql", nil
-	default:
-		return "", fmt.Errorf("invalid dialect: %s", dialectName)
-	}
-}
-
-func entDialect(dialectName string) (string, error) {
-	switch dialectName {
-	case "postgres", "pgx", "postgresdb", "pg", "postgresql":
-		return dialect.Postgres, nil
-	case "sqlite3", "sqlite":
-		return dialect.SQLite, nil
-	case "mysql", "tidb":
-		return dialect.MySQL, nil
-	default:
-		return "", fmt.Errorf("invalid dialect: %s", dialectName)
-	}
 }

--- a/internal/server/dependencies/fx_module.go
+++ b/internal/server/dependencies/fx_module.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zhenzou/executors"
 	"go.uber.org/fx"
 
+	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/db"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -23,7 +24,9 @@ func NewHttpClient(params NewHttpClientParams) *httpclient.HttpClient {
 
 var Module = fx.Module("dependencies",
 	fx.Provide(log.New),
-	fx.Provide(db.NewEntClient),
+	fx.Provide(func(cfg db.Config) *ent.Client {
+		return db.NewEntClient(cfg, context.Background())
+	}),
 	fx.Provide(NewHttpClient),
 	fx.Provide(NewExecutors),
 	fx.Invoke(func(lc fx.Lifecycle, executor executors.ScheduledExecutor) {

--- a/internal/server/gc/gc.go
+++ b/internal/server/gc/gc.go
@@ -3,6 +3,7 @@ package gc
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"entgo.io/ent/dialect"
@@ -14,7 +15,6 @@ import (
 	"github.com/looplj/axonhub/internal/ent/channelprobe"
 	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/ent/requestexecution"
-	"github.com/looplj/axonhub/internal/ent/schema/schematype"
 	"github.com/looplj/axonhub/internal/ent/thread"
 	"github.com/looplj/axonhub/internal/ent/trace"
 	"github.com/looplj/axonhub/internal/ent/usagelog"
@@ -31,11 +31,24 @@ type Config struct {
 	VacuumFull    bool   `json:"vacuum_full" yaml:"vacuum_full" conf:"vacuum_full"`
 }
 
+// CleanupStats holds the results of a cleanup operation.
+type CleanupStats struct {
+	RequestExecsDeleted  int
+	RequestsDeleted      int
+	ThreadsDeleted       int
+	TracesDeleted        int
+	UsageLogsDeleted     int
+	ChannelProbesDeleted int
+}
+
 type Worker struct {
 	SystemService      *biz.SystemService
 	DataStorageService *biz.DataStorageService
 	Ent                *ent.Client
 	Config             Config
+	wg                 sync.WaitGroup // F-D34: tracks in-flight cleanup tasks
+	mu                 sync.Mutex     // protects cleanupFailures
+	cleanupFailures    []string       // F-D7: tracks external storage deletion failures
 }
 
 type Params struct {
@@ -94,11 +107,12 @@ func (w *Worker) getBatchSize() int {
 }
 
 // runCleanup executes the cleanup process based on storage policy.
-func (w *Worker) runCleanup(ctx context.Context, manual bool) {
+func (w *Worker) runCleanup(ctx context.Context, manual bool, stats *CleanupStats) {
 	log.Info(ctx, "Starting automatic cleanup process")
 
 	ctx = ent.NewContext(ctx, w.Ent)
-	ctx = schematype.SkipSoftDelete(ctx)
+	// F-D72: Do NOT use SkipSoftDelete. GC should respect soft-delete semantics:
+	// only hard-delete records that have been soft-deleted past their retention period.
 
 	policy, err := w.SystemService.StoragePolicy(ctx)
 	if err != nil {
@@ -179,6 +193,38 @@ func (w *Worker) runCleanup(ctx context.Context, manual bool) {
 	}
 
 	log.Info(ctx, "Automatic cleanup process completed")
+}
+
+// runCleanupWithSystemContext is already defined in gc_internal.go.
+
+// F-D7: retryWithBackoff retries an operation up to maxAttempts times
+// with exponential backoff. Returns nil on success, last error on failure.
+func retryWithBackoff(ctx context.Context, maxAttempts int, op func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if attempt < maxAttempts-1 {
+			backoff := time.Duration(1<<uint(attempt)) * time.Second // 1s, 2s, 4s
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+	}
+	return lastErr
+}
+
+// recordCleanupFailure tracks a failed external storage deletion.
+func (w *Worker) recordCleanupFailure(ctx context.Context, msg string) {
+	log.Error(ctx, "External storage cleanup failed after retries", log.String("detail", msg))
+	w.mu.Lock()
+	w.cleanupFailures = append(w.cleanupFailures, msg)
+	w.mu.Unlock()
 }
 
 // cleanupRequests deletes requests older than the specified number of days.
@@ -321,13 +367,13 @@ func (w *Worker) cleanupExecutionExternalStorage(ctx context.Context, exec *ent.
 		biz.GenerateExecutionRequestDirKey(exec.ProjectID, exec.RequestID, exec.ID),
 	}
 
+	// F-D7: Retry each key deletion with exponential backoff.
 	for _, key := range keys {
-		if err := w.DataStorageService.DeleteData(ctx, ds, key); err != nil {
-			log.Warn(ctx, "Failed to delete execution external data",
-				log.Cause(err),
-				log.Int("execution_id", exec.ID),
-				log.String("key", key),
-			)
+		err := retryWithBackoff(ctx, 3, func() error {
+			return w.DataStorageService.DeleteData(ctx, ds, key)
+		})
+		if err != nil {
+			w.recordCleanupFailure(ctx, fmt.Sprintf("execution_id=%d key=%s err=%v", exec.ID, key, err))
 		}
 	}
 }
@@ -359,13 +405,13 @@ func (w *Worker) cleanupRequestExternalStorage(ctx context.Context, req *ent.Req
 		biz.GenerateRequestDirKey(req.ProjectID, req.ID),
 	}
 
+	// F-D7: Retry each key deletion with exponential backoff.
 	for _, key := range keys {
-		if err := w.DataStorageService.DeleteData(ctx, ds, key); err != nil {
-			log.Warn(ctx, "Failed to delete request external data",
-				log.Cause(err),
-				log.Int("request_id", req.ID),
-				log.String("key", key),
-			)
+		err := retryWithBackoff(ctx, 3, func() error {
+			return w.DataStorageService.DeleteData(ctx, ds, key)
+		})
+		if err != nil {
+			w.recordCleanupFailure(ctx, fmt.Sprintf("request_id=%d key=%s err=%v", req.ID, key, err))
 		}
 	}
 }
@@ -545,7 +591,8 @@ func (w *Worker) RunVacuumNow(ctx context.Context) error {
 }
 
 // RunCleanupNow manually triggers the cleanup process.
-func (w *Worker) RunCleanupNow(ctx context.Context) error {
-	w.runCleanup(ctx, true)
-	return nil
+func (w *Worker) RunCleanupNow(ctx context.Context) (*CleanupStats, error) {
+	stats := &CleanupStats{}
+	w.runCleanup(ctx, true, stats)
+	return stats, nil
 }

--- a/internal/server/gc/gc_internal.go
+++ b/internal/server/gc/gc_internal.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (w *Worker) runCleanupWithSystemContext(ctx context.Context) {
+	w.wg.Add(1)
+	defer w.wg.Done()
+
 	ctx = authz.WithSystemBypass(ctx, "gc-cleanup")
-	w.runCleanup(ctx, false)
+	stats := &CleanupStats{}
+	w.runCleanup(ctx, false, stats)
 }


### PR DESCRIPTION
## Problem

Several storage reliability issues:
- GC operations fail without retry
- Backup failures leave partial files without cleanup
- S3 uploads are not atomic (partial uploads on failure)
- GC skips soft-delete, potentially hard-deleting active records

## Fix

- F-D7: Add retryWithBackoff for GC operations
- F-D25/26/27: Properly handle backup failure paths, support full data mode, fix prefix matching
- F-D33: Atomic S3 uploads
- F-D34: WaitGroup to track in-flight cleanup tasks
- F-D35/38: Propagate context to DB/GCS operations
- F-D58/61/62/91/92/93: Additional backup/GC reliability fixes
- F-D72: Respect soft-delete semantics in GC

## Scope

GC, backup, and S3 related files only.