### PR TITLE
fix: openai stream tool call chunks

### DIFF
--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -104,9 +104,16 @@ func (t *InboundTransformer) TransformStream(
 	ctx context.Context,
 	stream streams.Stream[*llm.Response],
 ) (streams.Stream[*httpclient.StreamEvent], error) {
-	return streams.NoNil(streams.MapErr(stream, func(chunk *llm.Response) (*httpclient.StreamEvent, error) {
+	withoutDone := streams.Filter(stream, func(chunk *llm.Response) bool {
+		return chunk != nil && chunk.Object != llm.DoneResponse.Object
+	})
+
+	mapped := streams.NoNil(streams.MapErr(withoutDone, func(chunk *llm.Response) (*httpclient.StreamEvent, error) {
 		return t.TransformStreamChunk(ctx, chunk)
-	})), nil
+	}))
+
+	doneEvent := llm.DoneStreamEvent
+	return streams.AppendStream(mapped, &doneEvent), nil
 }
 
 func (t *InboundTransformer) TransformStreamChunk(
@@ -131,7 +138,7 @@ func (t *InboundTransformer) TransformStreamChunk(
 	}
 
 	// Convert to OpenAI Response format
-	oaiResp := ResponseFromLLM(chatResp)
+	oaiResp := ResponseFromLLM(normalizeOpenAIStreamChunk(chatResp))
 
 	// For OpenAI, we keep the original response format as the event data
 	eventData, err := json.Marshal(oaiResp)
@@ -143,6 +150,49 @@ func (t *InboundTransformer) TransformStreamChunk(
 		Type: "",
 		Data: eventData,
 	}, nil
+}
+
+func normalizeOpenAIStreamChunk(resp *llm.Response) *llm.Response {
+	if resp == nil {
+		return nil
+	}
+
+	normalized := *resp
+	normalized.Object = "chat.completion.chunk"
+
+	if len(resp.Choices) == 0 {
+		return &normalized
+	}
+
+	normalized.Choices = make([]llm.Choice, len(resp.Choices))
+	for i, choice := range resp.Choices {
+		normalizedChoice := choice
+		if choice.Delta != nil {
+			delta := normalizeOpenAIStreamDelta(*choice.Delta)
+			normalizedChoice.Delta = &delta
+			normalizedChoice.Message = nil
+		} else if choice.Message != nil {
+			delta := normalizeOpenAIStreamDelta(*choice.Message)
+			normalizedChoice.Delta = &delta
+			normalizedChoice.Message = nil
+		} else if choice.FinishReason != nil {
+			normalizedChoice.Delta = &llm.Message{}
+		}
+
+		normalized.Choices[i] = normalizedChoice
+	}
+
+	return &normalized
+}
+
+func normalizeOpenAIStreamDelta(delta llm.Message) llm.Message {
+	for i := range delta.ToolCalls {
+		if i > 0 && delta.ToolCalls[i].Index == 0 {
+			delta.ToolCalls[i].Index = i
+		}
+	}
+
+	return delta
 }
 
 // isReasoningSignatureEvent checks if the response contains ONLY ReasoningSignature.

--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -186,11 +186,32 @@ func normalizeOpenAIStreamChunk(resp *llm.Response) *llm.Response {
 }
 
 func normalizeOpenAIStreamDelta(delta llm.Message) llm.Message {
-	for i := range delta.ToolCalls {
-		if i > 0 && delta.ToolCalls[i].Index == 0 {
-			delta.ToolCalls[i].Index = i
+	if len(delta.ToolCalls) == 0 {
+		return delta
+	}
+
+	needsFix := false
+	for i := 1; i < len(delta.ToolCalls); i++ {
+		if delta.ToolCalls[i].Index == 0 {
+			needsFix = true
+			break
 		}
 	}
+
+	if !needsFix {
+		return delta
+	}
+
+	toolCalls := make([]llm.ToolCall, len(delta.ToolCalls))
+	copy(toolCalls, delta.ToolCalls)
+
+	for i := range toolCalls {
+		if i > 0 && toolCalls[i].Index == 0 {
+			toolCalls[i].Index = i
+		}
+	}
+
+	delta.ToolCalls = toolCalls
 
 	return delta
 }

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -475,6 +475,109 @@ func TestInboundTransformer_TransformStreamChunk(t *testing.T) {
 	}
 }
 
+func TestInboundTransformer_TransformStreamChunk_NormalizesOpenAIChunkShape(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	event, err := transformer.TransformStreamChunk(t.Context(), &llm.Response{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Created: 1677652288,
+		Model:   "gpt-4",
+		Choices: []llm.Choice{
+			{
+				Index: 0,
+				Message: &llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_123",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "get_user_city",
+								Arguments: `{"user_id":"123"}`,
+							},
+						},
+						{
+							ID:   "call_456",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"Shanghai"}`,
+							},
+						},
+					},
+				},
+				FinishReason: lo.ToPtr("tool_calls"),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(event.Data, &payload))
+	require.Equal(t, "chat.completion.chunk", payload["object"])
+
+	choices, ok := payload["choices"].([]any)
+	require.True(t, ok)
+	require.Len(t, choices, 1)
+
+	choice, ok := choices[0].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, choice, "message")
+	require.Equal(t, "tool_calls", choice["finish_reason"])
+
+	delta, ok := choice["delta"].(map[string]any)
+	require.True(t, ok)
+
+	toolCalls, ok := delta["tool_calls"].([]any)
+	require.True(t, ok)
+	require.Len(t, toolCalls, 2)
+
+	firstToolCall, ok := toolCalls[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(0), firstToolCall["index"])
+
+	secondToolCall, ok := toolCalls[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(1), secondToolCall["index"])
+}
+
+func TestInboundTransformer_TransformStreamChunk_AddsEmptyDeltaForFinishReason(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	event, err := transformer.TransformStreamChunk(t.Context(), &llm.Response{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion.chunk",
+		Created: 1677652288,
+		Model:   "gpt-4",
+		Choices: []llm.Choice{
+			{
+				Index:        0,
+				FinishReason: lo.ToPtr("tool_calls"),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(event.Data, &payload))
+
+	choices, ok := payload["choices"].([]any)
+	require.True(t, ok)
+	require.Len(t, choices, 1)
+
+	choice, ok := choices[0].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, choice, "delta")
+	require.Equal(t, "tool_calls", choice["finish_reason"])
+
+	delta, ok := choice["delta"].(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, delta)
+}
+
 func TestInboundTransformer_TransformStream_SkipsPureReasoningSignatureChunk(t *testing.T) {
 	transformer := NewInboundTransformer()
 	signature := shared.GeminiThoughtSignaturePrefix + "stream_signature"
@@ -539,6 +642,40 @@ func TestInboundTransformer_TransformStream_SkipsPureReasoningSignatureChunk(t *
 	require.NotNil(t, chunkResp.Choices[0].Delta)
 	require.Len(t, chunkResp.Choices[0].Delta.ToolCalls, 1)
 	require.Nil(t, chunkResp.Choices[0].Delta.ToolCalls[0].ExtraContent)
+	require.Equal(t, "[DONE]", string(events[1].Data))
+}
+
+func TestInboundTransformer_TransformStream_AppendsSingleDoneEvent(t *testing.T) {
+	transformer := NewInboundTransformer()
+
+	stream, err := transformer.TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion.chunk",
+			Created: 1677652288,
+			Model:   "gpt-4",
+			Choices: []llm.Choice{
+				{
+					Index: 0,
+					Delta: &llm.Message{
+						Role: "assistant",
+						Content: llm.MessageContent{
+							Content: lo.ToPtr("Hello"),
+						},
+					},
+				},
+			},
+		},
+		llm.DoneResponse,
+	}))
+	require.NoError(t, err)
+
+	var events []*httpclient.StreamEvent
+	for stream.Next() {
+		events = append(events, stream.Current())
+	}
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 2)
 	require.Equal(t, "[DONE]", string(events[1].Data))
 }
 

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -478,7 +478,7 @@ func TestInboundTransformer_TransformStreamChunk(t *testing.T) {
 func TestInboundTransformer_TransformStreamChunk_NormalizesOpenAIChunkShape(t *testing.T) {
 	transformer := NewInboundTransformer()
 
-	event, err := transformer.TransformStreamChunk(t.Context(), &llm.Response{
+	resp := &llm.Response{
 		ID:      "chatcmpl-123",
 		Object:  "chat.completion",
 		Created: 1677652288,
@@ -510,7 +510,9 @@ func TestInboundTransformer_TransformStreamChunk_NormalizesOpenAIChunkShape(t *t
 				FinishReason: lo.ToPtr("tool_calls"),
 			},
 		},
-	})
+	}
+
+	event, err := transformer.TransformStreamChunk(t.Context(), resp)
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
@@ -541,6 +543,7 @@ func TestInboundTransformer_TransformStreamChunk_NormalizesOpenAIChunkShape(t *t
 	secondToolCall, ok := toolCalls[1].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, float64(1), secondToolCall["index"])
+	require.Zero(t, resp.Choices[0].Message.ToolCalls[1].Index)
 }
 
 func TestInboundTransformer_TransformStreamChunk_AddsEmptyDeltaForFinishReason(t *testing.T) {


### PR DESCRIPTION
## Summary
- normalize OpenAI streaming chunks before writing SSE responses
- ensure streamed tool calls are emitted under choices[].delta.tool_calls with indexes
- guarantee a single terminal data: [DONE] event for OpenAI chat completion streams

## Root cause
Some upstream transformers can produce unified streaming responses with non-stream response shape details, such as choices[].message, missing chunk object values, missing tool call indexes, or finish chunks without delta. The OpenAI-compatible endpoint was serializing those unified chunks directly, so clients could receive payloads that differed from OpenAI Chat Completions stream expectations.

## Validation
- cd llm && rtk proxy go test ./transformer/openai