### PR TITLE
fix(llm): close text block before starting thinking block in inbound stream

### DIFF
--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -328,6 +328,26 @@ func (s *anthropicInboundStream) Next() bool {
 
 		// Handle reasoning content (thinking) delta
 		if choice.Delta != nil && choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+			// If the text content has started before the thinking content, we need to stop it
+			if s.hasTextContentStarted {
+				if err := s.flushPendingTextCitations(); err != nil {
+					s.err = fmt.Errorf("failed to flush text citations before thinking: %w", err)
+					return false
+				}
+
+				s.hasTextContentStarted = false
+
+				if err := s.enqueEvent(&StreamEvent{
+					Type:  "content_block_stop",
+					Index: &s.contentIndex,
+				}); err != nil {
+					s.err = fmt.Errorf("failed to enqueue content_block_stop event: %w", err)
+					return false
+				}
+
+				s.contentIndex += 1
+			}
+
 			// If the tool content has started before the thinking content, we need to stop it
 			if s.hasToolContentStarted {
 				s.hasToolContentStarted = false


### PR DESCRIPTION
## Summary

- Fix "Content block not found" error in Claude Code when using Anthropic format channels with extended thinking enabled
- The issue occurs when the upstream proxy (observed with **PackyCode** as the relay/proxy; unknown if official Anthropic API or other proxies exhibit the same behavior) returns a text content block **before** the thinking block (text → thinking order)
- The inbound stream transformer now properly closes an open text block before starting a thinking block, mirroring the existing tool block handling

## Root Cause

PackyCode proxy in extended thinking mode returns a short text block before the thinking block:

content_block_start  index=0  type="text"
content_block_delta  index=0  text_delta="\n"
content_block_stop   index=0                    ← text block closed normally
content_block_start  index=1  type="thinking"
content_block_delta  index=1  thinking_delta=...

The **outbound transformer** (Anthropic → LLM format) filters out `content_block_stop` events by design. So the LLM stream becomes:

chunk: {Content: "\n"}          ← from text_delta
chunk: {ReasoningContent: ...}  ← from thinking_delta

The "close" signal for the text block is lost.

The **inbound transformer** (LLM → Anthropic format) receives `Content: "\n"`, sets `hasTextContentStarted = true`, and emits `content_block_start(index=0, text)` + `content_block_delta`.

Then when it receives `ReasoningContent`, the code only checked `hasToolContentStarted` (to close tool blocks) but **did not check `hasTextContentStarted`**. It directly emitted `content_block_start(index=0, thinking)`, reusing index 0 without closing the text block first.

Claude Code sees two `content_block_start` events sharing index 0 with the first block never closed, and reports "Content block not found".

Closes #1655