### PR TITLE
fix: detect synthetic weekly quota exhausted state

### DIFF
--- a/internal/server/biz/provider_quota/claudecode_checker.go
+++ b/internal/server/biz/provider_quota/claudecode_checker.go
@@ -218,7 +218,7 @@ func (c *ClaudeCodeQuotaChecker) buildTokenLimit(windowKey string, headers http.
 		Type:        QuotaLimitTypeToken,
 		Status:      status,
 		UsageRatio:  utilization,
-		Ready:       status != "exhausted",
+		Ready:       IsReadyStatus(status),
 		NextResetAt: nextReset,
 	}
 }

--- a/internal/server/biz/provider_quota/nanogpt_checker.go
+++ b/internal/server/biz/provider_quota/nanogpt_checker.go
@@ -269,7 +269,7 @@ func buildNanoGPTLimitStatuses(imageWindow, dailyTokenWindow, weeklyTokenWindow 
 			Type:        w.limitType,
 			Status:      status,
 			UsageRatio:  usageRatio,
-			Ready:       status != "exhausted",
+			Ready:       IsReadyStatus(status),
 			NextResetAt: resetAt,
 		})
 	}

--- a/internal/server/biz/provider_quota/synthetic_checker.go
+++ b/internal/server/biz/provider_quota/synthetic_checker.go
@@ -209,7 +209,7 @@ func buildSyntheticLimitStatuses(weekly *SyntheticWeeklyTokenLimit, fiveHour *Sy
 			Type:        QuotaLimitTypeToken,
 			Status:      status,
 			UsageRatio:  usageRatio,
-			Ready:       status != "exhausted",
+			Ready:       IsReadyStatus(status),
 			NextResetAt: resetAt,
 		})
 	}
@@ -247,7 +247,7 @@ func weeklyTokenLimitStatus(weekly *SyntheticWeeklyTokenLimit) QuotaLimitStatus 
 		Type:        QuotaLimitTypeToken,
 		Status:      status,
 		UsageRatio:  usageRatio,
-		Ready:       status != "exhausted",
+		Ready:       IsReadyStatus(status),
 		NextResetAt: resetAt,
 	}
 }

--- a/internal/server/biz/provider_quota/synthetic_checker.go
+++ b/internal/server/biz/provider_quota/synthetic_checker.go
@@ -227,7 +227,10 @@ func weeklyTokenLimitStatus(weekly *SyntheticWeeklyTokenLimit) QuotaLimitStatus 
 
 	if weekly.PercentRemaining != nil {
 		usageRatio = 1.0 - (*weekly.PercentRemaining / 100.0)
-		if usageRatio > WarningThresholdRatio {
+
+		if usageRatio >= 1.0 {
+			status = "exhausted"
+		} else if usageRatio > WarningThresholdRatio {
 			status = "warning"
 		}
 	}
@@ -244,7 +247,7 @@ func weeklyTokenLimitStatus(weekly *SyntheticWeeklyTokenLimit) QuotaLimitStatus 
 		Type:        QuotaLimitTypeToken,
 		Status:      status,
 		UsageRatio:  usageRatio,
-		Ready:       true,
+		Ready:       status != "exhausted",
 		NextResetAt: resetAt,
 	}
 }

--- a/internal/server/biz/provider_quota/synthetic_checker_test.go
+++ b/internal/server/biz/provider_quota/synthetic_checker_test.go
@@ -170,9 +170,9 @@ func TestSynthetic_CheckQuota_ExhaustedState(t *testing.T) {
 	require.Equal(t, 1.0, quota.Limits[0].UsageRatio)
 	require.False(t, quota.Limits[0].Ready)
 
-	require.Equal(t, "warning", quota.Limits[1].Status)
+	require.Equal(t, "exhausted", quota.Limits[1].Status)
 	require.InDelta(t, 1.0, quota.Limits[1].UsageRatio, 0.001)
-	require.True(t, quota.Limits[1].Ready)
+	require.False(t, quota.Limits[1].Ready)
 }
 
 func TestSynthetic_CheckQuota_MissingCredentials(t *testing.T) {


### PR DESCRIPTION
Purpose/Goal: Fix synthetic weekly token quota never reporting exhausted state, causing requests to leak through to upstream provider instead of being blocked by AxonHub.

## Why
The synthetic weekly token quota was never reporting "exhausted" state even when usage reached 100%, causing requests to leak through to the upstream provider instead of being blocked by AxonHub.

## What Accomplished
- Added explicit check for `usageRatio >= 1.0` to set status as "exhausted"
- Updated `Ready` field to return `false` when quota is exhausted
- Test updated to verify correct exhausted state detection

## Spirit/Intent
Ensure AxonHub properly enforces synthetic token quota limits by correctly detecting and blocking requests when the weekly quota is fully consumed, preventing unauthorized upstream calls and protecting against quota exhaustion.