### PR TITLE
fix(transformer/copilot): strip reasoning input items from Responses API requests

### DIFF
--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -146,7 +146,10 @@ var defaultEndpointsForChannelType = map[channel.Type][]objects.ChannelEndpoint{
 		{APIFormat: llm.APIFormatJinaEmbedding.String()},
 	},
 	channel.TypeGithub:           openAICompatibleDefaultEndpoints,
-	channel.TypeGithubCopilot:    {{APIFormat: llm.APIFormatOpenAIChatCompletion.String()}},
+	channel.TypeGithubCopilot: {
+		{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
+		{APIFormat: llm.APIFormatOpenAIResponseCompact.String()},
+	},
 	channel.TypeClaudecode:       {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
 	channel.TypeCerebras:         {{APIFormat: llm.APIFormatOpenAIChatCompletion.String()}},
 	channel.TypeAntigravity:      {{APIFormat: llm.APIFormatGeminiContents.String()}},

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -101,6 +101,14 @@ func TestDefaultEndpointsForChannelType_UseLLMAPIFormatValues(t *testing.T) {
 				llm.APIFormatSeedanceVideo.String(),
 			},
 		},
+		{
+			name: "github copilot exposes chat and compact",
+			typ:  channel.TypeGithubCopilot,
+			expected: []string{
+				llm.APIFormatOpenAIChatCompletion.String(),
+				llm.APIFormatOpenAIResponseCompact.String(),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -122,7 +122,6 @@ func passThroughBodyNeedsModelPatch(apiFormat llm.APIFormat) bool {
 	switch apiFormat {
 	case llm.APIFormatOpenAIChatCompletion,
 		llm.APIFormatOpenAIResponse,
-		llm.APIFormatOpenAIResponseCompact,
 		llm.APIFormatOpenAIEmbedding,
 		llm.APIFormatJinaEmbedding,
 		llm.APIFormatJinaRerank,

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -69,6 +69,9 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 		if !outbound.isPassThroughEnabled(ctx, systemService) {
 			return request, nil
 		}
+		if request.Metadata != nil && request.Metadata[httpclient.MetadataKeyDisablePassThroughBody] == "true" {
+			return request, nil
+		}
 
 		channel := outbound.GetCurrentChannel()
 		llmReq := outbound.state.LlmRequest
@@ -115,7 +118,7 @@ func mergePassThroughRequestBody(rawBody []byte, apiFormat llm.APIFormat, model 
 }
 
 func passThroughBodyNeedsModelPatch(apiFormat llm.APIFormat) bool {
-	//nolint:exhaustive // ohter format do not need model field.
+	//nolint:exhaustive // other formats do not need a top-level model field patched.
 	switch apiFormat {
 	case llm.APIFormatOpenAIChatCompletion,
 		llm.APIFormatOpenAIResponse,

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -971,6 +971,48 @@ func TestApplyPassThroughBodyPreservesMappedModel(t *testing.T) {
 	require.Equal(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"temperature":0.4}`, string(outbound.state.LlmRequest.RawRequest.Body))
 }
 
+func TestApplyPassThroughBodySkipsWhenOutboundDisablesPassThrough(t *testing.T) {
+	ctx := context.Background()
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "pass-through-disabled-by-outbound",
+			Settings: &objects.ChannelSettings{
+				PassThroughBody: lo.ToPtr(true),
+			},
+		},
+	}
+
+	outbound := &PersistentOutboundTransformer{
+		state: &PersistenceState{
+			CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+			LlmRequest: &llm.Request{
+				Model:     "gpt-5.4",
+				APIFormat: llm.APIFormatOpenAIResponse,
+				RawRequest: &httpclient.Request{
+					APIFormat: string(llm.APIFormatOpenAIResponse),
+					Body:      []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","encrypted_content":"enc","summary":[]},{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`),
+				},
+			},
+		},
+	}
+
+	request := &httpclient.Request{
+		APIFormat: string(llm.APIFormatOpenAIResponse),
+		Body:      []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`),
+		Metadata: map[string]string{
+			httpclient.MetadataKeyDisablePassThroughBody: "true",
+		},
+	}
+
+	processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, string(request.Body), string(processed.Body))
+	require.Equal(t, 1, len(gjson.GetBytes(processed.Body, "input").Array()))
+	require.Equal(t, "message", gjson.GetBytes(processed.Body, "input.0.type").String())
+}
+
 func TestApplyPassThroughBodyPreservesMappedModelForJinaRerank(t *testing.T) {
 	ctx := context.Background()
 
@@ -1055,6 +1097,15 @@ func TestMergePassThroughBodySkipsFormatsWithoutTopLevelModel(t *testing.T) {
 	merged, err := mergePassThroughRequestBody(rawBody, llm.APIFormatGeminiContents, "gemini-2.5-pro")
 	require.NoError(t, err)
 	require.Equal(t, string(rawBody), string(merged))
+}
+
+func TestMergePassThroughBodyPatchesResponsesCompactModel(t *testing.T) {
+	rawBody := []byte(`{"model":"my-alias","input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]},{"type":"reasoning","encrypted_content":"enc","summary":[]}]}`)
+
+	merged, err := mergePassThroughRequestBody(rawBody, llm.APIFormatOpenAIResponseCompact, "gpt-5.4")
+	require.NoError(t, err)
+	require.Equal(t, "gpt-5.4", gjson.GetBytes(merged, "model").String())
+	require.Equal(t, 2, len(gjson.GetBytes(merged, "input").Array()))
 }
 
 // TestApplyUserAgentPassThrough tests the User-Agent pass-through middleware.

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1099,13 +1099,12 @@ func TestMergePassThroughBodySkipsFormatsWithoutTopLevelModel(t *testing.T) {
 	require.Equal(t, string(rawBody), string(merged))
 }
 
-func TestMergePassThroughBodyPatchesResponsesCompactModel(t *testing.T) {
-	rawBody := []byte(`{"model":"my-alias","input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]},{"type":"reasoning","encrypted_content":"enc","summary":[]}]}`)
+func TestMergePassThroughBodySkipsResponsesCompactModelPatch(t *testing.T) {
+	rawBody := []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]},{"type":"reasoning","encrypted_content":"enc","summary":[]}]}`)
 
 	merged, err := mergePassThroughRequestBody(rawBody, llm.APIFormatOpenAIResponseCompact, "gpt-5.4")
 	require.NoError(t, err)
-	require.Equal(t, "gpt-5.4", gjson.GetBytes(merged, "model").String())
-	require.Equal(t, 2, len(gjson.GetBytes(merged, "input").Array()))
+	require.Equal(t, string(rawBody), string(merged))
 }
 
 // TestApplyUserAgentPassThrough tests the User-Agent pass-through middleware.

--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -57,6 +57,8 @@ type Request struct {
 	SkipInboundQueryMerge bool `json:"-"`
 }
 
+const MetadataKeyDisablePassThroughBody = "disable_pass_through_body"
+
 // AuthConfig represents authentication configuration.
 type AuthConfig struct {
 	// Type represents the type of authentication.

--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -617,6 +617,10 @@ func (t *OutboundTransformer) transformResponsesRequest(ctx context.Context, llm
 		Type:   httpclient.AuthTypeBearer,
 		APIKey: token,
 	}
+	if responsesReq.Metadata == nil {
+		responsesReq.Metadata = make(map[string]string, 1)
+	}
+	responsesReq.Metadata[httpclient.MetadataKeyDisablePassThroughBody] = "true"
 
 	// Add Copilot-specific headers
 	SetCopilotHeaders(responsesReq.Headers)

--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -80,8 +80,9 @@ func NewOutboundTransformer(params OutboundTransformerParams) (*OutboundTransfor
 
 	// For GPT-5+ models that use Responses API
 	responsesTransformer, err := responses.NewOutboundTransformerWithConfig(&responses.Config{
-		BaseURL:        baseURL,
-		APIKeyProvider: auth.NewStaticKeyProvider(""),
+		BaseURL:             baseURL,
+		APIKeyProvider:      auth.NewStaticKeyProvider(""),
+		StripInputReasoning: true, // Copilot Responses API rejects type="reasoning" input items
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create responses transformer: %w", err)

--- a/llm/transformer/openai/copilot/outbound_test.go
+++ b/llm/transformer/openai/copilot/outbound_test.go
@@ -300,6 +300,46 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 			wantErr: false,
 			validate: func(t *testing.T, req *httpclient.Request) {
 				assert.Equal(t, DefaultCopilotBaseURL+"/v1/responses", req.URL)
+				assert.NotNil(t, req.Metadata)
+				assert.Equal(t, "true", req.Metadata[httpclient.MetadataKeyDisablePassThroughBody])
+			},
+		},
+		{
+			name: "compact requests use responses compact endpoint",
+			params: OutboundTransformerParams{
+				TokenProvider: &mockTokenProvider{token: mockToken},
+			},
+			request: &llm.Request{
+				Model:       "gpt-5.4",
+				RequestType: llm.RequestTypeCompact,
+				Compact: &llm.CompactRequest{
+					Input: []llm.Message{{
+						Role:    "user",
+						Content: llm.MessageContent{Content: lo.ToPtr("Hello, Copilot!")},
+					}},
+				},
+				Messages: []llm.Message{{
+					Role:    "user",
+					Content: llm.MessageContent{Content: lo.ToPtr("Hello, Copilot!")},
+				}},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, req *httpclient.Request) {
+				assert.Equal(t, DefaultCopilotBaseURL+"/v1/responses/compact", req.URL)
+
+				var body map[string]any
+				err := json.Unmarshal(req.Body, &body)
+				require.NoError(t, err)
+
+				input, ok := body["input"].([]any)
+				require.True(t, ok)
+				require.Len(t, input, 1)
+
+				item, ok := input[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "message", item["type"])
+				assert.NotNil(t, req.Metadata)
+				assert.Equal(t, "true", req.Metadata[httpclient.MetadataKeyDisablePassThroughBody])
 			},
 		},
 		{

--- a/llm/transformer/openai/responses/compact_outbound.go
+++ b/llm/transformer/openai/responses/compact_outbound.go
@@ -24,7 +24,7 @@ func (t *OutboundTransformer) transformCompactRequest(
 
 	// Build the compact API request payload
 	// Compact request input is always an ordered message array and must not be collapsed to plain text.
-	input := convertInputFromMessages(llmReq.Compact.Input, llm.TransformOptions{ArrayInputs: lo.ToPtr(true)})
+	input := convertInputFromMessages(llmReq.Compact.Input, llm.TransformOptions{ArrayInputs: lo.ToPtr(true)}, t.config.StripInputReasoning)
 
 	payload := CompactAPIRequest{
 		Model:          llmReq.Model,

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -36,6 +36,13 @@ type Config struct {
 
 	// APIKeyProvider provides API keys for authentication, required.
 	APIKeyProvider auth.APIKeyProvider `json:"-"`
+
+	// StripInputReasoning removes reasoning items (type="reasoning") from the
+	// input array when forwarding requests. Some Responses API providers
+	// (e.g. GitHub Copilot) reject reasoning input items with a 400 error.
+	// The encrypted_content in these items is opaque and only useful for
+	// providers that support OpenAI-style reasoning caching.
+	StripInputReasoning bool `json:"strip_input_reasoning,omitempty"`
 }
 
 func NewOutboundTransformer(baseURL, apiKey string) (*OutboundTransformer, error) {
@@ -167,7 +174,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	payload := Request{
 		Model:                llmReq.Model,
-		Input:                convertInputFromMessages(llmReq.Messages, llmReq.TransformOptions),
+		Input:                convertInputFromMessages(llmReq.Messages, llmReq.TransformOptions, t.config.StripInputReasoning),
 		Instructions:         convertInstructionsFromMessages(llmReq.Messages),
 		Tools:                tools,
 		ParallelToolCalls:    llmReq.ParallelToolCalls,

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -92,7 +92,7 @@ func convertInstructionsFromMessages(msgs []llm.Message) string {
 // User messages become items with content array containing input_text items.
 // Assistant messages become items with type "message" and content array containing output_text items.
 // Tool calls become function_call items, tool results become function_call_output items.
-func convertInputFromMessages(msgs []llm.Message, transformOptions llm.TransformOptions) Input {
+func convertInputFromMessages(msgs []llm.Message, transformOptions llm.TransformOptions, stripInputReasoning bool) Input {
 	if len(msgs) == 0 {
 		return Input{}
 	}
@@ -114,7 +114,7 @@ func convertInputFromMessages(msgs []llm.Message, transformOptions llm.Transform
 		case "user", "developer":
 			items = append(items, convertUserMessage(msg))
 		case "assistant":
-			assistantItems := convertAssistantMessage(msg)
+			assistantItems := convertAssistantMessage(msg, stripInputReasoning)
 			items = append(items, assistantItems...)
 
 			// Record tool call types for later tool result encoding.
@@ -192,7 +192,7 @@ func convertUserMessage(msg llm.Message) Item {
 
 // convertAssistantMessage converts an assistant message to Responses API Item(s) format.
 // Returns multiple items if the message contains tool calls.
-func convertAssistantMessage(msg llm.Message) []Item {
+func convertAssistantMessage(msg llm.Message, stripInputReasoning bool) []Item {
 	var (
 		items         []Item
 		toolCallItems []Item
@@ -206,7 +206,7 @@ func convertAssistantMessage(msg llm.Message) []Item {
 		encryptedContent = shared.DecodeOpenAIEncryptedContent(msg.ReasoningSignature)
 	}
 
-	if encryptedContent != nil {
+	if encryptedContent != nil && !stripInputReasoning {
 		summary := []ReasoningSummary{}
 		if msg.ReasoningContent != nil && *msg.ReasoningContent != "" {
 			summary = append(summary, ReasoningSummary{

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -704,7 +704,7 @@ func TestConvertInputFromMessages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertInputFromMessages(tt.msgs, tt.transformOptions)
+			result := convertInputFromMessages(tt.msgs, tt.transformOptions, false)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -1403,8 +1403,87 @@ func TestConvertAssistantMessage_WithCompactContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertAssistantMessage(tt.msg)
+			result := convertAssistantMessage(tt.msg, false)
 			tt.validate(t, result)
 		})
 	}
+}
+
+func TestConvertAssistantMessage_StripInputReasoning(t *testing.T) {
+	encryptedContent := "gAAAAABpg2hk4yLqQUPBKlNLPwYE5lSfBmhv0P1P10QyeNeFLD2yVYYnLJY8"
+
+	t.Run("reasoning item included when stripInputReasoning is false", func(t *testing.T) {
+		msg := llm.Message{
+			Role:               "assistant",
+			ReasoningSignature: lo.ToPtr(encryptedContent),
+			ReasoningContent:   lo.ToPtr("I need to think about this"),
+			Content: llm.MessageContent{
+				Content: lo.ToPtr("Hello"),
+			},
+		}
+		items := convertAssistantMessage(msg, false)
+		// Should have: reasoning + message
+		require.Len(t, items, 2)
+		require.Equal(t, "reasoning", items[0].Type)
+		require.Equal(t, encryptedContent, *items[0].EncryptedContent)
+		require.Len(t, items[0].Summary, 1)
+		require.Equal(t, "I need to think about this", items[0].Summary[0].Text)
+		require.Equal(t, "message", items[1].Type)
+	})
+
+	t.Run("reasoning item stripped when stripInputReasoning is true", func(t *testing.T) {
+		msg := llm.Message{
+			Role:               "assistant",
+			ReasoningSignature: lo.ToPtr(encryptedContent),
+			ReasoningContent:   lo.ToPtr("I need to think about this"),
+			Content: llm.MessageContent{
+				Content: lo.ToPtr("Hello"),
+			},
+		}
+		items := convertAssistantMessage(msg, true)
+		// Should only have: message (no reasoning item)
+		require.Len(t, items, 1)
+		require.Equal(t, "message", items[0].Type)
+	})
+
+	t.Run("reasoning with tool calls preserved when stripInputReasoning is true", func(t *testing.T) {
+		msg := llm.Message{
+			Role:               "assistant",
+			ReasoningSignature: lo.ToPtr(encryptedContent),
+			ReasoningContent:   lo.ToPtr("Thinking..."),
+			Content: llm.MessageContent{
+				Content: lo.ToPtr(""),
+			},
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "call_123",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "get_weather",
+						Arguments: `{"city":"Tokyo"}`,
+					},
+				},
+			},
+		}
+		items := convertAssistantMessage(msg, true)
+		// Should have: message + function_call (no reasoning)
+		require.Len(t, items, 2)
+		require.Equal(t, "message", items[0].Type)
+		require.Equal(t, "function_call", items[1].Type)
+		require.Equal(t, "call_123", items[1].CallID)
+	})
+
+	t.Run("no reasoning signature produces no reasoning item regardless of flag", func(t *testing.T) {
+		msg := llm.Message{
+			Role: "assistant",
+			Content: llm.MessageContent{
+				Content: lo.ToPtr("Hello"),
+			},
+		}
+		itemsFalse := convertAssistantMessage(msg, false)
+		itemsTrue := convertAssistantMessage(msg, true)
+		require.Equal(t, itemsFalse, itemsTrue)
+		require.Len(t, itemsFalse, 1)
+		require.Equal(t, "message", itemsFalse[0].Type)
+	})
 }


### PR DESCRIPTION
## Summary

GitHub Copilot's Responses API endpoint rejects requests containing `type="reasoning"` input items with a 400 error: `input[N].type "reasoning" is not a valid input item type`. This happens when multi-turn conversations include prior assistant messages that carried OpenAI-style encrypted reasoning content (e.g. from GPT-5.4 models), which gets forwarded verbatim on subsequent requests.

Note: This is distinct from #1656 which changed the chat-completions `ReasoningField` default. That fix doesn't help here because the Responses API uses a different input schema with typed `Item` objects — the `type="reasoning"` item is a Responses-API-specific construct.

## Spirit/Intent

Prevent 400 errors when proxying multi-turn Responses API requests through providers that don't support reasoning input items.

## Key Changes

- Add `StripInputReasoning` config field to `responses.Config` that removes `type="reasoning"` input items from the outbound request payload
- Thread `stripInputReasoning` flag through `convertInputFromMessages` → `convertAssistantMessage` call chain
- Enable `StripInputReasoning: true` in the Copilot outbound transformer (the primary provider that rejects these items)
- Add comprehensive tests covering: reasoning preserved (flag=false), reasoning stripped (flag=true), reasoning+tool-calls stripped, and no-signature passthrough

## Risks

- Providers that **do** support OpenAI reasoning caching (e.g. direct OpenAI API) will lose reasoning context on multi-turn when this flag is enabled. The flag defaults to `false` and is only enabled for Copilot where it's required.
- The encrypted content in reasoning items is opaque — stripping it means the upstream cannot continue a cached reasoning chain, but Copilot doesn't support that mechanism anyway.