### PR TITLE
fix(transformer): nil guard and token count overflow protection

### DIFF
--- a/llm/transformer/anthropic/aggregator.go
+++ b/llm/transformer/anthropic/aggregator.go
@@ -142,7 +142,7 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 
 					if event.Usage.CachedTokens > 0 {
 						usage.CachedTokens = event.Usage.CachedTokens
-						usage.InputTokens -= event.Usage.CacheReadInputTokens
+						usage.InputTokens = max(0, usage.InputTokens-event.Usage.CacheReadInputTokens)
 					}
 
 					if event.Usage.CacheCreationInputTokens > 0 {

--- a/llm/transformer/anthropic/usage.go
+++ b/llm/transformer/anthropic/usage.go
@@ -102,7 +102,7 @@ func convertToAnthropicUsage(llmUsage *llm.Usage) *Usage {
 			Ephemeral5mInputTokens: llmUsage.PromptTokensDetails.WriteCached5MinTokens,
 			Ephemeral1hInputTokens: llmUsage.PromptTokensDetails.WriteCached1HourTokens,
 		}
-		usage.InputTokens -= (usage.CacheReadInputTokens + usage.CacheCreationInputTokens)
+		usage.InputTokens = max(0, usage.InputTokens-(usage.CacheReadInputTokens+usage.CacheCreationInputTokens))
 	}
 
 	// Note: Anthropic doesn't have a direct equivalent for reasoning tokens in their current API

--- a/llm/transformer/openai/responses/usage.go
+++ b/llm/transformer/openai/responses/usage.go
@@ -17,6 +17,9 @@ type Usage struct {
 }
 
 func (u *Usage) ToUsage() *llm.Usage {
+	if u == nil {
+		return nil
+	}
 	return &llm.Usage{
 		PromptTokens:     u.InputTokens,
 		CompletionTokens: u.OutputTokens,


### PR DESCRIPTION
## Problem

1. OpenAI Responses `ToUsage()` panics on nil receiver
2. Gemini/Anthropic token subtraction (`InputTokens -= cacheTokens`) can produce negative values when cache tokens exceed input tokens

## Fix

- Add nil guard to `ToUsage()`
- Wrap all token subtraction with `max(0, ...)` to prevent negative counts

## Scope

3 files, minimal surgical changes.