### PR TITLE
fix(responses): add spawn_agent tool call arguments sanitizer

### DIFF
--- a/llm/transformer/openai/responses/spawn_agent_sanitizer.go
+++ b/llm/transformer/openai/responses/spawn_agent_sanitizer.go
@@ -1,0 +1,58 @@
+package responses
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// maybeSanitizeSpawnAgentArgs checks if spawn_agent argument sanitization is enabled
+// via the AXONHUB_SANITIZE_SPAWN_AGENT_ARGS environment variable, and if so,
+// sanitizes the tool call arguments.
+func maybeSanitizeSpawnAgentArgs(args string) string {
+	if os.Getenv("AXONHUB_SANITIZE_SPAWN_AGENT_ARGS") != "1" {
+		return args
+	}
+	return sanitizeSpawnAgentArguments(args)
+}
+
+// sanitizeSpawnAgentArguments cleans spawn_agent tool call arguments:
+// If the arguments contain a non-empty "message" field alongside an empty "items" array,
+// the "items" field is removed to prevent downstream parsing issues.
+func sanitizeSpawnAgentArguments(args string) string {
+	if args == "" {
+		return args
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil {
+		return args
+	}
+
+	// Check if "message" is present and non-empty
+	msgRaw, hasMsg := parsed["message"]
+	if !hasMsg {
+		return args
+	}
+	var msgStr string
+	if err := json.Unmarshal(msgRaw, &msgStr); err != nil || msgStr == "" {
+		return args
+	}
+
+	// Check if "items" is present and empty array
+	itemsRaw, hasItems := parsed["items"]
+	if !hasItems {
+		return args
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(itemsRaw, &items); err != nil || len(items) > 0 {
+		return args
+	}
+
+	// Remove empty items and re-serialize
+	delete(parsed, "items")
+	result, err := json.Marshal(parsed)
+	if err != nil {
+		return args
+	}
+	return string(result)
+}

--- a/llm/transformer/openai/responses/spawn_agent_sanitizer_test.go
+++ b/llm/transformer/openai/responses/spawn_agent_sanitizer_test.go
@@ -1,0 +1,28 @@
+package responses
+
+import "testing"
+
+func TestSanitizeSpawnAgentArguments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"invalid json", "not json", "not json"},
+		{"no message field", `{"items":[]}`, `{"items":[]}`},
+		{"empty message", `{"message":"","items":[]}`, `{"message":"","items":[]}`},
+		{"non-empty items", `{"message":"hello","items":["a"]}`, `{"message":"hello","items":["a"]}`},
+		{"message with empty items", `{"message":"hello","items":[]}`, `{"message":"hello"}`},
+		{"preserves other fields", `{"message":"hi","items":[],"other":42}`, `{"message":"hi","other":42}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSpawnAgentArguments(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeSpawnAgentArguments(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

LLMs sometimes produce spawn_agent tool call arguments with a non-empty message alongside an empty items array, causing downstream parsing issues.

## Fix

Add sanitizer that strips empty items array when message is present. Gated behind `AXONHUB_SANITIZE_SPAWN_AGENT_ARGS=1` env var for safe rollout.

## Scope

New files only (no existing code modified):
- `spawn_agent_sanitizer.go`
- `spawn_agent_sanitizer_test.go`