### PR TITLE
Support image parts in Ollama chat transformer

### DIFF
--- a/llm/transformer/ollama/outbound.go
+++ b/llm/transformer/ollama/outbound.go
@@ -52,6 +52,7 @@ type ChatRequest struct {
 type ChatMessage struct {
 	Role     string `json:"role"`
 	Content  string `json:"content"`
+	Images   []string `json:"images,omitempty"`
 	Thinking string `json:"thinking,omitempty"`
 }
 
@@ -106,10 +107,10 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	}
 
 	for _, msg := range llmReq.Messages {
-		content := getContentString(msg.Content)
 		ollamaReq.Messages = append(ollamaReq.Messages, ChatMessage{
 			Role:    msg.Role,
-			Content: content,
+			Content: getContentString(msg.Content),
+			Images:  getImages(msg.Content),
 		})
 	}
 
@@ -174,6 +175,35 @@ func getContentString(content llm.MessageContent) string {
 	}
 
 	return ""
+}
+
+func getImages(content llm.MessageContent) []string {
+	if len(content.MultipleContent) == 0 {
+		return nil
+	}
+
+	images := make([]string, 0)
+
+	for _, part := range content.MultipleContent {
+		if part.Type != "image_url" || part.ImageURL == nil {
+			continue
+		}
+
+		image := strings.TrimSpace(part.ImageURL.URL)
+		if image == "" {
+			continue
+		}
+
+		if comma := strings.Index(image, ","); strings.HasPrefix(image, "data:") && comma >= 0 {
+			image = image[comma+1:]
+		}
+
+		if image != "" {
+			images = append(images, image)
+		}
+	}
+
+	return images
 }
 
 func (t *OutboundTransformer) buildOptions(llmReq *llm.Request) *Options {

--- a/llm/transformer/ollama/outbound_test.go
+++ b/llm/transformer/ollama/outbound_test.go
@@ -1,0 +1,81 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestTransformRequestPreservesImageURLParts(t *testing.T) {
+	transformer, err := NewOutboundTransformerWithConfig(&Config{
+		BaseURL: "http://localhost:11434",
+	})
+	require.NoError(t, err)
+
+	req, err := transformer.TransformRequest(context.Background(), &llm.Request{
+		Model: "qwen3.5:4b-q4_K_M",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "text",
+							Text: lo.ToPtr("OCR this image."),
+						},
+						{
+							Type: "image_url",
+							ImageURL: &llm.ImageURL{
+								URL: "data:image/png;base64,Zm9v",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var got ChatRequest
+	require.NoError(t, json.Unmarshal(req.Body, &got))
+	require.Len(t, got.Messages, 1)
+	require.Equal(t, "OCR this image.", got.Messages[0].Content)
+	require.Equal(t, []string{"Zm9v"}, got.Messages[0].Images)
+}
+
+func TestTransformRequestPreservesPlainImageURLParts(t *testing.T) {
+	transformer, err := NewOutboundTransformerWithConfig(&Config{
+		BaseURL: "http://localhost:11434",
+	})
+	require.NoError(t, err)
+
+	req, err := transformer.TransformRequest(context.Background(), &llm.Request{
+		Model: "vision-model",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "image_url",
+							ImageURL: &llm.ImageURL{
+								URL: "https://example.com/image.png",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var got ChatRequest
+	require.NoError(t, json.Unmarshal(req.Body, &got))
+	require.Len(t, got.Messages, 1)
+	require.Equal(t, []string{"https://example.com/image.png"}, got.Messages[0].Images)
+}


### PR DESCRIPTION
## Summary
- pass OpenAI-style image_url message parts through to Ollama chat requests as message images
- strip data URL prefixes so Ollama receives raw base64 image payloads
- add transformer coverage for data URL and plain image URL image parts

## Testing
- Not run: Go toolchain is not installed in this environment.