### PR TITLE
fix(channels): import Qiniu icon in config_channels

### DIFF
--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -24,6 +24,7 @@ import {
   Github,
   Claude,
   Cerebras,
+  Qiniu,
   XiaomiMiMo,
   Fireworks,
   Ollama,


### PR DESCRIPTION
## Summary

- `CHANNEL_CONFIGS.qiniu` references `Qiniu` from `@lobehub/icons`, but the import was added only in `config_providers.ts` and missed in `config_channels.ts`.
- Throws `ReferenceError: Qiniu is not defined` at module evaluation, crashing every page that imports `config_channels` (channels list, project requests, etc.). React's error boundary catches it and shows the generic error page.
- One-line fix: add `Qiniu` to the `@lobehub/icons` import block in `config_channels.ts`.

Regression introduced in #1612.

## Test plan

- [x] `pnpm build` no longer fails / produces a runtime `ReferenceError`
- [x] Verified on a deployment running the fix: `/channels` and `/project/requests` render again