### PR TITLE
fix(security): mask API keys in log output

### DIFF
--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 
@@ -70,6 +71,25 @@ type AuthConfig struct {
 	HeaderKey string `json:"header_key,omitempty"`
 }
 
+// MarshalLog returns a masked representation for safe logging.
+func (a AuthConfig) MarshalLog() string {
+	if a.APIKey == "" {
+		return ""
+	}
+	return maskAPIKey(a.APIKey)
+}
+
+// LogValue implements slog.LogValuer so that slog outputs mask API keys.
+func (a AuthConfig) LogValue() slog.Value {
+	return slog.AnyValue(maskedAuthConfig{
+		Type:      a.Type,
+		APIKey:    a.MarshalLog(),
+		HeaderKey: a.HeaderKey,
+	})
+}
+
+type maskedAuthConfig struct{ Type, APIKey, HeaderKey string }
+
 const (
 	AuthTypeBearer = "bearer"
 	AuthTypeAPIKey = "api_key"
@@ -123,4 +143,13 @@ func EncodeStreamEventToJSON(event *StreamEvent) ([]byte, error) {
 		Type:        event.Type,
 		Data:        string(event.Data),
 	})
+}
+
+// maskAPIKey returns a masked version of the API key for display.
+// Shows first 4 and last 4 characters with **** in between.
+func maskAPIKey(key string) string {
+	if len(key) <= 8 {
+		return "****"
+	}
+	return key[:4] + "****" + key[len(key)-4:]
 }


### PR DESCRIPTION
## Problem

API keys are logged in plaintext via slog (e.g. `slog.Any("request", request)` in `llm/httpclient/client.go:187`), exposing credentials in application logs.

## Fix

Add `MarshalLog` and `LogValue` (implementing `slog.LogValuer`) to `AuthConfig` so that:

- `MarshalLog()` returns the masked key string (`sk-xxxx****xxxx`) for explicit calls
- `LogValue()` ensures automatic masking when `AuthConfig` is serialized by slog

The masked output preserves struct fields (Type, APIKey, HeaderKey) while masking only the sensitive APIKey value.

Also adds a local `maskAPIKey` helper function consistent with the existing pattern in `internal/server/orchestrator/tester.go`.

## Scope

Single file: `llm/httpclient/model.go`