### PR TITLE
fix: 修复了多图输入情况下转发失效的问题

### DIFF
--- a/llm/transformer/openai/image_outbound.go
+++ b/llm/transformer/openai/image_outbound.go
@@ -66,8 +66,16 @@ func (t *OutboundTransformer) buildImageGenerationAPIRequest(ctx context.Context
 	return rawReq, nil
 }
 
-func isModelSupportResponseFormat(model string) bool {
-	return !strings.HasPrefix(model, "gpt-image-")
+func supportsImageGenerationResponseFormat(model string) bool {
+	return model == "dall-e-2" || model == "dall-e-3"
+}
+
+func supportsImageEditResponseFormat(model string) bool {
+	return model == "dall-e-2"
+}
+
+func supportsImageVariationResponseFormat(model string) bool {
+	return model == "" || model == "dall-e-2"
 }
 
 // buildImageGenerateRequest builds request for Image Generation API (images/generations).
@@ -123,11 +131,11 @@ func (t *OutboundTransformer) buildImageGenerateRequest(chatReq *llm.Request, ap
 		reqBody["partial_images"] = *img.PartialImages
 	}
 
-	if img.ResponseFormat != "" && isModelSupportResponseFormat(model) {
+	if img.ResponseFormat != "" && supportsImageGenerationResponseFormat(model) {
 		reqBody["response_format"] = img.ResponseFormat
 	}
 
-	if isModelSupportResponseFormat(chatReq.Model) {
+	if supportsImageGenerationResponseFormat(chatReq.Model) {
 		if _, ok := reqBody["response_format"]; !ok {
 			reqBody["response_format"] = "b64_json"
 		}
@@ -212,10 +220,15 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
+	imageFieldName := "image"
+	if len(formFiles) > 1 {
+		imageFieldName = "image[]"
+	}
+
 	// Add images with proper MIME headers
 	for _, formFile := range formFiles {
 		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="image"; filename="%s"`, formFile.Filename))
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, imageFieldName, formFile.Filename))
 		h.Set("Content-Type", formFile.ContentType)
 
 		part, err := writer.CreatePart(h)
@@ -325,7 +338,7 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 			jsonBody["partial_images"] = *img.PartialImages
 		}
 
-		if img.ResponseFormat != "" && model != "gpt-image-1" {
+		if img.ResponseFormat != "" && supportsImageEditResponseFormat(model) {
 			if err := writer.WriteField("response_format", img.ResponseFormat); err != nil {
 				return nil, fmt.Errorf("failed to write response_format field: %w", err)
 			}
@@ -334,7 +347,7 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 		}
 	}
 
-	if model != "gpt-image-1" {
+	if supportsImageEditResponseFormat(model) {
 		if _, ok := jsonBody["response_format"]; !ok {
 			if err := writer.WriteField("response_format", "b64_json"); err != nil {
 				return nil, fmt.Errorf("failed to write response_format field: %w", err)
@@ -460,7 +473,7 @@ func (t *OutboundTransformer) buildImageVariationRequest(chatReq *llm.Request, a
 			jsonBody["size"] = img.Size
 		}
 
-		if img.ResponseFormat != "" && model != "gpt-image-1" {
+		if img.ResponseFormat != "" && supportsImageVariationResponseFormat(model) {
 			if err := writer.WriteField("response_format", img.ResponseFormat); err != nil {
 				return nil, fmt.Errorf("failed to write response_format field: %w", err)
 			}
@@ -469,7 +482,7 @@ func (t *OutboundTransformer) buildImageVariationRequest(chatReq *llm.Request, a
 		}
 	}
 
-	if model != "gpt-image-1" {
+	if supportsImageVariationResponseFormat(model) {
 		if _, ok := jsonBody["response_format"]; !ok {
 			if err := writer.WriteField("response_format", "b64_json"); err != nil {
 				return nil, fmt.Errorf("failed to write response_format field: %w", err)

--- a/llm/transformer/openai/image_outbound_test.go
+++ b/llm/transformer/openai/image_outbound_test.go
@@ -1,10 +1,13 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/samber/lo"
@@ -151,6 +154,28 @@ func TestBuildImageGenerateRequest_WithParameters(t *testing.T) {
 	assert.Equal(t, "transparent", body["background"])
 }
 
+func TestBuildImageGenerateRequest_GPTImageModelOmitsResponseFormat(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+	req := &llm.Request{
+		Model: "gpt-image-2",
+		Image: &llm.ImageRequest{
+			Prompt:         "A futuristic city",
+			ResponseFormat: "b64_json",
+		},
+	}
+
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
+	require.NoError(t, err)
+
+	var body map[string]any
+	err = json.Unmarshal(httpReq.Body, &body)
+	require.NoError(t, err)
+	assert.NotContains(t, body, "response_format")
+}
+
 func TestBuildImageGenerateRequest_NoPrompt(t *testing.T) {
 	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
 	require.NoError(t, err)
@@ -197,6 +222,58 @@ func TestBuildImageEditRequest_WithImage(t *testing.T) {
 
 	// Verify headers - should be multipart/form-data
 	assert.Contains(t, httpReq.Headers.Get("Content-Type"), "multipart/form-data")
+}
+
+func TestBuildImageEditRequest_GPTImage2OmitsResponseFormat(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+	imageData, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==")
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model:     "gpt-image-2",
+		APIFormat: llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt:         "Make this image brighter",
+			Images:         [][]byte{imageData},
+			ResponseFormat: "b64_json",
+		},
+	}
+
+	httpReq, err := ot.buildImageEditRequest(req, "test-key")
+	require.NoError(t, err)
+
+	var body map[string]any
+	err = json.Unmarshal(httpReq.JSONBody, &body)
+	require.NoError(t, err)
+	assert.NotContains(t, body, "response_format")
+}
+
+func TestBuildImageEditRequest_MultipleImagesUsesArrayField(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+	req := &llm.Request{
+		Model:     "gpt-image-2",
+		APIFormat: llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt: "Add the logo from the second image to the first image",
+			Images: [][]byte{[]byte("image1"), []byte("image2")},
+		},
+	}
+
+	httpReq, err := ot.buildImageEditRequest(req, "test-key")
+	require.NoError(t, err)
+
+	reader := multipart.NewReader(bytes.NewReader(httpReq.Body), strings.TrimPrefix(httpReq.Headers.Get("Content-Type"), "multipart/form-data; boundary="))
+	form, err := reader.ReadForm(1024)
+	require.NoError(t, err)
+
+	assert.Empty(t, form.File["image"])
+	assert.Len(t, form.File["image[]"], 2)
 }
 
 func TestBuildImageEditRequest_NoImage(t *testing.T) {


### PR DESCRIPTION
本次 PR 修复了以下我们在实际测试中发现的两个问题：

1. 使用 gpt-image-2 模型的 edit endpoint 的时候，网关会自动注入 `response_format` 字段，导致上游拒绝本次生图请求
2. 多图下使用 image[] 字段，网关代码硬编码了 name="image"，导致上游将请求内识别成为了重复字段拒绝生图请求

修复前后：

<img width="1260" height="216" alt="image" src="https://github.com/user-attachments/assets/c74d6c5d-4679-4833-b233-2f3c23f309d2" />
<img width="1314" height="445" alt="image" src="https://github.com/user-attachments/assets/95971417-4796-4b70-a1ef-d54fc74b0121" />

