### PR TITLE
fix(gc): avoid SELECT * when querying old requests/executions for cle…

### DIFF
--- a/internal/server/gc/gc.go
+++ b/internal/server/gc/gc.go
@@ -243,6 +243,12 @@ func (w *Worker) cleanupOldRequestExecutions(ctx context.Context, cutoffTime tim
 
 	for {
 		executions, err := w.Ent.RequestExecution.Query().
+			Select(
+				requestexecution.FieldID,
+				requestexecution.FieldProjectID,
+				requestexecution.FieldDataStorageID,
+				requestexecution.FieldRequestID,
+			).
 			Where(requestexecution.CreatedAtLT(cutoffTime)).
 			Order(ent.Asc(requestexecution.FieldID)).
 			Limit(batchSize).
@@ -286,6 +292,11 @@ func (w *Worker) cleanupOldRequestsRecords(ctx context.Context, cutoffTime time.
 
 	for {
 		reqs, err := w.Ent.Request.Query().
+			Select(
+				request.FieldID,
+				request.FieldProjectID,
+				request.FieldDataStorageID,
+			).
 			Where(request.CreatedAtLT(cutoffTime)).
 			Order(ent.Asc(request.FieldID)).
 			Limit(batchSize).


### PR DESCRIPTION
修复清理旧数据时 SELECT 全字段导致大量数据传输的问题

在 cleanupOldRequestExecutions 和 cleanupOldRequestsRecords 中，原先使用 .All(ctx) 进行 SELECT * 查询，会拉取 request_body、response_body、response_chunks 等大 JSON blob 字段导致：

1. PostgreSQL 到 AxonHub 的大流量数据传输
2. AxonHub内存需求暴涨导致 OOM/节点掉线
3. DELETE 语句尚未执行进程已崩溃，数据未被实际删除

修复方式：使用 .Select() 只查询清理所需的 int 类型字段（ID、ProjectID、DataStorageID、RequestID）