### PR TITLE
fix(llm): clear ReasoningEffort when DeepSeek thinking is disabled

### DIFF
--- a/llm/transformer/deepseek/outbound.go
+++ b/llm/transformer/deepseek/outbound.go
@@ -118,6 +118,9 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 	if thinkingDisabled {
 		dsReq.Thinking.Type = "disabled"
+		// Clear ReasoningEffort to avoid sending "none" to DeepSeek API,
+		// which only accepts high/low/medium/max/xhigh.
+		dsReq.Request.ReasoningEffort = ""
 	}
 
 	if !thinkingDisabled {


### PR DESCRIPTION
## Summary

When `reasoning_effort: "none"` is sent to disable thinking mode for DeepSeek channels, the outbound transformer correctly sets `thinking: {type: "disabled"}` but fails to clear the `ReasoningEffort` field from the underlying OpenAI Request struct. This causes the JSON body sent to DeepSeek API to contain both:

```json
{
    "reasoning_effort": "none",
    "thinking": {"type": "disabled"}
}
```

DeepSeek API rejects `reasoning_effort: "none"` as unknown (only accepts `high/low/medium/max/xhigh`), returning HTTP 400.

## Fix

Clear `Request.ReasoningEffort` to empty string when thinking is disabled, so it is omitted from JSON via `omitempty`. The DeepSeek API receives only `thinking: {type: "disabled"}` which correctly disables thinking.

## Changes

- `llm/transformer/deepseek/outbound.go`: Clear `ReasonableEffort` when `thinkingDisabled` is true

Note: The Anthropic-format DeepSeek path (`llm/transformer/anthropic/outbound_convert.go`) was already fixed in #1552 (commit 78ab459).

Closes #1662

## Test plan

- [ ] Send `reasoning_effort: "none"` to a DeepSeek channel via `/v1/chat/completions` — should return normal response without 400 error
- [ ] Send `reasoning_effort: "high"` — should still enable thinking with high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)