### PR TITLE
fix(gc): drop nil bind args so VACUUM actually runs on Postgres

### DIFF
--- a/internal/server/gc/gc.go
+++ b/internal/server/gc/gc.go
@@ -526,8 +526,7 @@ func (w *Worker) runVacuum(ctx context.Context) error {
 		vacuumSQL = "VACUUM"
 	}
 
-	_, err := sqlDriver.ExecContext(ctx, vacuumSQL, nil, nil)
-	if err != nil {
+	if _, err := sqlDriver.ExecContext(ctx, vacuumSQL); err != nil {
 		return fmt.Errorf("failed to execute %s: %w", vacuumSQL, err)
 	}
 

--- a/internal/server/gc/vacuum_test.go
+++ b/internal/server/gc/vacuum_test.go
@@ -19,10 +19,7 @@ import (
 func TestWorker_runVacuum_Disabled(t *testing.T) {
 	t.Parallel()
 
-	client := enttest.NewEntClient(t, "sqlite3", "file:vacdis?mode=memory&_fk=1")
-	t.Cleanup(func() { _ = client.Close() })
-
-	w := &Worker{Ent: client, Config: Config{VacuumEnabled: false}}
+	w := &Worker{Config: Config{VacuumEnabled: false}}
 	require.NoError(t, w.runVacuum(context.Background()))
 }
 

--- a/internal/server/gc/vacuum_test.go
+++ b/internal/server/gc/vacuum_test.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"testing"
 
-	entsql "entgo.io/ent/dialect/sql"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
+
+	entsql "entgo.io/ent/dialect/sql"
 
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/enttest"

--- a/internal/server/gc/vacuum_test.go
+++ b/internal/server/gc/vacuum_test.go
@@ -1,0 +1,83 @@
+package gc
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	entsql "entgo.io/ent/dialect/sql"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+)
+
+func TestWorker_runVacuum_Disabled(t *testing.T) {
+	t.Parallel()
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:vacdis?mode=memory&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	w := &Worker{Ent: client, Config: Config{VacuumEnabled: false}}
+	require.NoError(t, w.runVacuum(context.Background()))
+}
+
+func TestWorker_runVacuum_SQLite(t *testing.T) {
+	t.Parallel()
+
+	// Distinct DSN per subtest so the in-memory DBs don't collide.
+	for _, full := range []bool{false, true} {
+		name := "vacuum"
+		if full {
+			name = "vacuum_full_ignored_on_sqlite"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := "file:vac_" + name + "?mode=memory&_fk=1"
+			client := enttest.NewEntClient(t, "sqlite3", dsn)
+			t.Cleanup(func() { _ = client.Close() })
+
+			w := &Worker{Ent: client, Config: Config{VacuumEnabled: true, VacuumFull: full}}
+			require.NoError(t, w.runVacuum(context.Background()))
+		})
+	}
+}
+
+// TestWorker_runVacuum_Postgres exercises the real pgx code path that previously
+// failed with "mismatched param and argument count". Gated on AXONHUB_TEST_PG_DSN
+// because the project has no in-process Postgres harness.
+func TestWorker_runVacuum_Postgres(t *testing.T) {
+	dsn := os.Getenv("AXONHUB_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("AXONHUB_TEST_PG_DSN not set; skipping real-Postgres VACUUM check")
+	}
+
+	for _, full := range []bool{false, true} {
+		name := "vacuum"
+		if full {
+			name = "vacuum_full"
+		}
+		t.Run(name, func(t *testing.T) {
+			client := newPostgresEntClient(t, dsn)
+			t.Cleanup(func() { _ = client.Close() })
+
+			w := &Worker{Ent: client, Config: Config{VacuumEnabled: true, VacuumFull: full}}
+			require.NoError(t, w.runVacuum(context.Background()))
+		})
+	}
+}
+
+func newPostgresEntClient(t *testing.T, dsn string) *ent.Client {
+	t.Helper()
+
+	sqlDB, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+
+	require.NoError(t, sqlDB.PingContext(context.Background()))
+
+	return ent.NewClient(ent.Driver(entsql.OpenDB("postgres", sqlDB)))
+}


### PR DESCRIPTION
## Summary

- The post-cleanup `VACUUM` call passes its bind args via `(ctx, sql, nil, nil)` to the embedded `*sql.DB.ExecContext` (variadic `args ...any`), so two `nil`s are forwarded as bind parameters.
- pgx v5 rejects this for a parameter-less statement with `mismatched param and argument count`, and the auto-VACUUM has been silently failing every night on every Postgres deployment since #823 (2026-02-11).
- SQLite swallowed the extra nils, which is why the bug went unnoticed in the SQLite-only test path.
- Fix: drop the trailing `nil, nil` so the call is invoked as `sqlDriver.ExecContext(ctx, vacuumSQL)` (the standard `*sql.DB.ExecContext` form, no bind args).

Production confirmation on a 13 GB Postgres deployment after the fix:

\`\`\`
INFO  Starting database VACUUM operation   dialect=postgres vacuum_full=false
INFO  Database VACUUM completed successfully  duration=0.97s command=VACUUM
\`\`\`

Before the fix the same trigger emitted:

\`\`\`
ERROR Failed to run VACUUM after cleanup
      error="failed to execute VACUUM: mismatched param and argument count"
\`\`\`

### Note for users with `vacuum_full=true`

This bug effectively masked `VACUUM FULL` for ~3 months. The fix re-enables the configured behavior, so any Postgres deployment that has explicitly set `vacuum_full=true` will start taking `ACCESS EXCLUSIVE` locks per table. Default remains `false`; no action needed for default deployments.

## Test plan

- [x] `go test ./internal/server/gc/... -run TestWorker_runVacuum -v` (SQLite, always runs)
- [x] `AXONHUB_TEST_PG_DSN=... go test ./internal/server/gc/... -run TestWorker_runVacuum_Postgres -v` (Postgres 18 + pgx v5; covers both `VACUUM` and `VACUUM FULL`)
- [x] Reverse-verified: reverting the one-line fix makes only the Postgres test fail, with the exact production error message — confirming the regression test catches the bug
- [x] Deployed image to a 13 GB production Postgres deployment, manually triggered GC, verified `Database VACUUM completed successfully` in logs