### PR TITLE
chore: add gpt-5.5 for codex plans

### DIFF
--- a/llm/transformer/openai/codex/constants.go
+++ b/llm/transformer/openai/codex/constants.go
@@ -19,6 +19,7 @@ func DefaultModels() []string {
 		"gpt-5.3-codex-spark",
 		"gpt-5.4",
 		"gpt-5.4-mini",
+		"gpt-5.5",
 	}
 }
 


### PR DESCRIPTION
ChatGPT Codex CLI now lists `gpt-5.5 (current) - Frontier model for complex coding, research, and real-world work` as the headline model, and the upstream registry that this list mirrors (`router-for-me/CLIProxyAPI` `internal/registry/models/models.json`) already includes it.

Without this entry AxonHub fails inbound validation with `model not found: gpt-5.5` (HTTP 422), so codex channels cannot expose the new model even when it is available on the user account.

**Change**: one-line addition to `llm/transformer/openai/codex/constants.go`'s `DefaultModels()`, same shape as #1006 (gpt-5.4) and #1162 (gpt-5.4-mini / gpt-5.3-codex-spark).

**Tested locally**: with this change, a codex channel binding `claude-opus-4-7 → gpt-5.5` via `modelMappings` returns HTTP 200 from the ChatGPT Codex backend.