### PR TITLE
perf: add ORDER BY id to Limit queries without filtering conditions to optimize indexing.

### DIFF
--- a/internal/server/backup/backup_ops.go
+++ b/internal/server/backup/backup_ops.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/model"
+	"github.com/looplj/axonhub/internal/ent/project"
 )
 
 func (svc *BackupService) Backup(ctx context.Context, opts BackupOptions) ([]byte, error) {
@@ -39,7 +42,9 @@ func (svc *BackupService) doBackup(ctx context.Context, opts BackupOptions) ([]b
 	)
 
 	if opts.IncludeProjects {
-		projects, err := svc.db.Project.Query().All(ctx)
+		projects, err := svc.db.Project.Query().
+			Order(ent.Desc(project.FieldID)).
+			All(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +55,9 @@ func (svc *BackupService) doBackup(ctx context.Context, opts BackupOptions) ([]b
 	}
 
 	if opts.IncludeChannels {
-		channels, err := svc.db.Channel.Query().All(ctx)
+		channels, err := svc.db.Channel.Query().
+			Order(ent.Desc(channel.FieldID)).
+			All(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +95,9 @@ func (svc *BackupService) doBackup(ctx context.Context, opts BackupOptions) ([]b
 	var modelDataList []*BackupModel
 
 	if opts.IncludeModels {
-		models, err := svc.db.Model.Query().All(ctx)
+		models, err := svc.db.Model.Query().
+			Order(ent.Desc(model.FieldID)).
+			All(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/biz/prompt.go
+++ b/internal/server/biz/prompt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/project"
 	"github.com/looplj/axonhub/internal/ent/prompt"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
@@ -40,7 +41,9 @@ func NewPromptService(params PromptServiceParams) *PromptService {
 func (svc *PromptService) Initialize(ctx context.Context) error {
 	ctx = authz.WithSystemBypass(ctx, "prompt-initialize")
 
-	projects, err := svc.entFromContext(ctx).Project.Query().All(ctx)
+	projects, err := svc.entFromContext(ctx).Project.Query().
+		Order(ent.Desc(project.FieldID)).
+		All(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to query projects for initial prompt loading: %w", err)
 	}

--- a/internal/server/biz/provider_quota.go
+++ b/internal/server/biz/provider_quota.go
@@ -389,7 +389,9 @@ func (svc *ProviderQuotaService) getCheckInterval() time.Duration {
 }
 
 func (svc *ProviderQuotaService) loadQuotaCache(ctx context.Context) {
-	records, err := svc.db.ProviderQuotaStatus.Query().All(ctx)
+	records, err := svc.db.ProviderQuotaStatus.Query().
+		Order(ent.Desc(providerquotastatus.FieldID)).
+		All(ctx)
 	if err != nil {
 		log.Error(ctx, "Failed to load quota cache from DB", log.Cause(err))
 		return


### PR DESCRIPTION
## Slow SQL query statistics result

| SQLText | DBName | Table name | Execution time (seconds) | Number of rows returned |
|--------|--------|------|-------------|---------|
| `SELECT t.* FROM public.request_executions t LIMIT 501` | axonhub | request_executions | 55.334184 | 501 |
| `SELECT t.* FROM public.requests t WHERE channel_id NOT IN (1) LIMIT 501` | axonhub | requests | 47.477116 | 501 |
| `SELECT t.* FROM public.request_executions t LIMIT 501` | axonhub | request_executions | 45.671609 | 501 |
| `SELECT t.* FROM public.requests t LIMIT 501` | axonhub | requests | 25.270574 | 501 |
| `SELECT t.* FROM public.requests t LIMIT 501` | axonhub | requests | 24.046145 | 501 |
| `SELECT t.* FROM public.requests t LIMIT 501` | axonhub | requests | 22.988233 | 501 |
| `SELECT t.*, CTID FROM public.requests t LIMIT 501` | axonhub | requests | 10.107684 | 501 |
| `SELECT t.*, CTID FROM public.requests t LIMIT 501` | axonhub | requests | 9.98632 | 501 |

## Optimization

When these SQL queries in PostgreSQL do not specify WHERE and ORDER BY, LIMIT cannot utilize indexes for ordered Top-N queries, which may trigger a full table scan, resulting in extensive I/O and poor performance.

Unfiltered queries (no WHERE clause) cannot leverage index seek and require full table scan with filesort. Adding ORDER BY id (DESC) allows PostgreSQL to use the primary key B-tree index directly since it stores data in id order, avoiding the additional sort step.

## Changes:

- ProviderQuotaStatus.Query() in loadQuotaCache
- Project.Query() in PromptService.Initialize
- Project/Channel/Model.Query() in BackupService.doBackup