### PR TITLE
Preserve request log filters on detail navigation

### DIFF
--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -5,30 +5,26 @@ import { RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
+import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { DateRangePicker } from '@/components/date-range-picker';
-import { DataTableViewOptions } from './data-table-view-options';
 import { useApiKeys } from '@/features/apikeys/data';
 import { useMe } from '@/features/auth/data/auth';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { RequestStatus } from '../data/schema';
-import type { DateTimeRangeValue } from '@/utils/date-range';
-
+import { DataTableViewOptions } from './data-table-view-options';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
   dateRange?: DateTimeRangeValue;
   onDateRangeChange?: (range: DateTimeRangeValue | undefined) => void;
+  onResetFilters?: () => void;
   onRefresh?: () => void;
   showRefresh?: boolean;
-  apiKeyFilter?: string[];
-  onApiKeyFilterChange?: (filters: string[]) => void;
-  sourceFilter?: string[];
-  onSourceFilterChange?: (filters: string[]) => void;
   autoRefresh?: boolean;
   onAutoRefreshChange?: (enabled: boolean) => void;
 }
@@ -37,12 +33,9 @@ export function DataTableToolbar<TData>({
   table,
   dateRange,
   onDateRangeChange,
+  onResetFilters,
   onRefresh,
   showRefresh = false,
-  apiKeyFilter,
-  onApiKeyFilterChange,
-  sourceFilter,
-  onSourceFilterChange,
   autoRefresh = false,
   onAutoRefreshChange,
 }: DataTableToolbarProps<TData>) {
@@ -62,14 +55,10 @@ export function DataTableToolbar<TData>({
       if (currentFilter && currentFilter.length > 0) {
         // Compute visible IDs from raw data (filtering for non-archived status)
         const visibleIds = new Set(
-          apiKeysData?.edges
-            ?.filter((edge) => edge.node.status !== 'archived')
-            ?.map((edge) => edge.node.id) ?? []
+          apiKeysData?.edges?.filter((edge) => edge.node.status !== 'archived')?.map((edge) => edge.node.id) ?? []
         );
         const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
-        table
-          .getColumn('apiKey')
-          ?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
+        table.getColumn('apiKey')?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
       }
     }
   };
@@ -84,14 +73,10 @@ export function DataTableToolbar<TData>({
       if (currentFilter && currentFilter.length > 0) {
         // Compute visible IDs from raw data (filtering for non-archived status)
         const visibleIds = new Set(
-          channelsData?.edges
-            ?.filter((edge) => edge.node.status !== 'archived')
-            ?.map((edge) => edge.node.id) ?? []
+          channelsData?.edges?.filter((edge) => edge.node.status !== 'archived')?.map((edge) => edge.node.id) ?? []
         );
         const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
-        table
-          .getColumn('channel')
-          ?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
+        table.getColumn('channel')?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
       }
     }
   };
@@ -193,13 +178,9 @@ export function DataTableToolbar<TData>({
           <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
         )}
         {table.getColumn('source') && (
-          <DataTableFacetedFilter
-            column={table.getColumn('source')}
-            title={t('requests.filters.source')}
-            options={requestSources}
-          />
+          <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
         )}
-         {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+        {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
           <DataTableFacetedFilter
             column={table.getColumn('channel')}
             title={t('requests.filters.channel')}
@@ -224,7 +205,7 @@ export function DataTableToolbar<TData>({
             }
           />
         )}
-         {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+        {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
           <DataTableFacetedFilter
             column={table.getColumn('apiKey')}
             title={t('requests.filters.apiKey')}
@@ -256,14 +237,7 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
         {isFiltered && (
-          <Button
-            variant='ghost'
-            onClick={() => {
-              table.resetColumnFilters();
-              onDateRangeChange?.(undefined);
-            }}
-            className='h-8 px-2 lg:px-3'
-          >
+          <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
             {t('common.filters.reset')}
             <Cross2Icon className='ml-2 h-4 w-4' />
           </Button>

--- a/frontend/src/features/requests/components/index.ts
+++ b/frontend/src/features/requests/components/index.ts
@@ -1,4 +1,4 @@
-export { RequestsTable } from './requests-table';
+export { RequestsTable, type RequestTableFilters } from './requests-table';
 export { DataTableToolbar } from './data-table-toolbar';
 export { DataTableViewOptions } from './data-table-view-options';
 export { DataTablePagination } from './data-table-pagination';

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -342,8 +342,8 @@ export default function RequestDetailPage() {
   const handleBack = () => {
     navigate({
       to: '/project/requests',
-      search: currentSearch as any,
-    } as any);
+      search: currentSearch,
+    });
   };
 
   return (

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -1,17 +1,16 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { format } from 'date-fns';
-import { useParams, useNavigate } from '@tanstack/react-router';
+import { useParams, useNavigate, useRouterState } from '@tanstack/react-router';
 import { ArrowLeft, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { getTokenFromStorage } from '@/stores/authStore';
+import { useSelectedProjectId } from '@/stores/projectStore';
 import { extractNumberID } from '@/lib/utils';
-import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
 import { useStoragePolicy } from '@/features/system/data/system';
-import { useSelectedProjectId } from '@/stores/projectStore';
-import { getTokenFromStorage } from '@/stores/authStore';
 import { type Request, useRequest } from '../data';
 import { RequestDetailContent } from './request-detail-content';
 
@@ -120,7 +119,9 @@ export default function RequestDetailPage() {
   const { t } = useTranslation();
   const { requestId } = useParams({ from: '/_authenticated/project/requests/$requestId' });
   const navigate = useNavigate();
-  const { getSearchParams } = usePaginationSearch({ defaultPageSize: 20 });
+  const currentSearch = useRouterState({
+    select: (state) => (state.location.search ?? {}) as Record<string, unknown>,
+  });
   const selectedProjectId = useSelectedProjectId();
   const { data: storagePolicy } = useStoragePolicy();
   const isLivePreviewEnabled = storagePolicy?.livePreview ?? false;
@@ -130,10 +131,10 @@ export default function RequestDetailPage() {
   const previewCompletedRef = useRef(false);
   const previewChunkCountRef = useRef(0);
 
-  const {
-    data: requestData,
-    refetch: refetchRequest,
-  } = useRequest(requestId, { projectId: selectedProjectId, disableAutoRefresh: isPreviewStreaming });
+  const { data: requestData, refetch: refetchRequest } = useRequest(requestId, {
+    projectId: selectedProjectId,
+    disableAutoRefresh: isPreviewStreaming,
+  });
 
   const request = previewRequest ?? requestData;
 
@@ -246,12 +247,14 @@ export default function RequestDetailPage() {
         if (!contentType.includes('text/event-stream')) {
           const fallbackResponse = (await response.json()) as PreviewFallbackResponse;
           if (!isDisposed && fallbackResponse.mode === 'static-fetch') {
-            setPreviewRequest((currentRequest) => currentRequest
-              ? {
-                  ...currentRequest,
-                  responseChunks: fallbackResponse.responseChunks ?? currentRequest.responseChunks,
-                }
-              : currentRequest);
+            setPreviewRequest((currentRequest) =>
+              currentRequest
+                ? {
+                    ...currentRequest,
+                    responseChunks: fallbackResponse.responseChunks ?? currentRequest.responseChunks,
+                  }
+                : currentRequest
+            );
             setIsPreviewStreaming(false);
             setPreviewFallbackActive(true);
           } else if (!isDisposed) {
@@ -278,12 +281,14 @@ export default function RequestDetailPage() {
 
               const nextChunk = parsePreviewChunk(data);
               previewChunkCountRef.current += 1;
-              setPreviewRequest((currentRequest) => currentRequest
-                ? {
-                  ...currentRequest,
-                  responseChunks: [...(currentRequest.responseChunks ?? []), nextChunk],
-                }
-                : currentRequest);
+              setPreviewRequest((currentRequest) =>
+                currentRequest
+                  ? {
+                      ...currentRequest,
+                      responseChunks: [...(currentRequest.responseChunks ?? []), nextChunk],
+                    }
+                  : currentRequest
+              );
               return;
             }
 
@@ -337,8 +342,8 @@ export default function RequestDetailPage() {
   const handleBack = () => {
     navigate({
       to: '/project/requests',
-      search: getSearchParams(),
-    });
+      search: currentSearch as any,
+    } as any);
   };
 
   return (
@@ -356,7 +361,8 @@ export default function RequestDetailPage() {
             </div>
             <div>
               <h1 className='text-lg leading-none font-semibold'>
-                {t('requests.detail.title')} #{request ? extractNumberID(request.id) || request.id : extractNumberID(requestId) || requestId}
+                {t('requests.detail.title')} #
+                {request ? extractNumberID(request.id) || request.id : extractNumberID(requestId) || requestId}
               </h1>
               {request && (
                 <div className='mt-1 flex items-center gap-2'>

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-
 import { format } from 'date-fns';
 import { ColumnDef } from '@tanstack/react-table';
 import { IconRoute, IconArrowsJoin2 } from '@tabler/icons-react';
@@ -9,6 +8,7 @@ import { ArrowLeftRight, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { extractNumberID } from '@/lib/utils';
 import { formatDuration } from '@/utils/format-duration';
+import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -16,13 +16,12 @@ import { DataTableColumnHeader } from '@/components/data-table-column-header';
 import { useGeneralSettings } from '@/features/system/data/system';
 import { useRequestPermissions } from '../../../hooks/useRequestPermissions';
 import { Request } from '../data/schema';
-import { getStatusColor } from './help';
 import { calculateTokensPerSecond, useDisplayMode } from '../utils/tokens-per-second';
-
-import { usePaginationSearch } from '@/hooks/use-pagination-search';
+import { getStatusColor } from './help';
 
 interface UseRequestsColumnsOptions {
   onBodyClick?: (requestId: string, index: number) => void;
+  onViewDetail?: (requestId: string) => void;
 }
 
 export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnDef<Request>[] {
@@ -196,105 +195,103 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     // Channel column - only show if user has permission to view channels
     ...(permissions.canViewChannels
       ? ([
-        {
-          id: 'channel',
-          accessorFn: (row) => row.channel?.id || '',
-          header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.channel')} />,
-          enableSorting: false,
-          cell: ({ row }) => {
-            const request = row.original;
-            const channel = request.channel;
+          {
+            id: 'channel',
+            accessorFn: (row) => row.channel?.id || '',
+            header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.channel')} />,
+            enableSorting: false,
+            cell: ({ row }) => {
+              const request = row.original;
+              const channel = request.channel;
 
-            if (!channel) {
-              return <div className='text-muted-foreground font-mono text-xs'>-</div>;
-            }
+              if (!channel) {
+                return <div className='text-muted-foreground font-mono text-xs'>-</div>;
+              }
 
-            // Check if there are any executions with different channels
-            const executions = request.executions?.edges?.map((edge) => edge.node).filter((exe) => !!exe) || [];
-            const hasMultipleChannels = executions.some((exe) => exe.channel?.id && exe.channel.id !== channel.id);
+              // Check if there are any executions with different channels
+              const executions = request.executions?.edges?.map((edge) => edge.node).filter((exe) => !!exe) || [];
+              const hasMultipleChannels = executions.some((exe) => exe.channel?.id && exe.channel.id !== channel.id);
 
-            if (executions.length > 1 || hasMultipleChannels) {
-              const sortedExecutions = [...executions].sort((a, b) => {
-                const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-                const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-                return dateB - dateA;
-              });
+              if (executions.length > 1 || hasMultipleChannels) {
+                const sortedExecutions = [...executions].sort((a, b) => {
+                  const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+                  const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+                  return dateB - dateA;
+                });
 
-              return (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type='button'
-                      className='flex w-fit cursor-help items-center gap-1.5 rounded-lg border border-rose-200 bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700 transition-colors hover:bg-rose-100 dark:border-rose-800/50 dark:bg-rose-900/30 dark:text-rose-300 dark:hover:bg-rose-900/50'
-                    >
-                      <span>{channel.name}</span>
-                      <IconArrowsJoin2 className='h-3.5 w-3.5 opacity-80' />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side='right' className='border-rose-200 bg-white p-0 dark:bg-zinc-900'>
-                    <div className='flex min-w-[240px] flex-col'>
-                      <div className='flex flex-col gap-1 border-b p-3 bg-rose-50/50 dark:bg-rose-900/10'>
-                        <div className='text-rose-900 dark:text-rose-300 flex items-center gap-2 text-xs font-bold tracking-wider uppercase'>
-                          <IconArrowsJoin2 className='h-3.5 w-3.5' />
-                          {t('requests.columns.retryProcess')}
+                return (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type='button'
+                        className='flex w-fit cursor-help items-center gap-1.5 rounded-lg border border-rose-200 bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700 transition-colors hover:bg-rose-100 dark:border-rose-800/50 dark:bg-rose-900/30 dark:text-rose-300 dark:hover:bg-rose-900/50'
+                      >
+                        <span>{channel.name}</span>
+                        <IconArrowsJoin2 className='h-3.5 w-3.5 opacity-80' />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side='right' className='border-rose-200 bg-white p-0 dark:bg-zinc-900'>
+                      <div className='flex min-w-[240px] flex-col'>
+                        <div className='flex flex-col gap-1 border-b bg-rose-50/50 p-3 dark:bg-rose-900/10'>
+                          <div className='flex items-center gap-2 text-xs font-bold tracking-wider text-rose-900 uppercase dark:text-rose-300'>
+                            <IconArrowsJoin2 className='h-3.5 w-3.5' />
+                            {t('requests.columns.retryProcess')}
+                          </div>
+                        </div>
+                        <div className='flex flex-col gap-1 p-2'>
+                          {sortedExecutions.map((exe, idx) => (
+                            <div
+                              key={exe.id || idx}
+                              className='hover:bg-muted/50 flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors'
+                            >
+                              <Badge className={`${getStatusColor(exe.status || '')} h-5 shrink-0 px-1.5 text-[10px] font-bold uppercase`}>
+                                {t(`requests.status.${exe.status}`)}
+                              </Badge>
+                              <div className='flex min-w-0 flex-col'>
+                                <span className='text-foreground truncate text-xs font-semibold'>
+                                  {exe.channel?.name || t('requests.columns.unknown')}
+                                </span>
+                                {exe.createdAt && (
+                                  <span className='text-muted-foreground text-[10px]'>
+                                    {format(new Date(exe.createdAt), 'HH:mm:ss', { locale })}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       </div>
-                      <div className='flex flex-col gap-1 p-2'>
-                        {sortedExecutions.map((exe, idx) => (
-                          <div
-                            key={exe.id || idx}
-                            className='hover:bg-muted/50 flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors'
-                          >
-                            <Badge
-                              className={`${getStatusColor(exe.status || '')} h-5 shrink-0 px-1.5 text-[10px] font-bold uppercase`}
-                            >
-                              {t(`requests.status.${exe.status}`)}
-                            </Badge>
-                            <div className='flex min-w-0 flex-col'>
-                              <span className='text-foreground truncate text-xs font-semibold'>
-                                {exe.channel?.name || t('requests.columns.unknown')}
-                              </span>
-                              {exe.createdAt && (
-                                <span className='text-muted-foreground text-[10px]'>
-                                  {format(new Date(exe.createdAt), 'HH:mm:ss', { locale })}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            }
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              }
 
-            return <div className='px-2 font-mono text-xs'>{channel.name}</div>;
+              return <div className='px-2 font-mono text-xs'>{channel.name}</div>;
+            },
+            filterFn: (row, _id, value) => {
+              // For client-side filtering, check if any of the selected channels match
+              if (value.length === 0) return true; // No filter applied
+
+              const channel = row.original.channel;
+              if (!channel) return false;
+
+              return value.includes(channel.id);
+            },
           },
-          filterFn: (row, _id, value) => {
-            // For client-side filtering, check if any of the selected channels match
-            if (value.length === 0) return true; // No filter applied
-
-            const channel = row.original.channel;
-            if (!channel) return false;
-
-            return value.includes(channel.id);
-          },
-        },
-      ] as ColumnDef<Request>[])
+        ] as ColumnDef<Request>[])
       : []),
     // API Key column - only show if user has permission to view API keys
     ...(permissions.canViewApiKeys
       ? ([
-        {
-          accessorKey: 'apiKey',
-          header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiKey')} />,
-          enableSorting: false,
-          cell: ({ row }) => {
-            return <div className='font-mono text-xs'>{row.original.apiKey?.name || '-'}</div>;
+          {
+            accessorKey: 'apiKey',
+            header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiKey')} />,
+            enableSorting: false,
+            cell: ({ row }) => {
+              return <div className='font-mono text-xs'>{row.original.apiKey?.name || '-'}</div>;
+            },
           },
-        },
-      ] as ColumnDef<Request>[])
+        ] as ColumnDef<Request>[])
       : []),
 
     {
@@ -460,25 +457,22 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
       id: 'latency',
       accessorFn: (row) => row.metricsLatencyMs ?? null,
       header: ({ column }) => (
-        <div className="flex items-center gap-1">
+        <div className='flex items-center gap-1'>
           {displayMode === 'latency' ? (
-            <DataTableColumnHeader
-              column={column}
-              title={t('requests.columns.latency')}
-            />
+            <DataTableColumnHeader column={column} title={t('requests.columns.latency')} />
           ) : (
-            <span className="uppercase text-sm font-medium">{t('requests.columns.tokensPerSecond')}</span>
+            <span className='text-sm font-medium uppercase'>{t('requests.columns.tokensPerSecond')}</span>
           )}
           <button
             onClick={(e) => {
               e.stopPropagation();
-              setDisplayMode(prev => prev === 'latency' ? 'tokensPerSecond' : 'latency');
+              setDisplayMode((prev) => (prev === 'latency' ? 'tokensPerSecond' : 'latency'));
             }}
-            className="cursor-pointer hover:text-primary transition-colors"
+            className='hover:text-primary cursor-pointer transition-colors'
             title={displayMode === 'latency' ? t('requests.columns.showTokensPerSecond') : t('requests.columns.showLatency')}
-            type="button"
+            type='button'
           >
-            <ArrowLeftRight className="h-3 w-3 text-muted-foreground" />
+            <ArrowLeftRight className='text-muted-foreground h-3 w-3' />
           </button>
         </div>
       ),
@@ -524,12 +518,17 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         <Button
           variant='outline'
           size='sm'
-          onClick={() =>
+          onClick={() => {
+            if (options?.onViewDetail) {
+              options.onViewDetail(row.original.id);
+              return;
+            }
+
             navigateWithSearch({
               to: '/project/requests/$requestId',
               params: { requestId: row.original.id },
-            })
-          }
+            });
+          }}
         >
           <FileText className='mr-2 h-4 w-4' />
           {t('requests.actions.viewDetails')}

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   ColumnFiltersState,
   RowData,
@@ -14,15 +14,15 @@ import {
 } from '@tanstack/react-table';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import type { DateTimeRangeValue } from '@/utils/date-range';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TableSkeleton } from '@/components/ui/table-skeleton';
 import { ServerSidePagination } from '@/components/server-side-pagination';
-import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Request, RequestConnection } from '../data/schema';
 import { DataTableToolbar } from './data-table-toolbar';
-import { useRequestsColumns } from './requests-columns';
 import { RequestBodyDrawer } from './request-body-drawer';
+import { useRequestsColumns } from './requests-columns';
 
 const MotionTableRow = motion.create(TableRow);
 
@@ -43,21 +43,38 @@ interface RequestsTableProps {
   sourceFilter: string[];
   channelFilter: string[];
   apiKeyFilter: string[];
+  modelIDFilter: string;
   dateRange?: DateTimeRangeValue;
   queryWhere?: Record<string, any>;
   onNextPage: () => void;
   onPreviousPage: () => void;
   onPageSizeChange: (pageSize: number) => void;
-  onStatusFilterChange: (filters: string[]) => void;
-  onSourceFilterChange: (filters: string[]) => void;
-  onChannelFilterChange: (filters: string[]) => void;
-  onApiKeyFilterChange: (filters: string[]) => void;
-  onModelIDFilterChange: (filter: string) => void;
+  onFiltersChange: (filters: RequestTableFilters) => void;
   onDateRangeChange: (range: DateTimeRangeValue | undefined) => void;
+  onResetFilters: () => void;
+  onViewDetail: (requestId: string) => void;
   onRefresh: () => void;
   showRefresh: boolean;
   autoRefresh?: boolean;
   onAutoRefreshChange?: (enabled: boolean) => void;
+}
+
+export interface RequestTableFilters {
+  statusFilter: string[];
+  sourceFilter: string[];
+  channelFilter: string[];
+  apiKeyFilter: string[];
+  modelIDFilter: string;
+}
+
+function getFilterArrayValue(filters: ColumnFiltersState, id: string) {
+  const value = filters.find((filter) => filter.id === id)?.value;
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function getFilterStringValue(filters: ColumnFiltersState, id: string) {
+  const value = filters.find((filter) => filter.id === id)?.value;
+  return typeof value === 'string' ? value : '';
 }
 
 export function RequestsTable({
@@ -70,17 +87,16 @@ export function RequestsTable({
   sourceFilter,
   channelFilter,
   apiKeyFilter,
+  modelIDFilter,
   dateRange,
   queryWhere,
   onNextPage,
   onPreviousPage,
   onPageSizeChange,
-  onStatusFilterChange,
-  onSourceFilterChange,
-  onChannelFilterChange,
-  onApiKeyFilterChange,
-  onModelIDFilterChange,
+  onFiltersChange,
   onDateRangeChange,
+  onResetFilters,
+  onViewDetail,
   onRefresh,
   showRefresh,
   autoRefresh = false,
@@ -98,9 +114,8 @@ export function RequestsTable({
     setDrawerOpen(true);
   }, []);
 
-  const requestsColumns = useRequestsColumns({ onBodyClick: handleBodyClick });
+  const requestsColumns = useRequestsColumns({ onBodyClick: handleBodyClick, onViewDetail });
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
     const stored = localStorage.getItem('requests-table-column-visibility');
@@ -122,46 +137,40 @@ export function RequestsTable({
 
   const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 
-  // Sync filters with the server state
-  const handleColumnFiltersChange = (updater: any) => {
-    const newFilters = typeof updater === 'function' ? updater(columnFilters) : updater;
-    setColumnFilters(newFilters);
+  const columnFilters = useMemo<ColumnFiltersState>(() => {
+    const filters: ColumnFiltersState = [];
+    if (statusFilter.length > 0) {
+      filters.push({ id: 'status', value: statusFilter });
+    }
+    if (sourceFilter.length > 0) {
+      filters.push({ id: 'source', value: sourceFilter });
+    }
+    if (channelFilter.length > 0) {
+      filters.push({ id: 'channel', value: channelFilter });
+    }
+    if (apiKeyFilter.length > 0) {
+      filters.push({ id: 'apiKey', value: apiKeyFilter });
+    }
+    if (modelIDFilter) {
+      filters.push({ id: 'modelID', value: modelIDFilter });
+    }
+    return filters;
+  }, [statusFilter, sourceFilter, channelFilter, apiKeyFilter, modelIDFilter]);
 
-    const statusFilterValue = newFilters.find((filter: any) => filter.id === 'status')?.value;
-    const sourceFilterValue = newFilters.find((filter: any) => filter.id === 'source')?.value;
-    const channelFilterValue = newFilters.find((filter: any) => filter.id === 'channel')?.value;
-    const apiKeyFilterValue = newFilters.find((filter: any) => filter.id === 'apiKey')?.value;
-    const modelIDFilterValue = newFilters.find((filter: any) => filter.id === 'modelID')?.value;
+  const handleColumnFiltersChange = useCallback(
+    (updater: any) => {
+      const newFilters = typeof updater === 'function' ? updater(columnFilters) : updater;
 
-    const statusFilterArray = Array.isArray(statusFilterValue) ? statusFilterValue : [];
-    onStatusFilterChange(statusFilterArray);
-
-    const sourceFilterArray = Array.isArray(sourceFilterValue) ? sourceFilterValue : [];
-    onSourceFilterChange(sourceFilterArray);
-
-    const channelFilterArray = Array.isArray(channelFilterValue) ? channelFilterValue : [];
-    onChannelFilterChange(channelFilterArray);
-
-    const apiKeyFilterArray = Array.isArray(apiKeyFilterValue) ? apiKeyFilterValue : [];
-    onApiKeyFilterChange(apiKeyFilterArray);
-
-    onModelIDFilterChange(typeof modelIDFilterValue === 'string' ? modelIDFilterValue : '');
-  };
-
-  // Initialize filters in column filters if they exist
-  const initialColumnFilters = [];
-  if (statusFilter.length > 0) {
-    initialColumnFilters.push({ id: 'status', value: statusFilter });
-  }
-  if (sourceFilter.length > 0) {
-    initialColumnFilters.push({ id: 'source', value: sourceFilter });
-  }
-  if (channelFilter.length > 0) {
-    initialColumnFilters.push({ id: 'channel', value: channelFilter });
-  }
-  if (apiKeyFilter.length > 0) {
-    initialColumnFilters.push({ id: 'apiKey', value: apiKeyFilter });
-  }
+      onFiltersChange({
+        statusFilter: getFilterArrayValue(newFilters, 'status'),
+        sourceFilter: getFilterArrayValue(newFilters, 'source'),
+        channelFilter: getFilterArrayValue(newFilters, 'channel'),
+        apiKeyFilter: getFilterArrayValue(newFilters, 'apiKey'),
+        modelIDFilter: getFilterStringValue(newFilters, 'modelID'),
+      });
+    },
+    [columnFilters, onFiltersChange]
+  );
 
   const table = useReactTable({
     data: displayedData,
@@ -171,11 +180,7 @@ export function RequestsTable({
       sorting,
       columnVisibility,
       rowSelection,
-      columnFilters:
-        columnFilters.length === 0 &&
-        (statusFilter.length > 0 || sourceFilter.length > 0 || channelFilter.length > 0 || apiKeyFilter.length > 0)
-          ? initialColumnFilters
-          : columnFilters,
+      columnFilters,
     },
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
@@ -198,77 +203,74 @@ export function RequestsTable({
         table={table}
         dateRange={dateRange}
         onDateRangeChange={onDateRangeChange}
+        onResetFilters={onResetFilters}
         onRefresh={onRefresh}
         showRefresh={showRefresh}
-        apiKeyFilter={apiKeyFilter}
-        onApiKeyFilterChange={onApiKeyFilterChange}
-        sourceFilter={sourceFilter}
-        onSourceFilterChange={onSourceFilterChange}
         autoRefresh={autoRefresh}
         onAutoRefreshChange={onAutoRefreshChange}
       />
       <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
         <div className='min-w-max'>
           <Table data-testid='requests-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
-          <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className='group/row border-0'>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead
-                      key={header.id}
-                      colSpan={header.colSpan}
-                      className={`${header.column.columnDef.meta?.className ?? ''} text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
-                    >
-                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody className='space-y-1 !bg-[var(--table-background)] p-2'>
-            {loading ? (
-              <TableSkeleton rows={pageSize} columns={requestsColumns.length} />
-            ) : table.getRowModel().rows?.length ? (
-              <AnimatePresence initial={false} mode='popLayout'>
-                {table.getRowModel().rows.map((row) => (
-                  <MotionTableRow
-                    key={row.id}
-                    data-state={row.getIsSelected() && 'selected'}
-                    initial={{ opacity: 0, y: -20, height: 0 }}
-                    animate={{ opacity: 1, y: 0, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{
-                      type: 'spring',
-                      stiffness: 500,
-                      damping: 30,
-                      mass: 1,
-                      opacity: { duration: 0.2 },
-                    }}
-                    layout
-                    className='group/row hover:bg-muted/50 data-[state=selected]:bg-muted'
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell
-                        key={cell.id}
-                        className={`${cell.column.columnDef.meta?.className ?? ''} border-b border-[var(--table-border)] py-3 group-last/row:border-0`}
+            <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id} className='group/row border-0'>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead
+                        key={header.id}
+                        colSpan={header.colSpan}
+                        className={`${header.column.columnDef.meta?.className ?? ''} text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
                       >
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    ))}
-                  </MotionTableRow>
-                ))}
-              </AnimatePresence>
-            ) : (
-              <TableRow className='!bg-[var(--table-background)]'>
-                <TableCell colSpan={requestsColumns.length} className='h-24 !bg-[var(--table-background)] text-center'>
-                  {t('common.noData')}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+                        {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody className='space-y-1 !bg-[var(--table-background)] p-2'>
+              {loading ? (
+                <TableSkeleton rows={pageSize} columns={requestsColumns.length} />
+              ) : table.getRowModel().rows?.length ? (
+                <AnimatePresence initial={false} mode='popLayout'>
+                  {table.getRowModel().rows.map((row) => (
+                    <MotionTableRow
+                      key={row.id}
+                      data-state={row.getIsSelected() && 'selected'}
+                      initial={{ opacity: 0, y: -20, height: 0 }}
+                      animate={{ opacity: 1, y: 0, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{
+                        type: 'spring',
+                        stiffness: 500,
+                        damping: 30,
+                        mass: 1,
+                        opacity: { duration: 0.2 },
+                      }}
+                      layout
+                      className='group/row hover:bg-muted/50 data-[state=selected]:bg-muted'
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell
+                          key={cell.id}
+                          className={`${cell.column.columnDef.meta?.className ?? ''} border-b border-[var(--table-border)] py-3 group-last/row:border-0`}
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </MotionTableRow>
+                  ))}
+                </AnimatePresence>
+              ) : (
+                <TableRow className='!bg-[var(--table-background)]'>
+                  <TableCell colSpan={requestsColumns.length} className='h-24 !bg-[var(--table-background)] text-center'>
+                    {t('common.noData')}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
       </div>
       <div className='mt-4 flex-shrink-0'>
@@ -292,6 +294,7 @@ export function RequestsTable({
         initialRequests={data}
         pageInfo={pageInfo}
         queryWhere={queryWhere}
+        onViewDetail={onViewDetail}
       />
     </div>
   );

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -1,27 +1,190 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { useNavigate, useRouterState } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { buildDateRangeWhereClause, type DateTimeRangeValue } from '@/utils/date-range';
+import {
+  DEFAULT_END_TIME,
+  DEFAULT_START_TIME,
+  buildDateRangeWhereClause,
+  normalizeDateTimeRangeValue,
+  type DateTimeRangeValue,
+  type TimeValue,
+} from '@/utils/date-range';
 import { useDebounce } from '@/hooks/use-debounce';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
-import { RequestsTable } from './components';
+import { RequestsTable, type RequestTableFilters } from './components';
 import { RequestsProvider } from './context';
 import { useRequests } from './data';
 
+const REQUEST_FILTER_SEARCH_KEYS = {
+  status: 'status',
+  source: 'source',
+  channel: 'channel',
+  apiKey: 'apiKey',
+  modelID: 'modelID',
+  createdAtFrom: 'createdAtFrom',
+  createdAtTo: 'createdAtTo',
+  createdAtStartTime: 'createdAtStartTime',
+  createdAtEndTime: 'createdAtEndTime',
+} as const;
+
+const REQUEST_CURSOR_SEARCH_KEYS = ['startCursor', 'endCursor', 'cursorDirection', 'cursorHistory'] as const;
+
+type RequestSearchFilters = RequestTableFilters & {
+  dateRange?: DateTimeRangeValue;
+};
+
+function getSearchString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const first = value.find((item): item is string => typeof item === 'string');
+    return first ?? '';
+  }
+  return '';
+}
+
+function getSearchStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+  }
+
+  if (typeof value !== 'string' || value.length === 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string' && item.length > 0);
+    }
+  } catch {
+    // Fall through to comma-separated search values.
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function setSearchStringArray(draft: Record<string, unknown>, key: string, value: string[]) {
+  if (value.length > 0) {
+    draft[key] = value;
+  } else {
+    delete draft[key];
+  }
+}
+
+function setSearchString(draft: Record<string, unknown>, key: string, value: string) {
+  const normalized = value.trim();
+  if (normalized) {
+    draft[key] = normalized;
+  } else {
+    delete draft[key];
+  }
+}
+
+function pad2(value: number) {
+  return value.toString().padStart(2, '0');
+}
+
+function formatSearchDate(date: Date) {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+function parseSearchDate(value: unknown): Date | undefined {
+  const raw = getSearchString(value);
+  if (!raw) return undefined;
+
+  const dateOnly = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    const year = Number.parseInt(dateOnly[1], 10);
+    const month = Number.parseInt(dateOnly[2], 10);
+    const day = Number.parseInt(dateOnly[3], 10);
+    const date = new Date(year, month - 1, day);
+
+    if (date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day) {
+      return date;
+    }
+    return undefined;
+  }
+
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function clampTimePart(value: string | undefined, max: number, fallback: string) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return pad2(Math.min(Math.max(parsed, 0), max));
+}
+
+function formatSearchTime(time: TimeValue) {
+  return `${time.hh}:${time.mm}:${time.ss}`;
+}
+
+function parseSearchTime(value: unknown, fallback: TimeValue): TimeValue {
+  const raw = getSearchString(value);
+  if (!raw) return fallback;
+
+  const [hh, mm, ss] = raw.split(':');
+  return {
+    hh: clampTimePart(hh, 23, fallback.hh),
+    mm: clampTimePart(mm, 59, fallback.mm),
+    ss: clampTimePart(ss, 59, fallback.ss),
+  };
+}
+
+function parseRequestSearchFilters(search: Record<string, unknown>): RequestSearchFilters {
+  const from = parseSearchDate(search[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom]);
+  const to = parseSearchDate(search[REQUEST_FILTER_SEARCH_KEYS.createdAtTo]);
+  const hasDateRange = !!from || !!to;
+
+  return {
+    statusFilter: getSearchStringArray(search[REQUEST_FILTER_SEARCH_KEYS.status]),
+    sourceFilter: getSearchStringArray(search[REQUEST_FILTER_SEARCH_KEYS.source]),
+    channelFilter: getSearchStringArray(search[REQUEST_FILTER_SEARCH_KEYS.channel]),
+    apiKeyFilter: getSearchStringArray(search[REQUEST_FILTER_SEARCH_KEYS.apiKey]),
+    modelIDFilter: getSearchString(search[REQUEST_FILTER_SEARCH_KEYS.modelID]),
+    dateRange: hasDateRange
+      ? normalizeDateTimeRangeValue({
+          from,
+          to,
+          startTime: parseSearchTime(search[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime], DEFAULT_START_TIME),
+          endTime: parseSearchTime(search[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime], DEFAULT_END_TIME),
+        })
+      : undefined,
+  };
+}
+
+function clearRequestCursorSearch(draft: Record<string, unknown>) {
+  REQUEST_CURSOR_SEARCH_KEYS.forEach((key) => {
+    delete draft[key];
+  });
+}
+
+function clearRequestFilterSearch(draft: Record<string, unknown>) {
+  Object.values(REQUEST_FILTER_SEARCH_KEYS).forEach((key) => {
+    delete draft[key];
+  });
+}
+
 function RequestsContent() {
+  const navigate = useNavigate();
+  const currentSearch = useRouterState({
+    select: (state) => (state.location.search ?? {}) as Record<string, unknown>,
+  });
   const { pageSize, setCursors, setPageSize, resetCursor, paginationArgs, cursorHistory } = usePaginationSearch({
     defaultPageSize: 20,
     pageSizeStorageKey: 'requests-table-page-size',
   });
-  const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [sourceFilter, setSourceFilter] = useState<string[]>([]);
-  const [channelFilter, setChannelFilter] = useState<string[]>([]);
-  const [apiKeyFilter, setApiKeyFilter] = useState<string[]>([]);
-  const [modelIDFilter, setModelIDFilter] = useState<string>('');
+  const { statusFilter, sourceFilter, channelFilter, apiKeyFilter, modelIDFilter, dateRange } = useMemo(
+    () => parseRequestSearchFilters(currentSearch),
+    [currentSearch]
+  );
   const debouncedModelIDFilter = useDebounce(modelIDFilter, 300);
-  const [dateRange, setDateRange] = useState<DateTimeRangeValue | undefined>();
   const [autoRefresh, setAutoRefresh] = useState(false);
 
   // Build where clause with filters
@@ -85,52 +248,79 @@ function RequestsContent() {
     resetCursor();
   };
 
-  const handleStatusFilterChange = useCallback(
-    (filters: string[]) => {
-      setStatusFilter(filters);
-      resetCursor();
+  const updateRequestSearch = useCallback(
+    (apply: (draft: Record<string, unknown>) => void) => {
+      navigate({
+        search: ((prev: Record<string, unknown> | undefined) => {
+          const draft = { ...((prev ?? {}) as Record<string, unknown>) };
+          apply(draft);
+          clearRequestCursorSearch(draft);
+          return draft;
+        }) as any,
+        replace: true,
+      } as any);
     },
-    [resetCursor]
+    [navigate]
   );
 
-  const handleSourceFilterChange = useCallback(
-    (filters: string[]) => {
-      setSourceFilter(filters);
-      resetCursor();
+  const handleFiltersChange = useCallback(
+    (filters: RequestTableFilters) => {
+      updateRequestSearch((draft) => {
+        setSearchStringArray(draft, REQUEST_FILTER_SEARCH_KEYS.status, filters.statusFilter);
+        setSearchStringArray(draft, REQUEST_FILTER_SEARCH_KEYS.source, filters.sourceFilter);
+        setSearchStringArray(draft, REQUEST_FILTER_SEARCH_KEYS.channel, filters.channelFilter);
+        setSearchStringArray(draft, REQUEST_FILTER_SEARCH_KEYS.apiKey, filters.apiKeyFilter);
+        setSearchString(draft, REQUEST_FILTER_SEARCH_KEYS.modelID, filters.modelIDFilter);
+      });
     },
-    [resetCursor]
-  );
-
-  const handleChannelFilterChange = useCallback(
-    (filters: string[]) => {
-      setChannelFilter(filters);
-      resetCursor();
-    },
-    [resetCursor]
-  );
-
-  const handleApiKeyFilterChange = useCallback(
-    (filters: string[]) => {
-      setApiKeyFilter(filters);
-      resetCursor();
-    },
-    [resetCursor]
-  );
-
-  const handleModelIDFilterChange = useCallback(
-    (filter: string) => {
-      setModelIDFilter(filter);
-      resetCursor();
-    },
-    [resetCursor]
+    [updateRequestSearch]
   );
 
   const handleDateRangeChange = useCallback(
     (range: DateTimeRangeValue | undefined) => {
-      setDateRange(range);
-      resetCursor();
+      updateRequestSearch((draft) => {
+        const normalizedRange = range ? normalizeDateTimeRangeValue(range) : undefined;
+
+        if (!normalizedRange || (!normalizedRange.from && !normalizedRange.to)) {
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom];
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtTo];
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime];
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime];
+          return;
+        }
+
+        if (normalizedRange?.from) {
+          draft[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom] = formatSearchDate(normalizedRange.from);
+        } else {
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom];
+        }
+
+        if (normalizedRange?.to) {
+          draft[REQUEST_FILTER_SEARCH_KEYS.createdAtTo] = formatSearchDate(normalizedRange.to);
+        } else {
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtTo];
+        }
+
+        draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime] = formatSearchTime(normalizedRange.startTime);
+        draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime] = formatSearchTime(normalizedRange.endTime);
+      });
     },
-    [resetCursor]
+    [updateRequestSearch]
+  );
+
+  const handleResetFilters = useCallback(() => {
+    updateRequestSearch(clearRequestFilterSearch);
+  }, [updateRequestSearch]);
+
+  const handleViewDetail = useCallback(
+    (requestId: string) => {
+      navigate({
+        to: '/project/requests/$requestId',
+        params: { requestId },
+        search: currentSearch as any,
+      } as any);
+    },
+    [navigate, currentSearch]
   );
 
   return (
@@ -145,17 +335,16 @@ function RequestsContent() {
         sourceFilter={sourceFilter}
         channelFilter={channelFilter}
         apiKeyFilter={apiKeyFilter}
+        modelIDFilter={modelIDFilter}
         dateRange={dateRange}
         queryWhere={whereClause}
         onNextPage={handleNextPage}
         onPreviousPage={handlePreviousPage}
         onPageSizeChange={handlePageSizeChange}
-        onStatusFilterChange={handleStatusFilterChange}
-        onSourceFilterChange={handleSourceFilterChange}
-        onChannelFilterChange={handleChannelFilterChange}
-        onApiKeyFilterChange={handleApiKeyFilterChange}
-        onModelIDFilterChange={handleModelIDFilterChange}
+        onFiltersChange={handleFiltersChange}
         onDateRangeChange={handleDateRangeChange}
+        onResetFilters={handleResetFilters}
+        onViewDetail={handleViewDetail}
         onRefresh={refetch}
         showRefresh={isFirstPage}
         autoRefresh={autoRefresh}
@@ -174,7 +363,7 @@ export default function RequestsManagement() {
         <div className='flex flex-1 items-center justify-between'>
           <div>
             <h2 className='text-xl font-bold tracking-tight'>{t('requests.title')}</h2>
-            <p className='text-sm text-muted-foreground'>{t('requests.description')}</p>
+            <p className='text-muted-foreground text-sm'>{t('requests.description')}</p>
           </div>
         </div>
       </Header>

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_END_TIME,
   DEFAULT_START_TIME,
   buildDateRangeWhereClause,
+  isSameTime,
   normalizeDateTimeRangeValue,
   type DateTimeRangeValue,
   type TimeValue,
@@ -251,14 +252,14 @@ function RequestsContent() {
   const updateRequestSearch = useCallback(
     (apply: (draft: Record<string, unknown>) => void) => {
       navigate({
-        search: ((prev: Record<string, unknown> | undefined) => {
+        search: (prev: Record<string, unknown> | undefined) => {
           const draft = { ...((prev ?? {}) as Record<string, unknown>) };
           apply(draft);
           clearRequestCursorSearch(draft);
           return draft;
-        }) as any,
+        },
         replace: true,
-      } as any);
+      });
     },
     [navigate]
   );
@@ -289,20 +290,29 @@ function RequestsContent() {
           return;
         }
 
-        if (normalizedRange?.from) {
+        if (normalizedRange.from) {
           draft[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom] = formatSearchDate(normalizedRange.from);
+          if (isSameTime(normalizedRange.startTime, DEFAULT_START_TIME)) {
+            delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime];
+          } else {
+            draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime] = formatSearchTime(normalizedRange.startTime);
+          }
         } else {
           delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtFrom];
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime];
         }
 
-        if (normalizedRange?.to) {
+        if (normalizedRange.to) {
           draft[REQUEST_FILTER_SEARCH_KEYS.createdAtTo] = formatSearchDate(normalizedRange.to);
+          if (isSameTime(normalizedRange.endTime, DEFAULT_END_TIME)) {
+            delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime];
+          } else {
+            draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime] = formatSearchTime(normalizedRange.endTime);
+          }
         } else {
           delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtTo];
+          delete draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime];
         }
-
-        draft[REQUEST_FILTER_SEARCH_KEYS.createdAtStartTime] = formatSearchTime(normalizedRange.startTime);
-        draft[REQUEST_FILTER_SEARCH_KEYS.createdAtEndTime] = formatSearchTime(normalizedRange.endTime);
       });
     },
     [updateRequestSearch]
@@ -317,8 +327,8 @@ function RequestsContent() {
       navigate({
         to: '/project/requests/$requestId',
         params: { requestId },
-        search: currentSearch as any,
-      } as any);
+        search: currentSearch,
+      });
     },
     [navigate, currentSearch]
   );

--- a/frontend/src/routes/_authenticated/project/requests/$requestId.tsx
+++ b/frontend/src/routes/_authenticated/project/requests/$requestId.tsx
@@ -11,5 +11,6 @@ function ProtectedRequestDetail() {
 }
 
 export const Route = createFileRoute('/_authenticated/project/requests/$requestId')({
+  validateSearch: (search: Record<string, unknown>) => search,
   component: ProtectedRequestDetail,
 });

--- a/frontend/src/routes/_authenticated/project/requests/index.tsx
+++ b/frontend/src/routes/_authenticated/project/requests/index.tsx
@@ -11,5 +11,6 @@ function ProtectedProjectRequests() {
 }
 
 export const Route = createFileRoute('/_authenticated/project/requests/')({
+  validateSearch: (search: Record<string, unknown>) => search,
   component: ProtectedProjectRequests,
 });


### PR DESCRIPTION
## 背景

请求日志页面支持按状态、来源、渠道、API Key、模型 ID 和日期范围过滤请求记录。当前这些过滤条件主要保存在请求日志列表组件的 React state 中。

这会导致一个用户可见的问题：用户设置过滤条件后，打开某条请求详情页，再从详情页返回列表时，列表组件已经卸载并重新挂载，原来的过滤状态会恢复为空。用户需要重新设置过滤条件，排查请求时的上下文会丢失。

Fixes #1722

## 修改内容

### 1. 将请求日志过滤状态迁移到 URL search params

`frontend/src/features/requests/index.tsx` 新增了请求日志过滤参数的解析和写入逻辑，将以下过滤条件从组件内存状态迁移到 TanStack Router 的 search params：

- 状态过滤：`status`
- 来源过滤：`source`
- 渠道过滤：`channel`
- API Key 过滤：`apiKey`
- 模型 ID 过滤：`modelID`
- 创建时间范围：`createdAtFrom`、`createdAtTo`
- 创建时间的起止时分秒：`createdAtStartTime`、`createdAtEndTime`

列表页现在会从当前 URL search 中解析过滤条件，并据此生成 GraphQL 查询的 `where` 条件。

### 2. 过滤变化时同步更新 URL，并重置分页游标

过滤条件变化后，现在会写回当前路由的 search params，同时清理分页游标相关参数：

- `startCursor`
- `endCursor`
- `cursorDirection`
- `cursorHistory`

这样可以避免一个旧分页游标继续作用在新的过滤条件上，导致列表位置或查询结果不符合用户预期。

### 3. 将请求日志表格过滤状态改为受控状态

`frontend/src/features/requests/components/requests-table.tsx` 现在由父级传入 URL 派生出的过滤状态，并用这些状态控制 TanStack Table 的 `columnFilters`。

表格过滤变化时，通过统一的 `onFiltersChange` 回传完整过滤状态，而不是分别调用多个单独的过滤更新回调。这样可以减少多个过滤器连续更新时互相覆盖或状态不同步的风险。

### 4. 详情跳转保留完整 search params

请求日志列表中的“查看详情”按钮，以及抽屉中的“查看详情”入口，现在会使用列表页传入的详情跳转回调。

跳转到详情页时会保留当前完整 search params，因此详情页 URL 中包含进入详情前的列表过滤状态。

### 5. 详情页返回保留过滤状态

`frontend/src/features/requests/components/request-detail-page.tsx` 的返回按钮现在会读取详情页当前的 search params，并带着这些参数返回 `/project/requests`。

因此无论用户使用详情页返回按钮，还是使用浏览器后退，只要进入详情页时携带了过滤 search params，返回列表后都能恢复原来的过滤状态。

### 6. 重置过滤改为一次性清理请求日志过滤参数

工具栏的重置过滤按钮现在通过父级传入的 `onResetFilters` 一次性清理所有请求日志过滤 search params。

这样可以避免先清表格过滤、再清日期范围带来的多次路由更新竞态，保证表格过滤状态和日期范围状态一起恢复为空。

### 7. 明确请求日志路由的 search 类型

`frontend/src/routes/_authenticated/project/requests/index.tsx` 和 `frontend/src/routes/_authenticated/project/requests/$requestId.tsx` 新增 `validateSearch`，显式声明请求日志列表页和详情页接受 `Record<string, unknown>` search params。

这样可以移除请求日志列表页和详情页导航中的 `as any`，保留 TanStack Router 的类型检查能力。

### 8. 优化日期范围时间参数序列化

日期范围的时间参数现在只会在存在对应日期时写入 URL：

- 有 `createdAtFrom` 时才可能写入 `createdAtStartTime`
- 有 `createdAtTo` 时才可能写入 `createdAtEndTime`

同时，默认时间会从 URL 中省略：

- 默认开始时间 `00:00:00`
- 默认结束时间 `23:59:59`

这样可以避免孤立的 time 参数，也能减少默认日期范围场景下的 URL 噪音。

## 对外表现

修改后，请求日志页面的用户可见行为如下：

1. 用户在请求日志页面设置过滤条件后，URL 会反映当前过滤状态。
2. 从过滤后的列表打开请求详情页，再返回列表时，过滤条件仍然保留。
3. 使用浏览器后退或前进时，列表过滤状态会跟随浏览器历史恢复。
4. 刷新带过滤参数的请求日志页面时，页面会根据 URL 恢复过滤条件。
5. 点击重置过滤后，所有请求日志过滤条件会一起清空，并回到第一页查询。
6. 日期范围使用默认时间时，URL 不再额外显示默认时间参数。

## 作用

这个修改让请求日志页面的过滤状态从“组件生命周期内有效”变成“路由状态可恢复”。它改善了请求排查流程中的上下文保持能力，用户可以在列表和详情之间切换而不丢失筛选条件。

同时，过滤状态进入 URL 后，也便于复制当前过滤后的页面地址进行复现或协作排查。

## 关于分页游标的说明

详情页 URL 仍然保留完整列表 search，其中可能包含分页游标。这样做是为了保留既有行为：用户从请求日志第 2 页或更后面的页面打开详情页后，返回时仍能回到原来的列表位置。

如果只携带过滤 key，详情页 URL 会更短，但会改变现有分页恢复行为，用户可能从非第一页打开详情后返回到过滤后的第一页。因此本 PR 只在过滤条件变化时清理旧游标，详情导航仍保留完整列表上下文。

## 风险与兼容性

- 不涉及后端接口变更。
- 不改变 GraphQL 查询字段，只改变前端生成查询条件的状态来源。
- URL 中会出现请求日志过滤参数，但这些参数只表示用户已选择的过滤条件，不包含请求正文或响应内容。
- 主要风险是后续新增过滤字段时，需要同步维护 search params 的解析、写入和清理逻辑。

## 验证

- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/prettier --check src/features/requests/index.tsx src/features/requests/components/index.ts src/features/requests/components/requests-table.tsx src/features/requests/components/data-table-toolbar.tsx src/features/requests/components/requests-columns.tsx src/features/requests/components/request-detail-page.tsx src/routes/_authenticated/project/requests/index.tsx 'src/routes/_authenticated/project/requests/$requestId.tsx'`
- `git diff --check`
- 浏览器页面验证（本地前后端服务）：模型 ID、状态、来源过滤后，查看详情、详情页返回按钮、浏览器后退均保留过滤状态。