### PR TITLE
fix(bailian): strip unsupported response_format field

### DIFF
--- a/llm/transformer/bailian/outbound.go
+++ b/llm/transformer/bailian/outbound.go
@@ -61,6 +61,9 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
 	llmReq = mergeConsecutiveToolCallMessages(llmReq)
 
+	// Bailian API does not support response_format; strip it before forwarding.
+	llmReq.ResponseFormat = nil
+
 	return t.Outbound.TransformRequest(ctx, llmReq)
 }
 


### PR DESCRIPTION
## Problem

Bailian API does not support the `response_format` parameter. Forwarding it causes API errors.

## Fix

Strip `ResponseFormat` from outgoing requests in the Bailian transformer before forwarding.

## Scope

Single file: `llm/transformer/bailian/outbound.go`