### PR TITLE
feat: support Codex image API adapter

### DIFF
--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -90,12 +90,16 @@ var openAIChatOnlyDefaultEndpoints = []objects.ChannelEndpoint{
 var defaultEndpointsForChannelType = map[channel.Type][]objects.ChannelEndpoint{
 	channel.TypeOpenai:          openAICompatibleDefaultEndpoints,
 	channel.TypeOpenaiResponses: {{APIFormat: llm.APIFormatOpenAIResponse.String()}},
-	channel.TypeCodex:           {{APIFormat: llm.APIFormatOpenAIResponse.String()}},
-	channel.TypeVercel:          openAICompatibleDefaultEndpoints,
-	channel.TypeAnthropic:       {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
-	channel.TypeAnthropicAWS:    {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
-	channel.TypeAnthropicGcp:    {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
-	channel.TypeGeminiOpenai:    {{APIFormat: llm.APIFormatOpenAIChatCompletion.String()}},
+	channel.TypeCodex: {
+		{APIFormat: llm.APIFormatOpenAIResponse.String()},
+		{APIFormat: llm.APIFormatOpenAIImageGeneration.String()},
+		{APIFormat: llm.APIFormatOpenAIImageEdit.String()},
+	},
+	channel.TypeVercel:       openAICompatibleDefaultEndpoints,
+	channel.TypeAnthropic:    {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
+	channel.TypeAnthropicAWS: {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
+	channel.TypeAnthropicGcp: {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
+	channel.TypeGeminiOpenai: {{APIFormat: llm.APIFormatOpenAIChatCompletion.String()}},
 	channel.TypeGemini: {
 		{APIFormat: llm.APIFormatGeminiContents.String()},
 		{APIFormat: llm.APIFormatGeminiEmbedding.String()},

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -64,6 +64,15 @@ func TestDefaultEndpointsForChannelType_UseLLMAPIFormatValues(t *testing.T) {
 			expected: []string{llm.APIFormatOpenAIChatCompletion.String()},
 		},
 		{
+			name: "codex exposes responses and image tool endpoints",
+			typ:  channel.TypeCodex,
+			expected: []string{
+				llm.APIFormatOpenAIResponse.String(),
+				llm.APIFormatOpenAIImageGeneration.String(),
+				llm.APIFormatOpenAIImageEdit.String(),
+			},
+		},
+		{
 			name:     "nanogpt responses defaults to responses",
 			typ:      channel.TypeNanogptResponses,
 			expected: []string{llm.APIFormatOpenAIResponse.String()},

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -52,6 +52,8 @@ type AutoRefresher interface {
 // collide after lowercasing — higher number wins.
 var sourcePriority = map[string]int{"direct": 4, "auto_trim": 3, "mapping": 2, "prefix": 1}
 
+const codexBuiltinImageModelID = "gpt-image-2"
+
 func setupAutoRefresh(ch *Channel, refresher AutoRefresher, opts oauth.AutoRefreshOptions) {
 	ch.startTokenProvider = func() {
 		refresher.StartAutoRefresh(context.Background(), opts)
@@ -1039,6 +1041,16 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 				RequestModel: model,
 				ActualModel:  model,
 				Source:       "direct",
+			}
+		}
+	}
+
+	if ch.Type == channel.TypeCodex {
+		if _, exists := entries[codexBuiltinImageModelID]; !exists {
+			entries[codexBuiltinImageModelID] = ChannelModelEntry{
+				RequestModel: codexBuiltinImageModelID,
+				ActualModel:  codexBuiltinImageModelID,
+				Source:       "builtin",
 			}
 		}
 	}

--- a/internal/server/biz/channel_model_entry_test.go
+++ b/internal/server/biz/channel_model_entry_test.go
@@ -6,8 +6,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/objects"
 )
+
+func TestChannelGetModelEntries_CodexAddsBuiltinImageModel(t *testing.T) {
+	ch := &Channel{
+		Channel: &ent.Channel{
+			Type:            channel.TypeCodex,
+			SupportedModels: []string{"gpt-5.5"},
+		},
+	}
+
+	entries := ch.GetModelEntries()
+	require.Equal(t, ChannelModelEntry{
+		RequestModel: "gpt-image-2",
+		ActualModel:  "gpt-image-2",
+		Source:       "builtin",
+	}, entries["gpt-image-2"])
+}
 
 func TestChannel_GetUnifiedModels(t *testing.T) {
 	tests := []struct {

--- a/llm/transformer/openai/codex/image.go
+++ b/llm/transformer/openai/codex/image.go
@@ -33,6 +33,9 @@ func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq 
 	if llmReq.Image == nil {
 		return nil, errors.New("image request is required")
 	}
+	if llmReq.Image.N != nil && *llmReq.Image.N > 1 {
+		return nil, fmt.Errorf("codex image generation supports n=1 only, got %d", *llmReq.Image.N)
+	}
 
 	toolModel := strings.TrimSpace(llmReq.Model)
 	if toolModel == "" {
@@ -87,6 +90,7 @@ func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq 
 	}
 
 	imageReq := *llmReq
+	imageReq.TransformerMetadata = cloneTransformerMetadata(llmReq.TransformerMetadata)
 	imageReq.Model = codexImageMainModel()
 	imageReq.RequestType = llm.RequestTypeChat
 	imageReq.APIFormat = llm.APIFormatOpenAIResponse
@@ -110,10 +114,6 @@ func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq 
 	imageReq.ParallelToolCalls = lo.ToPtr(true)
 	imageReq.TransformOptions.ArrayInputs = lo.ToPtr(true)
 
-	if imageReq.TransformerMetadata == nil {
-		imageReq.TransformerMetadata = map[string]any{}
-	}
-
 	if imageTool.OutputFormat != "" {
 		imageReq.TransformerMetadata["image_output_format"] = imageTool.OutputFormat
 	}
@@ -128,6 +128,15 @@ func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq 
 	hreq.TransformerMetadata["codex_image_request_model"] = toolModel
 
 	return hreq, nil
+}
+
+func cloneTransformerMetadata(src map[string]any) map[string]any {
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
 }
 
 func imageDataURL(data []byte) string {

--- a/llm/transformer/openai/codex/image.go
+++ b/llm/transformer/openai/codex/image.go
@@ -1,0 +1,248 @@
+package codex
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+const (
+	defaultImageMainModel = "gpt-5.4-mini"
+	defaultImageToolModel = "gpt-image-2"
+)
+
+func codexImageMainModel() string {
+	if model := strings.TrimSpace(os.Getenv("AXONHUB_CODEX_IMAGE_MAIN_MODEL")); model != "" {
+		return model
+	}
+
+	return defaultImageMainModel
+}
+
+func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
+	if llmReq.Image == nil {
+		return nil, errors.New("image request is required")
+	}
+
+	toolModel := strings.TrimSpace(llmReq.Model)
+	if toolModel == "" {
+		toolModel = defaultImageToolModel
+	}
+
+	imageTool := &llm.ImageGeneration{
+		Model:             toolModel,
+		Background:        llmReq.Image.Background,
+		InputFidelity:     llmReq.Image.InputFidelity,
+		Moderation:        llmReq.Image.Moderation,
+		OutputCompression: llmReq.Image.OutputCompression,
+		OutputFormat:      llmReq.Image.OutputFormat,
+		PartialImages:     llmReq.Image.PartialImages,
+		N:                 llmReq.Image.N,
+		ResponseFormat:    llmReq.Image.ResponseFormat,
+		Quality:           llmReq.Image.Quality,
+		Size:              llmReq.Image.Size,
+		Style:             llmReq.Image.Style,
+	}
+
+	if len(llmReq.Image.Mask) > 0 {
+		imageTool.InputImageMask = map[string]any{
+			"image_url": imageDataURL(llmReq.Image.Mask),
+		}
+	}
+
+	contentParts := []llm.MessageContentPart{}
+	if llmReq.Image.Prompt != "" {
+		contentParts = append(contentParts, llm.MessageContentPart{
+			Type: "text",
+			Text: lo.ToPtr(llmReq.Image.Prompt),
+		})
+	}
+
+	for _, image := range llmReq.Image.Images {
+		if len(image) == 0 {
+			continue
+		}
+
+		url := imageDataURL(image)
+		contentParts = append(contentParts, llm.MessageContentPart{
+			Type: "image_url",
+			ImageURL: &llm.ImageURL{
+				URL: url,
+			},
+		})
+	}
+
+	if len(contentParts) == 0 {
+		return nil, errors.New("prompt or image is required for codex image request")
+	}
+
+	imageReq := *llmReq
+	imageReq.Model = codexImageMainModel()
+	imageReq.RequestType = llm.RequestTypeChat
+	imageReq.APIFormat = llm.APIFormatOpenAIResponse
+	imageReq.Messages = []llm.Message{{
+		Role: "user",
+		Content: llm.MessageContent{
+			MultipleContent: contentParts,
+		},
+	}}
+	imageReq.Tools = []llm.Tool{{
+		Type:            llm.ToolTypeImageGeneration,
+		ImageGeneration: imageTool,
+	}}
+	imageReq.ToolChoice = &llm.ToolChoice{
+		ToolChoice: lo.ToPtr("required"),
+	}
+	imageReq.Stream = lo.ToPtr(true)
+	imageReq.Store = lo.ToPtr(false)
+	imageReq.ParallelToolCalls = lo.ToPtr(true)
+	imageReq.TransformOptions.ArrayInputs = lo.ToPtr(true)
+
+	if imageReq.TransformerMetadata == nil {
+		imageReq.TransformerMetadata = map[string]any{}
+	}
+
+	if imageTool.OutputFormat != "" {
+		imageReq.TransformerMetadata["image_output_format"] = imageTool.OutputFormat
+	}
+
+	hreq, err := t.TransformRequest(ctx, &imageReq)
+	if err != nil {
+		return nil, err
+	}
+
+	hreq.RequestType = llm.RequestTypeImage.String()
+	hreq.APIFormat = string(llm.APIFormatOpenAIResponse)
+	hreq.TransformerMetadata["codex_image_request_model"] = toolModel
+
+	return hreq, nil
+}
+
+func imageDataURL(data []byte) string {
+	contentType := http.DetectContentType(data)
+	if !strings.HasPrefix(contentType, "image/") {
+		contentType = "image/png"
+	}
+
+	return fmt.Sprintf("data:%s;base64,%s", contentType, base64.StdEncoding.EncodeToString(data))
+}
+
+func (t *OutboundTransformer) transformImageResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
+	resp, err := t.responsesOutbound.TransformResponse(ctx, httpResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp == nil {
+		return nil, errors.New("codex image response is nil")
+	}
+
+	imageResp := &llm.ImageResponse{
+		Created: time.Now().Unix(),
+		Data:    []llm.ImageData{},
+	}
+
+	if resp.Created != 0 {
+		imageResp.Created = resp.Created
+	}
+
+	for _, choice := range resp.Choices {
+		if choice.Message == nil {
+			continue
+		}
+
+		for _, part := range choice.Message.Content.MultipleContent {
+			if part.Type != "image_url" || part.ImageURL == nil {
+				continue
+			}
+
+			format, encoded := splitImageDataURL(part.ImageURL.URL)
+			if encoded == "" {
+				continue
+			}
+
+			imageResp.Data = append(imageResp.Data, llm.ImageData{
+				B64JSON: encoded,
+			})
+
+			if format != "" && imageResp.OutputFormat == "" {
+				imageResp.OutputFormat = format
+			}
+
+			if part.TransformerMetadata != nil {
+				if v, ok := part.TransformerMetadata["background"].(*string); ok && v != nil {
+					imageResp.Background = *v
+				}
+				if v, ok := part.TransformerMetadata["output_format"].(*string); ok && v != nil {
+					imageResp.OutputFormat = *v
+				}
+				if v, ok := part.TransformerMetadata["quality"].(*string); ok && v != nil {
+					imageResp.Quality = *v
+				}
+				if v, ok := part.TransformerMetadata["size"].(*string); ok && v != nil {
+					imageResp.Size = *v
+				}
+			}
+		}
+
+		if choice.Delta != nil {
+			for _, part := range choice.Delta.Content.MultipleContent {
+				if part.Type != "image_url" || part.ImageURL == nil {
+					continue
+				}
+
+				format, encoded := splitImageDataURL(part.ImageURL.URL)
+				if encoded == "" {
+					continue
+				}
+
+				imageResp.Data = append(imageResp.Data, llm.ImageData{
+					B64JSON: encoded,
+				})
+
+				if format != "" && imageResp.OutputFormat == "" {
+					imageResp.OutputFormat = format
+				}
+			}
+		}
+	}
+
+	if len(imageResp.Data) == 0 {
+		return nil, errors.New("codex image response did not include image_generation_call result")
+	}
+
+	resp.RequestType = llm.RequestTypeImage
+	resp.Image = imageResp
+	resp.Choices = nil
+
+	return resp, nil
+}
+
+func splitImageDataURL(url string) (string, string) {
+	const prefix = "data:image/"
+	if !strings.HasPrefix(url, prefix) {
+		return "", ""
+	}
+
+	header, encoded, ok := strings.Cut(url, ",")
+	if !ok {
+		return "", ""
+	}
+
+	format := strings.TrimPrefix(header, prefix)
+	if before, _, ok := strings.Cut(format, ";"); ok {
+		format = before
+	}
+
+	return format, encoded
+}

--- a/llm/transformer/openai/codex/image.go
+++ b/llm/transformer/openai/codex/image.go
@@ -101,7 +101,9 @@ func (t *OutboundTransformer) transformImageRequest(ctx context.Context, llmReq 
 		ImageGeneration: imageTool,
 	}}
 	imageReq.ToolChoice = &llm.ToolChoice{
-		ToolChoice: lo.ToPtr("required"),
+		NamedToolChoice: &llm.NamedToolChoice{
+			Type: llm.ToolTypeImageGeneration,
+		},
 	}
 	imageReq.Stream = lo.ToPtr(true)
 	imageReq.Store = lo.ToPtr(false)

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -87,6 +87,10 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, errors.New("request is nil")
 	}
 
+	if llmReq.RequestType == llm.RequestTypeImage {
+		return t.transformImageRequest(ctx, llmReq)
+	}
+
 	rawSessionID := ""
 	rawOriginator := ""
 	rawUserAgent := ""
@@ -202,6 +206,10 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 }
 
 func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
+	if httpResp != nil && httpResp.Request != nil && httpResp.Request.RequestType == string(llm.RequestTypeImage) {
+		return t.transformImageResponse(ctx, httpResp)
+	}
+
 	// Codex upstream returns Responses API response.
 	return t.responsesOutbound.TransformResponse(ctx, httpResp)
 }

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -337,7 +337,8 @@ func TestCodexOutbound_TransformsImageGenerationToResponsesTool(t *testing.T) {
 	require.Equal(t, false, body["store"])
 	toolChoice, ok := body["tool_choice"].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "required", toolChoice["mode"])
+	require.Equal(t, "image_generation", toolChoice["type"])
+	require.NotContains(t, toolChoice, "name")
 	require.Equal(t, string(llm.RequestTypeImage), hreq.RequestType)
 
 	tools, ok := body["tools"].([]any)
@@ -435,6 +436,36 @@ func TestCodexOutbound_ImageResponseWrapsB64JSON(t *testing.T) {
 	require.NotNil(t, resp.Image)
 	require.Len(t, resp.Image.Data, 1)
 	require.Equal(t, "aW1hZ2U=", resp.Image.Data[0].B64JSON)
+}
+
+func TestCodexOutbound_ImageResponseWrapsAggregatedStreamResult(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	hreq := &httpclient.Request{
+		RequestType: string(llm.RequestTypeImage),
+		TransformerMetadata: map[string]any{
+			"image_output_format": "png",
+		},
+	}
+	executor := outbound.CustomizeExecutor(&mockCodexExecutor{
+		streamEvents: []*httpclient.StreamEvent{
+			{Type: "response.created", Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_img","object":"response","created_at":1700000000,"model":"gpt-5.4-mini","status":"in_progress","output":[]}}`)},
+			{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"id":"ig_1","type":"image_generation_call","status":"completed","result":"aW1hZ2U=","output_format":"png","quality":"high","size":"1024x1024"}}`)},
+			{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":2,"response":{"id":"resp_img","object":"response","created_at":1700000000,"model":"gpt-5.4-mini","status":"completed","output":[{"id":"ig_1","type":"image_generation_call","status":"completed","result":"aW1hZ2U=","output_format":"png","quality":"high","size":"1024x1024"}]}}`)},
+		},
+	})
+
+	httpResp, err := executor.Do(ctx, hreq)
+	require.NoError(t, err)
+
+	resp, err := outbound.TransformResponse(ctx, httpResp)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Image)
+	require.Len(t, resp.Image.Data, 1)
+	require.Equal(t, "aW1hZ2U=", resp.Image.Data[0].B64JSON)
+	require.Equal(t, "png", resp.Image.OutputFormat)
+	require.Equal(t, "high", resp.Image.Quality)
+	require.Equal(t, "1024x1024", resp.Image.Size)
 }
 
 func newTestCodexOutbound(t *testing.T) *OutboundTransformer {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -314,6 +314,129 @@ func TestCodexOutbound_ForcesArrayInputsForSingleMessage(t *testing.T) {
 	assert.Equal(t, "user", first["role"])
 }
 
+func TestCodexOutbound_TransformsImageGenerationToResponsesTool(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+
+	hreq, err := outbound.TransformRequest(ctx, &llm.Request{
+		Model:       "gpt-image-2",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageGeneration,
+		Image: &llm.ImageRequest{
+			Prompt:       "Draw a request flow",
+			Size:         "1024x1024",
+			Quality:      "high",
+			OutputFormat: "png",
+		},
+	})
+	require.NoError(t, err)
+
+	body := decodeCodexRequestBody(t, hreq)
+	require.Equal(t, defaultImageMainModel, body["model"])
+	require.Equal(t, true, body["stream"])
+	require.Equal(t, false, body["store"])
+	toolChoice, ok := body["tool_choice"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "required", toolChoice["mode"])
+	require.Equal(t, string(llm.RequestTypeImage), hreq.RequestType)
+
+	tools, ok := body["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "image_generation", tool["type"])
+	require.Equal(t, "gpt-image-2", tool["model"])
+	require.Equal(t, "1024x1024", tool["size"])
+	require.Equal(t, "high", tool["quality"])
+	require.Equal(t, "png", tool["output_format"])
+
+	input, ok := body["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 1)
+	message, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	content, ok := message["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	text, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "input_text", text["type"])
+	require.Equal(t, "Draw a request flow", text["text"])
+}
+
+func TestCodexOutbound_TransformsImageEditToResponsesTool(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	png := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0}
+
+	hreq, err := outbound.TransformRequest(ctx, &llm.Request{
+		Model:       "gpt-image-2",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt:       "Edit this image",
+			Images:       [][]byte{png},
+			Mask:         png,
+			Size:         "1024x1024",
+			Quality:      "high",
+			OutputFormat: "png",
+		},
+	})
+	require.NoError(t, err)
+
+	body := decodeCodexRequestBody(t, hreq)
+	tools := body["tools"].([]any)
+	tool := tools[0].(map[string]any)
+	require.Equal(t, "image_generation", tool["type"])
+	require.Equal(t, "gpt-image-2", tool["model"])
+	require.Equal(t, "high", tool["quality"])
+	require.Equal(t, "png", tool["output_format"])
+	require.Contains(t, tool, "input_image_mask")
+
+	input := body["input"].([]any)
+	message := input[0].(map[string]any)
+	content := message["content"].([]any)
+	require.Len(t, content, 2)
+	imagePart := content[1].(map[string]any)
+	require.Equal(t, "input_image", imagePart["type"])
+	require.True(t, strings.HasPrefix(imagePart["image_url"].(string), "data:image/png;base64,"))
+}
+
+func TestCodexOutbound_ImageResponseWrapsB64JSON(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	hreq := &httpclient.Request{
+		RequestType: string(llm.RequestTypeImage),
+		TransformerMetadata: map[string]any{
+			"image_output_format": "png",
+		},
+	}
+	respBody := []byte(`{
+		"id":"resp_img",
+		"object":"response",
+		"created_at":1700000000,
+		"model":"gpt-5.4-mini",
+		"status":"completed",
+		"output":[{
+			"id":"ig_1",
+			"type":"image_generation_call",
+			"status":"completed",
+			"result":"aW1hZ2U="
+		}]
+	}`)
+
+	resp, err := outbound.TransformResponse(ctx, &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Body:       respBody,
+		Request:    hreq,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Image)
+	require.Len(t, resp.Image.Data, 1)
+	require.Equal(t, "aW1hZ2U=", resp.Image.Data[0].B64JSON)
+}
+
 func newTestCodexOutbound(t *testing.T) *OutboundTransformer {
 	t.Helper()
 

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -366,6 +366,42 @@ func TestCodexOutbound_TransformsImageGenerationToResponsesTool(t *testing.T) {
 	require.Equal(t, "Draw a request flow", text["text"])
 }
 
+func TestCodexOutbound_ImageRequestDoesNotMutateTransformerMetadata(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	metadata := map[string]any{"existing": "value"}
+
+	_, err := outbound.TransformRequest(ctx, &llm.Request{
+		Model:               "gpt-image-2",
+		RequestType:         llm.RequestTypeImage,
+		APIFormat:           llm.APIFormatOpenAIImageGeneration,
+		TransformerMetadata: metadata,
+		Image: &llm.ImageRequest{
+			Prompt:       "Draw a request flow",
+			OutputFormat: "png",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"existing": "value"}, metadata)
+}
+
+func TestCodexOutbound_ImageRequestRejectsMultipleImages(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	n := int64(2)
+
+	_, err := outbound.TransformRequest(ctx, &llm.Request{
+		Model:       "gpt-image-2",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageGeneration,
+		Image: &llm.ImageRequest{
+			Prompt: "Draw a request flow",
+			N:      &n,
+		},
+	})
+	require.ErrorContains(t, err, "codex image generation supports n=1 only")
+}
+
 func TestCodexOutbound_TransformsImageEditToResponsesTool(t *testing.T) {
 	ctx := context.Background()
 	outbound := newTestCodexOutbound(t)

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -27,6 +27,10 @@ type streamAggregator struct {
 	// Fast lookup by item.id (and a fallback for cases where an upstream sends call_id as item_id).
 	outputItemsByID map[string]*aggregatedItem
 
+	// Final response output, used as a fallback when an upstream only includes
+	// completed items in response.completed.
+	completedOutput []Item
+
 	// Usage
 	usage *Usage
 }
@@ -41,6 +45,13 @@ type aggregatedItem struct {
 	Name             string
 	Arguments        *strings.Builder
 	EncryptedContent *string
+
+	// For image_generation_call type
+	Background   *string
+	OutputFormat *string
+	Quality      *string
+	Result       *string
+	Size         *string
 
 	// For custom_tool_call type
 	Input *string
@@ -240,6 +251,11 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			item.Arguments.WriteString(ev.Item.Arguments)
 			item.EncryptedContent = ev.Item.EncryptedContent
 			item.Input = ev.Item.Input
+			item.Background = ev.Item.Background
+			item.OutputFormat = ev.Item.OutputFormat
+			item.Quality = ev.Item.Quality
+			item.Result = ev.Item.Result
+			item.Size = ev.Item.Size
 
 			if len(ev.Item.Summary) > 0 {
 				for idx, s := range ev.Item.Summary {
@@ -433,8 +449,17 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			if item == nil {
 				item = a.lastItemByOutputIndex(ev.OutputIndex)
 			}
+			if item == nil {
+				item = newAggregatedItem()
+				a.outputItems[ev.OutputIndex] = append(a.outputItems[ev.OutputIndex], item)
+			}
 
 			if item != nil {
+				item.ID = ev.Item.ID
+				item.Type = ev.Item.Type
+				item.Role = ev.Item.Role
+				item.CallID = ev.Item.CallID
+				item.Name = ev.Item.Name
 				if ev.Item.Status != nil {
 					item.Status = *ev.Item.Status
 				}
@@ -461,6 +486,16 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 				if ev.Item.EncryptedContent != nil {
 					item.EncryptedContent = ev.Item.EncryptedContent
 				}
+
+				item.Background = ev.Item.Background
+				item.OutputFormat = ev.Item.OutputFormat
+				item.Quality = ev.Item.Quality
+				item.Result = ev.Item.Result
+				item.Size = ev.Item.Size
+
+				if item.ID != "" {
+					a.outputItemsByID[item.ID] = item
+				}
 			}
 		}
 
@@ -468,6 +503,7 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 		a.status = "completed"
 		if ev.Response != nil {
 			a.previousResponseID = ev.Response.PreviousResponseID
+			a.completedOutput = ev.Response.Output
 			if ev.Response.Usage != nil {
 				a.usage = ev.Response.Usage
 			}
@@ -544,6 +580,18 @@ func (a *streamAggregator) buildResponse() *Response {
 					Input:  item.Input,
 				})
 
+			case "image_generation_call":
+				output = append(output, Item{
+					ID:           item.ID,
+					Type:         item.Type,
+					Status:       lo.ToPtr(item.Status),
+					Background:   item.Background,
+					OutputFormat: item.OutputFormat,
+					Quality:      item.Quality,
+					Result:       item.Result,
+					Size:         item.Size,
+				})
+
 			case "reasoning":
 				var summary []ReasoningSummary
 
@@ -595,6 +643,10 @@ func (a *streamAggregator) buildResponse() *Response {
 				})
 			}
 		}
+	}
+
+	if len(output) == 0 && len(a.completedOutput) > 0 {
+		output = a.completedOutput
 	}
 
 	return &Response{

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -40,6 +40,8 @@ type Tool struct {
 	// This field is for ImageGeneration
 	InputFidelity string `json:"input_fidelity,omitempty"`
 	// This field is for ImageGeneration
+	InputImageMask map[string]any `json:"input_image_mask,omitempty"`
+	// This field is for ImageGeneration
 	Model string `json:"model,omitempty"`
 	// This field is for ImageGeneration
 	Moderation string `json:"moderation,omitempty"`

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -442,7 +442,9 @@ func convertToolChoice(src *llm.ToolChoice) *ToolChoice {
 	} else if src.NamedToolChoice != nil {
 		// Specific tool choice
 		result.Type = &src.NamedToolChoice.Type
-		result.Name = &src.NamedToolChoice.Function.Name
+		if src.NamedToolChoice.Function.Name != "" {
+			result.Name = &src.NamedToolChoice.Function.Name
+		}
 	}
 
 	return result

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -328,6 +328,7 @@ func convertImageGenerationToTool(src llm.Tool) Tool {
 		tool.Model = src.ImageGeneration.Model
 		tool.Background = src.ImageGeneration.Background
 		tool.InputFidelity = src.ImageGeneration.InputFidelity
+		tool.InputImageMask = src.ImageGeneration.InputImageMask
 		tool.Moderation = src.ImageGeneration.Moderation
 		tool.OutputCompression = src.ImageGeneration.OutputCompression
 		tool.OutputFormat = src.ImageGeneration.OutputFormat


### PR DESCRIPTION
## Summary
- Add Codex channel support for OpenAI-compatible /v1/images/generations and /v1/images/edits.
- Convert external gpt-image-2 image requests into Codex Responses API image_generation tool calls.
- Convert Codex image_generation_call results back to OpenAI Images API b64_json responses.
- Add built-in Codex model visibility for gpt-image-2 and default image endpoints.

## Testing
- go test ./transformer/openai/codex
- go test ./transformer/openai/responses -run 'TestAggregate|TestResponse|TestOutbound'
- go test ./internal/server/biz
- go test ./internal/server/orchestrator -run TestSelectAPIFormat
- Local manual test: POST /v1/images/generations with model=gpt-image-2 returned b64_json and saved a valid PNG.