### PR TITLE
feat: support disabling db auto migration

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -185,7 +185,7 @@ func setDefaults(v *viper.Viper) {
 	// Database defaults
 	v.SetDefault("db.dialect", "sqlite3")
 	v.SetDefault("db.dsn", "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)")
-	v.SetDefault("db.disable_schema_init", false)
+	v.SetDefault("db.disable_auto_migration", false)
 	v.SetDefault("db.disable_sqlite_auto_wal", false)
 	v.SetDefault("db.debug", false)
 	v.SetDefault("db.max_open_conns", 20)

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -185,6 +185,7 @@ func setDefaults(v *viper.Viper) {
 	// Database defaults
 	v.SetDefault("db.dialect", "sqlite3")
 	v.SetDefault("db.dsn", "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)")
+	v.SetDefault("db.disable_schema_init", false)
 	v.SetDefault("db.disable_sqlite_auto_wal", false)
 	v.SetDefault("db.debug", false)
 	v.SetDefault("db.max_open_conns", 20)

--- a/config.example.yml
+++ b/config.example.yml
@@ -56,6 +56,7 @@ server:
 db:
   dialect: "sqlite3"            # Database dialect: sqlite3, postgres, mysql (env: AXONHUB_DB_DIALECT)
   dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # Database connection string (env: AXONHUB_DB_DSN)
+  disable_schema_init: false    # Disable schema init (env: AXONHUB_DB_DISABLE_SCHEMA_INIT)
   disable_sqlite_auto_wal: false # Disable auto-enabling WAL mode for SQLite (env: AXONHUB_DB_DISABLE_SQLITE_AUTO_WAL)
   debug: false                  # Enable database debug logging (env: AXONHUB_DB_DEBUG)
   max_open_conns: 20            # Maximum open DB connections shared by the app (env: AXONHUB_DB_MAX_OPEN_CONNS)

--- a/config.example.yml
+++ b/config.example.yml
@@ -56,7 +56,7 @@ server:
 db:
   dialect: "sqlite3"            # Database dialect: sqlite3, postgres, mysql (env: AXONHUB_DB_DIALECT)
   dsn: "file:axonhub.db?cache=shared&_fk=1&_pragma=journal_mode(WAL)"  # Database connection string (env: AXONHUB_DB_DSN)
-  disable_schema_init: false    # Disable schema init (env: AXONHUB_DB_DISABLE_SCHEMA_INIT)
+  disable_auto_migration: false    # Disable auto-migration (env: AXONHUB_DB_DISABLE_AUTO_MIGRATION)
   disable_sqlite_auto_wal: false # Disable auto-enabling WAL mode for SQLite (env: AXONHUB_DB_DISABLE_SQLITE_AUTO_WAL)
   debug: false                  # Enable database debug logging (env: AXONHUB_DB_DEBUG)
   max_open_conns: 20            # Maximum open DB connections shared by the app (env: AXONHUB_DB_MAX_OPEN_CONNS)

--- a/internal/server/db/config.go
+++ b/internal/server/db/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	ConnMaxLifetime      time.Duration `conf:"conn_max_lifetime" yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
 	ConnMaxIdleTime      time.Duration `conf:"conn_max_idle_time" yaml:"conn_max_idle_time" json:"conn_max_idle_time"`
 	DisableSQLiteAutoWAL bool          `conf:"disable_sqlite_auto_wal" yaml:"disable_sqlite_auto_wal" json:"disable_sqlite_auto_wal"`
+	DisableSchemaInit    bool          `conf:"disable_schema_init" yaml:"disable_schema_init" json:"disable_schema_init"`
 
 	ReadReplica ReadReplicaConfig `conf:"read_replica" yaml:"read_replica" json:"read_replica"`
 }

--- a/internal/server/db/config.go
+++ b/internal/server/db/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	ConnMaxLifetime      time.Duration `conf:"conn_max_lifetime" yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
 	ConnMaxIdleTime      time.Duration `conf:"conn_max_idle_time" yaml:"conn_max_idle_time" json:"conn_max_idle_time"`
 	DisableSQLiteAutoWAL bool          `conf:"disable_sqlite_auto_wal" yaml:"disable_sqlite_auto_wal" json:"disable_sqlite_auto_wal"`
-	DisableSchemaInit    bool          `conf:"disable_schema_init" yaml:"disable_schema_init" json:"disable_schema_init"`
+	DisableAutoMigration bool          `conf:"disable_auto_migration" yaml:"disable_auto_migration" json:"disable_auto_migration"`
 
 	ReadReplica ReadReplicaConfig `conf:"read_replica" yaml:"read_replica" json:"read_replica"`
 }

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -61,7 +61,7 @@ func NewEntClient(cfg Config) *ent.Client {
 	opts = append(opts, ent.Driver(drv))
 	client := ent.NewClient(opts...)
 
-	if !cfg.DisableSchemaInit {
+	if !cfg.DisableAutoMigration {
 		err = client.Schema.Create(
 			context.Background(),
 			migrate.WithGlobalUniqueID(false),

--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -61,21 +61,23 @@ func NewEntClient(cfg Config) *ent.Client {
 	opts = append(opts, ent.Driver(drv))
 	client := ent.NewClient(opts...)
 
-	err = client.Schema.Create(
-		context.Background(),
-		migrate.WithGlobalUniqueID(false),
-		migrate.WithForeignKeys(false),
-		migrate.WithDropIndex(true),
-		migrate.WithDropColumn(true),
-		schema.WithHooks(schemahook.V0_3_0),
-	)
-	if err != nil {
-		panic(err)
-	}
+	if !cfg.DisableSchemaInit {
+		err = client.Schema.Create(
+			context.Background(),
+			migrate.WithGlobalUniqueID(false),
+			migrate.WithForeignKeys(false),
+			migrate.WithDropIndex(true),
+			migrate.WithDropColumn(true),
+			schema.WithHooks(schemahook.V0_3_0),
+		)
+		if err != nil {
+			panic(err)
+		}
 
-	migrator := datamigrate.NewMigrator(client)
-	if err := migrator.Run(context.Background()); err != nil {
-		panic(err)
+		migrator := datamigrate.NewMigrator(client)
+		if err := migrator.Run(context.Background()); err != nil {
+			panic(err)
+		}
 	}
 
 	return client


### PR DESCRIPTION
**需求背景**
部分国产化或分布式数据库对标准 MySQL/PostgreSQL 的 DML（数据操纵）支持较好，但在 DDL（数据定义/表结构变更）方面的兼容性相对较弱（如不支持某些物理约束）。

**主要修改**
增加了禁用系统自动初始化数据 Schema 的功能选项（默认是启用的，不改变原始逻辑）。

**业务收益**
解耦了代码与底层的建表逻辑，使得 AxonHub 能够更加顺滑、方便地部署在各类国产化数据库上（用户可采用离线 SQL 脚本等方式手动完成建表）。