### PR TITLE
fix(httpclient): add body size limit and ResponseHeaderTimeout

### DIFF
--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -16,6 +16,14 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
+const (
+	// maxBodySize is the maximum response body size we will fully read (100MB).
+	maxBodySize = 100 * 1024 * 1024
+
+	// maxDebugBodyLen caps the body length shown in debug logs (512 bytes).
+	maxDebugBodyLen = 512
+)
+
 // HttpClient implements the HttpClient interface.
 type HttpClient struct {
 	client      *http.Client
@@ -55,6 +63,7 @@ func NewHttpClientWithProxy(proxyConfig *ProxyConfig, opts ...ClientOption) *Htt
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
 	}
 
 	if options.insecureSkipVerify {
@@ -104,7 +113,7 @@ func getProxyFunc(config *ProxyConfig) func(*http.Request) (*url.URL, error) {
 	case ProxyTypeURL:
 		// Use configured URL with optional authentication
 		if config.URL == "" {
-			return func(*http.Request) (*url.URL, error) {
+			return func(_ *http.Request) (*url.URL, error) {
 				return nil, errors.New("proxy URL is required when type is 'url'")
 			}
 		}
@@ -137,28 +146,21 @@ func NewHttpClient(opts ...ClientOption) *HttpClient {
 		opt(&options)
 	}
 
-	client := &http.Client{}
+	transport := &http.Transport{
+		Proxy: getProxyFunc(nil),
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+	}
 
 	if options.insecureSkipVerify {
-		var transport *http.Transport
-		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
-			transport = defaultTransport.Clone()
-		} else {
-			// Fall back to a transport close to http.DefaultTransport when it has been replaced.
-			transport = (&http.Transport{
-				Proxy: getProxyFunc(nil),
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				ForceAttemptHTTP2:     true,
-				MaxIdleConns:          100,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			})
-		}
-
 		if transport.TLSClientConfig == nil {
 			transport.TLSClientConfig = &tls.Config{}
 		} else {
@@ -166,12 +168,13 @@ func NewHttpClient(opts ...ClientOption) *HttpClient {
 		}
 
 		transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // User-configured option for self-signed certificates
-		client.Transport = transport
 	}
 
 	return &HttpClient{
-		client: client,
-		opts:   opts,
+		client: &http.Client{
+			Transport: transport,
+		},
+		opts: opts,
 	}
 }
 
@@ -180,6 +183,14 @@ func NewHttpClientWithClient(client *http.Client) *HttpClient {
 	return &HttpClient{
 		client: client,
 	}
+}
+
+// truncateBody caps the body to maxDebugBodyLen bytes for safe debug logging.
+func truncateBody(body []byte) string {
+	if len(body) <= maxDebugBodyLen {
+		return string(body)
+	}
+	return string(body[:maxDebugBodyLen]) + "... [truncated]"
 }
 
 // Do executes the HTTP request.
@@ -205,9 +216,18 @@ func (hc *HttpClient) Do(ctx context.Context, request *Request) (*Response, erro
 		}
 	}()
 
-	body, err := io.ReadAll(rawResp.Body)
+	// Limit response body to maxBodySize to prevent OOM on oversized responses.
+	limitedReader := io.LimitReader(rawResp.Body, int64(maxBodySize))
+	body, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Peek one extra byte to detect silent truncation at the limit.
+	peekBuf := make([]byte, 1)
+	n, _ := rawResp.Body.Read(peekBuf)
+	if n > 0 {
+		return nil, fmt.Errorf("response body truncated: exceeded %d byte limit", maxBodySize)
 	}
 
 	if rawResp.StatusCode >= 400 {
@@ -216,7 +236,7 @@ func (hc *HttpClient) Do(ctx context.Context, request *Request) (*Response, erro
 				slog.String("method", rawReq.Method),
 				slog.String("url", rawReq.URL.String()),
 				slog.Int("status_code", rawResp.StatusCode),
-				slog.String("body", string(body)))
+				slog.String("body", truncateBody(body)))
 		}
 
 		return nil, &Error{
@@ -234,7 +254,7 @@ func (hc *HttpClient) Do(ctx context.Context, request *Request) (*Response, erro
 			slog.String("method", rawReq.Method),
 			slog.String("url", rawReq.URL.String()),
 			slog.Int("status_code", rawResp.StatusCode),
-			slog.String("body", string(body)))
+			slog.String("body", truncateBody(body)))
 	}
 
 	// Build generic response
@@ -280,8 +300,9 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 			}
 		}()
 
-		// Read error body for streaming requests
-		body, err := io.ReadAll(rawResp.Body)
+		// Read error body with size limit to prevent OOM.
+		limitedReader := io.LimitReader(rawResp.Body, int64(maxBodySize))
+		body, err := io.ReadAll(limitedReader)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +312,7 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 				slog.String("method", rawReq.Method),
 				slog.String("url", rawReq.URL.String()),
 				slog.Int("status_code", rawResp.StatusCode),
-				slog.String("body", string(body)))
+				slog.String("body", truncateBody(body)))
 		}
 
 		return nil, &Error{


### PR DESCRIPTION
## Problem

1. `Do()` and `DoStream()` use `io.ReadAll(resp.Body)` without size limit — oversized responses can cause OOM
2. HTTP transports lack `ResponseHeaderTimeout` — unresponsive servers cause indefinite hangs
3. `NewHttpClient` in non-proxy mode uses bare `http.Client{}` with no transport/timeout config

## Fix

- Add `io.LimitReader` (100MB) + truncation detection in `Do()` and `DoStream()` error path
- Add `ResponseHeaderTimeout: 60s` to all transport configs
- Ensure `NewHttpClient` always creates explicit transport with timeout settings
- Cap debug log body output at 512 bytes

## Test

Build and all existing tests pass.