### PR TITLE
fix(llm): accept structured response item arguments

### DIFF
--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -2,6 +2,7 @@
 package responses
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -505,6 +506,37 @@ type Item struct {
 	// Compaction fields (for type="compaction")
 	// The identifier of the actor that created the item.
 	CreatedBy *string `json:"created_by,omitempty"`
+}
+
+func (item *Item) UnmarshalJSON(data []byte) error {
+	type itemAlias Item
+	raw := struct {
+		itemAlias
+		Arguments json.RawMessage `json:"arguments"`
+	}{}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*item = Item(raw.itemAlias)
+	if len(raw.Arguments) == 0 || bytes.Equal(raw.Arguments, []byte("null")) {
+		return nil
+	}
+
+	var arguments string
+	if err := json.Unmarshal(raw.Arguments, &arguments); err == nil {
+		item.Arguments = arguments
+		return nil
+	}
+
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, raw.Arguments); err != nil {
+		return err
+	}
+	item.Arguments = compacted.String()
+
+	return nil
 }
 
 // MarshalJSON omits summary for non-reasoning items and forces an empty array for reasoning items.

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -202,6 +202,29 @@ func TestItemUnmarshalJSON_Compaction(t *testing.T) {
 	}
 }
 
+func TestItemUnmarshalJSON_AcceptsObjectArguments(t *testing.T) {
+	var item Item
+	err := json.Unmarshal([]byte(`{
+		"type": "tool_search_call",
+		"call_id": "call_123",
+		"arguments": {"query":"image generation","limit":10}
+	}`), &item)
+	require.NoError(t, err)
+	require.Equal(t, "tool_search_call", item.Type)
+	require.Equal(t, `{"query":"image generation","limit":10}`, item.Arguments)
+}
+
+func TestItemUnmarshalJSON_AcceptsStringArguments(t *testing.T) {
+	var item Item
+	err := json.Unmarshal([]byte(`{
+		"type": "function_call",
+		"call_id": "call_123",
+		"arguments": "{\"location\":\"NYC\"}"
+	}`), &item)
+	require.NoError(t, err)
+	require.Equal(t, `{"location":"NYC"}`, item.Arguments)
+}
+
 func TestInputUnmarshalJSON_ClearsConflictingRepresentation(t *testing.T) {
 	input := Input{
 		Text: lo.ToPtr("stale"),

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -260,6 +260,57 @@ func TestOutboundTransformer_TransformRequest_ReplaysProviderRawToolsAndToolChoi
 	require.Len(t, toolChoice["tools"], 1)
 }
 
+func TestOutboundTransformer_TransformRequest_ReplaysProviderRawInputItems(t *testing.T) {
+	inbound := NewInboundTransformer()
+	inboundReq := &httpclient.Request{
+		Body: []byte(`{
+			"model": "gpt-4o",
+			"input": [
+				{
+					"type": "tool_search_call",
+					"call_id": "call_search",
+					"status": "completed",
+					"arguments": {"query":"image generation","limit":10}
+				},
+				{
+					"type": "message",
+					"role": "user",
+					"content": [{"type":"input_text","text":"hello"}]
+				}
+			]
+		}`),
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), inboundReq)
+	require.NoError(t, err)
+
+	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	httpReq, err := outbound.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+
+	input, ok := payload["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 2)
+
+	rawItem, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "tool_search_call", rawItem["type"])
+	arguments, ok := rawItem["arguments"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "image generation", arguments["query"])
+	require.Equal(t, float64(10), arguments["limit"])
+
+	message, ok := input[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "message", message["type"])
+}
+
 func TestOutboundTransformer_TransformRequest_DoesNotReplayRawToolWhenToolsChanged(t *testing.T) {
 	inbound := NewInboundTransformer()
 	inboundReq := &httpclient.Request{

--- a/llm/transformer/openai/responses/request_extensions.go
+++ b/llm/transformer/openai/responses/request_extensions.go
@@ -201,7 +201,57 @@ func marshalRequestPayload(payload Request, llmReq *llm.Request) ([]byte, error)
 		obj["tool_choice"] = cloneRaw(requestExt.RawToolChoice)
 	}
 
+	if input, ok := mergeRawOnlyInputItems(obj["input"], requestExt); ok {
+		inputRaw, err := json.Marshal(input)
+		if err != nil {
+			return nil, err
+		}
+		obj["input"] = inputRaw
+	}
+
 	return json.Marshal(obj)
+}
+
+func mergeRawOnlyInputItems(structuredRaw json.RawMessage, requestExt *llm.OpenAIResponsesRequestExtensions) ([]json.RawMessage, bool) {
+	if requestExt == nil || len(requestExt.RawInputItems) == 0 {
+		return nil, false
+	}
+
+	var structuredItems []json.RawMessage
+	if len(structuredRaw) > 0 {
+		if err := json.Unmarshal(structuredRaw, &structuredItems); err != nil {
+			return nil, false
+		}
+	}
+
+	total := len(structuredItems) + len(requestExt.RawInputItems)
+	items := make([]json.RawMessage, 0, total)
+	structuredIndex := 0
+	rawByIndex := make(map[int]json.RawMessage, len(requestExt.RawInputItems))
+	for _, fragment := range requestExt.RawInputItems {
+		if len(fragment.Raw) == 0 || fragment.OriginalIndex < 0 {
+			return nil, false
+		}
+		rawByIndex[fragment.OriginalIndex] = cloneRaw(fragment.Raw)
+	}
+
+	for i := 0; i < total; i++ {
+		if raw, ok := rawByIndex[i]; ok {
+			items = append(items, raw)
+			continue
+		}
+		if structuredIndex >= len(structuredItems) {
+			return nil, false
+		}
+		items = append(items, cloneRaw(structuredItems[structuredIndex]))
+		structuredIndex++
+	}
+
+	if structuredIndex != len(structuredItems) {
+		return nil, false
+	}
+
+	return items, true
 }
 
 func mergeRawOnlyTools(structuredRaw json.RawMessage, requestExt *llm.OpenAIResponsesRequestExtensions) ([]json.RawMessage, bool) {


### PR DESCRIPTION
## 背景

Codex Desktop 发送到 `/v1/responses` 的历史上下文中可能包含 `tool_search_call` item。该 item 的 `arguments` 字段是 JSON object，例如：

```json
{"query":"...","limit":10}
```

当前 Responses 入站模型把 `Item.Arguments` 定义为 `string`，导致 Go JSON 解码在请求进入渠道前直接失败，返回 400：

```text
failed to decode responses api request: invalid input
```

同时，这类 `tool_search_call` 属于当前结构化转换未支持的 input item，应当按已有 raw item pass-through 设计原样回放给上游，避免把结构化 `arguments` 错误改写成字符串或直接丢弃。

## 变更

- 为 Responses `Item` 增加自定义 `UnmarshalJSON`。
- `arguments` 为 string 时保持现有行为。
- `arguments` 为 object/array 等结构化 JSON 时，压缩为 JSON 字符串保存，兼容现有下游 `llm.FunctionCall.Arguments` 的 string 表示。
- 补齐 raw input item 的出站合并逻辑：未结构化支持的 input item 会按原始 JSON 回放给上游，因此 `tool_search_call.arguments` 仍会以 JSON object 形式传递。
- 增加 string/object 两种 `arguments` 形态的单元测试，以及 raw input item 回放测试。

## 验证

- `cd llm && go test ./transformer/openai/responses`
- 使用最小 transform driver 确认 `tool_search_call.arguments` 出站仍是 JSON object。
- 使用原始复现用例重新请求本地 `/v1/responses`：修复前返回 400，修复后返回 200，SSE 包含 `response.completed`。
