### PR TITLE
chore: add claude-opus-4-7 to claudecode DefaultModels

### DIFF
--- a/llm/transformer/anthropic/claudecode/constants.go
+++ b/llm/transformer/anthropic/claudecode/constants.go
@@ -8,6 +8,7 @@ func DefaultModels() []string {
 		"claude-opus-4-5-20251101",
 		"claude-opus-4-6",
 		"claude-sonnet-4-6",
+		"claude-opus-4-7",
 	}
 }
 


### PR DESCRIPTION
Claude Code 2.x lists `claude-opus-4-7` as a first-class model, but `claudecode.DefaultModels()` still tops out at `claude-opus-4-6` / `claude-sonnet-4-6`.

Because `FetchModels` short-circuits on OAuth claudecode channels and returns this hardcoded list (`internal/server/biz/model_fetcher.go` → `getDefaultModelsByType(TypeClaudecode)`), the UI cannot surface 4-7 on a Claude MAX channel. The orchestrator route table then rejects requests for that model with `422 model not found: claude-opus-4-7`.

**Change**: one-line addition to `llm/transformer/anthropic/claudecode/constants.go`'s `DefaultModels()`, same shape as #1605 (gpt-5.5 for codex) and #1006 (gpt-5.4).

**Tested locally**: with this change, a Claude MAX OAuth channel whose `supportedModels` picks up `claude-opus-4-7` from `FetchModels` returns HTTP 200 from `api.anthropic.com/v1/messages` when Claude Code clients request `claude-opus-4-7`.

## Reference

- https://docs.claude.com/en/release-notes/claude-code (Claude Code 2.x release notes — Opus 4.7 is the headline model)
- claudecode `quotaCheckModel` is still `claude-haiku-4-5` (not touched here; 4.5 remains Haiku's current top)