### PR TITLE
feat(llm): support responses websocket sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ config.schema.json
 *.db-wal
 *.agent/summary
 .factory
+.omo/
+.playwright-mcp/

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -85,7 +85,7 @@ function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport 
 
 function getResponsesTransportFromChannel(channel?: Pick<Channel, 'baseURL' | 'endpoints'>): ResponsesTransport {
   const responsesEndpoint = channel?.endpoints?.find((endpoint) => endpoint.apiFormat === OPENAI_RESPONSES);
-  if (responsesEndpoint?.transport === 'websocket') return 'websocket';
+  if (responsesEndpoint?.transport === 'http' || responsesEndpoint?.transport === 'websocket') return responsesEndpoint.transport;
   return getResponsesTransportFromBaseURL(channel?.baseURL);
 }
 

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -83,6 +83,12 @@ function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport 
   return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';
 }
 
+function getResponsesTransportFromChannel(channel?: Pick<Channel, 'baseURL' | 'endpoints'>): ResponsesTransport {
+  const responsesEndpoint = channel?.endpoints?.find((endpoint) => endpoint.apiFormat === OPENAI_RESPONSES);
+  if (responsesEndpoint?.transport === 'websocket') return 'websocket';
+  return getResponsesTransportFromBaseURL(channel?.baseURL);
+}
+
 function getResponsesWebSocketBaseURL(channelType: ChannelType): string | undefined {
   if (channelType === 'codex') return CODEX_RESPONSES_WEBSOCKET_BASE_URL;
   if (channelType === 'openai_responses') return OPENAI_RESPONSES_WEBSOCKET_BASE_URL;
@@ -372,9 +378,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     }
     return 'openai/chat_completions';
   });
-  const [responsesTransport, setResponsesTransport] = useState<ResponsesTransport>(() =>
-    getResponsesTransportFromBaseURL(initialRow?.baseURL)
-  );
+  const [responsesTransport, setResponsesTransport] = useState<ResponsesTransport>(() => getResponsesTransportFromChannel(initialRow));
   const [useGeminiVertex, setUseGeminiVertex] = useState(() => {
     if (initialRow) {
       return initialRow.type === 'gemini_vertex';
@@ -401,7 +405,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     setSelectedProvider(provider);
     const apiFormat = CHANNEL_CONFIGS[initialRow.type as ChannelType]?.apiFormat || OPENAI_CHAT_COMPLETIONS;
     setSelectedApiFormat(apiFormat);
-    setResponsesTransport(getResponsesTransportFromBaseURL(initialRow.baseURL));
+    setResponsesTransport(getResponsesTransportFromChannel(initialRow));
     setUseGeminiVertex(initialRow.type === 'gemini_vertex');
     setUseAnthropicAws(initialRow.type === 'anthropic_aws');
     setUseKimiCoding(initialRow.type === 'moonshot_coding');

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -4,10 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { X, RefreshCw, Search, ChevronLeft, ChevronRight, PanelLeft, Plus, Trash2, Eye, EyeOff, Copy, Play, Info } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -24,6 +24,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { SelectDropdown } from '@/components/select-dropdown';
+import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/system';
 import { antigravityOAuthExchange, antigravityOAuthStart } from '../data/antigravity';
 import {
   useCreateChannel,
@@ -53,12 +54,11 @@ import {
 } from '../data/config_providers';
 import { Channel, ChannelType, ApiFormat, createChannelInputSchema, updateChannelInputSchema } from '../data/schema';
 import { ProxyConfig, useOAuthFlow } from '../hooks/use-oauth-flow';
-import { ManualModelBadge } from './manual-model-badge';
-import { CopilotDeviceFlow } from './copilot-device-flow';
-import { ProxyType } from './channels-proxy-dialog';
-import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/system';
 import { mergeChannelSettingsForUpdate } from '../utils/merge';
 import { matchesModelPattern } from '../utils/pattern';
+import { ProxyType } from './channels-proxy-dialog';
+import { CopilotDeviceFlow } from './copilot-device-flow';
+import { ManualModelBadge } from './manual-model-badge';
 
 interface Props {
   currentRow?: Channel;
@@ -71,6 +71,23 @@ interface Props {
 const MAX_MODELS_DISPLAY = 2;
 
 const duplicateNameRegex = /^(.*) \((\d+)\)$/;
+
+type ApiFormatOption = ApiFormat | 'openai/responses:websocket';
+type ResponsesTransport = 'http' | 'websocket';
+
+const OPENAI_RESPONSES_WEBSOCKET: ApiFormatOption = 'openai/responses:websocket';
+const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1/responses##';
+const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex/responses##';
+
+function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport {
+  return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';
+}
+
+function getResponsesWebSocketBaseURL(channelType: ChannelType): string | undefined {
+  if (channelType === 'codex') return CODEX_RESPONSES_WEBSOCKET_BASE_URL;
+  if (channelType === 'openai_responses') return OPENAI_RESPONSES_WEBSOCKET_BASE_URL;
+  return undefined;
+}
 
 // Custom hook for debounced value
 function useDebounce<T>(value: T, delay: number): T {
@@ -90,68 +107,59 @@ function useDebounce<T>(value: T, delay: number): T {
 }
 
 // Memoized FetchedModelItem component
-const FetchedModelItem = memo(({
-  model,
-  isAdded,
-  isSelected,
-  onToggle,
-  addedLabel,
-  willRemoveLabel
-}: {
-  model: string;
-  isAdded: boolean;
-  isSelected: boolean;
-  onToggle: () => void;
-  addedLabel: string;
-  willRemoveLabel: string;
-}) => (
-  <div
-    className={`flex items-center gap-2 rounded-md p-2 text-sm transition-colors ${
-      isAdded && !isSelected
-        ? 'bg-muted/50 text-muted-foreground'
-        : isSelected
-          ? 'bg-primary/10 border-primary/30 border'
-          : 'hover:bg-accent cursor-pointer'
-    }`}
-  >
-    <Checkbox checked={isSelected} onCheckedChange={onToggle} />
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className='flex-1 cursor-pointer truncate'
-          onClick={onToggle}
-        >
-          {model}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p className='max-w-xs break-all'>{model}</p>
-      </TooltipContent>
-    </Tooltip>
-    {isAdded && !isSelected && (
-      <Badge variant='secondary' className='shrink-0 text-xs'>
-        {addedLabel}
-      </Badge>
-    )}
-    {isAdded && isSelected && (
-      <Badge variant='destructive' className='shrink-0 text-xs'>
-        {willRemoveLabel}
-      </Badge>
-    )}
-  </div>
-));
+const FetchedModelItem = memo(
+  ({
+    model,
+    isAdded,
+    isSelected,
+    onToggle,
+    addedLabel,
+    willRemoveLabel,
+  }: {
+    model: string;
+    isAdded: boolean;
+    isSelected: boolean;
+    onToggle: () => void;
+    addedLabel: string;
+    willRemoveLabel: string;
+  }) => (
+    <div
+      className={`flex items-center gap-2 rounded-md p-2 text-sm transition-colors ${
+        isAdded && !isSelected
+          ? 'bg-muted/50 text-muted-foreground'
+          : isSelected
+            ? 'bg-primary/10 border-primary/30 border'
+            : 'hover:bg-accent cursor-pointer'
+      }`}
+    >
+      <Checkbox checked={isSelected} onCheckedChange={onToggle} />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className='flex-1 cursor-pointer truncate' onClick={onToggle}>
+            {model}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className='max-w-xs break-all'>{model}</p>
+        </TooltipContent>
+      </Tooltip>
+      {isAdded && !isSelected && (
+        <Badge variant='secondary' className='shrink-0 text-xs'>
+          {addedLabel}
+        </Badge>
+      )}
+      {isAdded && isSelected && (
+        <Badge variant='destructive' className='shrink-0 text-xs'>
+          {willRemoveLabel}
+        </Badge>
+      )}
+    </div>
+  )
+);
 FetchedModelItem.displayName = 'FetchedModelItem';
 
 // Memoized SupportedModelItem component
-const SupportedModelItem = memo(({
-  model,
-  isManual,
-  onRemove
-}: {
-  model: string;
-  isManual: boolean;
-  onRemove: () => void;
-}) => (
+const SupportedModelItem = memo(({ model, isManual, onRemove }: { model: string; isManual: boolean; onRemove: () => void }) => (
   <div className='hover:bg-accent flex items-center gap-2 rounded-md p-2 text-sm'>
     <Tooltip>
       <TooltipTrigger asChild>
@@ -162,13 +170,7 @@ const SupportedModelItem = memo(({
       </TooltipContent>
     </Tooltip>
     <ManualModelBadge isManual={isManual} />
-    <Button
-      type='button'
-      variant='ghost'
-      size='sm'
-      className='hover:text-destructive h-6 w-6 shrink-0 p-0'
-      onClick={onRemove}
-    >
+    <Button type='button' variant='ghost' size='sm' className='hover:text-destructive h-6 w-6 shrink-0 p-0' onClick={onRemove}>
       <X className='h-3 w-3' />
     </Button>
   </div>
@@ -370,6 +372,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     }
     return 'openai/chat_completions';
   });
+  const [responsesTransport, setResponsesTransport] = useState<ResponsesTransport>(() =>
+    getResponsesTransportFromBaseURL(initialRow?.baseURL)
+  );
   const [useGeminiVertex, setUseGeminiVertex] = useState(() => {
     if (initialRow) {
       return initialRow.type === 'gemini_vertex';
@@ -396,6 +401,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     setSelectedProvider(provider);
     const apiFormat = CHANNEL_CONFIGS[initialRow.type as ChannelType]?.apiFormat || OPENAI_CHAT_COMPLETIONS;
     setSelectedApiFormat(apiFormat);
+    setResponsesTransport(getResponsesTransportFromBaseURL(initialRow.baseURL));
     setUseGeminiVertex(initialRow.type === 'gemini_vertex');
     setUseAnthropicAws(initialRow.type === 'anthropic_aws');
     setUseKimiCoding(initialRow.type === 'moonshot_coding');
@@ -491,11 +497,37 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     return getApiFormatsForProvider(selectedProvider);
   }, [selectedProvider]);
 
+  const availableApiFormatOptions = useMemo<ApiFormatOption[]>(() => {
+    if (selectedProvider !== 'openai') return availableApiFormats;
+
+    const options: ApiFormatOption[] = [];
+    for (const format of availableApiFormats) {
+      options.push(format);
+      if (format === OPENAI_RESPONSES) {
+        options.push(OPENAI_RESPONSES_WEBSOCKET);
+      }
+    }
+    return options;
+  }, [availableApiFormats, selectedProvider]);
+
+  const selectedApiFormatOption: ApiFormatOption =
+    selectedApiFormat === OPENAI_RESPONSES && responsesTransport === 'websocket' ? OPENAI_RESPONSES_WEBSOCKET : selectedApiFormat;
+
   const getApiFormatLabel = useCallback(
     (format: ApiFormat) => {
       return t(`channels.dialogs.fields.apiFormat.formats.${format}`);
     },
     [t]
+  );
+
+  const getApiFormatOptionLabel = useCallback(
+    (format: ApiFormatOption) => {
+      if (format === OPENAI_RESPONSES_WEBSOCKET) {
+        return t('channels.dialogs.fields.apiFormat.formats.openai/responses_websocket');
+      }
+      return getApiFormatLabel(format);
+    },
+    [getApiFormatLabel, t]
   );
 
   // Determine the actual channel type based on provider and API format
@@ -620,8 +652,6 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const isClaudeCodeType = (selectedType || derivedChannelType) === 'claudecode';
   const isCopilotType = (selectedType || derivedChannelType) === 'github_copilot';
 
-
-
   // OAuth providers cannot have their provider/API format changed during edit.
   // Derived from currentRow credentials so it stays stable across re-renders
   // and is not affected by mutable authMode state.
@@ -681,6 +711,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         setSelectedApiFormat(OPENAI_RESPONSES);
         form.setValue('type', 'codex');
         if (!isEdit) {
+          const baseURL = responsesTransport === 'websocket' ? getResponsesWebSocketBaseURL('codex') : getDefaultBaseURL('codex');
+          if (baseURL && !isDuplicate) {
+            form.setValue('baseURL', baseURL, { shouldDirty: true });
+          }
           setFetchedModels([]);
           setUseFetchedModels(false);
         }
@@ -734,15 +768,19 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     },
-    [form, useGeminiVertex, useAnthropicAws, useKimiCoding, isDuplicate, isEdit, selectedApiFormat, isOAuthChannel]
+    [form, useGeminiVertex, useAnthropicAws, useKimiCoding, isDuplicate, isEdit, selectedApiFormat, isOAuthChannel, responsesTransport]
   );
 
   const handleApiFormatChange = useCallback(
-    (format: ApiFormat) => {
+    (formatOption: ApiFormatOption) => {
       if (isOAuthChannel) return;
       if (selectedProvider === 'codex' || selectedProvider === 'antigravity') return;
 
+      const format = formatOption === OPENAI_RESPONSES_WEBSOCKET ? OPENAI_RESPONSES : formatOption;
+      const nextResponsesTransport = formatOption === OPENAI_RESPONSES_WEBSOCKET ? 'websocket' : 'http';
+
       setSelectedApiFormat(format);
+      setResponsesTransport(nextResponsesTransport);
 
       // Reset vertex checkbox if not gemini/contents
       if (format !== 'gemini/contents') {
@@ -768,7 +806,12 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
         if (!isEdit) {
           const baseURLFieldState = form.getFieldState('baseURL', form.formState);
-          if (!baseURLFieldState.isDirty && !isDuplicate) {
+          if (nextResponsesTransport === 'websocket') {
+            const baseURL = getResponsesWebSocketBaseURL(newChannelType);
+            if (baseURL) {
+              form.resetField('baseURL', { defaultValue: baseURL });
+            }
+          } else if (!baseURLFieldState.isDirty && !isDuplicate) {
             const baseURL = getDefaultBaseURL(newChannelType);
             if (baseURL) {
               form.resetField('baseURL', { defaultValue: baseURL });
@@ -778,6 +821,20 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       }
     },
     [selectedProvider, form, useGeminiVertex, useAnthropicAws, useKimiCoding, isDuplicate, isEdit, isOAuthChannel]
+  );
+
+  const handleResponsesTransportChange = useCallback(
+    (transport: ResponsesTransport) => {
+      if (isOAuthChannel) return;
+      setResponsesTransport(transport);
+
+      const channelType = selectedProvider === 'codex' ? 'codex' : selectedType || derivedChannelType;
+      const baseURL = transport === 'websocket' ? getResponsesWebSocketBaseURL(channelType) : getDefaultBaseURL(channelType);
+      if (baseURL) {
+        form.setValue('baseURL', baseURL, { shouldDirty: true });
+      }
+    },
+    [derivedChannelType, form, isOAuthChannel, selectedProvider, selectedType]
   );
 
   const handleGeminiVertexChange = useCallback(
@@ -871,7 +928,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     let channelTypeForURL: ChannelType | undefined = providerToChannelType[selectedProvider];
 
     if (channelTypeForURL) {
-      const baseURL = getDefaultBaseURL(channelTypeForURL);
+      const baseURL =
+        channelTypeForURL === 'codex' && responsesTransport === 'websocket'
+          ? getResponsesWebSocketBaseURL(channelTypeForURL)
+          : getDefaultBaseURL(channelTypeForURL);
       if (baseURL) {
         // Use setValue instead of resetField to avoid infinite loop
         const currentURL = form.getValues('baseURL');
@@ -880,7 +940,18 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
       }
     }
-  }, [isEdit, isDuplicate, isCodexType, selectedProvider, authMode, form, codexOAuth, claudecodeOAuth, antigravityOAuth]);
+  }, [
+    isEdit,
+    isDuplicate,
+    isCodexType,
+    selectedProvider,
+    authMode,
+    form,
+    codexOAuth,
+    claudecodeOAuth,
+    antigravityOAuth,
+    responsesTransport,
+  ]);
 
   const renderOAuthSection = useCallback(
     (oauth: ReturnType<typeof useOAuthFlow>, description: string) => (
@@ -924,7 +995,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
             </Button>
           </div>
 
-          <p className='text-amber-600 dark:text-amber-400 mt-2 text-xs'>{t('channels.dialogs.proxy.oauthHint')}</p>
+          <p className='mt-2 text-xs text-amber-600 dark:text-amber-400'>{t('channels.dialogs.proxy.oauthHint')}</p>
           <p className='text-muted-foreground mt-2 text-xs'>{description}</p>
         </div>
       </div>
@@ -972,7 +1043,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         credentials: valuesForSubmit.credentials,
       };
 
-      if (((isCodexType && (authMode === 'official' || authMode === 'auth-json')) || (isClaudeCodeType && authMode === 'official')) && !isDuplicate) {
+      if (
+        ((isCodexType && (authMode === 'official' || authMode === 'auth-json')) || (isClaudeCodeType && authMode === 'official')) &&
+        !isDuplicate
+      ) {
         const currentType = selectedType || derivedChannelType;
         const baseURL = getDefaultBaseURL(currentType);
         if (baseURL) {
@@ -1259,7 +1333,15 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       models = models.filter((model) => model.toLowerCase().includes(search));
     }
     return models;
-  }, [fetchedModels, debouncedFetchedModelsSearch, showNotAddedModelsOnly, supportedModels, applyPatternFilter, watchedAutoSyncPattern, patternError]);
+  }, [
+    fetchedModels,
+    debouncedFetchedModelsSearch,
+    showNotAddedModelsOnly,
+    supportedModels,
+    applyPatternFilter,
+    watchedAutoSyncPattern,
+    patternError,
+  ]);
 
   // Toggle selection for fetched model
   const toggleFetchedModelSelection = useCallback((model: string) => {
@@ -1349,13 +1431,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     const fetchedModelsSet = new Set(fetchedModels);
     const manualModelsSet = new Set(manualModels);
     // Deprecated = not fetched AND not manual
-    const deprecatedModels = supportedModels.filter(
-      (model) => !fetchedModelsSet.has(model) && !manualModelsSet.has(model)
-    );
+    const deprecatedModels = supportedModels.filter((model) => !fetchedModelsSet.has(model) && !manualModelsSet.has(model));
     // Keep fetched models and manual models in supportedModels
-    setSupportedModels((prev) =>
-      prev.filter((model) => fetchedModelsSet.has(model) || manualModelsSet.has(model))
-    );
+    setSupportedModels((prev) => prev.filter((model) => fetchedModelsSet.has(model) || manualModelsSet.has(model)));
     // Remove deprecated models from manualModels (should be none, but for consistency)
     setManualModels((prev) => prev.filter((model) => !deprecatedModels.includes(model)));
   }, [fetchedModels, supportedModels, manualModels]);
@@ -1365,9 +1443,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     const fetchedModelsSet = new Set(fetchedModels);
     const manualModelsSet = new Set(manualModels);
     // Count only models that are neither fetched nor manual
-    return supportedModels.filter(
-      (model) => !fetchedModelsSet.has(model) && !manualModelsSet.has(model)
-    ).length;
+    return supportedModels.filter((model) => !fetchedModelsSet.has(model) && !manualModelsSet.has(model)).length;
   }, [supportedModels, fetchedModels, manualModels]);
 
   // Models to display (limited to MAX_MODELS_DISPLAY unless expanded)
@@ -1445,12 +1521,14 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
             if (initialRow) {
               setSelectedProvider(getProviderFromChannelType(initialRow.type) || 'openai');
               setSelectedApiFormat(CHANNEL_CONFIGS[initialRow.type as ChannelType]?.apiFormat || OPENAI_CHAT_COMPLETIONS);
+              setResponsesTransport(getResponsesTransportFromBaseURL(initialRow.baseURL));
               setUseGeminiVertex(initialRow.type === 'gemini_vertex');
               setUseAnthropicAws(initialRow.type === 'anthropic_aws');
               setUseKimiCoding(initialRow.type === 'moonshot_coding');
             } else {
               setSelectedProvider('openai');
               setSelectedApiFormat(OPENAI_CHAT_COMPLETIONS);
+              setResponsesTransport('http');
               setUseGeminiVertex(false);
               setUseAnthropicAws(false);
               setUseKimiCoding(false);
@@ -1484,11 +1562,17 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                           ref={providerListRef}
                           className={`flex-1 overflow-y-auto pr-2 ${isOAuthChannel ? 'cursor-not-allowed opacity-60' : ''}`}
                         >
-                          <RadioGroup value={selectedProvider} onValueChange={handleProviderChange} disabled={!!isOAuthChannel} className='space-y-2'>
+                          <RadioGroup
+                            value={selectedProvider}
+                            onValueChange={handleProviderChange}
+                            disabled={!!isOAuthChannel}
+                            className='space-y-2'
+                          >
                             {availableProviders.map((provider) => {
                               const Icon = provider.icon;
                               const isSelected = provider.key === selectedProvider;
-                              const isProviderDisabled = isOAuthChannel || (isEdit && !isOAuthChannel && alwaysOAuthProviderKeys.includes(provider.key));
+                              const isProviderDisabled =
+                                isOAuthChannel || (isEdit && !isOAuthChannel && alwaysOAuthProviderKeys.includes(provider.key));
                               return (
                                 <div
                                   key={provider.key}
@@ -1533,15 +1617,15 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                           <div className='max-w-64 space-y-1 md:col-span-6 md:max-w-none'>
                             <SelectDropdown
                               key={selectedProvider}
-                              defaultValue={selectedApiFormat}
-                              onValueChange={(value) => handleApiFormatChange(value as ApiFormat)}
+                              defaultValue={selectedApiFormatOption}
+                              onValueChange={(value) => handleApiFormatChange(value as ApiFormatOption)}
                               disabled={!!isOAuthChannel}
                               placeholder={t('channels.dialogs.fields.apiFormat.placeholder')}
                               data-testid='api-format-select'
                               isControlled={true}
-                              items={availableApiFormats.map((format) => ({
+                              items={availableApiFormatOptions.map((format) => ({
                                 value: format,
-                                label: getApiFormatLabel(format),
+                                label: getApiFormatOptionLabel(format),
                               }))}
                             />
                             {selectedApiFormat === 'gemini/contents' && (
@@ -1594,9 +1678,24 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                           <FormLabel className='pt-2 font-medium md:col-span-2 md:text-right'>
                             {t('channels.dialogs.fields.apiFormat.label')}
                           </FormLabel>
-                          <div className='space-y-1 md:col-span-6'>
-                            <div className='text-sm'>{getApiFormatLabel(OPENAI_RESPONSES)}</div>
-                            <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiFormat.editDisabled')}</p>
+                          <div className='max-w-64 space-y-1 md:col-span-6 md:max-w-none'>
+                            <SelectDropdown
+                              defaultValue={responsesTransport === 'websocket' ? OPENAI_RESPONSES_WEBSOCKET : OPENAI_RESPONSES}
+                              onValueChange={(value) =>
+                                handleResponsesTransportChange(value === OPENAI_RESPONSES_WEBSOCKET ? 'websocket' : 'http')
+                              }
+                              disabled={!!isOAuthChannel}
+                              placeholder={t('channels.dialogs.fields.apiFormat.placeholder')}
+                              data-testid='api-format-select'
+                              isControlled={true}
+                              items={[
+                                { value: OPENAI_RESPONSES, label: getApiFormatLabel(OPENAI_RESPONSES) },
+                                { value: OPENAI_RESPONSES_WEBSOCKET, label: getApiFormatOptionLabel(OPENAI_RESPONSES_WEBSOCKET) },
+                              ]}
+                            />
+                            {isOAuthChannel && (
+                              <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiFormat.editDisabled')}</p>
+                            )}
                           </div>
                         </FormItem>
                       )}
@@ -1681,9 +1780,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                   </Button>
                                 </div>
 
-                                <p className='text-amber-600 dark:text-amber-400 mt-2 text-xs'>
-                                  {t('channels.dialogs.proxy.oauthHint')}
-                                </p>
+                                <p className='mt-2 text-xs text-amber-600 dark:text-amber-400'>{t('channels.dialogs.proxy.oauthHint')}</p>
                                 <p className='text-muted-foreground mt-2 text-xs'>
                                   {t('channels.dialogs.fields.apiFormat.antigravity.description')}
                                 </p>
@@ -1832,9 +1929,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                               >
                                 <TabsList className={`grid w-full ${isCodexType ? 'grid-cols-3' : 'grid-cols-2'}`}>
                                   <TabsTrigger value='official'>{t('channels.dialogs.authMode.official')}</TabsTrigger>
-                                  {isCodexType && (
-                                    <TabsTrigger value='auth-json'>{t('channels.dialogs.authMode.authJson')}</TabsTrigger>
-                                  )}
+                                  {isCodexType && <TabsTrigger value='auth-json'>{t('channels.dialogs.authMode.authJson')}</TabsTrigger>}
                                   <TabsTrigger value='third-party'>{t('channels.dialogs.authMode.thirdParty')}</TabsTrigger>
                                 </TabsList>
                               </Tabs>
@@ -1842,9 +1937,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                               {isCodexType && authMode === 'auth-json' && (
                                 <div className='rounded-md border p-3'>
                                   <div className='space-y-2'>
-                                    <FormLabel className='text-sm font-medium'>
-                                      {t('channels.dialogs.codexAuthJson.label')}
-                                    </FormLabel>
+                                    <FormLabel className='text-sm font-medium'>{t('channels.dialogs.codexAuthJson.label')}</FormLabel>
                                     <Textarea
                                       value={codexAuthJSONText}
                                       onChange={(e) => setCodexAuthJSONText(e.target.value)}
@@ -1854,9 +1947,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                     <Button type='button' variant='secondary' onClick={applyCodexAuthJSON}>
                                       {t('channels.dialogs.codexAuthJson.applyButton')}
                                     </Button>
-                                    <p className='text-muted-foreground text-xs'>
-                                      {t('channels.dialogs.codexAuthJson.description')}
-                                    </p>
+                                    <p className='text-muted-foreground text-xs'>{t('channels.dialogs.codexAuthJson.description')}</p>
                                   </div>
                                 </div>
                               )}
@@ -1872,10 +1963,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             {isClaudeCodeType && (
                               <div className='space-y-2'>
                                 {authMode === 'official' &&
-                                  renderOAuthSection(
-                                    claudecodeOAuth,
-                                    t('channels.dialogs.fields.apiFormat.claudecode.description')
-                                  )}
+                                  renderOAuthSection(claudecodeOAuth, t('channels.dialogs.fields.apiFormat.claudecode.description'))}
                               </div>
                             )}
                           </div>
@@ -1898,8 +1986,8 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                 aria-invalid={!!fieldState.error}
                                 data-testid='channel-base-url-input'
                                 disabled={
-                                  ((isCodexType && (authMode === 'official' || authMode === 'auth-json')) ||
-                                    (isClaudeCodeType && authMode === 'official')) ||
+                                  (isCodexType && (authMode === 'official' || authMode === 'auth-json')) ||
+                                  (isClaudeCodeType && authMode === 'official') ||
                                   selectedProvider === 'antigravity'
                                 }
                                 {...field}
@@ -2134,9 +2222,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                 size='sm'
                                 className='h-6 px-2 text-xs'
                                 onClick={() => {
-                                  setShowSupportedModelsPanel(true)
-                                  setShowFetchedModelsPanel(false)
-                                  setShowApiKeysPanel(false)
+                                  setShowSupportedModelsPanel(true);
+                                  setShowFetchedModelsPanel(false);
+                                  setShowApiKeysPanel(false);
                                 }}
                               >
                                 <ChevronRight className='mr-1 h-3 w-3' />
@@ -2153,7 +2241,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                               control={form.control}
                               name='autoSyncSupportedModels'
                               render={({ field }) => (
-                                <FormItem className={`flex items-center gap-2 ${isCodexType || isClaudeCodeType || isCopilotType ? 'opacity-60' : ''}`}>
+                                <FormItem
+                                  className={`flex items-center gap-2 ${isCodexType || isClaudeCodeType || isCopilotType ? 'opacity-60' : ''}`}
+                                >
                                   {wrapUnsupported(
                                     isCodexType || isClaudeCodeType || isCopilotType,
                                     <Checkbox
@@ -2243,9 +2333,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                     <p className='text-muted-foreground text-xs'>
                                       {t('channels.dialogs.fields.autoSyncModelPattern.description')}
                                     </p>
-                                    {patternError && (
-                                      <p className='text-destructive text-xs'>{patternError}</p>
-                                    )}
+                                    {patternError && <p className='text-destructive text-xs'>{patternError}</p>}
                                   </FormItem>
                                 )}
                               />
@@ -2363,9 +2451,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             </SelectContent>
                           </Select>
                           {passThroughBody === true && (
-                            <p className='text-amber-600 dark:text-amber-400 text-xs'>
-                              {t('channels.dialogs.bodyPassThrough.warning')}
-                            </p>
+                            <p className='text-xs text-amber-600 dark:text-amber-400'>{t('channels.dialogs.bodyPassThrough.warning')}</p>
                           )}
                         </div>
                       </FormItem>
@@ -2455,7 +2541,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                 <div className='mb-3 flex items-center justify-between gap-2'>
                   <div className='flex flex-col gap-1.5'>
                     <label className='flex cursor-pointer items-center gap-2 text-xs'>
-                      <Checkbox checked={showNotAddedModelsOnly} onCheckedChange={(checked) => setShowNotAddedModelsOnly(checked === true)} />
+                      <Checkbox
+                        checked={showNotAddedModelsOnly}
+                        onCheckedChange={(checked) => setShowNotAddedModelsOnly(checked === true)}
+                      />
                       {t('channels.dialogs.fields.supportedModels.showNotAddedOnly')}
                     </label>
                     {watchedAutoSync && watchedAutoSyncPattern && !patternError && (
@@ -2574,89 +2663,98 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                       const validKeys = (apiKeys || []).map((k) => k.trim()).filter((k) => k.length > 0);
                       const isLastKey = validKeys.length <= 1;
                       return validKeys
-                      .filter((k) => {
-                        if (!apiKeysSearch.trim()) return true;
-                        const search = apiKeysSearch.trim().toLowerCase();
-                        return k.toLowerCase().includes(search) || k.slice(-4).toLowerCase().includes(search);
-                      })
-                      .map((key) => {
-                        const isSelected = selectedKeysToRemove.has(key);
-                        const isDisabled = disabledKeySet.has(key);
-                        const masked = key.length > 8 ? `${key.slice(0, 4)}****${key.slice(-4)}` : `****${key.slice(-4)}`;
+                        .filter((k) => {
+                          if (!apiKeysSearch.trim()) return true;
+                          const search = apiKeysSearch.trim().toLowerCase();
+                          return k.toLowerCase().includes(search) || k.slice(-4).toLowerCase().includes(search);
+                        })
+                        .map((key) => {
+                          const isSelected = selectedKeysToRemove.has(key);
+                          const isDisabled = disabledKeySet.has(key);
+                          const masked = key.length > 8 ? `${key.slice(0, 4)}****${key.slice(-4)}` : `****${key.slice(-4)}`;
 
-                        return (
-                          <div key={key} className='hover:bg-accent flex items-center justify-between gap-2 rounded-md p-2 text-sm'>
-                            <div className='flex min-w-0 items-center gap-2'>
-                              <Checkbox
-                                checked={isSelected}
-                                disabled={isLastKey}
-                                onCheckedChange={(checked) => {
-                                  setSelectedKeysToRemove((prev) => {
-                                    const next = new Set(prev);
-                                    if (checked) {
-                                      next.add(key);
-                                    } else {
-                                      next.delete(key);
-                                    }
-                                    return next;
-                                  });
-                                }}
-                                aria-label={t('common.columns.selectRow')}
-                              />
+                          return (
+                            <div key={key} className='hover:bg-accent flex items-center justify-between gap-2 rounded-md p-2 text-sm'>
+                              <div className='flex min-w-0 items-center gap-2'>
+                                <Checkbox
+                                  checked={isSelected}
+                                  disabled={isLastKey}
+                                  onCheckedChange={(checked) => {
+                                    setSelectedKeysToRemove((prev) => {
+                                      const next = new Set(prev);
+                                      if (checked) {
+                                        next.add(key);
+                                      } else {
+                                        next.delete(key);
+                                      }
+                                      return next;
+                                    });
+                                  }}
+                                  aria-label={t('common.columns.selectRow')}
+                                />
 
-                              <div className='min-w-0'>
-                                <div className='flex min-w-0 items-center gap-2'>
-                                  <code className='bg-muted shrink-0 rounded px-2 py-0.5 font-mono text-xs'>{masked}</code>
+                                <div className='min-w-0'>
+                                  <div className='flex min-w-0 items-center gap-2'>
+                                    <code className='bg-muted shrink-0 rounded px-2 py-0.5 font-mono text-xs'>{masked}</code>
+                                    {isDisabled && (
+                                      <Badge variant='destructive' className='h-5 px-2 text-[10px]'>
+                                        {t('channels.dialogs.fields.apiKey.disabled')}
+                                      </Badge>
+                                    )}
+                                  </div>
                                   {isDisabled && (
-                                    <Badge variant='destructive' className='h-5 px-2 text-[10px]'>
-                                      {t('channels.dialogs.fields.apiKey.disabled')}
-                                    </Badge>
+                                    <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiKey.disabledHint')}</p>
                                   )}
                                 </div>
-                                {isDisabled && (
-                                  <p className='text-muted-foreground mt-1 text-xs'>{t('channels.dialogs.fields.apiKey.disabledHint')}</p>
-                                )}
                               </div>
-                            </div>
 
-                            {isLastKey ? (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span className='inline-flex'>
-                                    <Button type='button' variant='ghost' size='sm' className='text-muted-foreground h-7 w-7 p-0' disabled>
+                              {isLastKey ? (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className='inline-flex'>
+                                      <Button
+                                        type='button'
+                                        variant='ghost'
+                                        size='sm'
+                                        className='text-muted-foreground h-7 w-7 p-0'
+                                        disabled
+                                      >
+                                        <Trash2 className='h-4 w-4' />
+                                      </Button>
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>{t('channels.dialogs.fields.apiKey.mustKeepOne')}</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              ) : (
+                                <Popover
+                                  open={confirmRemoveKey === key}
+                                  onOpenChange={(isOpen) => setConfirmRemoveKey(isOpen ? key : null)}
+                                >
+                                  <PopoverTrigger asChild>
+                                    <Button type='button' variant='ghost' size='sm' className='text-destructive h-7 w-7 p-0'>
                                       <Trash2 className='h-4 w-4' />
                                     </Button>
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  <p>{t('channels.dialogs.fields.apiKey.mustKeepOne')}</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            ) : (
-                              <Popover open={confirmRemoveKey === key} onOpenChange={(isOpen) => setConfirmRemoveKey(isOpen ? key : null)}>
-                                <PopoverTrigger asChild>
-                                  <Button type='button' variant='ghost' size='sm' className='text-destructive h-7 w-7 p-0'>
-                                    <Trash2 className='h-4 w-4' />
-                                  </Button>
-                                </PopoverTrigger>
-                                <PopoverContent className='w-72'>
-                                  <div className='flex flex-col gap-3'>
-                                    <p className='text-sm'>{t('channels.dialogs.fields.apiKey.confirmRemoveSingle')}</p>
-                                    <div className='flex justify-end gap-2'>
-                                      <Button size='sm' variant='outline' onClick={() => setConfirmRemoveKey(null)}>
-                                        {t('common.buttons.cancel')}
-                                      </Button>
-                                      <Button size='sm' variant='destructive' onClick={() => removeApiKeys([key])}>
-                                        {t('common.buttons.confirm')}
-                                      </Button>
+                                  </PopoverTrigger>
+                                  <PopoverContent className='w-72'>
+                                    <div className='flex flex-col gap-3'>
+                                      <p className='text-sm'>{t('channels.dialogs.fields.apiKey.confirmRemoveSingle')}</p>
+                                      <div className='flex justify-end gap-2'>
+                                        <Button size='sm' variant='outline' onClick={() => setConfirmRemoveKey(null)}>
+                                          {t('common.buttons.cancel')}
+                                        </Button>
+                                        <Button size='sm' variant='destructive' onClick={() => removeApiKeys([key])}>
+                                          {t('common.buttons.confirm')}
+                                        </Button>
+                                      </div>
                                     </div>
-                                  </div>
-                                </PopoverContent>
-                              </Popover>
-                            )}
-                          </div>
-                        );
-                      });
+                                  </PopoverContent>
+                                </Popover>
+                              )}
+                            </div>
+                          );
+                        });
                     })()}
                   </div>
                 </ScrollArea>
@@ -2791,11 +2889,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                             transform: `translateY(${virtualItem.start}px)`,
                           }}
                         >
-                          <SupportedModelItem
-                            model={model}
-                            isManual={isModelManual(model)}
-                            onRemove={() => removeModel(model)}
-                          />
+                          <SupportedModelItem model={model} isManual={isModelManual(model)} onRemove={() => removeModel(model)} />
                         </div>
                       );
                     })}

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -77,7 +77,7 @@ type ResponsesTransport = 'http' | 'websocket';
 
 const OPENAI_RESPONSES_WEBSOCKET: ApiFormatOption = 'openai/responses:websocket';
 const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1/responses##';
-const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex/responses##';
+const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex#';
 
 function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport {
   return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -76,8 +76,8 @@ type ApiFormatOption = ApiFormat | 'openai/responses:websocket';
 type ResponsesTransport = 'http' | 'websocket';
 
 const OPENAI_RESPONSES_WEBSOCKET: ApiFormatOption = 'openai/responses:websocket';
-const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1/responses##';
-const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex/responses##';
+const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1#';
+const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex#';
 
 function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport {
   return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -858,7 +858,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         form.setValue('baseURL', baseURL, { shouldDirty: true });
       }
     },
-    [derivedChannelType, form, isOAuthChannel, selectedProvider, selectedType]
+    [derivedChannelType, form, isDuplicate, isOAuthChannel, selectedProvider, selectedType]
   );
 
   const handleGeminiVertexChange = useCallback(

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -83,6 +83,20 @@ function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport 
   return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';
 }
 
+function baseURLMatchesResponsesTransport(baseURL: string | undefined, transport: ResponsesTransport): boolean {
+  const normalized = baseURL?.trim().toLowerCase() ?? '';
+  if (transport === 'websocket') {
+    return normalized.startsWith('ws://') || normalized.startsWith('wss://');
+  }
+  return normalized.startsWith('http://') || normalized.startsWith('https://');
+}
+
+function getResponsesTransportBaseURLError(transport: ResponsesTransport): string {
+  return transport === 'websocket'
+    ? 'channels.dialogs.fields.baseURL.errors.websocketScheme'
+    : 'channels.dialogs.fields.baseURL.errors.httpScheme';
+}
+
 function getResponsesTransportFromChannel(channel?: Pick<Channel, 'baseURL' | 'endpoints'>): ResponsesTransport {
   const responsesEndpoint = channel?.endpoints?.find((endpoint) => endpoint.apiFormat === OPENAI_RESPONSES);
   if (responsesEndpoint?.transport === 'http' || responsesEndpoint?.transport === 'websocket') return responsesEndpoint.transport;
@@ -686,12 +700,18 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
   const baseURLPlaceholder = useMemo(() => {
     const currentType = selectedType || derivedChannelType;
+    if (selectedApiFormat === OPENAI_RESPONSES && responsesTransport === 'websocket') {
+      const websocketBaseURL = getResponsesWebSocketBaseURL(currentType);
+      if (websocketBaseURL) {
+        return websocketBaseURL;
+      }
+    }
     const defaultURL = getDefaultBaseURL(currentType);
     if (defaultURL) {
       return defaultURL;
     }
     return t('channels.dialogs.fields.baseURL.placeholder');
-  }, [selectedType, derivedChannelType, t]);
+  }, [selectedType, derivedChannelType, selectedApiFormat, responsesTransport, t]);
 
   // Sync form type when provider or API format changes
   const handleProviderChange = useCallback(
@@ -1053,12 +1073,18 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       ) {
         const currentType = selectedType || derivedChannelType;
         const baseURL =
-          isCodexType && responsesTransport === 'websocket'
-            ? getResponsesWebSocketBaseURL('codex')
-            : getDefaultBaseURL(currentType);
+          isCodexType && responsesTransport === 'websocket' ? getResponsesWebSocketBaseURL('codex') : getDefaultBaseURL(currentType);
         if (baseURL) {
           dataWithModels.baseURL = baseURL;
         }
+      }
+
+      if (selectedApiFormat === OPENAI_RESPONSES && !baseURLMatchesResponsesTransport(dataWithModels.baseURL, responsesTransport)) {
+        form.setError('baseURL', {
+          type: 'manual',
+          message: t(getResponsesTransportBaseURLError(responsesTransport)),
+        });
+        return;
       }
 
       if (isEdit && currentRow) {
@@ -1528,7 +1554,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
             if (initialRow) {
               setSelectedProvider(getProviderFromChannelType(initialRow.type) || 'openai');
               setSelectedApiFormat(CHANNEL_CONFIGS[initialRow.type as ChannelType]?.apiFormat || OPENAI_CHAT_COMPLETIONS);
-              setResponsesTransport(getResponsesTransportFromBaseURL(initialRow.baseURL));
+              setResponsesTransport(getResponsesTransportFromChannel(initialRow));
               setUseGeminiVertex(initialRow.type === 'gemini_vertex');
               setUseAnthropicAws(initialRow.type === 'anthropic_aws');
               setUseKimiCoding(initialRow.type === 'moonshot_coding');

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -76,6 +76,9 @@ type ApiFormatOption = ApiFormat | 'openai/responses:websocket';
 type ResponsesTransport = 'http' | 'websocket';
 
 const OPENAI_RESPONSES_WEBSOCKET: ApiFormatOption = 'openai/responses:websocket';
+// A single trailing # suppresses automatic version suffix appending while still
+// allowing the Responses transformer to append /responses. Do not replace these
+// defaults with ## unless the upstream URL should be used fully raw.
 const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1#';
 const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex#';
 

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -854,7 +854,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
       const channelType = selectedProvider === 'codex' ? 'codex' : selectedType || derivedChannelType;
       const baseURL = transport === 'websocket' ? getResponsesWebSocketBaseURL(channelType) : getDefaultBaseURL(channelType);
-      if (baseURL) {
+      if (baseURL && !isDuplicate) {
         form.setValue('baseURL', baseURL, { shouldDirty: true });
       }
     },

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -77,7 +77,7 @@ type ResponsesTransport = 'http' | 'websocket';
 
 const OPENAI_RESPONSES_WEBSOCKET: ApiFormatOption = 'openai/responses:websocket';
 const OPENAI_RESPONSES_WEBSOCKET_BASE_URL = 'wss://api.openai.com/v1/responses##';
-const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex#';
+const CODEX_RESPONSES_WEBSOCKET_BASE_URL = 'wss://chatgpt.com/backend-api/codex/responses##';
 
 function getResponsesTransportFromBaseURL(baseURL?: string): ResponsesTransport {
   return baseURL?.trim().toLowerCase().startsWith('ws') ? 'websocket' : 'http';
@@ -1048,7 +1048,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         !isDuplicate
       ) {
         const currentType = selectedType || derivedChannelType;
-        const baseURL = getDefaultBaseURL(currentType);
+        const baseURL =
+          isCodexType && responsesTransport === 'websocket'
+            ? getResponsesWebSocketBaseURL('codex')
+            : getDefaultBaseURL(currentType);
         if (baseURL) {
           dataWithModels.baseURL = baseURL;
         }

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -1953,7 +1953,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                   setAuthMode(mode);
                                   if (mode !== 'third-party') {
                                     const currentType = selectedType || derivedChannelType;
-                                    const defaultURL = getDefaultBaseURL(currentType);
+                                    const defaultURL =
+                                      isCodexType && responsesTransport === 'websocket'
+                                        ? getResponsesWebSocketBaseURL('codex')
+                                        : getDefaultBaseURL(currentType);
                                     if (defaultURL) {
                                       form.setValue('baseURL', defaultURL);
                                     }

--- a/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
@@ -104,12 +104,8 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
   }, [open, channel.endpoints]);
 
   const usedApiFormats = useMemo(() => new Set(endpoints.map((ep) => ep.apiFormat)), [endpoints]);
-  const defaultApiFormats = useMemo(() => new Set(defaultEndpoints.map((ep) => ep.apiFormat)), [defaultEndpoints]);
 
-  const availableApiFormats = useMemo(
-    () => configurableChannelEndpointApiFormats.filter((f) => !usedApiFormats.has(f) && !defaultApiFormats.has(f)),
-    [defaultApiFormats, usedApiFormats]
-  );
+  const availableApiFormats = useMemo(() => configurableChannelEndpointApiFormats.filter((f) => !usedApiFormats.has(f)), [usedApiFormats]);
 
   const handleAddEndpoint = useCallback(() => {
     setError(null);
@@ -122,11 +118,6 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
 
     if (!ALLOWED_API_FORMATS.includes(newApiFormat as (typeof ALLOWED_API_FORMATS)[number])) {
       setError(t('channels.endpoints.invalidApiFormat', 'Unsupported API format'));
-      return;
-    }
-
-    if (defaultApiFormats.has(newApiFormat)) {
-      setError(t('channels.endpoints.defaultConflictError', 'Cannot override a default endpoint'));
       return;
     }
 
@@ -149,7 +140,7 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
     setNewApiFormat('');
     setNewPath('');
     setNewBaseURL('');
-  }, [defaultApiFormats, newApiFormat, newPath, newBaseURL, usedApiFormats, t]);
+  }, [newApiFormat, newPath, newBaseURL, usedApiFormats, t]);
 
   const handleRemoveEndpoint = useCallback((apiFormat: string) => {
     setEndpoints((prev) => prev.filter((ep) => ep.apiFormat !== apiFormat));
@@ -172,12 +163,6 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
       return;
     }
 
-    const conflictingDefaultApiFormat = apiFormats.find((format) => defaultApiFormats.has(format));
-    if (conflictingDefaultApiFormat) {
-      setError(t('channels.endpoints.defaultConflictError', 'Cannot override a default endpoint'));
-      return;
-    }
-
     try {
       await saveEndpoints.mutateAsync({
         channelID: channel.id,
@@ -191,7 +176,7 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
     } catch {
       // error handled by hook
     }
-  }, [channel.id, defaultApiFormats, endpoints, onOpenChange, saveEndpoints, t]);
+  }, [channel.id, endpoints, onOpenChange, saveEndpoints, t]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
@@ -170,6 +170,7 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
           apiFormat: ep.apiFormat,
           path: ep.path || undefined,
           baseURL: ep.baseURL || undefined,
+          transport: ep.transport || undefined,
         })),
       });
       onOpenChange(false);

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -112,11 +112,13 @@ const CREATE_CHANNEL_MUTATION = `
         apiFormat
         path
         baseURL
+        transport
       }
       endpoints {
         apiFormat
         path
         baseURL
+        transport
       }
     }
   }
@@ -171,11 +173,13 @@ const BULK_CREATE_CHANNELS_MUTATION = `
         apiFormat
         path
         baseURL
+        transport
       }
       endpoints {
         apiFormat
         path
         baseURL
+        transport
       }
     }
   }
@@ -231,11 +235,13 @@ const UPDATE_CHANNEL_MUTATION = `
         apiFormat
         path
         baseURL
+        transport
       }
       endpoints {
         apiFormat
         path
         baseURL
+        transport
       }
     }
   }
@@ -296,11 +302,13 @@ const SAVE_CHANNEL_ENDPOINTS_MUTATION = `
         apiFormat
         path
         baseURL
+        transport
       }
       endpoints {
         apiFormat
         path
         baseURL
+        transport
       }
     }
   }
@@ -968,7 +976,7 @@ export function useUpdateChannel() {
 
 export interface SaveChannelEndpointsInput {
   channelID: string;
-  endpoints: Array<{ apiFormat: string; path?: string; baseURL?: string }>;
+  endpoints: Array<{ apiFormat: string; path?: string; baseURL?: string; transport?: string }>;
 }
 
 export function useSaveChannelEndpoints() {

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -719,11 +719,13 @@ const QUERY_CHANNELS_QUERY = `
             apiFormat
             path
             baseURL
+            transport
           }
           endpoints {
             apiFormat
             path
             baseURL
+            transport
           }
           disabledAPIKeys {
             key

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -368,11 +368,13 @@ const BULK_IMPORT_CHANNELS_MUTATION = `
           apiFormat
           path
           baseURL
+          transport
         }
         endpoints {
           apiFormat
           path
           baseURL
+          transport
         }
         settings {
           extraModelPrefix
@@ -552,11 +554,13 @@ const BULK_UPDATE_CHANNEL_ORDERING_MUTATION = `
           apiFormat
           path
           baseURL
+          transport
         }
         endpoints {
           apiFormat
           path
           baseURL
+          transport
         }
         settings {
           extraModelPrefix
@@ -595,6 +599,7 @@ const ALL_CHANNEL_SUMMARYS_QUERY = `
         apiFormat
         path
         baseURL
+        transport
       }
       allModelEntries {
         requestModel

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -41,6 +41,7 @@ export const channelEndpointSchema = z.object({
   apiFormat: z.string().min(1),
   path: z.string().optional(),
   baseURL: z.url('Invalid URL').optional().or(z.literal('')),
+  transport: z.enum(['http', 'websocket']).optional().or(z.literal('')),
 });
 export type ChannelEndpoint = z.infer<typeof channelEndpointSchema>;
 

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -694,6 +694,7 @@ export const channelSummarySchema = z.object({
   baseURL: z.string(),
   orderingWeight: z.number(),
   tags: z.array(z.string()).optional().default([]).nullable(),
+  endpoints: z.array(channelEndpointSchema).optional().default([]),
   allModelEntries: z.array(channelModelEntrySchema).optional().default([]),
 });
 export type ChannelSummary = z.infer<typeof channelSummarySchema>;

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -291,6 +291,8 @@
   "channels.dialogs.fields.provider.label": "Provider",
   "channels.dialogs.fields.baseURL.label": "Base URL",
   "channels.dialogs.fields.baseURL.placeholder": "https://api.openai.com/v1",
+  "channels.dialogs.fields.baseURL.errors.httpScheme": "HTTP transport requires an http:// or https:// Base URL",
+  "channels.dialogs.fields.baseURL.errors.websocketScheme": "WebSocket transport requires a ws:// or wss:// Base URL",
   "channels.dialogs.fields.streamPolicy.label": "Stream Policy",
   "channels.dialogs.fields.streamPolicy.placeholder": "Select policy",
   "channels.dialogs.fields.streamPolicy.options.unlimited": "Unlimited (follow request)",

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -284,6 +284,7 @@
   "channels.dialogs.fields.apiFormat.claudecode.description": "Complete OAuth flow above to authenticate with Claude Code. The credentials will be auto-filled.",
   "channels.dialogs.fields.apiFormat.formats.openai/chat_completions": "OpenAI (Chat Completions)",
   "channels.dialogs.fields.apiFormat.formats.openai/responses": "OpenAI (Responses)",
+  "channels.dialogs.fields.apiFormat.formats.openai/responses_websocket": "OpenAI (Responses WebSocket)",
   "channels.dialogs.fields.apiFormat.formats.anthropic/messages": "Anthropic (Messages)",
   "channels.dialogs.fields.apiFormat.formats.gemini/contents": "Gemini (Contents)",
   "channels.dialogs.fields.apiFormat.kimiCoding.label": "Kimi Coding (api.kimi.com)",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -288,6 +288,8 @@
   "channels.dialogs.fields.provider.label": "服务商",
   "channels.dialogs.fields.baseURL.label": "Base URL",
   "channels.dialogs.fields.baseURL.placeholder": "https://api.openai.com/v1",
+  "channels.dialogs.fields.baseURL.errors.httpScheme": "HTTP 传输要求 Base URL 使用 http:// 或 https://",
+  "channels.dialogs.fields.baseURL.errors.websocketScheme": "WebSocket 传输要求 Base URL 使用 ws:// 或 wss://",
   "channels.dialogs.fields.streamPolicy.label": "流式策略",
   "channels.dialogs.fields.streamPolicy.placeholder": "选择策略",
   "channels.dialogs.fields.streamPolicy.options.unlimited": "没有限制 (遵循请求)",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -282,6 +282,7 @@
   "channels.dialogs.fields.apiFormat.claudecode.description": "完成上方的 OAuth 流程以通过 Claude Code 进行身份验证。凭证将自动填充。",
   "channels.dialogs.fields.apiFormat.formats.openai/chat_completions": "OpenAI (Chat Completions)",
   "channels.dialogs.fields.apiFormat.formats.openai/responses": "OpenAI (Responses)",
+  "channels.dialogs.fields.apiFormat.formats.openai/responses_websocket": "OpenAI (Responses WebSocket)",
   "channels.dialogs.fields.apiFormat.formats.anthropic/messages": "Anthropic (Messages)",
   "channels.dialogs.fields.apiFormat.formats.gemini/contents": "Gemini (Contents)",
   "channels.dialogs.fields.provider.label": "服务商",

--- a/internal/objects/channel.go
+++ b/internal/objects/channel.go
@@ -17,7 +17,13 @@ type ChannelEndpoint struct {
 	APIFormat string `json:"api_format"`
 	Path      string `json:"path,omitempty"`
 	BaseURL   string `json:"base_url,omitempty"`
+	Transport string `json:"transport,omitempty"`
 }
+
+const (
+	ChannelEndpointTransportHTTP      = "http"
+	ChannelEndpointTransportWebSocket = "websocket"
+)
 
 type (
 	ProxyType   = httpclient.ProxyType

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -662,8 +662,8 @@ func (svc *ChannelService) asyncReloadChannels() {
 }
 
 // SaveChannelEndpoints updates the endpoints field for a channel.
-// Validates that api_format values are unique and do not conflict with the
-// channel type's default endpoints.
+// Validates user-configured endpoint overrides before storing them. Runtime
+// endpoint resolution merges matching api_format entries with defaults.
 func (svc *ChannelService) SaveChannelEndpoints(ctx context.Context, input SaveChannelEndpointsInput) (*ent.Channel, error) {
 	if err := ValidateEndpoints(input.Endpoints); err != nil {
 		return nil, fmt.Errorf("invalid endpoints: %w", err)
@@ -672,15 +672,6 @@ func (svc *ChannelService) SaveChannelEndpoints(ctx context.Context, input SaveC
 	ch, err := svc.entFromContext(ctx).Channel.Get(ctx, input.ChannelID.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get channel: %w", err)
-	}
-
-	defaults := DefaultEndpointsForChannelType(ch.Type)
-	for _, userEP := range input.Endpoints {
-		for _, defaultEP := range defaults {
-			if userEP.APIFormat == defaultEP.APIFormat {
-				return nil, fmt.Errorf("endpoint api_format %q conflicts with default endpoint for channel type %s", userEP.APIFormat, ch.Type)
-			}
-		}
 	}
 
 	ch, err = svc.entFromContext(ctx).Channel.UpdateOne(ch).

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -278,6 +278,35 @@ func (svc *ChannelService) onEnabledChannelsSwap(old, new []*Channel) {
 		if ch != nil && ch.stopTokenProvider != nil {
 			ch.stopTokenProvider()
 		}
+		stopChannelOutbounds(ch)
+	}
+}
+
+type stoppableOutbound interface {
+	Stop()
+}
+
+func stopChannelOutbounds(ch *Channel) {
+	if ch == nil {
+		return
+	}
+
+	seen := map[stoppableOutbound]struct{}{}
+	stopOutbound := func(out transformer.Outbound) {
+		stoppable, ok := out.(stoppableOutbound)
+		if !ok || stoppable == nil {
+			return
+		}
+		if _, ok := seen[stoppable]; ok {
+			return
+		}
+		seen[stoppable] = struct{}{}
+		stoppable.Stop()
+	}
+
+	stopOutbound(ch.Outbound)
+	for _, out := range ch.Outbounds {
+		stopOutbound(out)
 	}
 }
 

--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -52,8 +52,8 @@ func ValidateEndpoints(endpoints []objects.ChannelEndpoint) error {
 			return fmt.Errorf("endpoint[%d]: unsupported transport %q", i, ep.Transport)
 		}
 
-		if ep.Transport == objects.ChannelEndpointTransportWebSocket && ep.APIFormat != llm.APIFormatOpenAIResponse.String() {
-			return fmt.Errorf("endpoint[%d]: websocket transport only supports api_format %q", i, llm.APIFormatOpenAIResponse.String())
+		if ep.Transport == objects.ChannelEndpointTransportWebSocket && !supportsWebSocketTransport(ep.APIFormat) {
+			return fmt.Errorf("endpoint[%d]: websocket transport only supports api_format %q or %q", i, llm.APIFormatOpenAIResponse.String(), llm.APIFormatOpenAIResponseCompact.String())
 		}
 
 		if ep.Path != "" {
@@ -68,6 +68,10 @@ func ValidateEndpoints(endpoints []objects.ChannelEndpoint) error {
 	}
 
 	return nil
+}
+
+func supportsWebSocketTransport(apiFormat string) bool {
+	return apiFormat == llm.APIFormatOpenAIResponse.String() || apiFormat == llm.APIFormatOpenAIResponseCompact.String()
 }
 
 var openAICompatibleDefaultEndpoints = []objects.ChannelEndpoint{

--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -48,6 +48,14 @@ func ValidateEndpoints(endpoints []objects.ChannelEndpoint) error {
 
 		seen[ep.APIFormat] = true
 
+		if ep.Transport != "" && ep.Transport != objects.ChannelEndpointTransportHTTP && ep.Transport != objects.ChannelEndpointTransportWebSocket {
+			return fmt.Errorf("endpoint[%d]: unsupported transport %q", i, ep.Transport)
+		}
+
+		if ep.Transport == objects.ChannelEndpointTransportWebSocket && ep.APIFormat != llm.APIFormatOpenAIResponse.String() {
+			return fmt.Errorf("endpoint[%d]: websocket transport only supports api_format %q", i, llm.APIFormatOpenAIResponse.String())
+		}
+
 		if ep.Path != "" {
 			if strings.HasPrefix(ep.Path, "http://") || strings.HasPrefix(ep.Path, "https://") {
 				return fmt.Errorf("endpoint[%d]: path must not be a full URL, got %q", i, ep.Path)

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -200,7 +200,7 @@ func TestValidateEndpoints(t *testing.T) {
 func TestPrimaryEndpointTransport(t *testing.T) {
 	t.Run("infers websocket from primary base url", func(t *testing.T) {
 		transport := primaryEndpointTransport(&ent.Channel{
-			BaseURL: "wss://api.openai.com/v1/responses##",
+			BaseURL: "wss://api.openai.com/v1#",
 		}, llm.APIFormatOpenAIResponse.String())
 
 		require.Equal(t, objects.ChannelEndpointTransportWebSocket, transport)

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -183,6 +183,13 @@ func TestValidateEndpoints(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("websocket compact responses endpoint passes validation", func(t *testing.T) {
+		err := ValidateEndpoints([]objects.ChannelEndpoint{
+			{APIFormat: llm.APIFormatOpenAIResponseCompact.String(), Transport: objects.ChannelEndpointTransportWebSocket},
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("valid endpoints pass validation", func(t *testing.T) {
 		err := ValidateEndpoints([]objects.ChannelEndpoint{
 			{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -197,6 +197,27 @@ func TestValidateEndpoints(t *testing.T) {
 	})
 }
 
+func TestPrimaryEndpointTransport(t *testing.T) {
+	t.Run("infers websocket from primary base url", func(t *testing.T) {
+		transport := primaryEndpointTransport(&ent.Channel{
+			BaseURL: "wss://api.openai.com/v1/responses##",
+		}, llm.APIFormatOpenAIResponse.String())
+
+		require.Equal(t, objects.ChannelEndpointTransportWebSocket, transport)
+	})
+
+	t.Run("uses matching endpoint transport override", func(t *testing.T) {
+		transport := primaryEndpointTransport(&ent.Channel{
+			BaseURL: "https://api.openai.com/v1",
+			Endpoints: []objects.ChannelEndpoint{
+				{APIFormat: llm.APIFormatOpenAIResponse.String(), Transport: objects.ChannelEndpointTransportWebSocket},
+			},
+		}, llm.APIFormatOpenAIResponse.String())
+
+		require.Equal(t, objects.ChannelEndpointTransportWebSocket, transport)
+	})
+}
+
 func TestResolveEndpoints_MergesDefaultsAndUserOverrides(t *testing.T) {
 	ch := &Channel{
 		Channel: &ent.Channel{

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -168,6 +168,21 @@ func TestValidateEndpoints(t *testing.T) {
 		require.Contains(t, err.Error(), "path must not be a full URL")
 	})
 
+	t.Run("websocket transport only supports responses", func(t *testing.T) {
+		err := ValidateEndpoints([]objects.ChannelEndpoint{
+			{APIFormat: llm.APIFormatOpenAIChatCompletion.String(), Transport: objects.ChannelEndpointTransportWebSocket},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "websocket transport only supports")
+	})
+
+	t.Run("websocket responses endpoint passes validation", func(t *testing.T) {
+		err := ValidateEndpoints([]objects.ChannelEndpoint{
+			{APIFormat: llm.APIFormatOpenAIResponse.String(), Transport: objects.ChannelEndpointTransportWebSocket},
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("valid endpoints pass validation", func(t *testing.T) {
 		err := ValidateEndpoints([]objects.ChannelEndpoint{
 			{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -330,7 +330,9 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 	ch *Channel,
 	ep objects.ChannelEndpoint,
 ) (transformer.Outbound, error) {
-	apiKeyProvider := getAPIKeyProvider(ch)
+	apiKeyProvider := func() auth.APIKeyProvider {
+		return getAPIKeyProvider(ch)
+	}
 
 	baseURL := c.BaseURL
 	if ep.BaseURL != "" {
@@ -344,13 +346,13 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 		return openai.NewOutboundTransformerWithConfig(&openai.Config{
 			PlatformType:   openai.PlatformOpenAI,
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 		})
 	case llm.APIFormatOpenAICompletion.String():
 		return openai.NewCompletionOutboundTransformer(&openai.Config{
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 		})
 	case llm.APIFormatOpenAIResponse.String(),
@@ -362,7 +364,7 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 
 		return responses.NewOutboundTransformerWithConfig(&responses.Config{
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 			Transport:      transport,
 		})
@@ -374,34 +376,34 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 		return openai.NewOutboundTransformerWithConfig(&openai.Config{
 			PlatformType:   openai.PlatformOpenAI,
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 		})
 	case llm.APIFormatAnthropicMessage.String():
 		return anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
 			Type:           anthropic.PlatformDirect,
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 		})
 	case llm.APIFormatGeminiContents.String():
 		return gemini.NewOutboundTransformerWithConfig(gemini.Config{
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 			PlatformType:   ch.platformTypeForGeminiEndpoint(),
 		})
 	case llm.APIFormatGeminiEmbedding.String():
 		return gemini.NewOutboundTransformerWithConfig(gemini.Config{
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 			PlatformType:   ch.platformTypeForGeminiEndpoint(),
 		})
 	case llm.APIFormatJinaRerank.String(), llm.APIFormatJinaEmbedding.String():
 		return jina.NewOutboundTransformerWithConfig(&jina.Config{
 			BaseURL:        baseURL,
-			APIKeyProvider: apiKeyProvider,
+			APIKeyProvider: apiKeyProvider(),
 			EndpointPath:   ep.Path,
 		})
 	default:

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -242,6 +242,26 @@ func endpointTransport(ep objects.ChannelEndpoint) string {
 	return ""
 }
 
+func primaryEndpointTransport(c *ent.Channel, apiFormat string) string {
+	if c == nil {
+		return ""
+	}
+
+	for _, ep := range c.Endpoints {
+		if ep.APIFormat != apiFormat {
+			continue
+		}
+
+		if ep.BaseURL == "" {
+			ep.BaseURL = c.BaseURL
+		}
+
+		return endpointTransport(ep)
+	}
+
+	return endpointTransport(objects.ChannelEndpoint{BaseURL: c.BaseURL})
+}
+
 func (svc *ChannelService) buildCodexOutbound(
 	c *ent.Channel,
 	ch *Channel,
@@ -805,7 +825,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel) (*Channel
 
 		return ch, nil
 	case channel.TypeCodex:
-		transport := endpointTransport(objects.ChannelEndpoint{BaseURL: c.BaseURL})
+		transport := primaryEndpointTransport(c, llm.APIFormatOpenAIResponse.String())
 		transformer, err := svc.buildCodexOutbound(c, ch, c.BaseURL, transport, httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create codex outbound transformer: %w", err)
@@ -893,6 +913,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel) (*Channel
 		transformer, err := responses.NewOutboundTransformerWithConfig(&responses.Config{
 			BaseURL:        c.BaseURL,
 			APIKeyProvider: getAPIKeyProvider(ch),
+			Transport:      primaryEndpointTransport(c, llm.APIFormatOpenAIResponse.String()),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -229,6 +229,78 @@ func (svc *ChannelService) buildChannelWithOutbounds(c *ent.Channel) (*Channel, 
 	return ch, nil
 }
 
+func endpointTransport(ep objects.ChannelEndpoint) string {
+	if ep.Transport != "" {
+		return ep.Transport
+	}
+
+	baseURL := strings.TrimSpace(strings.ToLower(ep.BaseURL))
+	if strings.HasPrefix(baseURL, "ws://") || strings.HasPrefix(baseURL, "wss://") {
+		return objects.ChannelEndpointTransportWebSocket
+	}
+
+	return ""
+}
+
+func (svc *ChannelService) buildCodexOutbound(
+	c *ent.Channel,
+	ch *Channel,
+	baseURL string,
+	transport string,
+	httpClient *httpclient.HttpClient,
+) (transformer.Outbound, error) {
+	if c.Credentials.IsOAuth() {
+		credsJSON := strings.TrimSpace(c.Credentials.APIKey)
+		if c.Credentials.OAuth != nil {
+			o := c.Credentials.OAuth
+
+			creds, err := (&oauth.OAuthCredentials{
+				AccessToken:  o.AccessToken,
+				RefreshToken: o.RefreshToken,
+				ClientID:     o.ClientID,
+				ExpiresAt:    o.ExpiresAt,
+				TokenType:    o.TokenType,
+				Scopes:       o.Scopes,
+			}).ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode codex oauth credentials: %w", err)
+			}
+
+			credsJSON = creds
+		}
+
+		creds, err := oauth.ParseCredentialsJSON(credsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse codex oauth credentials: %w", err)
+		}
+
+		p := codex.NewTokenProvider(codex.TokenProviderParams{
+			Credentials: creds,
+			HTTPClient:  httpClient,
+			OnRefreshed: svc.onTokenRefreshed(c),
+		})
+
+		if ch != nil && ch.startTokenProvider == nil {
+			setupAutoRefresh(ch, p, oauth.AutoRefreshOptions{})
+		}
+
+		return codex.NewOutboundTransformer(codex.Params{
+			TokenProvider: p,
+			BaseURL:       baseURL,
+			Transport:     transport,
+		})
+	}
+
+	apiKeyProvider := getAPIKeyProvider(ch)
+	tokens := oauth.NewAPIKeyTokenProvider(apiKeyProvider.Get)
+
+	return codex.NewOutboundTransformer(codex.Params{
+		TokenProvider: tokens,
+		BaseURL:       baseURL,
+		Transport:     transport,
+	})
+}
+
 // buildNonDefaultEndpointOutbound creates a transformer for a user-configured
 // endpoint override. Default endpoints are handled by buildChannelWithOutbounds
 // and always use the primary outbound.
@@ -261,10 +333,16 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 		})
 	case llm.APIFormatOpenAIResponse.String(),
 		llm.APIFormatOpenAIResponseCompact.String():
+		transport := endpointTransport(ep)
+		if c.Type == channel.TypeCodex && ep.APIFormat == llm.APIFormatOpenAIResponse.String() {
+			return svc.buildCodexOutbound(c, ch, baseURL, transport, ch.HTTPClient)
+		}
+
 		return responses.NewOutboundTransformerWithConfig(&responses.Config{
 			BaseURL:        baseURL,
 			APIKeyProvider: apiKeyProvider,
 			EndpointPath:   ep.Path,
+			Transport:      transport,
 		})
 	case llm.APIFormatOpenAIEmbedding.String(),
 		llm.APIFormatOpenAIImageGeneration.String(),
@@ -727,60 +805,8 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel) (*Channel
 
 		return ch, nil
 	case channel.TypeCodex:
-		// Check if using OAuth credentials first
-		if c.Credentials.IsOAuth() {
-			credsJSON := strings.TrimSpace(c.Credentials.APIKey)
-			if c.Credentials.OAuth != nil {
-				o := c.Credentials.OAuth
-
-				creds, err := (&oauth.OAuthCredentials{
-					AccessToken:  o.AccessToken,
-					RefreshToken: o.RefreshToken,
-					ClientID:     o.ClientID,
-					ExpiresAt:    o.ExpiresAt,
-					TokenType:    o.TokenType,
-					Scopes:       o.Scopes,
-				}).ToJSON()
-				if err != nil {
-					return nil, fmt.Errorf("failed to encode codex oauth credentials: %w", err)
-				}
-
-				credsJSON = creds
-			}
-
-			creds, err := oauth.ParseCredentialsJSON(credsJSON)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse codex oauth credentials: %w", err)
-			}
-
-			p := codex.NewTokenProvider(codex.TokenProviderParams{
-				Credentials: creds,
-				HTTPClient:  httpClient,
-				OnRefreshed: svc.onTokenRefreshed(c),
-			})
-
-			transformer, err := codex.NewOutboundTransformer(codex.Params{
-				TokenProvider: p,
-				BaseURL:       c.BaseURL,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create codex outbound transformer: %w", err)
-			}
-
-			ch.Outbound = transformer
-			setupAutoRefresh(ch, p, oauth.AutoRefreshOptions{})
-
-			return ch, nil
-		}
-
-		// Non-OAuth: use APIKeyProvider for multi-key rotation support
-		apiKeyProvider := getAPIKeyProvider(ch)
-		tokens := oauth.NewAPIKeyTokenProvider(apiKeyProvider.Get)
-
-		transformer, err := codex.NewOutboundTransformer(codex.Params{
-			TokenProvider: tokens,
-			BaseURL:       c.BaseURL,
-		})
+		transport := endpointTransport(objects.ChannelEndpoint{BaseURL: c.BaseURL})
+		transformer, err := svc.buildCodexOutbound(c, ch, c.BaseURL, transport, httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create codex outbound transformer: %w", err)
 		}

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -335,6 +335,8 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 	baseURL := c.BaseURL
 	if ep.BaseURL != "" {
 		baseURL = ep.BaseURL
+	} else {
+		ep.BaseURL = baseURL
 	}
 
 	switch ep.APIFormat {

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -270,6 +270,18 @@ func (svc *ChannelService) buildCodexOutbound(
 	httpClient *httpclient.HttpClient,
 ) (transformer.Outbound, error) {
 	if c.Credentials.IsOAuth() {
+		if ch != nil {
+			if existing, ok := ch.Outbound.(*codex.OutboundTransformer); ok {
+				if tokens := existing.TokenProvider(); tokens != nil {
+					return codex.NewOutboundTransformer(codex.Params{
+						TokenProvider: tokens,
+						BaseURL:       baseURL,
+						Transport:     transport,
+					})
+				}
+			}
+		}
+
 		credsJSON := strings.TrimSpace(c.Credentials.APIKey)
 		if c.Credentials.OAuth != nil {
 			o := c.Credentials.OAuth

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 	"github.com/looplj/axonhub/llm/transformer/openai/codex"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
@@ -171,4 +174,50 @@ func TestCodexOAuthWebSocketEndpointBuildsWithoutAPIKey(t *testing.T) {
 	custom, ok := outbound.(pipeline.ChannelCustomizedExecutor)
 	require.True(t, ok)
 	require.NotNil(t, custom.CustomizeExecutor(nil))
+}
+
+type testStoppableOutbound struct {
+	stops int
+}
+
+func (t *testStoppableOutbound) APIFormat() llm.APIFormat { return llm.APIFormatOpenAIResponse }
+
+func (t *testStoppableOutbound) TransformRequest(context.Context, *llm.Request) (*httpclient.Request, error) {
+	return nil, nil
+}
+
+func (t *testStoppableOutbound) TransformResponse(context.Context, *httpclient.Response) (*llm.Response, error) {
+	return nil, nil
+}
+
+func (t *testStoppableOutbound) TransformStream(context.Context, *httpclient.Request, streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+	return nil, nil
+}
+
+func (t *testStoppableOutbound) TransformError(context.Context, *httpclient.Error) *llm.ResponseError {
+	return nil
+}
+
+func (t *testStoppableOutbound) AggregateStreamChunks(context.Context, *httpclient.Request, []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {
+	return nil, llm.ResponseMeta{}, nil
+}
+
+func (t *testStoppableOutbound) Stop() {
+	t.stops++
+}
+
+func TestStopChannelOutboundsStopsEachOutboundOnce(t *testing.T) {
+	primary := &testStoppableOutbound{}
+	secondary := &testStoppableOutbound{}
+
+	stopChannelOutbounds(&Channel{
+		Outbound: primary,
+		Outbounds: map[string]transformer.Outbound{
+			llm.APIFormatOpenAIResponse.String():        primary,
+			llm.APIFormatOpenAIResponseCompact.String(): secondary,
+		},
+	})
+
+	require.Equal(t, 1, primary.stops)
+	require.Equal(t, 1, secondary.stops)
 }

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
 func TestOpenAICompatibleChannel_BuildChannelWithOutbounds(t *testing.T) {
@@ -87,5 +89,39 @@ func TestAtlasCloudChannel_BuildChannelWithOutbounds(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, embeddingOutbound)
 	_, ok := embeddingOutbound.(*openai.OutboundTransformer)
+	require.True(t, ok)
+}
+
+func TestOpenAIResponsesEndpoint_InheritsWebSocketTransportFromBaseURL(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+
+	entChannel := client.Channel.Create().
+		SetName("Responses WebSocket Channel").
+		SetType(channel.TypeOpenaiResponses).
+		SetBaseURL("wss://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-5"}).
+		SetDefaultTestModel("gpt-5").
+		SetEndpoints([]objects.ChannelEndpoint{{
+			APIFormat: llm.APIFormatOpenAIResponse.String(),
+			Path:      "/custom/responses",
+		}}).
+		SaveX(ctx)
+
+	channelSvc := NewChannelServiceForTest(client)
+
+	built, err := channelSvc.buildChannelWithOutbounds(entChannel)
+	require.NoError(t, err)
+
+	outbound, err := BuildOutboundByAPIFormat(built, llm.APIFormatOpenAIResponse.String())
+	require.NoError(t, err)
+	custom, ok := outbound.(pipeline.ChannelCustomizedExecutor)
+	require.True(t, ok)
+
+	executor := custom.CustomizeExecutor(nil)
+	_, ok = executor.(*responses.WebSocketExecutor)
 	require.True(t, ok)
 }

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -124,4 +125,41 @@ func TestOpenAIResponsesEndpoint_InheritsWebSocketTransportFromBaseURL(t *testin
 	executor := custom.CustomizeExecutor(nil)
 	_, ok = executor.(*responses.WebSocketExecutor)
 	require.True(t, ok)
+}
+
+func TestCodexOAuthWebSocketEndpointBuildsWithoutAPIKey(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+
+	entChannel := client.Channel.Create().
+		SetName("Codex OAuth WebSocket Channel").
+		SetType(channel.TypeCodex).
+		SetBaseURL("wss://chatgpt.com/backend-api/codex#").
+		SetCredentials(objects.ChannelCredentials{
+			OAuth: &objects.OAuthCredentials{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			},
+		}).
+		SetSupportedModels([]string{"gpt-5.5"}).
+		SetDefaultTestModel("gpt-5.5").
+		SetEndpoints([]objects.ChannelEndpoint{{
+			APIFormat: llm.APIFormatOpenAIResponse.String(),
+			Transport: objects.ChannelEndpointTransportWebSocket,
+		}}).
+		SaveX(ctx)
+
+	channelSvc := NewChannelServiceForTest(client)
+
+	built, err := channelSvc.buildChannelWithOutbounds(entChannel)
+	require.NoError(t, err)
+
+	outbound, err := BuildOutboundByAPIFormat(built, llm.APIFormatOpenAIResponse.String())
+	require.NoError(t, err)
+	custom, ok := outbound.(pipeline.ChannelCustomizedExecutor)
+	require.True(t, ok)
+	require.NotNil(t, custom.CustomizeExecutor(nil))
 }

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/openai/codex"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
@@ -157,8 +158,16 @@ func TestCodexOAuthWebSocketEndpointBuildsWithoutAPIKey(t *testing.T) {
 	built, err := channelSvc.buildChannelWithOutbounds(entChannel)
 	require.NoError(t, err)
 
+	primary, ok := built.Outbound.(*codex.OutboundTransformer)
+	require.True(t, ok)
+	require.NotNil(t, primary.TokenProvider())
+
 	outbound, err := BuildOutboundByAPIFormat(built, llm.APIFormatOpenAIResponse.String())
 	require.NoError(t, err)
+	override, ok := outbound.(*codex.OutboundTransformer)
+	require.True(t, ok)
+	require.True(t, primary.TokenProvider() == override.TokenProvider())
+
 	custom, ok := outbound.(pipeline.ChannelCustomizedExecutor)
 	require.True(t, ok)
 	require.NotNil(t, custom.CustomizeExecutor(nil))

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -74,12 +74,14 @@ type ChannelEndpoint {
   apiFormat: String!
   path: String
   baseURL: String
+  transport: String
 }
 
 input ChannelEndpointInput {
   apiFormat: String!
   path: String
   baseURL: String
+  transport: String
 }
 
 input SaveChannelEndpointsInput {

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -339,6 +339,7 @@ type ComplexityRoot struct {
 		APIFormat func(childComplexity int) int
 		BaseURL   func(childComplexity int) int
 		Path      func(childComplexity int) int
+		Transport func(childComplexity int) int
 	}
 
 	ChannelLimiterStats struct {
@@ -3245,6 +3246,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ChannelEndpoint.Path(childComplexity), true
+	case "ChannelEndpoint.transport":
+		if e.complexity.ChannelEndpoint.Transport == nil {
+			break
+		}
+
+		return e.complexity.ChannelEndpoint.Transport(childComplexity), true
 
 	case "ChannelLimiterStats.capacity":
 		if e.complexity.ChannelLimiterStats.Capacity == nil {
@@ -18108,6 +18115,8 @@ func (ec *executionContext) fieldContext_Channel_endpoints(_ context.Context, fi
 				return ec.fieldContext_ChannelEndpoint_path(ctx, field)
 			case "baseURL":
 				return ec.fieldContext_ChannelEndpoint_baseURL(ctx, field)
+			case "transport":
+				return ec.fieldContext_ChannelEndpoint_transport(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ChannelEndpoint", field.Name)
 		},
@@ -18441,6 +18450,8 @@ func (ec *executionContext) fieldContext_Channel_defaultEndpoints(_ context.Cont
 				return ec.fieldContext_ChannelEndpoint_path(ctx, field)
 			case "baseURL":
 				return ec.fieldContext_ChannelEndpoint_baseURL(ctx, field)
+			case "transport":
+				return ec.fieldContext_ChannelEndpoint_transport(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ChannelEndpoint", field.Name)
 		},
@@ -19038,6 +19049,35 @@ func (ec *executionContext) _ChannelEndpoint_baseURL(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_ChannelEndpoint_baseURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ChannelEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ChannelEndpoint_transport(ctx context.Context, field graphql.CollectedField, obj *objects.ChannelEndpoint) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ChannelEndpoint_transport,
+		func(ctx context.Context) (any, error) {
+			return obj.Transport, nil
+		},
+		nil,
+		ec.marshalOString2string,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ChannelEndpoint_transport(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ChannelEndpoint",
 		Field:      field,
@@ -59571,7 +59611,7 @@ func (ec *executionContext) unmarshalInputChannelEndpointInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"apiFormat", "path", "baseURL"}
+	fieldsInOrder := [...]string{"apiFormat", "path", "baseURL", "transport"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -59599,6 +59639,13 @@ func (ec *executionContext) unmarshalInputChannelEndpointInput(ctx context.Conte
 				return it, err
 			}
 			it.BaseURL = data
+		case "transport":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("transport"))
+			data, err := ec.unmarshalOString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Transport = data
 		}
 	}
 
@@ -85323,6 +85370,8 @@ func (ec *executionContext) _ChannelEndpoint(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._ChannelEndpoint_path(ctx, field, obj)
 		case "baseURL":
 			out.Values[i] = ec._ChannelEndpoint_baseURL(ctx, field, obj)
+		case "transport":
+			out.Values[i] = ec._ChannelEndpoint_transport(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // WithAPIKeyAuth 中间件用于验证 API key.
@@ -55,6 +57,8 @@ func WithAPIKeyConfig(auth *biz.AuthService, config *APIKeyConfig) gin.HandlerFu
 			ctx = contexts.WithProjectID(ctx, apiKey.Edges.Project.ID)
 		}
 
+		ctx = withSessionScopeForAPIKey(ctx, apiKey)
+
 		ctx, err = withAPIKeyPrincipal(ctx, apiKey)
 		if err != nil {
 			AbortWithError(c, http.StatusUnauthorized, errors.New("Invalid authentication context"))
@@ -90,6 +94,8 @@ func WithJWTAuth(auth *biz.AuthService) gin.HandlerFunc {
 		}
 
 		ctx := contexts.WithUser(c.Request.Context(), user)
+
+		ctx = shared.WithSessionScope(ctx, "user:"+strconv.Itoa(user.ID))
 
 		ctx, err = withUserPrincipal(ctx, user)
 		if err != nil {
@@ -138,6 +144,8 @@ func WithOpenAPIAuth(auth *biz.AuthService) gin.HandlerFunc {
 			ctx = contexts.WithProjectID(ctx, apiKey.Edges.Project.ID)
 		}
 
+		ctx = withSessionScopeForAPIKey(ctx, apiKey)
+
 		ctx, err = withAPIKeyPrincipal(ctx, apiKey)
 		if err != nil {
 			AbortWithError(c, http.StatusUnauthorized, errors.New("Invalid authentication context"))
@@ -182,6 +190,8 @@ func WithGeminiKeyAuth(auth *biz.AuthService) gin.HandlerFunc {
 			ctx = contexts.WithProjectID(ctx, apiKey.Edges.Project.ID)
 		}
 
+		ctx = withSessionScopeForAPIKey(ctx, apiKey)
+
 		ctx, err = withAPIKeyPrincipal(ctx, apiKey)
 		if err != nil {
 			AbortWithError(c, http.StatusUnauthorized, errors.New("Invalid authentication context"))
@@ -201,6 +211,14 @@ func WithSource(source request.Source) gin.HandlerFunc {
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}
+}
+
+func withSessionScopeForAPIKey(ctx context.Context, key *ent.APIKey) context.Context {
+	scope := "api_key:" + strconv.Itoa(key.ID)
+	if key.Edges.Project != nil {
+		scope += ":project:" + strconv.Itoa(key.Edges.Project.ID)
+	}
+	return shared.WithSessionScope(ctx, scope)
 }
 
 func withUserPrincipal(ctx context.Context, user *ent.User) (context.Context, error) {

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -686,8 +686,12 @@ func (p *PersistentOutboundTransformer) CustomizeExecutor(executor pipeline.Exec
 		// Use the channel's own HTTP client, which is pre-configured with its proxy settings.
 		customizedExecutor = channel.HTTPClient
 	}
-	// 2. Allow the specific outbound transformer (e.g., for AWS signing) to further customize the client.
-	if custom, ok := channel.Outbound.(pipeline.ChannelCustomizedExecutor); ok {
+	// 2. Allow the selected outbound transformer (e.g., for AWS signing or Responses WebSocket) to further customize the client.
+	outbound := p.wrapped
+	if outbound == nil {
+		outbound = channel.Outbound
+	}
+	if custom, ok := outbound.(pipeline.ChannelCustomizedExecutor); ok {
 		return custom.CustomizeExecutor(customizedExecutor)
 	}
 

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/jsonschema-go v0.3.1-0.20251120200837-98a387e3b975
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/kaptinlin/jsonrepair v0.2.4
 	github.com/klauspost/compress v1.17.9
 	github.com/samber/lo v1.52.0

--- a/llm/go.sum
+++ b/llm/go.sum
@@ -267,6 +267,8 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -83,6 +83,14 @@ func (hc *HttpClient) GetNativeClient() *http.Client {
 	return hc.client
 }
 
+func (hc *HttpClient) ProxyFunc() func(*http.Request) (*url.URL, error) {
+	if hc == nil {
+		return http.ProxyFromEnvironment
+	}
+
+	return getProxyFunc(hc.proxyConfig)
+}
+
 // getProxyFunc returns a proxy function based on the proxy configuration.
 func getProxyFunc(config *ProxyConfig) func(*http.Request) (*url.URL, error) {
 	// Handle nil config (backward compatibility) - default to environment

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -299,6 +299,9 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 	if err := stream.Err(); err != nil {
 		return nil, err
 	}
+	if err := responses.TopLevelWebSocketError(chunks); err != nil {
+		return nil, err
+	}
 
 	body, _, err := e.transformer.AggregateStreamChunks(ctx, request, chunks)
 	if err != nil {

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -29,7 +29,8 @@ const (
 //
 //nolint:containedctx // It is used as a transformer.
 type OutboundTransformer struct {
-	tokens oauth.TokenGetter
+	tokens    oauth.TokenGetter
+	transport string
 
 	// reuse existing Responses outbound for payload building.
 	responsesOutbound *responses.OutboundTransformer
@@ -43,6 +44,7 @@ var (
 type Params struct {
 	TokenProvider oauth.TokenGetter
 	BaseURL       string
+	Transport     string
 }
 
 func NewOutboundTransformer(params Params) (*OutboundTransformer, error) {
@@ -61,6 +63,7 @@ func NewOutboundTransformer(params Params) (*OutboundTransformer, error) {
 	ro, err := responses.NewOutboundTransformerWithConfig(&responses.Config{
 		BaseURL:        baseURL,
 		APIKeyProvider: auth.NewStaticKeyProvider("dummy"),
+		Transport:      params.Transport,
 	})
 	if err != nil {
 		return nil, err
@@ -68,6 +71,7 @@ func NewOutboundTransformer(params Params) (*OutboundTransformer, error) {
 
 	return &OutboundTransformer{
 		tokens:            params.TokenProvider,
+		transport:         params.Transport,
 		responsesOutbound: ro,
 	}, nil
 }
@@ -213,8 +217,13 @@ func (t *OutboundTransformer) AggregateStreamChunks(ctx context.Context, req *ht
 }
 
 func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipeline.Executor {
+	inner := executor
+	if t != nil && t.transport == responses.TransportWebSocket {
+		inner = responses.NewWebSocketExecutor(inner)
+	}
+
 	return &codexExecutor{
-		inner:       executor,
+		inner:       inner,
 		transformer: t,
 	}
 }

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -34,6 +35,9 @@ type OutboundTransformer struct {
 
 	// reuse existing Responses outbound for payload building.
 	responsesOutbound *responses.OutboundTransformer
+
+	executorMu        sync.Mutex
+	webSocketExecutor *responses.WebSocketExecutor
 }
 
 var (
@@ -219,13 +223,24 @@ func (t *OutboundTransformer) AggregateStreamChunks(ctx context.Context, req *ht
 func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipeline.Executor {
 	inner := executor
 	if t != nil && t.transport == responses.TransportWebSocket {
-		inner = responses.NewWebSocketExecutor(inner)
+		inner = t.customizeWebSocketExecutor(inner)
 	}
 
 	return &codexExecutor{
 		inner:       inner,
 		transformer: t,
 	}
+}
+
+func (t *OutboundTransformer) customizeWebSocketExecutor(executor pipeline.Executor) pipeline.Executor {
+	t.executorMu.Lock()
+	defer t.executorMu.Unlock()
+
+	if t.webSocketExecutor == nil {
+		t.webSocketExecutor = responses.NewWebSocketExecutor(executor)
+	}
+
+	return t.webSocketExecutor
 }
 
 type codexExecutor struct {

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -85,6 +85,14 @@ func (t *OutboundTransformer) APIFormat() llm.APIFormat {
 	return llm.APIFormatOpenAIResponse
 }
 
+func (t *OutboundTransformer) TokenProvider() oauth.TokenGetter {
+	if t == nil {
+		return nil
+	}
+
+	return t.tokens
+}
+
 func (t *OutboundTransformer) TransformError(ctx context.Context, rawErr *httpclient.Error) *llm.ResponseError {
 	return t.responsesOutbound.TransformError(ctx, rawErr)
 }

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"reflect"
 	"sync"
 
 	"github.com/google/uuid"
@@ -36,8 +37,8 @@ type OutboundTransformer struct {
 	// reuse existing Responses outbound for payload building.
 	responsesOutbound *responses.OutboundTransformer
 
-	executorMu        sync.Mutex
-	webSocketExecutor *responses.WebSocketExecutor
+	executorMu         sync.Mutex
+	webSocketExecutors map[pipeline.Executor]*responses.WebSocketExecutor
 }
 
 var (
@@ -233,14 +234,32 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 }
 
 func (t *OutboundTransformer) customizeWebSocketExecutor(executor pipeline.Executor) pipeline.Executor {
+	if !executorComparable(executor) {
+		return responses.NewWebSocketExecutor(executor)
+	}
+
 	t.executorMu.Lock()
 	defer t.executorMu.Unlock()
 
-	if t.webSocketExecutor == nil {
-		t.webSocketExecutor = responses.NewWebSocketExecutor(executor)
+	if t.webSocketExecutors == nil {
+		t.webSocketExecutors = make(map[pipeline.Executor]*responses.WebSocketExecutor)
+	}
+	if cached, ok := t.webSocketExecutors[executor]; ok {
+		return cached
 	}
 
-	return t.webSocketExecutor
+	webSocketExecutor := responses.NewWebSocketExecutor(executor)
+	t.webSocketExecutors[executor] = webSocketExecutor
+
+	return webSocketExecutor
+}
+
+func executorComparable(executor pipeline.Executor) bool {
+	if executor == nil {
+		return true
+	}
+
+	return reflect.TypeOf(executor).Comparable()
 }
 
 type codexExecutor struct {

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"reflect"
 	"sync"
 
 	"github.com/google/uuid"
@@ -242,7 +241,7 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 }
 
 func (t *OutboundTransformer) customizeWebSocketExecutor(executor pipeline.Executor) pipeline.Executor {
-	if !executorComparable(executor) {
+	if !responses.ExecutorComparable(executor) {
 		return responses.NewWebSocketExecutor(executor)
 	}
 
@@ -262,12 +261,22 @@ func (t *OutboundTransformer) customizeWebSocketExecutor(executor pipeline.Execu
 	return webSocketExecutor
 }
 
-func executorComparable(executor pipeline.Executor) bool {
-	if executor == nil {
-		return true
+func (t *OutboundTransformer) Stop() {
+	if t == nil {
+		return
 	}
 
-	return reflect.TypeOf(executor).Comparable()
+	t.executorMu.Lock()
+	executors := make([]*responses.WebSocketExecutor, 0, len(t.webSocketExecutors))
+	for _, executor := range t.webSocketExecutors {
+		executors = append(executors, executor)
+	}
+	t.webSocketExecutors = nil
+	t.executorMu.Unlock()
+
+	for _, executor := range executors {
+		_ = executor.Close()
+	}
 }
 
 type codexExecutor struct {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -120,7 +120,7 @@ func TestCodexOutbound_StreamAllowsDownstreamIdentityOverrides(t *testing.T) {
 	assert.Equal(t, "Bearer "+accessToken, headers.Get("Authorization"))
 }
 
-func TestCodexOutbound_CustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
+func TestCodexOutbound_CustomizeExecutorUsesCurrentExecutor(t *testing.T) {
 	outbound, err := NewOutboundTransformer(Params{
 		BaseURL:       "wss://chatgpt.com/backend-api/codex/responses##",
 		Transport:     responses.TransportWebSocket,
@@ -128,17 +128,27 @@ func TestCodexOutbound_CustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	first, ok := outbound.CustomizeExecutor(nil).(*codexExecutor)
+	firstClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeDisabled})
+	secondClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeURL, URL: "http://127.0.0.1:18081"})
+
+	first, ok := outbound.CustomizeExecutor(firstClient).(*codexExecutor)
 	require.True(t, ok)
 	firstInner, ok := first.inner.(*responses.WebSocketExecutor)
 	require.True(t, ok)
 
-	second, ok := outbound.CustomizeExecutor(nil).(*codexExecutor)
+	second, ok := outbound.CustomizeExecutor(secondClient).(*codexExecutor)
 	require.True(t, ok)
 	secondInner, ok := second.inner.(*responses.WebSocketExecutor)
 	require.True(t, ok)
+	again, ok := outbound.CustomizeExecutor(firstClient).(*codexExecutor)
+	require.True(t, ok)
+	againInner, ok := again.inner.(*responses.WebSocketExecutor)
+	require.True(t, ok)
 
-	require.Same(t, firstInner, secondInner)
+	require.NotSame(t, firstInner, secondInner)
+	require.Same(t, firstInner, againInner)
+	require.Same(t, firstClient, firstInner.Inner())
+	require.Same(t, secondClient, secondInner.Inner())
 }
 
 func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T) {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -122,7 +122,7 @@ func TestCodexOutbound_StreamAllowsDownstreamIdentityOverrides(t *testing.T) {
 
 func TestCodexOutbound_CustomizeExecutorUsesCurrentExecutor(t *testing.T) {
 	outbound, err := NewOutboundTransformer(Params{
-		BaseURL:       "wss://chatgpt.com/backend-api/codex/responses##",
+		BaseURL:       "wss://chatgpt.com/backend-api/codex#",
 		Transport:     responses.TransportWebSocket,
 		TokenProvider: staticTokenGetter{creds: &oauth.OAuthCredentials{AccessToken: testAccessTokenWithAccountID(t), ExpiresAt: time.Now().Add(time.Hour)}},
 	})

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -191,6 +191,33 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 	assert.Equal(t, "gpt-5-codex", body["model"])
 }
 
+func TestCodexOutbound_DoReturnsWebSocketErrorEvents(t *testing.T) {
+	ctx := context.Background()
+	accessToken := testAccessTokenWithAccountID(t)
+
+	outbound, err := NewOutboundTransformer(Params{
+		BaseURL: "https://chatgpt.com/backend-api/codex#",
+		TokenProvider: staticTokenGetter{
+			creds: &oauth.OAuthCredentials{
+				AccessToken: accessToken,
+				ExpiresAt:   time.Now().Add(time.Hour),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	request := buildCodexStreamRequest(t, ctx, outbound, false)
+	executor := outbound.CustomizeExecutor(&mockCodexExecutor{
+		streamEvents: []*httpclient.StreamEvent{
+			{Type: "error", Data: []byte(`{"type":"error","code":"bad_request","message":"invalid websocket request"}`)},
+		},
+	})
+
+	response, err := executor.Do(ctx, request)
+	require.Nil(t, response)
+	require.ErrorContains(t, err, "bad_request: invalid websocket request")
+}
+
 var _ pipeline.ChannelCustomizedExecutor = (*OutboundTransformer)(nil)
 
 type mockCodexExecutor struct {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
 	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
 func TestCodexOutbound_StreamAcceptHeader(t *testing.T) {
@@ -117,6 +118,27 @@ func TestCodexOutbound_StreamAllowsDownstreamIdentityOverrides(t *testing.T) {
 	assert.Contains(t, strings.ToLower(headers.Get("User-Agent")), legacyCodexOriginator())
 	assert.Equal(t, testChatAccountID, headers.Get("Chatgpt-Account-Id"))
 	assert.Equal(t, "Bearer "+accessToken, headers.Get("Authorization"))
+}
+
+func TestCodexOutbound_CustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
+	outbound, err := NewOutboundTransformer(Params{
+		BaseURL:       "wss://chatgpt.com/backend-api/codex/responses##",
+		Transport:     responses.TransportWebSocket,
+		TokenProvider: staticTokenGetter{creds: &oauth.OAuthCredentials{AccessToken: testAccessTokenWithAccountID(t), ExpiresAt: time.Now().Add(time.Hour)}},
+	})
+	require.NoError(t, err)
+
+	first, ok := outbound.CustomizeExecutor(nil).(*codexExecutor)
+	require.True(t, ok)
+	firstInner, ok := first.inner.(*responses.WebSocketExecutor)
+	require.True(t, ok)
+
+	second, ok := outbound.CustomizeExecutor(nil).(*codexExecutor)
+	require.True(t, ok)
+	secondInner, ok := second.inner.(*responses.WebSocketExecutor)
+	require.True(t, ok)
+
+	require.Same(t, firstInner, secondInner)
 }
 
 func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T) {

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -515,19 +515,19 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 
 	case StreamEventTypeResponseFailed:
 		a.applyResponseSnapshot(ev.Response)
-		if a.status == "" {
+		if ev.Response == nil || ev.Response.Status == nil {
 			a.status = "failed"
 		}
 
 	case StreamEventTypeResponseCancelled:
 		a.applyResponseSnapshot(ev.Response)
-		if a.status == "" {
-			a.status = "cancelled"
+		if ev.Response == nil || ev.Response.Status == nil {
+			a.status = "canceled"
 		}
 
 	case StreamEventTypeResponseIncomplete:
 		a.applyResponseSnapshot(ev.Response)
-		if a.status == "" {
+		if ev.Response == nil || ev.Response.Status == nil {
 			a.status = "incomplete"
 		}
 	}

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -29,6 +29,10 @@ type streamAggregator struct {
 
 	// Usage
 	usage *Usage
+
+	// Terminal response details
+	responseError     *Error
+	incompleteDetails *ResponseIncompleteDetails
 }
 
 // aggregatedItem holds the accumulated state for an output item.
@@ -510,10 +514,53 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 		}
 
 	case StreamEventTypeResponseFailed:
-		a.status = "failed"
+		a.applyResponseSnapshot(ev.Response)
+		if a.status == "" {
+			a.status = "failed"
+		}
+
+	case StreamEventTypeResponseCancelled:
+		a.applyResponseSnapshot(ev.Response)
+		if a.status == "" {
+			a.status = "cancelled"
+		}
 
 	case StreamEventTypeResponseIncomplete:
-		a.status = "incomplete"
+		a.applyResponseSnapshot(ev.Response)
+		if a.status == "" {
+			a.status = "incomplete"
+		}
+	}
+}
+
+func (a *streamAggregator) applyResponseSnapshot(response *Response) {
+	if response == nil {
+		return
+	}
+
+	if response.ID != "" {
+		a.responseID = response.ID
+	}
+	if response.Model != "" {
+		a.model = response.Model
+	}
+	if response.CreatedAt != 0 {
+		a.createdAt = response.CreatedAt
+	}
+	if response.PreviousResponseID != nil {
+		a.previousResponseID = response.PreviousResponseID
+	}
+	if response.Status != nil {
+		a.status = *response.Status
+	}
+	if response.Usage != nil {
+		a.usage = response.Usage
+	}
+	if response.Error != nil {
+		a.responseError = response.Error
+	}
+	if response.IncompleteDetails != nil {
+		a.incompleteDetails = response.IncompleteDetails
 	}
 }
 
@@ -643,5 +690,7 @@ func (a *streamAggregator) buildResponse() *Response {
 		Output:             output,
 		Usage:              a.usage,
 		PreviousResponseID: a.previousResponseID,
+		Error:              a.responseError,
+		IncompleteDetails:  a.incompleteDetails,
 	}
 }

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -42,6 +42,18 @@ func TestAggregateStreamChunks(t *testing.T) {
 	}
 }
 
+func TestAggregateStreamChunks_CancelledFallbackUsesCanonicalStatus(t *testing.T) {
+	resultBytes, _, err := AggregateStreamChunks(t.Context(), []*httpclient.StreamEvent{
+		{Type: "response.cancelled", Data: []byte(`{"type":"response.cancelled","response":{"id":"resp_canceled","object":"response","created_at":1700000000,"model":"gpt-5","output":[]}}`)},
+	})
+	require.NoError(t, err)
+
+	var body Response
+	require.NoError(t, json.Unmarshal(resultBytes, &body))
+	require.NotNil(t, body.Status)
+	require.Equal(t, "canceled", *body.Status)
+}
+
 func TestAggregateStreamChunks_WithTestData(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -54,6 +54,22 @@ func TestAggregateStreamChunks_CancelledFallbackUsesCanonicalStatus(t *testing.T
 	require.Equal(t, "canceled", *body.Status)
 }
 
+func TestAggregateStreamChunks_CancelledSnapshotPreservesStatus(t *testing.T) {
+	resultBytes, _, err := AggregateStreamChunks(t.Context(), []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_canceled","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+		{Type: "response.cancelled", Data: []byte(`{"type":"response.cancelled","response":{"id":"resp_canceled","object":"response","created_at":1700000001,"model":"gpt-5-codex","status":"canceled","output":[]}}`)},
+	})
+	require.NoError(t, err)
+
+	var body Response
+	require.NoError(t, json.Unmarshal(resultBytes, &body))
+	require.Equal(t, "resp_canceled", body.ID)
+	require.Equal(t, "gpt-5-codex", body.Model)
+	require.Equal(t, int64(1700000001), body.CreatedAt)
+	require.NotNil(t, body.Status)
+	require.Equal(t, "canceled", *body.Status)
+}
+
 func TestAggregateStreamChunks_WithTestData(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -14,13 +14,22 @@ import (
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/internal/pkg/xmap"
+	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
-var _ transformer.Outbound = (*OutboundTransformer)(nil)
+var (
+	_ transformer.Outbound               = (*OutboundTransformer)(nil)
+	_ pipeline.ChannelCustomizedExecutor = (*OutboundTransformer)(nil)
+)
 
 // Config holds all configuration for the OpenAI Responses outbound transformer.
+const (
+	TransportHTTP      = "http"
+	TransportWebSocket = "websocket"
+)
+
 type Config struct {
 	// BaseURL is the base URL for the OpenAI API, required.
 	BaseURL string `json:"base_url,omitempty"`
@@ -36,6 +45,10 @@ type Config struct {
 
 	// APIKeyProvider provides API keys for authentication, required.
 	APIKeyProvider auth.APIKeyProvider `json:"-"`
+
+	// Transport selects the upstream transport for Responses API requests.
+	// Empty and "http" use the existing HTTP/SSE transport; "websocket" uses Responses WebSocket mode.
+	Transport string `json:"transport,omitempty"`
 }
 
 func NewOutboundTransformer(baseURL, apiKey string) (*OutboundTransformer, error) {
@@ -74,6 +87,14 @@ func NewOutboundTransformerWithConfig(config *Config) (*OutboundTransformer, err
 	return &OutboundTransformer{
 		config: config,
 	}, nil
+}
+
+func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipeline.Executor {
+	if t == nil || t.config == nil || t.config.Transport != TransportWebSocket {
+		return executor
+	}
+
+	return NewWebSocketExecutor(executor)
 }
 
 type OutboundTransformer struct {

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -95,21 +96,39 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 		return executor
 	}
 
+	if !executorComparable(executor) {
+		return NewWebSocketExecutor(executor)
+	}
+
 	t.executorMu.Lock()
 	defer t.executorMu.Unlock()
 
-	if t.webSocketExecutor == nil {
-		t.webSocketExecutor = NewWebSocketExecutor(executor)
+	if t.webSocketExecutors == nil {
+		t.webSocketExecutors = make(map[pipeline.Executor]*WebSocketExecutor)
+	}
+	if cached, ok := t.webSocketExecutors[executor]; ok {
+		return cached
 	}
 
-	return t.webSocketExecutor
+	webSocketExecutor := NewWebSocketExecutor(executor)
+	t.webSocketExecutors[executor] = webSocketExecutor
+
+	return webSocketExecutor
+}
+
+func executorComparable(executor pipeline.Executor) bool {
+	if executor == nil {
+		return true
+	}
+
+	return reflect.TypeOf(executor).Comparable()
 }
 
 type OutboundTransformer struct {
 	config *Config
 
-	executorMu        sync.Mutex
-	webSocketExecutor *WebSocketExecutor
+	executorMu         sync.Mutex
+	webSocketExecutors map[pipeline.Executor]*WebSocketExecutor
 }
 
 func (t *OutboundTransformer) APIFormat() llm.APIFormat {

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/samber/lo"
 
@@ -94,11 +95,21 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 		return executor
 	}
 
-	return NewWebSocketExecutor(executor)
+	t.executorMu.Lock()
+	defer t.executorMu.Unlock()
+
+	if t.webSocketExecutor == nil {
+		t.webSocketExecutor = NewWebSocketExecutor(executor)
+	}
+
+	return t.webSocketExecutor
 }
 
 type OutboundTransformer struct {
 	config *Config
+
+	executorMu        sync.Mutex
+	webSocketExecutor *WebSocketExecutor
 }
 
 func (t *OutboundTransformer) APIFormat() llm.APIFormat {

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -96,7 +96,7 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 		return executor
 	}
 
-	if !executorComparable(executor) {
+	if !ExecutorComparable(executor) {
 		return NewWebSocketExecutor(executor)
 	}
 
@@ -116,7 +116,25 @@ func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipe
 	return webSocketExecutor
 }
 
-func executorComparable(executor pipeline.Executor) bool {
+func (t *OutboundTransformer) Stop() {
+	if t == nil {
+		return
+	}
+
+	t.executorMu.Lock()
+	executors := make([]*WebSocketExecutor, 0, len(t.webSocketExecutors))
+	for _, executor := range t.webSocketExecutors {
+		executors = append(executors, executor)
+	}
+	t.webSocketExecutors = nil
+	t.executorMu.Unlock()
+
+	for _, executor := range executors {
+		_ = executor.Close()
+	}
+}
+
+func ExecutorComparable(executor pipeline.Executor) bool {
 	if executor == nil {
 		return true
 	}

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -383,6 +383,8 @@ func (t *OutboundTransformer) transformStandardResponse(
 			choice.FinishReason = lo.ToPtr("error")
 		case "incomplete":
 			choice.FinishReason = lo.ToPtr("length")
+		case "canceled", "cancelled":
+			choice.FinishReason = lo.ToPtr("cancelled")
 		}
 	}
 

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ErrStreamIncomplete is returned when the stream ends without a terminal event
-// (response.completed, response.failed, or response.incomplete).
+// (response.completed, response.failed, response.cancelled, or response.incomplete).
 var ErrStreamIncomplete = errors.New("stream ended without terminal event")
 
 // TransformStream transforms OpenAI Responses API SSE events to unified llm.Response stream.
@@ -530,6 +530,17 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		// Response incomplete (e.g., max tokens)
 		s.responseCompleted = true
 		finishReason := "length"
+		resp.Choices = []llm.Choice{
+			{
+				Index:        0,
+				FinishReason: &finishReason,
+			},
+		}
+
+	case StreamEventTypeResponseCancelled:
+		// Response cancelled
+		s.responseCompleted = true
+		finishReason := "cancelled"
 		resp.Choices = []llm.Choice{
 			{
 				Index:        0,

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -136,7 +136,6 @@ func TestOutboundTransformer_TransformStream_ResponseCancelledCompletes(t *testi
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)
 
-	status := "canceled"
 	events := []*httpclient.StreamEvent{
 		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_cancelled","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
 		{Type: "response.cancelled", Data: []byte(`{"type":"response.cancelled","response":{"id":"resp_cancelled","object":"response","created_at":1700000000,"model":"gpt-5","status":"canceled","output":[]}}`)},
@@ -149,10 +148,12 @@ func TestOutboundTransformer_TransformStream_ResponseCancelledCompletes(t *testi
 	require.NoError(t, err)
 	require.Len(t, responses, 3)
 	require.Equal(t, llm.DoneResponse, responses[2])
+	require.Equal(t, "resp_cancelled", responses[1].ID)
+	require.Equal(t, "gpt-5", responses[1].Model)
+	require.Equal(t, int64(1700000000), responses[1].Created)
 	require.NotEmpty(t, responses[1].Choices)
 	require.NotNil(t, responses[1].Choices[0].FinishReason)
 	require.Equal(t, "cancelled", *responses[1].Choices[0].FinishReason)
-	require.Equal(t, status, "canceled")
 }
 
 func TestOutboundTransformer_TransformStream_PreservesFinalItemAnnotations(t *testing.T) {

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -132,6 +132,29 @@ func TestOutboundTransformer_StreamTransformation_ErrorEvent(t *testing.T) {
 	require.Contains(t, err.Error(), "Something went wrong")
 }
 
+func TestOutboundTransformer_TransformStream_ResponseCancelledCompletes(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	status := "canceled"
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_cancelled","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+		{Type: "response.cancelled", Data: []byte(`{"type":"response.cancelled","response":{"id":"resp_cancelled","object":"response","created_at":1700000000,"model":"gpt-5","status":"canceled","output":[]}}`)},
+	}
+
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Len(t, responses, 3)
+	require.Equal(t, llm.DoneResponse, responses[2])
+	require.NotEmpty(t, responses[1].Choices)
+	require.NotNil(t, responses[1].Choices[0].FinishReason)
+	require.Equal(t, "cancelled", *responses[1].Choices[0].FinishReason)
+	require.Equal(t, status, "canceled")
+}
+
 func TestOutboundTransformer_TransformStream_PreservesFinalItemAnnotations(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -99,6 +99,12 @@ func TestOutboundTransformer_buildFullRequestURL(t *testing.T) {
 			expected: "https://api.openai.com/custom/responses",
 		},
 		{
+			name:     "websocket codex base with # suffix",
+			baseURL:  "wss://chatgpt.com/backend-api/codex#",
+			rawURL:   true,
+			expected: "wss://chatgpt.com/backend-api/codex/responses",
+		},
+		{
 			name:     "raw url with explicit config",
 			baseURL:  "https://api.openai.com/custom#",
 			rawURL:   true,

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -67,6 +67,20 @@ func TestNewOutboundTransformer(t *testing.T) {
 	}
 }
 
+func TestOutboundTransformer_TransformResponse_CanceledFinishReason(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	result, err := transformer.TransformResponse(context.Background(), &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Body:       []byte(`{"id":"resp_canceled","object":"response","created_at":1700000000,"status":"canceled","model":"gpt-5","output":[]}`),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Choices, 1)
+	require.NotNil(t, result.Choices[0].FinishReason)
+	require.Equal(t, "cancelled", *result.Choices[0].FinishReason)
+}
+
 func TestOutboundTransformer_buildFullRequestURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/llm/transformer/openai/responses/stream_event.go
+++ b/llm/transformer/openai/responses/stream_event.go
@@ -15,6 +15,7 @@ const (
 	StreamEventTypeResponseCompleted  StreamEventType = "response.completed"
 	StreamEventTypeResponseQueued     StreamEventType = "response.queued"
 	StreamEventTypeResponseFailed     StreamEventType = "response.failed"
+	StreamEventTypeResponseCancelled  StreamEventType = "response.cancelled"
 	StreamEventTypeResponseIncomplete StreamEventType = "response.incomplete"
 
 	// Output item events.

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -110,6 +110,11 @@ func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request)
 		return nil, err
 	}
 
+	// Response-level terminal events (response.failed, response.cancelled,
+	// response.incomplete) are valid Responses API payloads, not transport
+	// failures. Keep them as HTTP 200 response objects so callers can inspect
+	// body.status/error/incomplete_details instead of retrying or disabling the
+	// channel as if the WebSocket transport failed.
 	return &httpclient.Response{
 		StatusCode: http.StatusOK,
 		Headers: http.Header{
@@ -974,6 +979,9 @@ func (s *webSocketStream) Next() bool {
 		Data: normalizeWebSocketEvent(msg),
 	})
 	if isTerminalWebSocketEvent(typ) {
+		// Only top-level `error` events are transport failures. Response-level
+		// terminal events are yielded and then close the stream normally so the
+		// non-streaming Do path can aggregate their response object.
 		evict := terminalWebSocketEventEvicts(typ)
 		if typ == "response.completed" {
 			responseID := responseIDFromWebSocketEvent(msg)

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -252,6 +252,11 @@ func (e *WebSocketExecutor) acquire(ctx context.Context, request *httpclient.Req
 
 		select {
 		case pc.inFlight <- struct{}{}:
+			if pc.isClosed() {
+				<-pc.inFlight
+				e.evict(pc)
+				continue
+			}
 			if pc.expired(time.Now(), e.maxLifetime) {
 				<-pc.inFlight
 				e.evict(pc)

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -38,6 +38,7 @@ const (
 	defaultWebSocketMaxLifetime   = 30 * time.Minute
 	defaultWebSocketMaxPoolSize   = 128
 	defaultWebSocketMaxRetainedIn = 1 << 20
+	minWebSocketCleanupDelay      = 10 * time.Millisecond
 )
 
 type WebSocketExecutor struct {
@@ -46,6 +47,7 @@ type WebSocketExecutor struct {
 
 	mu               sync.Mutex
 	pool             map[webSocketPoolKey]*pooledWebSocketConn
+	cleanupScheduled bool
 	idleTTL          time.Duration
 	maxLifetime      time.Duration
 	maxPoolSize      int
@@ -335,6 +337,7 @@ func (e *WebSocketExecutor) getOrDialPooled(ctx context.Context, request *httpcl
 		return nil, fmt.Errorf("websocket session pool is full")
 	}
 	e.pool[key] = pc
+	e.scheduleCleanupLocked(now)
 	e.mu.Unlock()
 
 	return pc, nil
@@ -389,7 +392,14 @@ func headerPoolIdentity(headers http.Header) string {
 	}
 	keys := make([]string, 0, len(headers))
 	for key := range headers {
-		keys = append(keys, http.CanonicalHeaderKey(key))
+		canonical := http.CanonicalHeaderKey(key)
+		if _, excluded := webSocketPoolIdentityExcludedHeaders[canonical]; excluded {
+			continue
+		}
+		keys = append(keys, canonical)
+	}
+	if len(keys) == 0 {
+		return ""
 	}
 	sort.Strings(keys)
 
@@ -407,6 +417,55 @@ func headerPoolIdentity(headers http.Header) string {
 	}
 
 	return hashSecret(builder.String())
+}
+
+var webSocketPoolIdentityExcludedHeaders = canonicalHeaderSet(
+	// Already represented as dedicated webSocketPoolKey fields.
+	"Authorization",
+	webSocketSessionHeader,
+	webSocketAccountIDHeader,
+	webSocketOriginatorHeader,
+	webSocketUserAgentHeader,
+	webSocketOrgHeader,
+	webSocketProjectHeader,
+	"OpenAI-Beta",
+
+	// Protocol/request-shape headers do not affect the WebSocket session identity.
+	"Accept",
+	"Cache-Control",
+	"Connection",
+
+	// Per-request observability headers must not shard the session pool.
+	"Baggage",
+	"Traceparent",
+	"Tracestate",
+	"Sentry-Trace",
+	"Uber-Trace-Id",
+	"X-Amzn-Trace-Id",
+	"X-B3-Flags",
+	"X-B3-ParentSpanId",
+	"X-B3-Sampled",
+	"X-B3-SpanId",
+	"X-B3-TraceId",
+	"X-Cloud-Trace-Context",
+	"X-Client-Request-Id",
+	"X-Codex-Turn-Metadata",
+	"X-Correlation-Id",
+	"X-Datadog-Parent-Id",
+	"X-Datadog-Sampling-Priority",
+	"X-Datadog-Trace-Id",
+	"X-Request-Id",
+	"X-Request-Start",
+	"X-Span-Id",
+	"X-Trace-Id",
+)
+
+func canonicalHeaderSet(keys ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[http.CanonicalHeaderKey(key)] = struct{}{}
+	}
+	return set
 }
 
 func authPoolIdentity(auth *httpclient.AuthConfig, headers http.Header) string {
@@ -467,11 +526,82 @@ func (e *WebSocketExecutor) cleanupExpiredLocked(now time.Time) {
 		if len(pc.inFlight) > 0 {
 			continue
 		}
-		if now.Sub(lastUsedAt) > e.idleTTL || expired {
+		if expired || (e.idleTTL > 0 && now.Sub(lastUsedAt) > e.idleTTL) {
 			delete(e.pool, key)
 			pc.close()
 		}
 	}
+}
+
+func (e *WebSocketExecutor) scheduleCleanup() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.scheduleCleanupLocked(time.Now())
+	e.mu.Unlock()
+}
+
+func (e *WebSocketExecutor) scheduleCleanupLocked(now time.Time) {
+	if e.cleanupScheduled || len(e.pool) == 0 || (e.idleTTL <= 0 && e.maxLifetime <= 0) {
+		return
+	}
+	delay := e.nextCleanupDelayLocked(now)
+	e.cleanupScheduled = true
+	time.AfterFunc(delay, e.runScheduledCleanup)
+}
+
+func (e *WebSocketExecutor) runScheduledCleanup() {
+	now := time.Now()
+	e.mu.Lock()
+	e.cleanupScheduled = false
+	e.cleanupExpiredLocked(now)
+	e.scheduleCleanupLocked(now)
+	e.mu.Unlock()
+}
+
+func (e *WebSocketExecutor) nextCleanupDelayLocked(now time.Time) time.Duration {
+	var delay time.Duration
+	for _, pc := range e.pool {
+		if pc == nil || len(pc.inFlight) > 0 {
+			continue
+		}
+		closed, lastUsedAt, expired := pc.poolState(now, e.maxLifetime)
+		if closed || expired {
+			return minWebSocketCleanupDelay
+		}
+		if e.idleTTL > 0 {
+			remaining := e.idleTTL - now.Sub(lastUsedAt)
+			if remaining <= 0 {
+				return minWebSocketCleanupDelay
+			}
+			if delay == 0 || remaining < delay {
+				delay = remaining
+			}
+		}
+		if e.maxLifetime > 0 {
+			remaining := e.maxLifetime - now.Sub(pc.createdAt)
+			if remaining <= 0 {
+				return minWebSocketCleanupDelay
+			}
+			if delay == 0 || remaining < delay {
+				delay = remaining
+			}
+		}
+	}
+	if delay <= 0 {
+		if e.idleTTL > 0 {
+			return e.idleTTL
+		}
+		if e.maxLifetime > 0 {
+			return e.maxLifetime
+		}
+		return minWebSocketCleanupDelay
+	}
+	if delay < minWebSocketCleanupDelay {
+		return minWebSocketCleanupDelay
+	}
+	return delay
 }
 
 func (e *WebSocketExecutor) evict(pc *pooledWebSocketConn) {
@@ -574,6 +704,9 @@ func (l *webSocketLease) release(evict bool) {
 			}
 		} else {
 			l.pooled.markUsed()
+			if l.owner != nil {
+				l.owner.scheduleCleanup()
+			}
 		}
 		select {
 		case <-l.pooled.inFlight:

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -48,6 +48,8 @@ type WebSocketExecutor struct {
 	mu               sync.Mutex
 	pool             map[webSocketPoolKey]*pooledWebSocketConn
 	cleanupScheduled bool
+	cleanupTimer     *time.Timer
+	closed           bool
 	idleTTL          time.Duration
 	maxLifetime      time.Duration
 	maxPoolSize      int
@@ -213,6 +215,38 @@ func (e *WebSocketExecutor) Inner() pipeline.Executor {
 	return e.inner
 }
 
+func (e *WebSocketExecutor) Close() error {
+	if e == nil {
+		return nil
+	}
+
+	e.mu.Lock()
+	e.closed = true
+	if e.cleanupTimer != nil {
+		e.cleanupTimer.Stop()
+		e.cleanupTimer = nil
+	}
+	e.cleanupScheduled = false
+	idle := make([]*pooledWebSocketConn, 0, len(e.pool))
+	for key, pc := range e.pool {
+		if pc == nil {
+			delete(e.pool, key)
+			continue
+		}
+		if len(pc.inFlight) > 0 {
+			continue
+		}
+		delete(e.pool, key)
+		idle = append(idle, pc)
+	}
+	e.mu.Unlock()
+
+	for _, pc := range idle {
+		pc.close()
+	}
+	return nil
+}
+
 type webSocketPoolKey struct {
 	URL        string
 	SessionID  string
@@ -332,6 +366,10 @@ func (e *WebSocketExecutor) acquire(ctx context.Context, request *httpclient.Req
 func (e *WebSocketExecutor) getOrDialPooled(ctx context.Context, request *httpclient.Request, key webSocketPoolKey, wsURL string, headers http.Header) (*pooledWebSocketConn, error) {
 	now := time.Now()
 	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil, fmt.Errorf("websocket executor is closed")
+	}
 	e.cleanupExpiredLocked(now)
 	if pc := e.pool[key]; pc != nil && !pc.isClosed() {
 		e.mu.Unlock()
@@ -353,6 +391,11 @@ func (e *WebSocketExecutor) getOrDialPooled(ctx context.Context, request *httpcl
 	}
 
 	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		_ = conn.Close()
+		return nil, fmt.Errorf("websocket executor is closed")
+	}
 	if existing := e.pool[key]; existing != nil && !existing.isClosed() {
 		e.mu.Unlock()
 		_ = conn.Close()
@@ -570,18 +613,23 @@ func (e *WebSocketExecutor) scheduleCleanup() {
 }
 
 func (e *WebSocketExecutor) scheduleCleanupLocked(now time.Time) {
-	if e.cleanupScheduled || len(e.pool) == 0 || (e.idleTTL <= 0 && e.maxLifetime <= 0) {
+	if e.closed || e.cleanupScheduled || len(e.pool) == 0 || (e.idleTTL <= 0 && e.maxLifetime <= 0) {
 		return
 	}
 	delay := e.nextCleanupDelayLocked(now)
 	e.cleanupScheduled = true
-	time.AfterFunc(delay, e.runScheduledCleanup)
+	e.cleanupTimer = time.AfterFunc(delay, e.runScheduledCleanup)
 }
 
 func (e *WebSocketExecutor) runScheduledCleanup() {
 	now := time.Now()
 	e.mu.Lock()
 	e.cleanupScheduled = false
+	e.cleanupTimer = nil
+	if e.closed {
+		e.mu.Unlock()
+		return
+	}
 	e.cleanupExpiredLocked(now)
 	e.scheduleCleanupLocked(now)
 	e.mu.Unlock()
@@ -723,23 +771,35 @@ func (l *webSocketLease) release(evict bool) {
 			_ = l.conn.Close()
 			return
 		}
-		if evict {
-			if l.owner != nil {
-				l.owner.evict(l.pooled)
-			} else {
-				l.pooled.close()
-			}
+		if l.owner != nil {
+			l.owner.releasePooled(l.pooled, evict)
+		} else if evict {
+			l.pooled.close()
 		} else {
 			l.pooled.markUsed()
-			if l.owner != nil {
-				l.owner.scheduleCleanup()
-			}
 		}
 		select {
 		case <-l.pooled.inFlight:
 		default:
 		}
 	})
+}
+
+func (e *WebSocketExecutor) releasePooled(pc *pooledWebSocketConn, evict bool) {
+	e.mu.Lock()
+	closed := e.closed
+	if (evict || closed) && e.pool[pc.key] == pc {
+		delete(e.pool, pc.key)
+	}
+	e.mu.Unlock()
+
+	if evict || closed {
+		pc.close()
+		return
+	}
+
+	pc.markUsed()
+	e.scheduleCleanup()
 }
 
 func toWebSocketURL(rawURL string) (string, error) {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -731,6 +731,9 @@ func (s *webSocketStream) Next() bool {
 	_, msg, err := s.lease.conn.ReadMessage()
 	if err != nil {
 		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				s.setErr(ctxErr)
+			}
 			s.finish(true)
 			return false
 		}

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -605,9 +605,12 @@ func prepareWebSocketPayloadForLease(payload map[string]any, lease *webSocketLea
 	if !lease.reused || previousResponseID == "" || len(previousInput) == 0 {
 		return nil
 	}
+	if explicitPreviousResponseID(payload) != "" && explicitPreviousResponseID(payload) != previousResponseID {
+		return &webSocketReconnectRequiredError{}
+	}
 
 	suffix, ok := inputSuffix(previousInput, fullInput)
-	if !ok || len(suffix) == 0 {
+	if !ok || len(suffix) == 0 || suffixStartsWithResponseOutput(suffix) {
 		return &webSocketReconnectRequiredError{}
 	}
 
@@ -615,6 +618,38 @@ func prepareWebSocketPayloadForLease(payload map[string]any, lease *webSocketLea
 	payload["previous_response_id"] = previousResponseID
 
 	return nil
+}
+
+func explicitPreviousResponseID(payload map[string]any) string {
+	value, ok := payload["previous_response_id"]
+	if !ok {
+		return ""
+	}
+	previousResponseID, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(previousResponseID)
+}
+
+func suffixStartsWithResponseOutput(suffix []json.RawMessage) bool {
+	if len(suffix) == 0 {
+		return false
+	}
+
+	var item struct {
+		Type string `json:"type"`
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal(suffix[0], &item); err != nil {
+		return false
+	}
+
+	switch item.Type {
+	case "reasoning", "function_call", "custom_tool_call":
+		return true
+	}
+	return item.Role == "assistant"
 }
 
 func payloadInputItems(payload map[string]any) ([]json.RawMessage, bool, error) {
@@ -749,6 +784,7 @@ type webSocketStream struct {
 	current  *httpclient.StreamEvent
 	err      error
 	closed   bool
+	sawEvent bool
 }
 
 func (s *webSocketStream) Next() bool {
@@ -768,6 +804,8 @@ func (s *webSocketStream) Next() bool {
 		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
 			if ctxErr := s.ctx.Err(); ctxErr != nil {
 				s.setErr(ctxErr)
+			} else if !s.hasSeenEvent() {
+				s.setErr(fmt.Errorf("websocket closed before response event"))
 			}
 			s.finish(true)
 			return false
@@ -824,7 +862,14 @@ func (s *webSocketStream) isClosed() bool {
 func (s *webSocketStream) setCurrent(event *httpclient.StreamEvent) {
 	s.mu.Lock()
 	s.current = event
+	s.sawEvent = true
 	s.mu.Unlock()
+}
+
+func (s *webSocketStream) hasSeenEvent() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sawEvent
 }
 
 func (s *webSocketStream) setErr(err error) {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -407,6 +407,10 @@ func (e *WebSocketExecutor) getOrDialPooled(ctx context.Context, request *httpcl
 		_ = conn.Close()
 		return existing, nil
 	}
+	// maxPoolSize is a hard cap on tracked pooled sessions (idle + in-flight).
+	// If every tracked session is currently in-flight, this returns capacity
+	// backpressure instead of opening unbounded overflow WebSockets. Same-session
+	// concurrency does not hit this branch; it waits on that session's inFlight slot.
 	if e.maxPoolSize > 0 && len(e.pool) >= e.maxPoolSize && !e.evictOldestIdleLocked() {
 		e.mu.Unlock()
 		_ = conn.Close()

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -965,18 +965,15 @@ type webSocketStream struct {
 	err      error
 	closed   bool
 	sawEvent bool
+	terminal bool
 }
 
 func (s *webSocketStream) Next() bool {
-	if s.isClosed() {
+	if s.contextCancelled() {
 		return false
 	}
-	select {
-	case <-s.ctx.Done():
-		s.setErr(s.ctx.Err())
-		s.finish(true)
+	if s.isClosed() {
 		return false
-	default:
 	}
 
 	_, msg, err := s.lease.conn.ReadMessage()
@@ -1001,6 +998,7 @@ func (s *webSocketStream) Next() bool {
 		Data: normalizeWebSocketEvent(msg),
 	})
 	if isTerminalWebSocketEvent(typ) {
+		s.markTerminal()
 		// Only top-level `error` events are transport failures. Response-level
 		// terminal events are yielded and then close the stream normally so the
 		// non-streaming Do path can aggregate their response object.
@@ -1036,6 +1034,25 @@ func (s *webSocketStream) Close() error {
 	return nil
 }
 
+func (s *webSocketStream) contextCancelled() bool {
+	select {
+	case <-s.ctx.Done():
+		s.setContextErr()
+		s.finish(true)
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *webSocketStream) setContextErr() {
+	s.mu.Lock()
+	if s.err == nil && !s.terminal {
+		s.err = s.ctx.Err()
+	}
+	s.mu.Unlock()
+}
+
 func (s *webSocketStream) isClosed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1053,6 +1070,12 @@ func (s *webSocketStream) hasSeenEvent() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sawEvent
+}
+
+func (s *webSocketStream) markTerminal() {
+	s.mu.Lock()
+	s.terminal = true
+	s.mu.Unlock()
 }
 
 func (s *webSocketStream) setErr(err error) {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -59,6 +59,11 @@ func NewWebSocketExecutor(inner pipeline.Executor) *WebSocketExecutor {
 	}
 	if hc, ok := inner.(*httpclient.HttpClient); ok {
 		dialer.Proxy = hc.ProxyFunc()
+		if native := hc.GetNativeClient(); native != nil {
+			if transport, ok := native.Transport.(*http.Transport); ok && transport.TLSClientConfig != nil {
+				dialer.TLSClientConfig = transport.TLSClientConfig.Clone()
+			}
+		}
 	}
 
 	return &WebSocketExecutor{

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -94,6 +94,9 @@ func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request)
 	if err := stream.Err(); err != nil {
 		return nil, err
 	}
+	if err := topLevelWebSocketError(chunks); err != nil {
+		return nil, err
+	}
 
 	body, _, err := AggregateStreamChunks(ctx, chunks)
 	if err != nil {
@@ -108,6 +111,32 @@ func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request)
 		Body:    body,
 		Request: request,
 	}, nil
+}
+
+func topLevelWebSocketError(chunks []*httpclient.StreamEvent) error {
+	for _, chunk := range chunks {
+		if chunk == nil || chunk.Type != string(StreamEventTypeError) {
+			continue
+		}
+
+		var event StreamEvent
+		if err := json.Unmarshal(chunk.Data, &event); err != nil {
+			return fmt.Errorf("websocket error event")
+		}
+		if event.Code != "" && event.Message != "" {
+			return fmt.Errorf("websocket error event: %s: %s", event.Code, event.Message)
+		}
+		if event.Message != "" {
+			return fmt.Errorf("websocket error event: %s", event.Message)
+		}
+		if event.Code != "" {
+			return fmt.Errorf("websocket error event: %s", event.Code)
+		}
+
+		return fmt.Errorf("websocket error event")
+	}
+
+	return nil
 }
 
 func (e *WebSocketExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1,13 +1,20 @@
 package responses
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -15,13 +22,34 @@ import (
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 const WebSocketBetaHeaderValue = "responses_websockets=2026-02-06"
 
+const (
+	webSocketSessionHeader        = "Session_id"
+	webSocketAccountIDHeader      = "Chatgpt-Account-Id"
+	webSocketOriginatorHeader     = "Originator"
+	webSocketUserAgentHeader      = "User-Agent"
+	webSocketOrgHeader            = "OpenAI-Organization"
+	webSocketProjectHeader        = "OpenAI-Project"
+	defaultWebSocketIdleTTL       = 10 * time.Minute
+	defaultWebSocketMaxLifetime   = 30 * time.Minute
+	defaultWebSocketMaxPoolSize   = 128
+	defaultWebSocketMaxRetainedIn = 1 << 20
+)
+
 type WebSocketExecutor struct {
 	inner  pipeline.Executor
 	dialer *websocket.Dialer
+
+	mu               sync.Mutex
+	pool             map[webSocketPoolKey]*pooledWebSocketConn
+	idleTTL          time.Duration
+	maxLifetime      time.Duration
+	maxPoolSize      int
+	maxRetainedInput int
 }
 
 func NewWebSocketExecutor(inner pipeline.Executor) *WebSocketExecutor {
@@ -34,8 +62,13 @@ func NewWebSocketExecutor(inner pipeline.Executor) *WebSocketExecutor {
 	}
 
 	return &WebSocketExecutor{
-		inner:  inner,
-		dialer: dialer,
+		inner:            inner,
+		dialer:           dialer,
+		pool:             map[webSocketPoolKey]*pooledWebSocketConn{},
+		idleTTL:          defaultWebSocketIdleTTL,
+		maxLifetime:      defaultWebSocketMaxLifetime,
+		maxPoolSize:      defaultWebSocketMaxPoolSize,
+		maxRetainedInput: defaultWebSocketMaxRetainedIn,
 	}
 }
 
@@ -90,6 +123,11 @@ func (e *WebSocketExecutor) DoStream(ctx context.Context, request *httpclient.Re
 		return nil, err
 	}
 
+	payload, err := buildWebSocketCreatePayload(request.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	headers := request.Headers.Clone()
 	if headers == nil {
 		headers = http.Header{}
@@ -104,6 +142,169 @@ func (e *WebSocketExecutor) DoStream(ctx context.Context, request *httpclient.Re
 	}
 	headers.Set("OpenAI-Beta", WebSocketBetaHeaderValue)
 
+	lease, err := e.acquirePreparedLease(ctx, request, wsURL, headers, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := lease.conn.WriteJSON(payload); err != nil {
+		lease.release(true)
+		return nil, fmt.Errorf("failed to write response.create websocket event: %w", err)
+	}
+
+	stream := &webSocketStream{ctx: ctx, lease: lease, done: make(chan struct{})}
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = stream.Close()
+		case <-stream.done:
+		}
+	}()
+
+	return stream, nil
+}
+
+func (e *WebSocketExecutor) Inner() pipeline.Executor {
+	if e == nil {
+		return nil
+	}
+	return e.inner
+}
+
+type webSocketPoolKey struct {
+	URL        string
+	SessionID  string
+	Scope      string
+	Auth       string
+	AccountID  string
+	Originator string
+	UserAgent  string
+	Org        string
+	Project    string
+	BetaHeader string
+	Headers    string
+}
+
+type pooledWebSocketConn struct {
+	key        webSocketPoolKey
+	conn       *websocket.Conn
+	inFlight   chan struct{}
+	createdAt  time.Time
+	lastUsedAt time.Time
+	used       bool
+
+	mu             sync.Mutex
+	closed         bool
+	lastInput      []json.RawMessage
+	lastResponseID string
+}
+
+type webSocketLease struct {
+	conn          *websocket.Conn
+	owner         *WebSocketExecutor
+	pooled        *pooledWebSocketConn
+	reused        bool
+	nextFullInput []json.RawMessage
+	once          sync.Once
+}
+
+func (e *WebSocketExecutor) acquirePreparedLease(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header, payload map[string]any) (*webSocketLease, error) {
+	lease, err := e.acquire(ctx, request, wsURL, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := prepareWebSocketPayloadForLease(payload, lease); err != nil {
+		lease.release(true)
+		var reconnectErr *webSocketReconnectRequiredError
+		if !errors.As(err, &reconnectErr) {
+			return nil, err
+		}
+
+		lease, err = e.acquire(ctx, request, wsURL, headers)
+		if err != nil {
+			return nil, err
+		}
+		if err := prepareWebSocketPayloadForLease(payload, lease); err != nil {
+			lease.release(true)
+			return nil, err
+		}
+	}
+
+	return lease, nil
+}
+
+func (e *WebSocketExecutor) acquire(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header) (*webSocketLease, error) {
+	key, ok := e.poolKey(ctx, request, wsURL, headers)
+	if !ok {
+		conn, err := e.dial(ctx, request, wsURL, headers)
+		if err != nil {
+			return nil, err
+		}
+		return &webSocketLease{conn: conn}, nil
+	}
+
+	for {
+		pc, err := e.getOrDialPooled(ctx, request, key, wsURL, headers)
+		if err != nil {
+			return nil, err
+		}
+
+		select {
+		case pc.inFlight <- struct{}{}:
+			if pc.expired(time.Now(), e.maxLifetime) {
+				<-pc.inFlight
+				e.evict(pc)
+				continue
+			}
+			return &webSocketLease{conn: pc.conn, owner: e, pooled: pc, reused: pc.used}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (e *WebSocketExecutor) getOrDialPooled(ctx context.Context, request *httpclient.Request, key webSocketPoolKey, wsURL string, headers http.Header) (*pooledWebSocketConn, error) {
+	now := time.Now()
+	e.mu.Lock()
+	e.cleanupExpiredLocked(now)
+	if pc := e.pool[key]; pc != nil && !pc.isClosed() {
+		e.mu.Unlock()
+		return pc, nil
+	}
+	e.mu.Unlock()
+
+	conn, err := e.dial(ctx, request, wsURL, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &pooledWebSocketConn{
+		key:        key,
+		conn:       conn,
+		inFlight:   make(chan struct{}, 1),
+		createdAt:  now,
+		lastUsedAt: now,
+	}
+
+	e.mu.Lock()
+	if existing := e.pool[key]; existing != nil && !existing.isClosed() {
+		e.mu.Unlock()
+		_ = conn.Close()
+		return existing, nil
+	}
+	if e.maxPoolSize > 0 && len(e.pool) >= e.maxPoolSize && !e.evictOldestIdleLocked() {
+		e.mu.Unlock()
+		_ = conn.Close()
+		return nil, fmt.Errorf("websocket session pool is full")
+	}
+	e.pool[key] = pc
+	e.mu.Unlock()
+
+	return pc, nil
+}
+
+func (e *WebSocketExecutor) dial(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header) (*websocket.Conn, error) {
 	dialer := e.dialer
 	if dialer == nil {
 		dialer = websocket.DefaultDialer
@@ -113,25 +314,212 @@ func (e *WebSocketExecutor) DoStream(ctx context.Context, request *httpclient.Re
 	if err != nil {
 		return nil, newWebSocketDialError(request, resp, err)
 	}
-
-	payload, err := buildWebSocketCreatePayload(request.Body)
-	if err != nil {
-		_ = conn.Close()
-		return nil, err
-	}
-	if err := conn.WriteJSON(payload); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to write response.create websocket event: %w", err)
-	}
-
-	return &webSocketStream{conn: conn}, nil
+	return conn, nil
 }
 
-func (e *WebSocketExecutor) Inner() pipeline.Executor {
-	if e == nil {
-		return nil
+func (e *WebSocketExecutor) poolKey(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header) (webSocketPoolKey, bool) {
+	sessionID := strings.TrimSpace(headers.Get(webSocketSessionHeader))
+	if sessionID == "" {
+		if value, ok := shared.GetSessionID(ctx); ok {
+			sessionID = strings.TrimSpace(value)
+		}
 	}
-	return e.inner
+	if sessionID == "" {
+		return webSocketPoolKey{}, false
+	}
+	scope, ok := shared.GetSessionScope(ctx)
+	if !ok || strings.TrimSpace(scope) == "" {
+		return webSocketPoolKey{}, false
+	}
+
+	return webSocketPoolKey{
+		URL:        wsURL,
+		SessionID:  sessionID,
+		Scope:      strings.TrimSpace(scope),
+		Auth:       authPoolIdentity(request.Auth, headers),
+		AccountID:  strings.TrimSpace(headers.Get(webSocketAccountIDHeader)),
+		Originator: strings.TrimSpace(headers.Get(webSocketOriginatorHeader)),
+		UserAgent:  strings.TrimSpace(headers.Get(webSocketUserAgentHeader)),
+		Org:        strings.TrimSpace(headers.Get(webSocketOrgHeader)),
+		Project:    strings.TrimSpace(headers.Get(webSocketProjectHeader)),
+		BetaHeader: strings.TrimSpace(headers.Get("OpenAI-Beta")),
+		Headers:    headerPoolIdentity(headers),
+	}, true
+}
+
+func headerPoolIdentity(headers http.Header) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, http.CanonicalHeaderKey(key))
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	for _, key := range keys {
+		values := slices.Clone(headers.Values(key))
+		sort.Strings(values)
+		builder.WriteString(key)
+		builder.WriteByte(':')
+		for _, value := range values {
+			builder.WriteString(value)
+			builder.WriteByte('\x00')
+		}
+		builder.WriteByte('\n')
+	}
+
+	return hashSecret(builder.String())
+}
+
+func authPoolIdentity(auth *httpclient.AuthConfig, headers http.Header) string {
+	if auth != nil {
+		return auth.Type + ":" + auth.HeaderKey + ":" + hashSecret(auth.APIKey)
+	}
+	return hashSecret(headers.Get("Authorization"))
+}
+
+func hashSecret(value string) string {
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func (e *WebSocketExecutor) evictOldestIdleLocked() bool {
+	var oldestKey webSocketPoolKey
+	var oldest *pooledWebSocketConn
+	for key, pc := range e.pool {
+		if pc == nil || pc.isClosed() {
+			delete(e.pool, key)
+			continue
+		}
+		if len(pc.inFlight) > 0 {
+			continue
+		}
+		if oldest == nil || pc.lastUsedAt.Before(oldest.lastUsedAt) {
+			oldestKey = key
+			oldest = pc
+		}
+	}
+	if oldest == nil {
+		return false
+	}
+	delete(e.pool, oldestKey)
+	oldest.close()
+	return true
+}
+
+func (e *WebSocketExecutor) cleanupExpiredLocked(now time.Time) {
+	for key, pc := range e.pool {
+		if pc == nil || pc.isClosed() {
+			delete(e.pool, key)
+			continue
+		}
+		if len(pc.inFlight) > 0 {
+			continue
+		}
+		if now.Sub(pc.lastUsedAt) > e.idleTTL || pc.expired(now, e.maxLifetime) {
+			delete(e.pool, key)
+			pc.close()
+		}
+	}
+}
+
+func (e *WebSocketExecutor) evict(pc *pooledWebSocketConn) {
+	if pc == nil {
+		return
+	}
+	e.mu.Lock()
+	if e.pool[pc.key] == pc {
+		delete(e.pool, pc.key)
+	}
+	e.mu.Unlock()
+	pc.close()
+}
+
+func (pc *pooledWebSocketConn) expired(now time.Time, maxLifetime time.Duration) bool {
+	return maxLifetime > 0 && now.Sub(pc.createdAt) > maxLifetime
+}
+
+func (pc *pooledWebSocketConn) isClosed() bool {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.closed
+}
+
+func (pc *pooledWebSocketConn) markUsed() {
+	pc.mu.Lock()
+	pc.lastUsedAt = time.Now()
+	pc.used = true
+	pc.mu.Unlock()
+}
+
+func (pc *pooledWebSocketConn) close() {
+	pc.mu.Lock()
+	if pc.closed {
+		pc.mu.Unlock()
+		return
+	}
+	pc.closed = true
+	pc.lastInput = nil
+	pc.lastResponseID = ""
+	pc.mu.Unlock()
+	_ = pc.conn.Close()
+}
+
+func (pc *pooledWebSocketConn) previousTurn() ([]json.RawMessage, string) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return cloneRawMessages(pc.lastInput), pc.lastResponseID
+}
+
+func (pc *pooledWebSocketConn) rememberTurn(input []json.RawMessage, responseID string, maxInputBytes int) bool {
+	if strings.TrimSpace(responseID) == "" {
+		return false
+	}
+	if len(input) == 0 {
+		pc.mu.Lock()
+		pc.lastInput = nil
+		pc.lastResponseID = ""
+		pc.mu.Unlock()
+		return true
+	}
+	if maxInputBytes > 0 && rawMessagesSize(input) > maxInputBytes {
+		return false
+	}
+	pc.mu.Lock()
+	pc.lastInput = cloneRawMessages(input)
+	pc.lastResponseID = strings.TrimSpace(responseID)
+	pc.mu.Unlock()
+	return true
+}
+
+func (l *webSocketLease) release(evict bool) {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		if l.pooled == nil {
+			_ = l.conn.Close()
+			return
+		}
+		if evict {
+			if l.owner != nil {
+				l.owner.evict(l.pooled)
+			} else {
+				l.pooled.close()
+			}
+		} else {
+			l.pooled.markUsed()
+		}
+		select {
+		case <-l.pooled.inFlight:
+		default:
+		}
+	})
 }
 
 func toWebSocketURL(rawURL string) (string, error) {
@@ -151,6 +539,105 @@ func toWebSocketURL(rawURL string) (string, error) {
 	}
 
 	return u.String(), nil
+}
+
+type webSocketReconnectRequiredError struct{}
+
+func (e *webSocketReconnectRequiredError) Error() string {
+	return "websocket session context changed; reconnect and send full context"
+}
+
+func prepareWebSocketPayloadForLease(payload map[string]any, lease *webSocketLease) error {
+	if lease == nil || lease.pooled == nil {
+		return nil
+	}
+
+	fullInput, ok, err := payloadInputItems(payload)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	lease.nextFullInput = cloneRawMessages(fullInput)
+
+	previousInput, previousResponseID := lease.pooled.previousTurn()
+	if !lease.reused || previousResponseID == "" || len(previousInput) == 0 {
+		return nil
+	}
+
+	suffix, ok := inputSuffix(previousInput, fullInput)
+	if !ok || len(suffix) == 0 {
+		return &webSocketReconnectRequiredError{}
+	}
+
+	payload["input"] = suffix
+	payload["previous_response_id"] = previousResponseID
+
+	return nil
+}
+
+func payloadInputItems(payload map[string]any) ([]json.RawMessage, bool, error) {
+	inputValue, ok := payload["input"]
+	if !ok || inputValue == nil {
+		return nil, false, nil
+	}
+
+	inputRaw, err := json.Marshal(inputValue)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode websocket input payload: %w", err)
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(inputRaw, &items); err != nil {
+		return nil, false, nil
+	}
+
+	return items, true, nil
+}
+
+func inputSuffix(previous, current []json.RawMessage) ([]json.RawMessage, bool) {
+	if len(previous) >= len(current) {
+		return nil, false
+	}
+	for i := range previous {
+		if !jsonRawEqual(previous[i], current[i]) {
+			return nil, false
+		}
+	}
+
+	return cloneRawMessages(current[len(previous):]), true
+}
+
+func jsonRawEqual(a, b json.RawMessage) bool {
+	var compactA bytes.Buffer
+	if err := json.Compact(&compactA, a); err != nil {
+		return bytes.Equal(a, b)
+	}
+	var compactB bytes.Buffer
+	if err := json.Compact(&compactB, b); err != nil {
+		return bytes.Equal(a, b)
+	}
+	return bytes.Equal(compactA.Bytes(), compactB.Bytes())
+}
+
+func cloneRawMessages(src []json.RawMessage) []json.RawMessage {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]json.RawMessage, len(src))
+	for i := range src {
+		out[i] = append(json.RawMessage(nil), src[i]...)
+	}
+	return out
+}
+
+func rawMessagesSize(messages []json.RawMessage) int {
+	total := 0
+	for _, msg := range messages {
+		total += len(msg)
+	}
+	return total
 }
 
 func buildWebSocketCreatePayload(body []byte) (map[string]any, error) {
@@ -214,52 +701,124 @@ func newWebSocketDialError(request *httpclient.Request, resp *http.Response, err
 }
 
 type webSocketStream struct {
-	conn    *websocket.Conn
-	current *httpclient.StreamEvent
-	err     error
-	closed  bool
+	ctx      context.Context
+	lease    *webSocketLease
+	done     chan struct{}
+	doneOnce sync.Once
+	mu       sync.Mutex
+	current  *httpclient.StreamEvent
+	err      error
+	closed   bool
 }
 
 func (s *webSocketStream) Next() bool {
-	if s.err != nil || s.closed {
+	if s.isClosed() {
 		return false
 	}
+	select {
+	case <-s.ctx.Done():
+		s.setErr(s.ctx.Err())
+		s.finish(true)
+		return false
+	default:
+	}
 
-	_, msg, err := s.conn.ReadMessage()
+	_, msg, err := s.lease.conn.ReadMessage()
 	if err != nil {
 		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
+			s.finish(true)
 			return false
 		}
-		s.err = err
+		s.setErr(err)
+		s.finish(true)
 		return false
 	}
 
 	typ := streamEventType(msg)
-	s.current = &httpclient.StreamEvent{
+	s.setCurrent(&httpclient.StreamEvent{
 		Type: typ,
 		Data: normalizeWebSocketEvent(msg),
-	}
+	})
 	if isTerminalWebSocketEvent(typ) {
-		s.closed = true
+		evict := terminalWebSocketEventEvicts(typ)
+		if typ == "response.completed" {
+			responseID := responseIDFromWebSocketEvent(msg)
+			if responseID == "" {
+				evict = true
+			} else if !s.lease.rememberTurn(responseID) {
+				evict = true
+			}
+		}
+		s.finish(evict)
 	}
 
 	return true
 }
 
 func (s *webSocketStream) Current() *httpclient.StreamEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.current
 }
 
 func (s *webSocketStream) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.err
 }
 
 func (s *webSocketStream) Close() error {
-	if s.closed {
-		return nil
+	s.finish(true)
+	return nil
+}
+
+func (s *webSocketStream) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err != nil || s.closed
+}
+
+func (s *webSocketStream) setCurrent(event *httpclient.StreamEvent) {
+	s.mu.Lock()
+	s.current = event
+	s.mu.Unlock()
+}
+
+func (s *webSocketStream) setErr(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+func (s *webSocketStream) finish(evict bool) {
+	s.doneOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+		s.lease.release(evict)
+		close(s.done)
+	})
+}
+
+func (l *webSocketLease) rememberTurn(responseID string) bool {
+	if l == nil || l.pooled == nil {
+		return false
 	}
-	s.closed = true
-	return s.conn.Close()
+	maxInputBytes := 0
+	if l.owner != nil {
+		maxInputBytes = l.owner.maxRetainedInput
+	}
+	return l.pooled.rememberTurn(l.nextFullInput, responseID, maxInputBytes)
+}
+
+func responseIDFromWebSocketEvent(raw []byte) string {
+	var payload struct {
+		Response struct {
+			ID string `json:"id"`
+		} `json:"response"`
+	}
+	_ = json.Unmarshal(raw, &payload)
+	return payload.Response.ID
 }
 
 func streamEventType(raw []byte) string {
@@ -272,7 +831,16 @@ func streamEventType(raw []byte) string {
 
 func isTerminalWebSocketEvent(eventType string) bool {
 	switch eventType {
-	case "response.completed", "response.failed", "response.cancelled", "error":
+	case "response.completed", "response.failed", "response.cancelled", "response.incomplete", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalWebSocketEventEvicts(eventType string) bool {
+	switch eventType {
+	case "response.failed", "response.cancelled", "response.incomplete", "error":
 		return true
 	default:
 		return false

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1,0 +1,309 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+const WebSocketBetaHeaderValue = "responses_websockets=2026-02-06"
+
+type WebSocketExecutor struct {
+	inner  pipeline.Executor
+	dialer *websocket.Dialer
+}
+
+func NewWebSocketExecutor(inner pipeline.Executor) *WebSocketExecutor {
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: 30 * time.Second,
+		Proxy:            http.ProxyFromEnvironment,
+	}
+	if hc, ok := inner.(*httpclient.HttpClient); ok {
+		dialer.Proxy = hc.ProxyFunc()
+	}
+
+	return &WebSocketExecutor{
+		inner:  inner,
+		dialer: dialer,
+	}
+}
+
+func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	stream, err := e.DoStream(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = stream.Close() }()
+
+	chunks := make([]*httpclient.StreamEvent, 0, 16)
+	for stream.Next() {
+		ev := stream.Current()
+		if ev == nil {
+			continue
+		}
+		chunks = append(chunks, &httpclient.StreamEvent{
+			Type:        ev.Type,
+			LastEventID: ev.LastEventID,
+			Data:        append([]byte(nil), ev.Data...),
+		})
+	}
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+
+	body, _, err := AggregateStreamChunks(ctx, chunks)
+	if err != nil {
+		return nil, err
+	}
+
+	return &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body:    body,
+		Request: request,
+	}, nil
+}
+
+func (e *WebSocketExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+	if e == nil {
+		return nil, fmt.Errorf("websocket executor is nil")
+	}
+
+	wsURL, err := toWebSocketURL(request.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := request.Headers.Clone()
+	if headers == nil {
+		headers = http.Header{}
+	}
+	for k := range managedWebSocketHeaders() {
+		headers.Del(k)
+	}
+	if request.Auth != nil {
+		if err := applyWebSocketAuth(headers, request.Auth); err != nil {
+			return nil, err
+		}
+	}
+	headers.Set("OpenAI-Beta", WebSocketBetaHeaderValue)
+
+	dialer := e.dialer
+	if dialer == nil {
+		dialer = websocket.DefaultDialer
+	}
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	if err != nil {
+		return nil, newWebSocketDialError(request, resp, err)
+	}
+
+	payload, err := buildWebSocketCreatePayload(request.Body)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err := conn.WriteJSON(payload); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to write response.create websocket event: %w", err)
+	}
+
+	return &webSocketStream{conn: conn}, nil
+}
+
+func (e *WebSocketExecutor) Inner() pipeline.Executor {
+	if e == nil {
+		return nil
+	}
+	return e.inner
+}
+
+func toWebSocketURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid websocket request url: %w", err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "wss", "ws":
+	default:
+		return "", fmt.Errorf("unsupported websocket request scheme %q", u.Scheme)
+	}
+
+	return u.String(), nil
+}
+
+func buildWebSocketCreatePayload(body []byte) (map[string]any, error) {
+	payload := map[string]any{}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, fmt.Errorf("failed to decode responses request body: %w", err)
+		}
+	}
+
+	payload["type"] = "response.create"
+	delete(payload, "stream")
+	delete(payload, "background")
+
+	return payload, nil
+}
+
+func applyWebSocketAuth(headers http.Header, auth *httpclient.AuthConfig) error {
+	switch auth.Type {
+	case httpclient.AuthTypeBearer:
+		headers.Set("Authorization", "Bearer "+auth.APIKey)
+	case httpclient.AuthTypeAPIKey:
+		if auth.HeaderKey == "" {
+			return fmt.Errorf("api key header is required")
+		}
+		headers.Set(auth.HeaderKey, auth.APIKey)
+	default:
+		return fmt.Errorf("unsupported auth type %q", auth.Type)
+	}
+
+	return nil
+}
+
+func managedWebSocketHeaders() map[string]struct{} {
+	return map[string]struct{}{
+		"Content-Length": {},
+		"Content-Type":   {},
+		"Host":           {},
+	}
+}
+
+func newWebSocketDialError(request *httpclient.Request, resp *http.Response, err error) error {
+	if resp == nil {
+		return fmt.Errorf("websocket dial failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("websocket dial failed: %w", err)
+	}
+
+	return &httpclient.Error{
+		Method:     request.Method,
+		URL:        request.URL,
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       body,
+		Headers:    resp.Header,
+	}
+}
+
+type webSocketStream struct {
+	conn    *websocket.Conn
+	current *httpclient.StreamEvent
+	err     error
+	closed  bool
+}
+
+func (s *webSocketStream) Next() bool {
+	if s.err != nil || s.closed {
+		return false
+	}
+
+	_, msg, err := s.conn.ReadMessage()
+	if err != nil {
+		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
+			return false
+		}
+		s.err = err
+		return false
+	}
+
+	typ := streamEventType(msg)
+	s.current = &httpclient.StreamEvent{
+		Type: typ,
+		Data: normalizeWebSocketEvent(msg),
+	}
+	if isTerminalWebSocketEvent(typ) {
+		s.closed = true
+	}
+
+	return true
+}
+
+func (s *webSocketStream) Current() *httpclient.StreamEvent {
+	return s.current
+}
+
+func (s *webSocketStream) Err() error {
+	return s.err
+}
+
+func (s *webSocketStream) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.conn.Close()
+}
+
+func streamEventType(raw []byte) string {
+	var payload struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(raw, &payload)
+	return payload.Type
+}
+
+func isTerminalWebSocketEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.cancelled", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeWebSocketEvent(raw []byte) []byte {
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return append([]byte(nil), raw...)
+	}
+	if payload["type"] != "error" {
+		return append([]byte(nil), raw...)
+	}
+	errorValue, ok := payload["error"].(map[string]any)
+	if !ok {
+		return append([]byte(nil), raw...)
+	}
+	if value, ok := errorValue["code"]; ok {
+		payload["code"] = value
+	} else if value, ok := errorValue["type"]; ok {
+		payload["code"] = value
+	}
+	for _, key := range []string{"message", "param"} {
+		if value, ok := errorValue[key]; ok {
+			payload[key] = value
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return append([]byte(nil), raw...)
+	}
+	return body
+}

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -251,6 +251,7 @@ type webSocketLease struct {
 }
 
 func (e *WebSocketExecutor) acquirePreparedLease(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header, payload map[string]any) (*webSocketLease, error) {
+	originalPayload := clonePayloadMap(payload)
 	lease, err := e.acquire(ctx, request, wsURL, headers)
 	if err != nil {
 		return nil, err
@@ -263,6 +264,7 @@ func (e *WebSocketExecutor) acquirePreparedLease(ctx context.Context, request *h
 			return nil, err
 		}
 
+		restorePayloadMap(payload, originalPayload)
 		lease, err = e.acquire(ctx, request, wsURL, headers)
 		if err != nil {
 			return nil, err
@@ -274,6 +276,26 @@ func (e *WebSocketExecutor) acquirePreparedLease(ctx context.Context, request *h
 	}
 
 	return lease, nil
+}
+
+func clonePayloadMap(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	clone := make(map[string]any, len(payload))
+	for key, value := range payload {
+		clone[key] = value
+	}
+	return clone
+}
+
+func restorePayloadMap(payload, original map[string]any) {
+	for key := range payload {
+		delete(payload, key)
+	}
+	for key, value := range original {
+		payload[key] = value
+	}
 }
 
 func (e *WebSocketExecutor) acquire(ctx context.Context, request *httpclient.Request, wsURL string, headers http.Header) (*webSocketLease, error) {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -99,7 +99,7 @@ func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request)
 	if err := stream.Err(); err != nil {
 		return nil, err
 	}
-	if err := topLevelWebSocketError(chunks); err != nil {
+	if err := TopLevelWebSocketError(chunks); err != nil {
 		return nil, err
 	}
 
@@ -118,7 +118,8 @@ func (e *WebSocketExecutor) Do(ctx context.Context, request *httpclient.Request)
 	}, nil
 }
 
-func topLevelWebSocketError(chunks []*httpclient.StreamEvent) error {
+// TopLevelWebSocketError returns an error when collected WebSocket stream events contain a top-level protocol error.
+func TopLevelWebSocketError(chunks []*httpclient.StreamEvent) error {
 	for _, chunk := range chunks {
 		if chunk == nil || chunk.Type != string(StreamEventTypeError) {
 			continue

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1077,8 +1077,12 @@ func (s *webSocketStream) Next() bool {
 			responseID := responseIDFromWebSocketEvent(msg)
 			if responseID == "" {
 				evict = true
-			} else if !s.lease.rememberTurn(responseID) {
-				evict = true
+			} else {
+				// Retaining the full input is a local cache optimization for
+				// future incremental sends. If the input exceeds the memory
+				// budget, keep the healthy WebSocket connection and let the
+				// next turn send full context instead of evicting the session.
+				s.lease.rememberTurn(responseID)
 			}
 		}
 		s.finish(evict)

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -287,17 +287,13 @@ func (e *WebSocketExecutor) acquire(ctx context.Context, request *httpclient.Req
 
 		select {
 		case pc.inFlight <- struct{}{}:
-			if pc.isClosed() {
+			closed, expired, used := pc.leaseState(time.Now(), e.maxLifetime)
+			if closed || expired {
 				<-pc.inFlight
 				e.evict(pc)
 				continue
 			}
-			if pc.expired(time.Now(), e.maxLifetime) {
-				<-pc.inFlight
-				e.evict(pc)
-				continue
-			}
-			return &webSocketLease{conn: pc.conn, owner: e, pooled: pc, reused: pc.used}, nil
+			return &webSocketLease{conn: pc.conn, owner: e, pooled: pc, reused: used}, nil
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -432,14 +428,19 @@ func (e *WebSocketExecutor) evictOldestIdleLocked() bool {
 	var oldestKey webSocketPoolKey
 	var oldest *pooledWebSocketConn
 	for key, pc := range e.pool {
-		if pc == nil || pc.isClosed() {
+		if pc == nil {
+			delete(e.pool, key)
+			continue
+		}
+		closed, lastUsedAt, _ := pc.poolState(time.Now(), e.maxLifetime)
+		if closed {
 			delete(e.pool, key)
 			continue
 		}
 		if len(pc.inFlight) > 0 {
 			continue
 		}
-		if oldest == nil || pc.lastUsedAt.Before(oldest.lastUsedAt) {
+		if oldest == nil || lastUsedAt.Before(oldest.poolLastUsedAt()) {
 			oldestKey = key
 			oldest = pc
 		}
@@ -454,14 +455,19 @@ func (e *WebSocketExecutor) evictOldestIdleLocked() bool {
 
 func (e *WebSocketExecutor) cleanupExpiredLocked(now time.Time) {
 	for key, pc := range e.pool {
-		if pc == nil || pc.isClosed() {
+		if pc == nil {
+			delete(e.pool, key)
+			continue
+		}
+		closed, lastUsedAt, expired := pc.poolState(now, e.maxLifetime)
+		if closed {
 			delete(e.pool, key)
 			continue
 		}
 		if len(pc.inFlight) > 0 {
 			continue
 		}
-		if now.Sub(pc.lastUsedAt) > e.idleTTL || pc.expired(now, e.maxLifetime) {
+		if now.Sub(lastUsedAt) > e.idleTTL || expired {
 			delete(e.pool, key)
 			pc.close()
 		}
@@ -480,8 +486,22 @@ func (e *WebSocketExecutor) evict(pc *pooledWebSocketConn) {
 	pc.close()
 }
 
-func (pc *pooledWebSocketConn) expired(now time.Time, maxLifetime time.Duration) bool {
-	return maxLifetime > 0 && now.Sub(pc.createdAt) > maxLifetime
+func (pc *pooledWebSocketConn) leaseState(now time.Time, maxLifetime time.Duration) (closed bool, expired bool, used bool) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.closed, maxLifetime > 0 && now.Sub(pc.createdAt) > maxLifetime, pc.used
+}
+
+func (pc *pooledWebSocketConn) poolState(now time.Time, maxLifetime time.Duration) (closed bool, lastUsedAt time.Time, expired bool) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.closed, pc.lastUsedAt, maxLifetime > 0 && now.Sub(pc.createdAt) > maxLifetime
+}
+
+func (pc *pooledWebSocketConn) poolLastUsedAt() time.Time {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.lastUsedAt
 }
 
 func (pc *pooledWebSocketConn) isClosed() bool {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -28,14 +28,20 @@ import (
 const WebSocketBetaHeaderValue = "responses_websockets=2026-02-06"
 
 const (
-	webSocketSessionHeader        = "Session_id"
-	webSocketAccountIDHeader      = "Chatgpt-Account-Id"
-	webSocketOriginatorHeader     = "Originator"
-	webSocketUserAgentHeader      = "User-Agent"
-	webSocketOrgHeader            = "OpenAI-Organization"
-	webSocketProjectHeader        = "OpenAI-Project"
-	defaultWebSocketIdleTTL       = 10 * time.Minute
-	defaultWebSocketMaxLifetime   = 30 * time.Minute
+	webSocketSessionHeader    = "Session_id"
+	webSocketAccountIDHeader  = "Chatgpt-Account-Id"
+	webSocketOriginatorHeader = "Originator"
+	webSocketUserAgentHeader  = "User-Agent"
+	webSocketOrgHeader        = "OpenAI-Organization"
+	webSocketProjectHeader    = "OpenAI-Project"
+	// OpenAI limits Responses WebSocket connections to 60 minutes. The
+	// Codex store=false path depends on connection-local state: real upstream
+	// probes show reconnecting loses previous_response_id recovery, and
+	// prompt-cache hits appear only when the same WebSocket is reused. Keep
+	// useful idle connections close to the upstream cap, but leave enough
+	// headroom for a new turn to finish before that cap is reached.
+	defaultWebSocketIdleTTL       = 50 * time.Minute
+	defaultWebSocketMaxLifetime   = 50 * time.Minute
 	defaultWebSocketMaxPoolSize   = 128
 	defaultWebSocketMaxRetainedIn = 1 << 20
 	minWebSocketCleanupDelay      = 10 * time.Millisecond

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -1,0 +1,130 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestWebSocketExecutorDoStreamSendsResponseCreate(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, WebSocketBetaHeaderValue, r.Header.Get("OpenAI-Beta"))
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.Equal(t, "response.create", payload["type"])
+		require.Equal(t, "gpt-5", payload["model"])
+		require.Equal(t, "Be concise", payload["instructions"])
+		require.NotContains(t, payload, "stream")
+		require.NotContains(t, payload, "background")
+
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type":            "response.completed",
+			"sequence_number": 1,
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+		require.NoError(t, conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5","instructions":"Be concise","stream":true,"background":false}`),
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.True(t, stream.Next())
+	event := stream.Current()
+	require.Equal(t, "response.completed", event.Type)
+	require.JSONEq(t, `{"type":"response.completed","sequence_number":1,"response":{"id":"resp_test","object":"response","created_at":1700000000,"model":"gpt-5","status":"completed","output":[]}}`, string(event.Data))
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+}
+
+func TestWebSocketStreamStopsAfterTerminalEventWithoutCloseFrame(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+}
+
+func TestNormalizeWebSocketEventFlattensNestedError(t *testing.T) {
+	raw := []byte(`{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"bad request","param":"model","code":"bad_model"}}`)
+
+	normalized := normalizeWebSocketEvent(raw)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(normalized, &payload))
+	require.Equal(t, "error", payload["type"])
+	require.Equal(t, "bad_model", payload["code"])
+	require.Equal(t, "bad request", payload["message"])
+	require.Equal(t, "model", payload["param"])
+}
+
+func TestToWebSocketURL(t *testing.T) {
+	got, err := toWebSocketURL("https://api.openai.com/v1/responses")
+	require.NoError(t, err)
+	require.Equal(t, "wss://api.openai.com/v1/responses", got)
+
+	got, err = toWebSocketURL("http://localhost:8080/v1/responses")
+	require.NoError(t, err)
+	require.Equal(t, "ws://localhost:8080/v1/responses", got)
+}

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -203,6 +203,28 @@ func TestWebSocketStreamReportsContextCancellationWhileReadBlocks(t *testing.T) 
 	require.ErrorIs(t, stream.Err(), context.Canceled)
 }
 
+func TestWebSocketStreamReportsContextCancellationWhenAlreadyClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(webSocketTestContext())
+	stream := &webSocketStream{ctx: ctx, done: make(chan struct{})}
+
+	stream.finish(true)
+	cancel()
+
+	require.False(t, stream.Next())
+	require.ErrorIs(t, stream.Err(), context.Canceled)
+}
+
+func TestWebSocketStreamDoesNotOverwriteTerminalResponseWithContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(webSocketTestContext())
+	stream := &webSocketStream{ctx: ctx, done: make(chan struct{})}
+	stream.markTerminal()
+	stream.finish(false)
+	cancel()
+
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+}
+
 func TestWebSocketExecutorDoReturnsErrorForTopLevelErrorEvent(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -41,7 +41,7 @@ func TestOutboundCustomizeExecutorUsesCurrentExecutor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	firstClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeDisabled})
+	firstClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeDisabled}, httpclient.WithInsecureSkipVerify(true))
 	secondClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeURL, URL: "http://127.0.0.1:18080"})
 
 	first, ok := outbound.CustomizeExecutor(firstClient).(*WebSocketExecutor)
@@ -55,6 +55,8 @@ func TestOutboundCustomizeExecutorUsesCurrentExecutor(t *testing.T) {
 	require.Same(t, first, again)
 	require.Same(t, firstClient, first.Inner())
 	require.Same(t, secondClient, second.Inner())
+	require.NotNil(t, first.dialer.TLSClientConfig)
+	require.True(t, first.dialer.TLSClientConfig.InsecureSkipVerify)
 
 	req := &http.Request{URL: mustParseURL(t, "https://example.com/v1/responses")}
 	firstProxy, err := first.dialer.Proxy(req)

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -201,6 +201,82 @@ func TestWebSocketStreamReportsContextCancellationWhileReadBlocks(t *testing.T) 
 	require.ErrorIs(t, stream.Err(), context.Canceled)
 }
 
+func TestWebSocketExecutorDoReturnsErrorForTopLevelErrorEvent(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type":    "error",
+			"code":    "bad_request",
+			"message": "invalid websocket request",
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	resp, err := executor.Do(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5"}`),
+	})
+
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "bad_request: invalid websocket request")
+}
+
+func TestWebSocketExecutorDoAggregatesFailedResponseEvent(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		status := "failed"
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.failed",
+			"response": map[string]any{
+				"id":         "resp_failed",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     status,
+				"error": map[string]any{
+					"code":    "server_error",
+					"message": "upstream failed",
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	resp, err := executor.Do(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body Response
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "resp_failed", body.ID)
+	require.NotNil(t, body.Status)
+	require.Equal(t, "failed", *body.Status)
+	require.NotNil(t, body.Error)
+	require.Equal(t, "server_error", body.Error.Code)
+	require.Equal(t, "upstream failed", body.Error.Message)
+}
+
 func TestWebSocketExecutorReusesConnectionForSameSession(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -573,6 +573,26 @@ func TestWebSocketExecutorReconnectsForDifferentExplicitPreviousResponseID(t *te
 	require.Equal(t, int32(2), upgrades.Load())
 }
 
+func TestRestorePayloadMapRestoresMutatedPayload(t *testing.T) {
+	originalInput := []any{
+		map[string]any{"id": "user_1", "type": "message", "role": "user"},
+		map[string]any{"id": "user_2", "type": "message", "role": "user"},
+	}
+	payload := map[string]any{
+		"model": "gpt-5",
+		"input": originalInput,
+	}
+	original := clonePayloadMap(payload)
+
+	payload["input"] = []json.RawMessage{json.RawMessage(`{"id":"user_2","type":"message","role":"user"}`)}
+	payload["previous_response_id"] = "resp_1"
+	restorePayloadMap(payload, original)
+
+	require.Equal(t, "gpt-5", payload["model"])
+	require.Equal(t, originalInput, payload["input"])
+	require.NotContains(t, payload, "previous_response_id")
+}
+
 func TestWebSocketExecutorReconnectsWhenSuffixStartsWithAssistantOutput(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -13,12 +13,29 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
+	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func webSocketTestContext() context.Context {
 	return shared.WithSessionScope(context.Background(), "test-scope")
+}
+
+func TestOutboundCustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
+	outbound, err := NewOutboundTransformerWithConfig(&Config{
+		BaseURL:        "https://api.openai.com/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+		Transport:      TransportWebSocket,
+	})
+	require.NoError(t, err)
+
+	first, ok := outbound.CustomizeExecutor(nil).(*WebSocketExecutor)
+	require.True(t, ok)
+	second, ok := outbound.CustomizeExecutor(nil).(*WebSocketExecutor)
+	require.True(t, ok)
+
+	require.Same(t, first, second)
 }
 
 func TestWebSocketExecutorDoStreamSendsResponseCreate(t *testing.T) {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -22,7 +23,16 @@ func webSocketTestContext() context.Context {
 	return shared.WithSessionScope(context.Background(), "test-scope")
 }
 
-func TestOutboundCustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	return parsed
+}
+
+func TestOutboundCustomizeExecutorUsesCurrentExecutor(t *testing.T) {
 	outbound, err := NewOutboundTransformerWithConfig(&Config{
 		BaseURL:        "https://api.openai.com/v1",
 		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
@@ -30,12 +40,28 @@ func TestOutboundCustomizeExecutorReusesWebSocketExecutor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	first, ok := outbound.CustomizeExecutor(nil).(*WebSocketExecutor)
+	firstClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeDisabled})
+	secondClient := httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeURL, URL: "http://127.0.0.1:18080"})
+
+	first, ok := outbound.CustomizeExecutor(firstClient).(*WebSocketExecutor)
 	require.True(t, ok)
-	second, ok := outbound.CustomizeExecutor(nil).(*WebSocketExecutor)
+	second, ok := outbound.CustomizeExecutor(secondClient).(*WebSocketExecutor)
+	require.True(t, ok)
+	again, ok := outbound.CustomizeExecutor(firstClient).(*WebSocketExecutor)
 	require.True(t, ok)
 
-	require.Same(t, first, second)
+	require.NotSame(t, first, second)
+	require.Same(t, first, again)
+	require.Same(t, firstClient, first.Inner())
+	require.Same(t, secondClient, second.Inner())
+
+	req := &http.Request{URL: mustParseURL(t, "https://example.com/v1/responses")}
+	firstProxy, err := first.dialer.Proxy(req)
+	require.NoError(t, err)
+	require.Nil(t, firstProxy)
+	secondProxy, err := second.dialer.Proxy(req)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:18080", secondProxy.String())
 }
 
 func TestWebSocketExecutorDoStreamSendsResponseCreate(t *testing.T) {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -3,16 +3,23 @@ package responses
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
+
+func webSocketTestContext() context.Context {
+	return shared.WithSessionScope(context.Background(), "test-scope")
+}
 
 func TestWebSocketExecutorDoStreamSendsResponseCreate(t *testing.T) {
 	upgrader := websocket.Upgrader{}
@@ -49,7 +56,7 @@ func TestWebSocketExecutorDoStreamSendsResponseCreate(t *testing.T) {
 	defer server.Close()
 
 	executor := NewWebSocketExecutor(nil)
-	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
 		Method: http.MethodPost,
 		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
 		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
@@ -91,7 +98,7 @@ func TestWebSocketStreamStopsAfterTerminalEventWithoutCloseFrame(t *testing.T) {
 	defer server.Close()
 
 	executor := NewWebSocketExecutor(nil)
-	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
 		Method: http.MethodPost,
 		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
 		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
@@ -104,6 +111,474 @@ func TestWebSocketStreamStopsAfterTerminalEventWithoutCloseFrame(t *testing.T) {
 	require.Equal(t, "response.completed", stream.Current().Type)
 	require.False(t, stream.Next())
 	require.NoError(t, stream.Err())
+}
+
+func TestWebSocketExecutorReusesConnectionForSameSession(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "session-1", r.Header.Get(webSocketSessionHeader))
+		upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		for i := 0; i < 2; i++ {
+			var payload map[string]any
+			require.NoError(t, conn.ReadJSON(&payload))
+			require.Equal(t, "response.create", payload["type"])
+			require.Equal(t, fmt.Sprintf("turn-%d", i+1), payload["instructions"])
+
+			require.NoError(t, conn.WriteJSON(map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id":         fmt.Sprintf("resp_%d", i+1),
+					"object":     "response",
+					"created_at": 1700000000,
+					"model":      "gpt-5",
+					"status":     "completed",
+					"output":     []any{},
+				},
+			}))
+		}
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	for i := 0; i < 2; i++ {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"session-1"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: []byte(fmt.Sprintf(`{"model":"gpt-5","instructions":"turn-%d"}`, i+1)),
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(1), upgrades.Load())
+}
+
+func TestWebSocketExecutorDoesNotPoolWithoutSession(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	for i := 0; i < 2; i++ {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body:   []byte(`{"model":"gpt-5"}`),
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(2), upgrades.Load())
+}
+
+func TestWebSocketExecutorKeepsExplicitPreviousResponseIDOnFreshConnection(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.Equal(t, "client_prev", payload["previous_response_id"])
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"explicit-previous"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5","previous_response_id":"client_prev","input":[{"id":"first","type":"message"}]}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+	require.NoError(t, stream.Close())
+}
+
+func TestWebSocketExecutorSeparatesPoolByOrganizationHeaders(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	for _, org := range []string{"org-a", "org-b"} {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"org-session"},
+				webSocketOrgHeader:     []string{org},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message"}]}`),
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(2), upgrades.Load())
+}
+
+func TestWebSocketExecutorEvictsPooledConnectionOnFailedOrCancelled(t *testing.T) {
+	for _, terminalType := range []string{"response.failed", "response.cancelled", "response.incomplete"} {
+		t.Run(terminalType, func(t *testing.T) {
+			upgrader := websocket.Upgrader{}
+			var upgrades atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upgrade := upgrades.Add(1)
+
+				conn, err := upgrader.Upgrade(w, r, nil)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				var payload map[string]any
+				require.NoError(t, conn.ReadJSON(&payload))
+				require.NotContains(t, payload, "previous_response_id")
+
+				if upgrade == 1 {
+					require.NoError(t, conn.WriteJSON(map[string]any{
+						"type": terminalType,
+						"response": map[string]any{
+							"id":     "resp_bad",
+							"status": strings.TrimPrefix(terminalType, "response."),
+						},
+					}))
+					return
+				}
+
+				require.NoError(t, conn.WriteJSON(map[string]any{
+					"type": "response.completed",
+					"response": map[string]any{
+						"id":         "resp_ok",
+						"object":     "response",
+						"created_at": 1700000000,
+						"model":      "gpt-5",
+						"status":     "completed",
+						"output":     []any{},
+					},
+				}))
+			}))
+			defer server.Close()
+
+			executor := NewWebSocketExecutor(nil)
+			body := []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message"}]}`)
+			for i := 0; i < 2; i++ {
+				stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+					Method: http.MethodPost,
+					URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+					Headers: http.Header{
+						webSocketSessionHeader: []string{"terminal-evict-" + terminalType},
+					},
+					Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+					Body: body,
+				})
+				require.NoError(t, err)
+				require.True(t, stream.Next())
+				if i == 0 {
+					require.Equal(t, terminalType, stream.Current().Type)
+				} else {
+					require.Equal(t, "response.completed", stream.Current().Type)
+				}
+				require.False(t, stream.Next())
+				require.NoError(t, stream.Err())
+				require.NoError(t, stream.Close())
+			}
+
+			require.Equal(t, int32(2), upgrades.Load())
+		})
+	}
+}
+
+func TestWebSocketExecutorSendsOnlyNewInputOnReusedSession(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var first map[string]any
+		require.NoError(t, conn.ReadJSON(&first))
+		firstInput, ok := first["input"].([]any)
+		require.True(t, ok)
+		require.Len(t, firstInput, 1)
+		require.NotContains(t, first, "previous_response_id")
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_1",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+
+		var second map[string]any
+		require.NoError(t, conn.ReadJSON(&second))
+		require.Equal(t, "resp_1", second["previous_response_id"])
+		secondInput, ok := second["input"].([]any)
+		require.True(t, ok)
+		require.Len(t, secondInput, 1)
+		message, ok := secondInput[0].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "second", message["id"])
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_2",
+				"object":     "response",
+				"created_at": 1700000001,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	firstBody := []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}]}`)
+	secondBody := []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user","content":[{"type":"input_text","text":"first"}]},{"id":"second","type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
+
+	for _, body := range [][]byte{firstBody, secondBody} {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"diff-session"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: body,
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(1), upgrades.Load())
+}
+
+func TestWebSocketExecutorReconnectsWhenInputIsNotAppendOnly(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrade := upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		input, ok := payload["input"].([]any)
+		require.True(t, ok)
+		require.Len(t, input, 1)
+		require.NotContains(t, payload, "previous_response_id")
+
+		responseID := "resp_1"
+		if upgrade == 2 {
+			message, ok := input[0].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "rewritten", message["id"])
+			responseID = "resp_rewritten"
+		}
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         responseID,
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+		if upgrade == 1 {
+			_, _, err = conn.ReadMessage()
+			require.Error(t, err)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	firstBody := []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}]}`)
+	rewrittenBody := []byte(`{"model":"gpt-5","input":[{"id":"rewritten","type":"message","role":"user","content":[{"type":"input_text","text":"rewritten"}]}]}`)
+
+	for _, body := range [][]byte{firstBody, rewrittenBody} {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"rewrite-session"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: body,
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(2), upgrades.Load())
+}
+
+func TestWebSocketExecutorEvictsPooledConnectionOnEarlyClose(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	firstPayloadRead := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		upgrade := upgrades.Add(1)
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+
+		if upgrade == 1 {
+			close(firstPayloadRead)
+			_, _, err = conn.ReadMessage()
+			require.Error(t, err)
+			return
+		}
+
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_test",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"session-early-close"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	<-firstPayloadRead
+	require.NoError(t, stream.Close())
+
+	stream, err = executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"session-early-close"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+	require.NoError(t, stream.Close())
+	require.Equal(t, int32(2), upgrades.Load())
 }
 
 func TestNormalizeWebSocketEventFlattensNestedError(t *testing.T) {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -955,6 +955,78 @@ func TestWebSocketExecutorEvictsPooledConnectionOnEarlyClose(t *testing.T) {
 	require.Equal(t, int32(2), upgrades.Load())
 }
 
+func TestHeaderPoolIdentityIgnoresPerRequestTraceHeaders(t *testing.T) {
+	base := http.Header{
+		"X-Trace-Id":           []string{"trace-1"},
+		"X-Request-Id":         []string{"request-1"},
+		"Traceparent":          []string{"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"},
+		"X-Custom-Routing":     []string{"stable"},
+		"OpenAI-Beta":          []string{WebSocketBetaHeaderValue},
+		webSocketSessionHeader: []string{"session-1"},
+	}
+	changedTrace := base.Clone()
+	changedTrace.Set("X-Trace-Id", "trace-2")
+	changedTrace.Set("X-Request-Id", "request-2")
+	changedTrace.Set("Traceparent", "00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01")
+
+	reKeyed := base.Clone()
+	reKeyed.Set("X-Custom-Routing", "other")
+
+	require.Equal(t, headerPoolIdentity(base), headerPoolIdentity(changedTrace))
+	require.NotEqual(t, headerPoolIdentity(base), headerPoolIdentity(reKeyed))
+}
+
+func TestWebSocketExecutorBackgroundCleanupClosesIdleConnections(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	connectionClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer close(connectionClosed)
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_cleanup",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	executor.idleTTL = 20 * time.Millisecond
+	executor.maxLifetime = time.Hour
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"cleanup-session"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+
+	select {
+	case <-connectionClosed:
+	case <-time.After(time.Second):
+		t.Fatal("idle websocket connection was not closed by background cleanup")
+	}
+}
+
 func TestNormalizeWebSocketEventFlattensNestedError(t *testing.T) {
 	raw := []byte(`{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"bad request","param":"model","code":"bad_model"}}`)
 

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -946,6 +946,66 @@ func TestWebSocketExecutorSendsOnlyNewInputOnReusedSession(t *testing.T) {
 	require.Equal(t, int32(1), upgrades.Load())
 }
 
+func TestWebSocketExecutorKeepsConnectionWhenInputExceedsRetainedLimit(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrades.Add(1)
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		for i := 0; i < 2; i++ {
+			var payload map[string]any
+			if err := conn.ReadJSON(&payload); err != nil {
+				return
+			}
+			require.NotContains(t, payload, "previous_response_id")
+			input, ok := payload["input"].([]any)
+			require.True(t, ok)
+			require.Len(t, input, 1)
+
+			require.NoError(t, conn.WriteJSON(map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id":         fmt.Sprintf("resp_%d", i+1),
+					"object":     "response",
+					"created_at": 1700000000 + i,
+					"model":      "gpt-5",
+					"status":     "completed",
+					"output":     []any{},
+				},
+			}))
+		}
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	executor.maxRetainedInput = 1
+	body := []byte(`{"model":"gpt-5","input":[{"id":"large","type":"message","role":"user","content":[{"type":"input_text","text":"larger than retained limit"}]}]}`)
+
+	for i := 0; i < 2; i++ {
+		stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"large-input-session"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: body,
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(1), upgrades.Load())
+}
+
 func TestWebSocketExecutorReconnectsWhenInputIsNotAppendOnly(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -279,6 +279,88 @@ func TestWebSocketExecutorDoAggregatesFailedResponseEvent(t *testing.T) {
 	require.Equal(t, "upstream failed", body.Error.Message)
 }
 
+func TestWebSocketExecutorDoAggregatesCancelledAndIncompleteResponseEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventType  string
+		status     string
+		responseID string
+		response   map[string]any
+		assertBody func(*testing.T, Response)
+	}{
+		{
+			name:       "cancelled",
+			eventType:  "response.cancelled",
+			status:     "canceled",
+			responseID: "resp_cancelled",
+			response:   map[string]any{},
+		},
+		{
+			name:       "incomplete",
+			eventType:  "response.incomplete",
+			status:     "incomplete",
+			responseID: "resp_incomplete",
+			response: map[string]any{
+				"incomplete_details": map[string]any{"reason": "max_output_tokens"},
+			},
+			assertBody: func(t *testing.T, body Response) {
+				t.Helper()
+				require.NotNil(t, body.IncompleteDetails)
+				require.Equal(t, "max_output_tokens", body.IncompleteDetails.Reason)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upgrader := websocket.Upgrader{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				var payload map[string]any
+				require.NoError(t, conn.ReadJSON(&payload))
+				response := map[string]any{
+					"id":         tt.responseID,
+					"object":     "response",
+					"created_at": 1700000000,
+					"model":      "gpt-5",
+					"status":     tt.status,
+					"output":     []any{},
+				}
+				for key, value := range tt.response {
+					response[key] = value
+				}
+				require.NoError(t, conn.WriteJSON(map[string]any{
+					"type":     tt.eventType,
+					"response": response,
+				}))
+			}))
+			defer server.Close()
+
+			executor := NewWebSocketExecutor(nil)
+			resp, err := executor.Do(webSocketTestContext(), &httpclient.Request{
+				Method: http.MethodPost,
+				URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+				Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+				Body:   []byte(`{"model":"gpt-5"}`),
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var body Response
+			require.NoError(t, json.Unmarshal(resp.Body, &body))
+			require.Equal(t, tt.responseID, body.ID)
+			require.NotNil(t, body.Status)
+			require.Equal(t, tt.status, *body.Status)
+			if tt.assertBody != nil {
+				tt.assertBody(t, body)
+			}
+		})
+	}
+}
+
 func TestWebSocketExecutorReusesConnectionForSameSession(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -1151,6 +1151,58 @@ func TestWebSocketExecutorBackgroundCleanupClosesIdleConnections(t *testing.T) {
 	}
 }
 
+func TestWebSocketExecutorCloseClosesIdleConnections(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	connectionClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer close(connectionClosed)
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_close",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"close-session"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+	require.NoError(t, executor.Close())
+
+	select {
+	case <-connectionClosed:
+	case <-time.After(time.Second):
+		t.Fatal("idle websocket connection was not closed by executor Close")
+	}
+	require.Empty(t, executor.pool)
+	require.False(t, executor.cleanupScheduled)
+}
+
 func TestNormalizeWebSocketEventFlattensNestedError(t *testing.T) {
 	raw := []byte(`{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"bad request","param":"model","code":"bad_model"}}`)
 

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -419,6 +419,214 @@ func TestWebSocketExecutorKeepsExplicitPreviousResponseIDOnFreshConnection(t *te
 	require.NoError(t, stream.Close())
 }
 
+func TestWebSocketExecutorReconnectsForDifferentExplicitPreviousResponseID(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrade := upgrades.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+
+		if upgrade == 1 {
+			require.NotContains(t, payload, "previous_response_id")
+			require.NoError(t, conn.WriteJSON(map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id":         "resp_1",
+					"object":     "response",
+					"created_at": 1700000000,
+					"model":      "gpt-5",
+					"status":     "completed",
+					"output":     []any{},
+				},
+			}))
+			return
+		}
+
+		require.Equal(t, "client_prev", payload["previous_response_id"])
+		input, ok := payload["input"].([]any)
+		require.True(t, ok)
+		require.Len(t, input, 2)
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_2",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	ctx := webSocketTestContext()
+	for _, body := range [][]byte{
+		[]byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user"}]}`),
+		[]byte(`{"model":"gpt-5","previous_response_id":"client_prev","input":[{"id":"first","type":"message","role":"user"},{"id":"second","type":"message","role":"user"}]}`),
+	} {
+		stream, err := executor.DoStream(ctx, &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"explicit-reconnect"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: body,
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(2), upgrades.Load())
+}
+
+func TestWebSocketExecutorReconnectsWhenSuffixStartsWithAssistantOutput(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrade := upgrades.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+
+		if upgrade == 1 {
+			require.NotContains(t, payload, "previous_response_id")
+			require.NoError(t, conn.WriteJSON(map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id":         "resp_1",
+					"object":     "response",
+					"created_at": 1700000000,
+					"model":      "gpt-5",
+					"status":     "completed",
+					"output":     []any{},
+				},
+			}))
+			return
+		}
+
+		require.NotContains(t, payload, "previous_response_id")
+		input, ok := payload["input"].([]any)
+		require.True(t, ok)
+		require.Len(t, input, 3)
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":         "resp_2",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "completed",
+				"output":     []any{},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	ctx := webSocketTestContext()
+	for _, body := range [][]byte{
+		[]byte(`{"model":"gpt-5","input":[{"id":"user_1","type":"message","role":"user"}]}`),
+		[]byte(`{"model":"gpt-5","input":[{"id":"user_1","type":"message","role":"user"},{"id":"assistant_1","type":"message","role":"assistant"},{"id":"user_2","type":"message","role":"user"}]}`),
+	} {
+		stream, err := executor.DoStream(ctx, &httpclient.Request{
+			Method: http.MethodPost,
+			URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+			Headers: http.Header{
+				webSocketSessionHeader: []string{"assistant-reconnect"},
+			},
+			Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+			Body: body,
+		})
+		require.NoError(t, err)
+		require.True(t, stream.Next())
+		require.Equal(t, "response.completed", stream.Current().Type)
+		require.False(t, stream.Next())
+		require.NoError(t, stream.Err())
+		require.NoError(t, stream.Close())
+	}
+
+	require.Equal(t, int32(2), upgrades.Load())
+}
+
+func TestWebSocketStreamReturnsErrorWhenReusedConnectionClosesBeforeEvent(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var upgrades atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrade := upgrades.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		if upgrade == 1 {
+			require.NoError(t, conn.WriteJSON(map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id":         "resp_1",
+					"object":     "response",
+					"created_at": 1700000000,
+					"model":      "gpt-5",
+					"status":     "completed",
+					"output":     []any{},
+				},
+			}))
+			require.NoError(t, conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+			return
+		}
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	ctx := webSocketTestContext()
+	stream, err := executor.DoStream(ctx, &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"stale-close"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user"}]}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.NoError(t, stream.Err())
+	require.NoError(t, stream.Close())
+
+	stream, err = executor.DoStream(ctx, &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Headers: http.Header{
+			webSocketSessionHeader: []string{"stale-close"},
+		},
+		Auth: &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body: []byte(`{"model":"gpt-5","input":[{"id":"first","type":"message","role":"user"},{"id":"second","type":"message","role":"user"}]}`),
+	})
+	if err != nil {
+		return
+	}
+	defer stream.Close()
+	require.False(t, stream.Next())
+	require.ErrorContains(t, stream.Err(), "websocket closed before response event")
+}
+
 func TestWebSocketExecutorSeparatesPoolByOrganizationHeaders(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
@@ -154,6 +155,50 @@ func TestWebSocketStreamStopsAfterTerminalEventWithoutCloseFrame(t *testing.T) {
 	require.Equal(t, "response.completed", stream.Current().Type)
 	require.False(t, stream.Next())
 	require.NoError(t, stream.Err())
+}
+
+func TestWebSocketStreamReportsContextCancellationWhileReadBlocks(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	payloadRead := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		close(payloadRead)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(webSocketTestContext())
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(ctx, &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	<-payloadRead
+	nextResult := make(chan bool, 1)
+	go func() {
+		nextResult <- stream.Next()
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case ok := <-nextResult:
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("stream.Next did not unblock after context cancellation")
+	}
+	require.ErrorIs(t, stream.Err(), context.Canceled)
 }
 
 func TestWebSocketExecutorReusesConnectionForSameSession(t *testing.T) {

--- a/llm/transformer/shared/session.go
+++ b/llm/transformer/shared/session.go
@@ -7,6 +7,9 @@ import (
 // sessionContextKey is the key used to store and retrieve the session ID from the context.
 type sessionContextKey struct{}
 
+// sessionScopeContextKey is the key used to namespace client-provided session IDs.
+type sessionScopeContextKey struct{}
+
 // WithSessionID sets the session ID in the context.
 // This is essential for features that require cross-request state, such as:
 // 1. Prompt Caching: Providers like Anthropic use session/trace IDs to optimize cache hits.
@@ -19,4 +22,15 @@ func WithSessionID(ctx context.Context, sessionID string) context.Context {
 func GetSessionID(ctx context.Context) (string, bool) {
 	sessionID, ok := ctx.Value(sessionContextKey{}).(string)
 	return sessionID, ok
+}
+
+// WithSessionScope sets a trusted server-side namespace for session-scoped upstream state.
+func WithSessionScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, sessionScopeContextKey{}, scope)
+}
+
+// GetSessionScope retrieves the trusted server-side namespace for session-scoped upstream state.
+func GetSessionScope(ctx context.Context) (string, bool) {
+	scope, ok := ctx.Value(sessionScopeContextKey{}).(string)
+	return scope, ok
 }

--- a/llm/transformer/url.go
+++ b/llm/transformer/url.go
@@ -6,9 +6,13 @@ import (
 
 // NormalizeBaseURL normalizes the base URL for API endpoints.
 // It ensures that the URL ends with the specified version and handles special cases:
-// - URLs ending with "#" are treated as raw URLs (version not appended)
-// - Trailing slashes are removed
-// - Version is appended only if not already present.
+//   - URLs ending with "#" have the marker stripped and skip version appending.
+//     Endpoint paths such as "/responses" may still be appended later by BuildRequestURL.
+//   - Trailing slashes are removed.
+//   - Version is appended only if not already present.
+//
+// This is distinct from transformer-specific "##" handling, which enables true raw URL mode
+// where no default endpoint path is appended.
 func NormalizeBaseURL(url, version string) string {
 	if url == "" {
 		return ""


### PR DESCRIPTION
## 变更说明

本 PR 为 AxonHub 增加上游 OpenAI Responses WebSocket 支持，并在同一会话内复用上游 WebSocket 连接：

- 新增 Responses WebSocket executor，使用 `response.create` 协议并复用现有 Responses stream 聚合链路。
- 支持 OpenAI / Codex Responses WebSocket transport 配置与前端入口。
- 同一受信任会话内复用上游 WS 连接，并把下游完整上下文自动压缩为新增 `input` suffix + `previous_response_id`。
- 当历史上下文被改写、连接中断、取消、失败、不完整或错误时，淘汰旧连接并回退到新连接完整上下文发送。
- WebSocket session pool 绑定服务端认证作用域、上游 URL/auth/header 指纹，避免仅凭客户端 session id 复用连接。
- 增加池大小、连接生命周期和保留 input 大小上限，避免无限保留连接和 prompt 内容。
- 默认 WS 连接保留策略调整为 `idleTTL=50m`、`maxLifetime=50m`：尽量保留连接本地缓存，同时低于 OpenAI 60 分钟连接上限并给新一轮请求保留约 10 分钟余量。

## 连接复用与缓存观察

OpenAI WebSocket 文档说明：活跃 WS 连接会保留一个 connection-local 的最近 `previous_response_id` 状态；连接关闭后，`store=true` 可以尝试从持久化状态恢复，`store=false` / ZDR 没有持久化 fallback。

对 Codex WS 的真实上游探针结果：

- 同一 WS 连接上，`store=false + previous_response_id` 可以成功续接。
- 新 WS 连接上，`store=false + previous_response_id` 返回 `previous_response_not_found`。
- Codex WS 上 `store=true` 被拒绝：`Store must be set to false`。
- 两条新连接重复同一长前缀与同一 `prompt_cache_key`：`cached_tokens=0 / 0`。
- 同一连接重复同一长前缀与同一 `prompt_cache_key`：`cached_tokens=0 / 14080`。

因此 Codex WS 路径下，连接复用不仅减少握手，还直接关系到 `previous_response_id` 续接和实际观测到的 prompt-cache 命中。AxonHub 应避免过早关闭可复用连接。

## 验证

已执行：

- `cd llm && go test ./transformer/openai/responses ./transformer/openai/codex`
- `cd llm && go test -race ./transformer/openai/responses -run 'TestWebSocket'`
- `go test ./internal/server/middleware -run 'Test.*Auth|Test.*Trace'`
- 临时 Go driver 通过 `httptest` WebSocket 服务验证：同一 trusted session 只升级 1 次连接，第二轮携带 `previous_response_id=resp_1` 且只发送 1 条新增 input。
- 真实 Codex WS 探针验证：断开后 `store=false + previous_response_id` 失败、`store=true` 被拒绝、同连接重复长前缀可命中 `cached_tokens=14080`。
- 临时 package-level Go driver 验证默认 WS pool 参数为 `idleTTL=50m`、`maxLifetime=50m`。

## 注意事项

- WebSocket 仅用于上游 `openai/responses` transport；下游仍保持 HTTP/SSE。
- `previous_response_id` 是上游连接本地语义；连接不可复用时会回退为完整上下文新连接。
