### PR TITLE
修复 Responses 非透传模式下工具原语保真

### DIFF
--- a/llm/model.go
+++ b/llm/model.go
@@ -272,6 +272,10 @@ type Request struct {
 	// - "truncation": *string - truncation strategy ("auto", "disabled")
 	// - "include_obfuscation": *bool - whether to enable stream obfuscation (Responses API specific)
 	TransformerMetadata map[string]any `json:"transformer_metadata,omitempty"`
+
+	// ProviderExtensions stores provider/API-format private sidecar data.
+	// It is intentionally excluded from normal JSON output to avoid leaking raw prompts or tool outputs.
+	ProviderExtensions *ProviderExtensions `json:"-"`
 }
 
 type StreamOptions struct {

--- a/llm/provider_extensions.go
+++ b/llm/provider_extensions.go
@@ -1,0 +1,87 @@
+package llm
+
+import "encoding/json"
+
+// ProviderExtensions carries provider/API-format private data that should not
+// be serialized through the common llm request/response JSON model.
+type ProviderExtensions struct {
+	OpenAIResponses *OpenAIResponsesProviderExtensions `json:"-"`
+}
+
+type OpenAIResponsesProviderExtensions struct {
+	Request *OpenAIResponsesRequestExtensions `json:"-"`
+}
+
+type OpenAIResponsesRequestExtensions struct {
+	RawTools       []OpenAIResponsesRawFragment `json:"-"`
+	ToolSignatures []string                     `json:"-"`
+	RawToolChoice  json.RawMessage              `json:"-"`
+	RawInputItems  []OpenAIResponsesRawFragment `json:"-"`
+}
+
+type OpenAIResponsesRawFragment struct {
+	Type          string          `json:"-"`
+	Name          string          `json:"-"`
+	CallID        string          `json:"-"`
+	OriginalIndex int             `json:"-"`
+	Raw           json.RawMessage `json:"-"`
+}
+
+func EnsureOpenAIResponsesProviderExtensions(req *Request) *OpenAIResponsesProviderExtensions {
+	if req == nil {
+		return nil
+	}
+
+	if req.ProviderExtensions == nil {
+		req.ProviderExtensions = &ProviderExtensions{}
+	}
+
+	if req.ProviderExtensions.OpenAIResponses == nil {
+		req.ProviderExtensions.OpenAIResponses = &OpenAIResponsesProviderExtensions{}
+	}
+
+	return req.ProviderExtensions.OpenAIResponses
+}
+
+func CloneProviderExtensions(src *ProviderExtensions) *ProviderExtensions {
+	if src == nil {
+		return nil
+	}
+
+	cloned := &ProviderExtensions{}
+	if src.OpenAIResponses != nil {
+		cloned.OpenAIResponses = &OpenAIResponsesProviderExtensions{}
+		if src.OpenAIResponses.Request != nil {
+			cloned.OpenAIResponses.Request = &OpenAIResponsesRequestExtensions{
+				RawTools:       cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawTools),
+				ToolSignatures: append([]string(nil), src.OpenAIResponses.Request.ToolSignatures...),
+				RawToolChoice:  cloneRawMessage(src.OpenAIResponses.Request.RawToolChoice),
+				RawInputItems:  cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawInputItems),
+			}
+		}
+	}
+
+	return cloned
+}
+
+func cloneOpenAIResponsesRawFragments(src []OpenAIResponsesRawFragment) []OpenAIResponsesRawFragment {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make([]OpenAIResponsesRawFragment, len(src))
+	for i := range src {
+		out[i] = src[i]
+		out[i].Raw = cloneRawMessage(src[i].Raw)
+	}
+
+	return out
+}
+
+func cloneRawMessage(src json.RawMessage) json.RawMessage {
+	if len(src) == 0 {
+		return nil
+	}
+
+	return append(json.RawMessage(nil), src...)
+}

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -60,7 +60,7 @@ func (t *InboundTransformer) TransformRequest(ctx context.Context, httpReq *http
 		return nil, fmt.Errorf("%w: model is required", transformer.ErrInvalidRequest)
 	}
 
-	return convertToLLMRequest(&req)
+	return convertToLLMRequest(&req, httpReq.Body)
 }
 
 // TransformResponse transforms llm.Response to OpenAI Responses API HTTP response.
@@ -166,7 +166,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 }
 
 // convertToLLMRequest converts OpenAI Responses API Request to llm.Request.
-func convertToLLMRequest(req *Request) (*llm.Request, error) {
+func convertToLLMRequest(req *Request, rawBody ...[]byte) (*llm.Request, error) {
 	chatReq := &llm.Request{
 		Model:               req.Model,
 		Temperature:         req.Temperature,
@@ -293,6 +293,10 @@ func convertToLLMRequest(req *Request) (*llm.Request, error) {
 	// Convert text verbosity
 	if req.Text != nil {
 		chatReq.Verbosity = req.Text.Verbosity
+	}
+
+	if len(rawBody) > 0 {
+		attachOpenAIResponsesRequestExtensions(chatReq, req, rawBody[0])
 	}
 
 	return chatReq, nil

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -154,6 +154,43 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "captures responses provider raw tools and tool choice",
+			httpReq: &httpclient.Request{
+				Body: []byte(`{
+					"model": "gpt-4o",
+					"input": "Search and run shell.",
+					"tools": [
+						{
+							"type": "tool_search",
+							"name": "search_docs",
+							"namespace": "docs"
+						},
+						{
+							"type": "function",
+							"name": "get_weather",
+							"parameters": {"type": "object", "properties": {}}
+						}
+					],
+					"tool_choice": {
+						"type": "tool_search",
+						"tools": [
+							{"type": "tool_search", "name": "search_docs"}
+						]
+					}
+				}`),
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *llm.Request) {
+				require.Len(t, result.Tools, 1)
+				require.NotNil(t, result.ProviderExtensions)
+				require.NotNil(t, result.ProviderExtensions.OpenAIResponses)
+				require.NotNil(t, result.ProviderExtensions.OpenAIResponses.Request)
+				require.Len(t, result.ProviderExtensions.OpenAIResponses.Request.RawTools, 1)
+				require.JSONEq(t, `{"type":"tool_search","name":"search_docs","namespace":"docs"}`, string(result.ProviderExtensions.OpenAIResponses.Request.RawTools[0].Raw))
+				require.JSONEq(t, `{"type":"tool_search","tools":[{"type":"tool_search","name":"search_docs"}]}`, string(result.ProviderExtensions.OpenAIResponses.Request.RawToolChoice))
+			},
+		},
+		{
 			name: "request with image generation tool",
 			httpReq: &httpclient.Request{
 				Body: []byte(`{

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -208,7 +208,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		payload.MaxOutputTokens = llmReq.MaxTokens
 	}
 
-	body, err := json.Marshal(payload)
+	body, err := marshalRequestPayload(payload, llmReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal responses api request: %w", err)
 	}

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -204,6 +204,131 @@ func TestOutboundTransformer_TransformRequest_WebSearchRequiredToolChoice(t *tes
 	require.Equal(t, "required", payload["tool_choice"])
 }
 
+func TestOutboundTransformer_TransformRequest_ReplaysProviderRawToolsAndToolChoice(t *testing.T) {
+	inbound := NewInboundTransformer()
+	inboundReq := &httpclient.Request{
+		Body: []byte(`{
+			"model": "gpt-4o",
+			"input": "Search and run shell.",
+			"tools": [
+				{
+					"type": "tool_search",
+					"name": "search_docs",
+					"namespace": "docs"
+				},
+				{
+					"type": "function",
+					"name": "get_weather",
+					"parameters": {"type": "object", "properties": {}}
+				}
+			],
+			"tool_choice": {
+				"type": "tool_search",
+				"tools": [
+					{"type": "tool_search", "name": "search_docs"}
+				]
+			}
+		}`),
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), inboundReq)
+	require.NoError(t, err)
+	llmReq.Model = "mapped-model"
+
+	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	httpReq, err := outbound.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+	require.Equal(t, "mapped-model", payload["model"])
+
+	tools, ok := payload["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 2)
+	rawTool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "tool_search", rawTool["type"])
+	require.Equal(t, "docs", rawTool["namespace"])
+
+	toolChoice, ok := payload["tool_choice"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "tool_search", toolChoice["type"])
+	require.Len(t, toolChoice["tools"], 1)
+}
+
+func TestOutboundTransformer_TransformRequest_DoesNotReplayRawToolWhenToolsChanged(t *testing.T) {
+	inbound := NewInboundTransformer()
+	inboundReq := &httpclient.Request{
+		Body: []byte(`{
+			"model": "gpt-4o",
+			"input": "Search and run shell.",
+			"tools": [
+				{"type": "tool_search", "name": "search_docs", "namespace": "docs"},
+				{"type": "function", "name": "get_weather", "parameters": {"type": "object", "properties": {}}}
+			]
+		}`),
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), inboundReq)
+	require.NoError(t, err)
+	llmReq.Tools = []llm.Tool{{
+		Type: "function",
+		Function: llm.Function{
+			Name:       "different_tool",
+			Parameters: json.RawMessage(`{"type":"object","properties":{}}`),
+		},
+	}}
+
+	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	httpReq, err := outbound.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+
+	tools, ok := payload["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "function", tool["type"])
+	require.Equal(t, "different_tool", tool["name"])
+}
+
+func TestProviderExtensions_NotSerializedWithLLMRequest(t *testing.T) {
+	req := &llm.Request{
+		Model: "gpt-4o",
+		Messages: []llm.Message{{
+			Role:    "user",
+			Content: llm.MessageContent{Content: lo.ToPtr("hi")},
+		}},
+		ProviderExtensions: &llm.ProviderExtensions{
+			OpenAIResponses: &llm.OpenAIResponsesProviderExtensions{
+				Request: &llm.OpenAIResponsesRequestExtensions{
+					RawTools: []llm.OpenAIResponsesRawFragment{{
+						Type: "tool_search",
+						Raw:  json.RawMessage(`{"secret":"raw prompt"}`),
+					}},
+					RawToolChoice: json.RawMessage(`{"secret":"raw choice"}`),
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "raw prompt")
+	require.NotContains(t, string(data), "raw choice")
+	require.NotContains(t, string(data), "provider_extensions")
+}
+
 func TestOutboundTransformer_TransformRequest(t *testing.T) {
 	transformer, _ := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 

--- a/llm/transformer/openai/responses/request_extensions.go
+++ b/llm/transformer/openai/responses/request_extensions.go
@@ -1,0 +1,314 @@
+package responses
+
+import (
+	"encoding/json"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func attachOpenAIResponsesRequestExtensions(chatReq *llm.Request, req *Request, rawBody []byte) {
+	if chatReq == nil || req == nil {
+		return
+	}
+
+	raw := parseRawRequestFragments(rawBody)
+	requestExt := &llm.OpenAIResponsesRequestExtensions{
+		RawTools:       buildRawOnlyToolFragments(req.Tools, raw.Tools),
+		ToolSignatures: buildRepresentedToolSignatures(req.Tools),
+		RawToolChoice:  rawUnsupportedToolChoice(req.ToolChoice, raw.ToolChoice),
+		RawInputItems:  buildRawOnlyInputFragments(req.Input, raw.InputItems),
+	}
+
+	if len(requestExt.RawTools) == 0 && len(requestExt.RawToolChoice) == 0 && len(requestExt.RawInputItems) == 0 {
+		return
+	}
+
+	ext := llm.EnsureOpenAIResponsesProviderExtensions(chatReq)
+	if ext == nil {
+		return
+	}
+	ext.Request = requestExt
+}
+
+type rawRequestFragments struct {
+	Tools      []json.RawMessage
+	ToolChoice json.RawMessage
+	InputItems []json.RawMessage
+}
+
+func parseRawRequestFragments(rawBody []byte) rawRequestFragments {
+	if len(rawBody) == 0 {
+		return rawRequestFragments{}
+	}
+
+	var raw struct {
+		Tools      []json.RawMessage `json:"tools"`
+		ToolChoice json.RawMessage   `json:"tool_choice"`
+		Input      json.RawMessage   `json:"input"`
+	}
+	if err := json.Unmarshal(rawBody, &raw); err != nil {
+		return rawRequestFragments{}
+	}
+
+	var inputItems []json.RawMessage
+	if len(raw.Input) > 0 && json.Unmarshal(raw.Input, &inputItems) != nil {
+		inputItems = nil
+	}
+
+	return rawRequestFragments{
+		Tools:      raw.Tools,
+		ToolChoice: raw.ToolChoice,
+		InputItems: inputItems,
+	}
+}
+
+func buildRepresentedToolSignatures(tools []Tool) []string {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	signatures := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if !isStructurallyRepresentedToolType(tool.Type) {
+			continue
+		}
+		signatures = append(signatures, responseToolSignature(tool))
+	}
+
+	return signatures
+}
+
+func buildRawOnlyToolFragments(tools []Tool, rawTools []json.RawMessage) []llm.OpenAIResponsesRawFragment {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	fragments := make([]llm.OpenAIResponsesRawFragment, 0, len(tools))
+	for i := range tools {
+		if i >= len(rawTools) || len(rawTools[i]) == 0 || isStructurallyRepresentedToolType(tools[i].Type) {
+			continue
+		}
+
+		fragments = append(fragments, llm.OpenAIResponsesRawFragment{
+			Type:          tools[i].Type,
+			Name:          tools[i].Name,
+			OriginalIndex: i,
+			Raw:           cloneRaw(rawTools[i]),
+		})
+	}
+
+	return fragments
+}
+
+func isStructurallyRepresentedToolType(toolType string) bool {
+	switch toolType {
+	case "function", "image_generation", "web_search", "custom":
+		return true
+	default:
+		return false
+	}
+}
+
+func responseToolSignature(tool Tool) string {
+	switch tool.Type {
+	case "function", "custom":
+		return tool.Type + ":" + tool.Name
+	default:
+		return tool.Type
+	}
+}
+
+func rawUnsupportedToolChoice(choice *ToolChoice, rawChoice json.RawMessage) json.RawMessage {
+	if choice == nil || len(rawChoice) == 0 {
+		return nil
+	}
+
+	if len(choice.Tools) > 0 {
+		return cloneRaw(rawChoice)
+	}
+
+	return nil
+}
+
+func buildRawOnlyInputFragments(input Input, rawItems []json.RawMessage) []llm.OpenAIResponsesRawFragment {
+	if len(input.Items) == 0 {
+		return nil
+	}
+
+	fragments := make([]llm.OpenAIResponsesRawFragment, 0)
+	for i := range input.Items {
+		item := input.Items[i]
+		if i >= len(rawItems) || len(rawItems[i]) == 0 || isStructurallyRepresentedInputItem(item.Type) {
+			continue
+		}
+
+		fragments = append(fragments, llm.OpenAIResponsesRawFragment{
+			Type:          item.Type,
+			Name:          item.Name,
+			CallID:        item.CallID,
+			OriginalIndex: i,
+			Raw:           cloneRaw(rawItems[i]),
+		})
+	}
+
+	return fragments
+}
+
+func isStructurallyRepresentedInputItem(itemType string) bool {
+	switch itemType {
+	case "", "message", "input_text", "input_image", "function_call", "function_call_output",
+		"custom_tool_call", "custom_tool_call_output", "reasoning", "compaction", "compaction_summary":
+		return true
+	default:
+		return false
+	}
+}
+
+func openAIResponsesRequestExtensions(llmReq *llm.Request) *llm.OpenAIResponsesRequestExtensions {
+	if llmReq == nil || llmReq.ProviderExtensions == nil || llmReq.ProviderExtensions.OpenAIResponses == nil {
+		return nil
+	}
+	requestExt := llmReq.ProviderExtensions.OpenAIResponses.Request
+
+	return requestExt
+}
+
+func marshalRequestPayload(payload Request, llmReq *llm.Request) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	requestExt := openAIResponsesRequestExtensions(llmReq)
+	if requestExt == nil {
+		return body, nil
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, err
+	}
+
+	if tools, ok := mergeRawOnlyTools(obj["tools"], requestExt); ok {
+		toolsRaw, err := json.Marshal(tools)
+		if err != nil {
+			return nil, err
+		}
+		obj["tools"] = toolsRaw
+	}
+
+	if len(requestExt.RawToolChoice) > 0 && rawToolChoiceMatchesCurrentTools(requestExt.RawToolChoice, payload.ToolChoice) {
+		obj["tool_choice"] = cloneRaw(requestExt.RawToolChoice)
+	}
+
+	return json.Marshal(obj)
+}
+
+func mergeRawOnlyTools(structuredRaw json.RawMessage, requestExt *llm.OpenAIResponsesRequestExtensions) ([]json.RawMessage, bool) {
+	if requestExt == nil || len(requestExt.RawTools) == 0 {
+		return nil, false
+	}
+
+	var structuredTools []json.RawMessage
+	if len(structuredRaw) > 0 {
+		if err := json.Unmarshal(structuredRaw, &structuredTools); err != nil {
+			return nil, false
+		}
+	}
+	if !structuredToolSignaturesMatch(structuredTools, requestExt.ToolSignatures) {
+		return nil, false
+	}
+
+	total := len(structuredTools) + len(requestExt.RawTools)
+	tools := make([]json.RawMessage, 0, total)
+	structuredIndex := 0
+	rawByIndex := make(map[int]json.RawMessage, len(requestExt.RawTools))
+	for _, fragment := range requestExt.RawTools {
+		if len(fragment.Raw) == 0 || fragment.OriginalIndex < 0 {
+			return nil, false
+		}
+		rawByIndex[fragment.OriginalIndex] = cloneRaw(fragment.Raw)
+	}
+
+	for i := 0; i < total; i++ {
+		if raw, ok := rawByIndex[i]; ok {
+			tools = append(tools, raw)
+			continue
+		}
+		if structuredIndex >= len(structuredTools) {
+			return nil, false
+		}
+		tools = append(tools, cloneRaw(structuredTools[structuredIndex]))
+		structuredIndex++
+	}
+
+	if structuredIndex != len(structuredTools) {
+		return nil, false
+	}
+
+	return tools, true
+}
+
+func structuredToolSignaturesMatch(structuredTools []json.RawMessage, expected []string) bool {
+	if len(structuredTools) != len(expected) {
+		return false
+	}
+
+	for i, rawTool := range structuredTools {
+		var tool Tool
+		if err := json.Unmarshal(rawTool, &tool); err != nil {
+			return false
+		}
+		if responseToolSignature(tool) != expected[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func rawToolChoiceMatchesCurrentTools(raw json.RawMessage, current *ToolChoice) bool {
+	if current == nil {
+		return true
+	}
+
+	var rawChoice ToolChoice
+	if err := json.Unmarshal(raw, &rawChoice); err != nil {
+		return false
+	}
+
+	currentSignature := toolChoiceSignature(current)
+	if currentSignature == "" {
+		return true
+	}
+
+	return toolChoiceSignature(&rawChoice) == currentSignature
+}
+
+func toolChoiceSignature(choice *ToolChoice) string {
+	if choice == nil {
+		return ""
+	}
+
+	if choice.Mode != nil {
+		return "mode:" + *choice.Mode
+	}
+
+	if choice.Type != nil && choice.Name != nil {
+		return "named:" + *choice.Type + ":" + *choice.Name
+	}
+
+	if len(choice.Tools) > 0 {
+		return "tools"
+	}
+
+	return ""
+}
+
+func cloneRaw(src json.RawMessage) json.RawMessage {
+	if len(src) == 0 {
+		return nil
+	}
+
+	return append(json.RawMessage(nil), src...)
+}


### PR DESCRIPTION
# 修复 Responses 非透传模式下工具原语保真

## 背景

OpenAI Responses 非透传转换链路会将请求归一化为通用 `llm.Request`，部分 Provider 原生字段无法完整表达，例如 `tool_search`、`tool_choice.tools` 以及部分原始 `input` item，导致出站请求丢失工具相关信息。

## 修改内容

- 为 `llm.Request` 增加 `ProviderExtensions` sidecar，用于保存 Provider 私有原始片段，并通过 `json:"-"` 避免污染通用序列化。
- 在 Responses inbound 阶段捕获无法映射到通用模型的 tools、tool_choice 和 input item。
- 在 Responses outbound 阶段以结构化 payload 为主，兼容时回填原始 Provider 片段。
- 增加 tool signature 保护，避免结构化 tools 已变化时错误回放旧 raw tool。
- 补充单元测试覆盖捕获、回放、工具变更不回放，以及 `ProviderExtensions` 不参与 JSON 序列化。

## 变更范围

本次修复仅覆盖 OpenAI Responses 请求侧的非透传转换链路，不涉及响应/SSE 透传、UI、GraphQL 或系统配置。

## 验证

已运行：

```bash
cd llm && go test ./transformer/openai/responses
```

关联：https://github.com/looplj/axonhub/issues/1525