### PR TITLE
fix(storage): add GC retry and atomic file writes

### DIFF
--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -502,6 +503,37 @@ func (s *DataStorageService) GetFileSystem(ctx context.Context, ds *ent.DataStor
 	return fs, nil
 }
 
+// atomicWriteFile writes data to a temporary file first, then renames it to the
+// target path. This prevents partial file artifacts on write failure.
+// On failure, the temporary file is cleaned up.
+func atomicWriteFile(fs afero.Fs, key string, data []byte, perm os.FileMode) error {
+	base := filepath.Base(key)
+	tmpDir := filepath.Join(filepath.Dir(key), ".tmp")
+	tmpName := fmt.Sprintf("%d-%s", rand.Int63(), base)
+	tmpPath := filepath.Join(tmpDir, tmpName)
+
+	// Ensure .tmp directory exists
+	if err := fs.MkdirAll(tmpDir, 0o777); err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	// Write to temporary file
+	if err := afero.WriteFile(fs, tmpPath, data, perm); err != nil {
+		// Clean up temp file on failure
+		_ = fs.Remove(tmpPath)
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	// Atomic rename to target path
+	if err := fs.Rename(tmpPath, key); err != nil {
+		// Clean up temp file on rename failure
+		_ = fs.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp file to target: %w", err)
+	}
+
+	return nil
+}
+
 // SaveData saves data to the specified data storage.
 func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, key string, data []byte) error {
 	switch ds.Type {
@@ -545,9 +577,9 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			_ = f.Close()
 		}
 
-		// Write data to file
-		if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
-			return fmt.Errorf("failed to write file: %w, key: %s", err, key)
+		// Write data to file atomically (temp + rename)
+		if err := atomicWriteFile(fs, key, data, 0o777); err != nil {
+			return err
 		}
 
 		return nil

--- a/internal/server/gc/gc.go
+++ b/internal/server/gc/gc.go
@@ -3,6 +3,7 @@ package gc
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"entgo.io/ent/dialect"
@@ -67,12 +68,41 @@ func (w *Worker) RegisterScheduledTasks(ctx context.Context, s *scheduler.Schedu
 	}, w.runCleanupWithSystemContext)
 }
 
+
+// retryWithBackoff retries an operation with exponential backoff and jitter.
+func retryWithBackoff(ctx context.Context, maxAttempts int, op func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if attempt < maxAttempts-1 {
+			base := time.Duration(1<<uint(attempt)) * time.Second
+			jitter := time.Duration(rand.Int63n(int64(base) / 2))
+			backoff := base + jitter
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+	}
+	return lastErr
+}
+
 // deleteInBatches deletes records in batches to avoid memory issues.
 func (w *Worker) deleteInBatches(ctx context.Context, deleteFunc func() (int, error)) (int, error) {
 	totalDeleted := 0
 
 	for {
-		deleted, err := deleteFunc()
+		var deleted int
+		err := retryWithBackoff(ctx, 3, func() error {
+			d, err := deleteFunc()
+			deleted = d
+			return err
+		})
 		if err != nil {
 			return totalDeleted, fmt.Errorf("failed to delete batch: %w", err)
 		}


### PR DESCRIPTION
## Problem

1. GC deleteInBatches fails without retry — transient S3/DB errors cause premature exit
2. Data storage saves write directly to target path — failures leave partial/corrupt files

## Fix

- Add `retryWithBackoff()` (3 attempts, exponential backoff with jitter) to GC batch deletion
- Implement atomic writes: write to temp file then rename to target
- Clean up temp files on failure

## Scope

`internal/server/gc/gc.go` + `internal/server/biz/data_storage.go`