### PR TITLE
修改前端，"测试场"新增测试模型网关模型

### DIFF
--- a/frontend/src/features/models/data/models.ts
+++ b/frontend/src/features/models/data/models.ts
@@ -471,13 +471,14 @@ interface QueryModelsArgs {
   before?: string;
   where?: Record<string, any>;
   orderBy?: {
-    field: 'CREATED_AT' | 'UPDATED_AT' | 'NAME' | 'MODEL_ID';
+    field: 'CREATED_AT' | 'UPDATED_AT' | 'NAME';
     direction: 'ASC' | 'DESC';
   };
 }
 
-export function useQueryModels(args: QueryModelsArgs) {
+export function useQueryModels(args: QueryModelsArgs, options?: { enabled?: boolean }) {
   return useQuery({
+    enabled: options?.enabled ?? true,
     queryKey: ['models', args],
     queryFn: async () => {
       const data = await graphqlRequest<{ models: ModelConnection }>(MODELS_QUERY, args);

--- a/frontend/src/features/playground/index.tsx
+++ b/frontend/src/features/playground/index.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Actions, Action } from '@/components/ai-elements/actions';
@@ -24,10 +25,11 @@ import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { useQueryChannels } from '@/features/channels/data/channels';
 import { useQueryModels } from '@/features/models/data/models';
 
-const MODEL_PAGE_CHANNEL_VALUE = '__axonhub_model_page_models__';
+type PlaygroundModelSource = 'channel' | 'model_gateway';
 
 export default function Playground() {
   const { t } = useTranslation();
+  const [modelSource, setModelSource] = useState<PlaygroundModelSource>('channel');
   const [selectedChannel, setSelectedChannel] = useState<string>('');
   const [model, setModel] = useState('');
   const [temperature, setTemperature] = useState(0.6);
@@ -40,6 +42,7 @@ export default function Playground() {
   const maxTokensRef = useRef(maxTokens);
   const systemPromptRef = useRef(systemPrompt);
   const selectedChannelRef = useRef(selectedChannel);
+  const modelSourceRef = useRef(modelSource);
 
   // Keep refs synchronized with state
   useEffect(() => {
@@ -62,6 +65,10 @@ export default function Playground() {
     selectedChannelRef.current = selectedChannel;
   }, [selectedChannel]);
 
+  useEffect(() => {
+    modelSourceRef.current = modelSource;
+  }, [modelSource]);
+
   const { accessToken } = useAuthStore((state) => state.auth);
   const selectedProjectId = useSelectedProjectId();
 
@@ -73,7 +80,7 @@ export default function Playground() {
       statusIn: ['enabled', 'disabled'],
     },
   });
-  const isModelPageChannel = selectedChannel === MODEL_PAGE_CHANNEL_VALUE;
+  const isModelGatewaySource = modelSource === 'model_gateway';
   const { data: modelsData, isLoading: modelsLoading } = useQueryModels(
     {
       first: 10000,
@@ -83,7 +90,7 @@ export default function Playground() {
         typeIn: ['chat'],
       },
     },
-    { enabled: isModelPageChannel }
+    { enabled: isModelGatewaySource }
   );
 
   const [input, setInput] = useState('');
@@ -97,7 +104,7 @@ export default function Playground() {
           Authorization: 'Bearer ' + accessToken,
           'X-Project-ID': selectedProjectId || '',
         };
-        if (selectedChannelRef.current && selectedChannelRef.current !== MODEL_PAGE_CHANNEL_VALUE) {
+        if (modelSourceRef.current === 'channel' && selectedChannelRef.current) {
           headers['X-Channel-ID'] = selectedChannelRef.current;
         }
         return headers;
@@ -221,16 +228,8 @@ export default function Playground() {
     }
   }, [messages, regenerate, setMessages]);
 
-  const modelPageChannelOption = useMemo(
-    () => ({
-      value: MODEL_PAGE_CHANNEL_VALUE,
-      label: t('playground.settings.modelPageModelsChannel'),
-    }),
-    [t]
-  );
-
   // 渠道选项列表
-  const realChannelOptions = useMemo(() => {
+  const channelOptions = useMemo(() => {
     if (!channelsData?.edges) return [];
     return channelsData.edges
       .filter((edge) => edge.node.supportedModels.length > 0)
@@ -239,10 +238,6 @@ export default function Playground() {
         label: edge.node.name,
       }));
   }, [channelsData]);
-
-  const channelOptions = useMemo(() => {
-    return [modelPageChannelOption, ...realChannelOptions];
-  }, [modelPageChannelOption, realChannelOptions]);
 
   const modelPageModelOptions = useMemo(() => {
     if (!modelsData?.edges) return [];
@@ -257,7 +252,7 @@ export default function Playground() {
 
   // 根据选中渠道过滤出模型列表
   const modelOptions = useMemo(() => {
-    if (isModelPageChannel) return modelPageModelOptions;
+    if (isModelGatewaySource) return modelPageModelOptions;
     if (!channelsData?.edges || !selectedChannel) return [];
     const channelEdge = channelsData.edges.find((edge) => edge.node.id === selectedChannel);
     if (!channelEdge) return [];
@@ -265,37 +260,47 @@ export default function Playground() {
       value: m,
       label: m,
     }));
-  }, [channelsData, isModelPageChannel, modelPageModelOptions, selectedChannel]);
+  }, [channelsData, isModelGatewaySource, modelPageModelOptions, selectedChannel]);
 
-  const selectedModelSourceLoading = isModelPageChannel ? modelsLoading : channelsLoading;
+  const selectedModelSourceLoading = isModelGatewaySource ? modelsLoading : channelsLoading;
 
   // 处理渠道选择，自动选第一个模型
   const handleChannelChange = useCallback(
     (channelId: string) => {
       setSelectedChannel(channelId);
-      if (channelId === MODEL_PAGE_CHANNEL_VALUE) {
-        setModel(modelPageModelOptions[0]?.value ?? '');
-        return;
-      }
       const channelEdge = channelsData?.edges?.find((edge) => edge.node.id === channelId);
       const firstModel = channelEdge?.node.supportedModels[0] ?? '';
       setModel(firstModel);
     },
-    [channelsData, modelPageModelOptions]
+    [channelsData]
+  );
+
+  const handleModelSourceChange = useCallback(
+    (source: string) => {
+      const nextSource = source as PlaygroundModelSource;
+      setModelSource(nextSource);
+      if (nextSource === 'model_gateway') {
+        setModel(modelPageModelOptions[0]?.value ?? '');
+        return;
+      }
+      const channelEdge = channelsData?.edges?.find((edge) => edge.node.id === selectedChannel);
+      setModel(channelEdge?.node.supportedModels[0] ?? '');
+    },
+    [channelsData, modelPageModelOptions, selectedChannel]
   );
 
   // 初始化：默认选第一个渠道和第一个模型
   useEffect(() => {
     if (!selectedChannel && !channelsLoading && channelOptions.length > 0) {
-      handleChannelChange(realChannelOptions[0]?.value ?? MODEL_PAGE_CHANNEL_VALUE);
+      handleChannelChange(channelOptions[0].value);
     }
-  }, [channelOptions, channelsLoading, handleChannelChange, realChannelOptions, selectedChannel]);
+  }, [channelOptions, channelsLoading, handleChannelChange, selectedChannel]);
 
   useEffect(() => {
-    if (isModelPageChannel && !model && modelPageModelOptions.length > 0) {
+    if (isModelGatewaySource && !model && modelPageModelOptions.length > 0) {
       setModel(modelPageModelOptions[0].value);
     }
-  }, [isModelPageChannel, model, modelPageModelOptions]);
+  }, [isModelGatewaySource, model, modelPageModelOptions]);
 
   return (
     <TooltipProvider>
@@ -326,18 +331,30 @@ export default function Playground() {
           <ScrollArea className='min-h-0 flex-1 p-4'>
             <div className='space-y-6'>
               <div className='space-y-3'>
-                <Label htmlFor='channel' className='text-xs font-semibold'>
-                  {t('playground.settings.channel')}
-                </Label>
-                <AutoCompleteSelect
-                  selectedValue={selectedChannel}
-                  onSelectedValueChange={(v) => handleChannelChange(v)}
-                  items={channelOptions}
-                  isLoading={channelsLoading}
-                  emptyMessage={t('playground.errors.noChannelsAvailable')}
-                  placeholder={channelsLoading ? t('loading') : t('playground.settings.selectChannel')}
-                />
+                <Label className='text-xs font-semibold'>{t('playground.settings.modelSource')}</Label>
+                <Tabs value={modelSource} onValueChange={handleModelSourceChange}>
+                  <TabsList className='grid w-full grid-cols-2'>
+                    <TabsTrigger value='channel'>{t('playground.settings.channel')}</TabsTrigger>
+                    <TabsTrigger value='model_gateway'>{t('playground.settings.modelGateway')}</TabsTrigger>
+                  </TabsList>
+                </Tabs>
               </div>
+
+              {modelSource === 'channel' && (
+                <div className='space-y-3'>
+                  <Label htmlFor='channel' className='text-xs font-semibold'>
+                    {t('playground.settings.channel')}
+                  </Label>
+                  <AutoCompleteSelect
+                    selectedValue={selectedChannel}
+                    onSelectedValueChange={(v) => handleChannelChange(v)}
+                    items={channelOptions}
+                    isLoading={channelsLoading}
+                    emptyMessage={t('playground.errors.noChannelsAvailable')}
+                    placeholder={channelsLoading ? t('loading') : t('playground.settings.selectChannel')}
+                  />
+                </div>
+              )}
 
               <div className='space-y-3'>
                 <Label htmlFor='model' className='text-xs font-semibold'>
@@ -354,13 +371,13 @@ export default function Playground() {
                 {selectedModelSourceLoading && <p className='text-muted-foreground text-[10px]'>{t('loading')}...</p>}
                 {!selectedModelSourceLoading && modelOptions.length > 0 && (
                   <p className='text-muted-foreground text-[10px]'>
-                    {isModelPageChannel
+                    {isModelGatewaySource
                       ? t('playground.modelPageModelsAvailable', {
                           count: modelOptions.length,
                         })
                       : t('playground.modelsAvailable', {
                           count: modelOptions.length,
-                          channels: realChannelOptions.length,
+                          channels: channelOptions.length,
                         })}
                   </p>
                 )}

--- a/frontend/src/features/playground/index.tsx
+++ b/frontend/src/features/playground/index.tsx
@@ -22,6 +22,9 @@ import { Reasoning, ReasoningTrigger, ReasoningContent } from '@/components/ai-e
 import { Response as UIResponse } from '@/components/ai-elements/response';
 import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { useQueryChannels } from '@/features/channels/data/channels';
+import { useQueryModels } from '@/features/models/data/models';
+
+const MODEL_PAGE_CHANNEL_VALUE = '__axonhub_model_page_models__';
 
 export default function Playground() {
   const { t } = useTranslation();
@@ -70,6 +73,18 @@ export default function Playground() {
       statusIn: ['enabled', 'disabled'],
     },
   });
+  const isModelPageChannel = selectedChannel === MODEL_PAGE_CHANNEL_VALUE;
+  const { data: modelsData, isLoading: modelsLoading } = useQueryModels(
+    {
+      first: 10000,
+      orderBy: { field: 'NAME', direction: 'ASC' },
+      where: {
+        statusIn: ['enabled'],
+        typeIn: ['chat'],
+      },
+    },
+    { enabled: isModelPageChannel }
+  );
 
   const [input, setInput] = useState('');
 
@@ -78,11 +93,14 @@ export default function Playground() {
       api: '/admin/playground/chat',
       credentials: 'include',
       headers: () => {
-        return {
+        const headers: Record<string, string> = {
           Authorization: 'Bearer ' + accessToken,
-          'X-Channel-ID': selectedChannelRef.current || '',
           'X-Project-ID': selectedProjectId || '',
         };
+        if (selectedChannelRef.current && selectedChannelRef.current !== MODEL_PAGE_CHANNEL_VALUE) {
+          headers['X-Channel-ID'] = selectedChannelRef.current;
+        }
+        return headers;
       },
       body: () => {
         return {
@@ -203,8 +221,16 @@ export default function Playground() {
     }
   }, [messages, regenerate, setMessages]);
 
+  const modelPageChannelOption = useMemo(
+    () => ({
+      value: MODEL_PAGE_CHANNEL_VALUE,
+      label: t('playground.settings.modelPageModelsChannel'),
+    }),
+    [t]
+  );
+
   // 渠道选项列表
-  const channelOptions = useMemo(() => {
+  const realChannelOptions = useMemo(() => {
     if (!channelsData?.edges) return [];
     return channelsData.edges
       .filter((edge) => edge.node.supportedModels.length > 0)
@@ -214,8 +240,24 @@ export default function Playground() {
       }));
   }, [channelsData]);
 
+  const channelOptions = useMemo(() => {
+    return [modelPageChannelOption, ...realChannelOptions];
+  }, [modelPageChannelOption, realChannelOptions]);
+
+  const modelPageModelOptions = useMemo(() => {
+    if (!modelsData?.edges) return [];
+    return modelsData.edges.map((edge) => {
+      const modelID = edge.node.modelID;
+      return {
+        value: modelID,
+        label: edge.node.name || modelID,
+      };
+    });
+  }, [modelsData]);
+
   // 根据选中渠道过滤出模型列表
   const modelOptions = useMemo(() => {
+    if (isModelPageChannel) return modelPageModelOptions;
     if (!channelsData?.edges || !selectedChannel) return [];
     const channelEdge = channelsData.edges.find((edge) => edge.node.id === selectedChannel);
     if (!channelEdge) return [];
@@ -223,25 +265,37 @@ export default function Playground() {
       value: m,
       label: m,
     }));
-  }, [channelsData, selectedChannel]);
+  }, [channelsData, isModelPageChannel, modelPageModelOptions, selectedChannel]);
+
+  const selectedModelSourceLoading = isModelPageChannel ? modelsLoading : channelsLoading;
 
   // 处理渠道选择，自动选第一个模型
   const handleChannelChange = useCallback(
     (channelId: string) => {
       setSelectedChannel(channelId);
+      if (channelId === MODEL_PAGE_CHANNEL_VALUE) {
+        setModel(modelPageModelOptions[0]?.value ?? '');
+        return;
+      }
       const channelEdge = channelsData?.edges?.find((edge) => edge.node.id === channelId);
       const firstModel = channelEdge?.node.supportedModels[0] ?? '';
       setModel(firstModel);
     },
-    [channelsData]
+    [channelsData, modelPageModelOptions]
   );
 
   // 初始化：默认选第一个渠道和第一个模型
   useEffect(() => {
-    if (!selectedChannel && channelOptions.length > 0) {
-      handleChannelChange(channelOptions[0].value);
+    if (!selectedChannel && !channelsLoading && channelOptions.length > 0) {
+      handleChannelChange(realChannelOptions[0]?.value ?? MODEL_PAGE_CHANNEL_VALUE);
     }
-  }, [channelOptions, handleChannelChange, selectedChannel]);
+  }, [channelOptions, channelsLoading, handleChannelChange, realChannelOptions, selectedChannel]);
+
+  useEffect(() => {
+    if (isModelPageChannel && !model && modelPageModelOptions.length > 0) {
+      setModel(modelPageModelOptions[0].value);
+    }
+  }, [isModelPageChannel, model, modelPageModelOptions]);
 
   return (
     <TooltipProvider>
@@ -293,17 +347,21 @@ export default function Playground() {
                   selectedValue={model}
                   onSelectedValueChange={(v) => setModel(v)}
                   items={modelOptions}
-                  isLoading={channelsLoading}
-                  emptyMessage={t('playground.errors.noChannelsAvailable')}
-                  placeholder={channelsLoading ? t('loading') : t('playground.settings.selectModel')}
+                  isLoading={selectedModelSourceLoading}
+                  emptyMessage={t('playground.errors.noModelsAvailable')}
+                  placeholder={selectedModelSourceLoading ? t('loading') : t('playground.settings.selectModel')}
                 />
-                {channelsLoading && <p className='text-muted-foreground text-[10px]'>{t('loading')}...</p>}
-                {!channelsLoading && modelOptions.length > 0 && (
+                {selectedModelSourceLoading && <p className='text-muted-foreground text-[10px]'>{t('loading')}...</p>}
+                {!selectedModelSourceLoading && modelOptions.length > 0 && (
                   <p className='text-muted-foreground text-[10px]'>
-                    {t('playground.modelsAvailable', {
-                      count: modelOptions.length,
-                      channels: channelOptions.length,
-                    })}
+                    {isModelPageChannel
+                      ? t('playground.modelPageModelsAvailable', {
+                          count: modelOptions.length,
+                        })
+                      : t('playground.modelsAvailable', {
+                          count: modelOptions.length,
+                          channels: realChannelOptions.length,
+                        })}
                   </p>
                 )}
               </div>

--- a/frontend/src/locales/en/playground.json
+++ b/frontend/src/locales/en/playground.json
@@ -1,9 +1,10 @@
 {
   "playground.title": "Playground",
   "playground.description": "Interactive environment for testing AI models.",
+  "playground.settings.modelSource": "Test mode",
   "playground.settings.channel": "Channel",
   "playground.settings.selectChannel": "Select a channel",
-  "playground.settings.modelPageModelsChannel": "Model gateway",
+  "playground.settings.modelGateway": "Model gateway",
   "playground.settings.model": "Model",
   "playground.settings.selectModel": "Select a model",
   "playground.settings.temperature": "Temperature",
@@ -20,5 +21,5 @@
   "playground.errors.noChannelsAvailable": "No channels available",
   "playground.errors.noModelsAvailable": "No models available",
   "playground.modelsAvailable": "{{count}} models available across {{channels}} channels",
-  "playground.modelPageModelsAvailable": "{{count}} model page models available"
+  "playground.modelPageModelsAvailable": "{{count}} model gateway models available"
 }

--- a/frontend/src/locales/en/playground.json
+++ b/frontend/src/locales/en/playground.json
@@ -3,6 +3,7 @@
   "playground.description": "Interactive environment for testing AI models.",
   "playground.settings.channel": "Channel",
   "playground.settings.selectChannel": "Select a channel",
+  "playground.settings.modelPageModelsChannel": "Model gateway",
   "playground.settings.model": "Model",
   "playground.settings.selectModel": "Select a model",
   "playground.settings.temperature": "Temperature",
@@ -16,6 +17,8 @@
   "playground.chat.typeMessageBelow": "Type your message below to begin",
   "playground.chat.typeMessage": "Type a message...",
   "playground.chat.noMessages": "No messages to retry",
-  "playground.errors.noChannelsAvailable": "No models available",
-  "playground.modelsAvailable": "{{count}} models available across {{channels}} channels"
+  "playground.errors.noChannelsAvailable": "No channels available",
+  "playground.errors.noModelsAvailable": "No models available",
+  "playground.modelsAvailable": "{{count}} models available across {{channels}} channels",
+  "playground.modelPageModelsAvailable": "{{count}} model page models available"
 }

--- a/frontend/src/locales/zh-CN/playground.json
+++ b/frontend/src/locales/zh-CN/playground.json
@@ -3,6 +3,7 @@
   "playground.description": "用于测试 AI 模型的交互式环境。",
   "playground.settings.channel": "渠道",
   "playground.settings.selectChannel": "选择渠道",
+  "playground.settings.modelPageModelsChannel": "模型网关",
   "playground.settings.model": "模型",
   "playground.settings.selectModel": "选择模型",
   "playground.settings.temperature": "温度",
@@ -16,6 +17,8 @@
   "playground.chat.typeMessageBelow": "在下方输入消息开始交流",
   "playground.chat.typeMessage": "输入消息...",
   "playground.chat.noMessages": "没有消息可重试",
-  "playground.errors.noChannelsAvailable": "没有可用的模型",
-  "playground.modelsAvailable": "{{count}} 个模型可用，跨 {{channels}} 个渠道"
+  "playground.errors.noChannelsAvailable": "没有可用渠道",
+  "playground.errors.noModelsAvailable": "没有可用模型",
+  "playground.modelsAvailable": "{{count}} 个模型可用，跨 {{channels}} 个渠道",
+  "playground.modelPageModelsAvailable": "{{count}} 个模型页模型可用"
 }

--- a/frontend/src/locales/zh-CN/playground.json
+++ b/frontend/src/locales/zh-CN/playground.json
@@ -1,9 +1,10 @@
 {
   "playground.title": "测试场",
   "playground.description": "用于测试 AI 模型的交互式环境。",
+  "playground.settings.modelSource": "测试模式",
   "playground.settings.channel": "渠道",
   "playground.settings.selectChannel": "选择渠道",
-  "playground.settings.modelPageModelsChannel": "模型网关",
+  "playground.settings.modelGateway": "模型网关",
   "playground.settings.model": "模型",
   "playground.settings.selectModel": "选择模型",
   "playground.settings.temperature": "温度",
@@ -20,5 +21,5 @@
   "playground.errors.noChannelsAvailable": "没有可用渠道",
   "playground.errors.noModelsAvailable": "没有可用模型",
   "playground.modelsAvailable": "{{count}} 个模型可用，跨 {{channels}} 个渠道",
-  "playground.modelPageModelsAvailable": "{{count}} 个模型页模型可用"
+  "playground.modelPageModelsAvailable": "{{count}} 个模型网关模型可用"
 }


### PR DESCRIPTION
在测试场的渠道下拉中新增“模型网关”选项，用于通过默认路由流程测试模型页配置的模型。
选择“模型网关”时，模型下拉会加载模型页中已启用的聊天模型并显示模型名；发送请求时不再携带 X-Channel-ID，让后端根据模型关联规则自动解析可用渠道。原有按渠道测试的流程保持不变。
<img width="835" height="107" alt="image" src="https://github.com/user-attachments/assets/36846b76-86b0-4ac4-b795-4dc00dc7b1d4" />
