### PR TITLE
fix(channels): show real i18n label for single-variant types like opencode_go

### DIFF
--- a/frontend/src/features/channels/components/channels-type-tabs.tsx
+++ b/frontend/src/features/channels/components/channels-type-tabs.tsx
@@ -22,10 +22,16 @@ interface GroupedTypeCount {
  */
 function groupTypesByPrefix(typeCounts: ChannelTypeCount[]): GroupedTypeCount[] {
   const groups = new Map<string, { types: string[]; totalCount: number }>();
+  // Only fold `<prefix>_<suffix>` under `<prefix>` when `<prefix>` itself is
+  // also a known channel type in this batch — otherwise the bare prefix has
+  // no i18n entry and the tab label falls back to the raw key
+  // (e.g. `opencode_go` has no sibling `opencode`, so it stays as
+  // `opencode_go`; `deepseek_anthropic` + `deepseek` still fold to `deepseek`).
+  const knownTypes = new Set(typeCounts.map(({ type }) => type));
 
   typeCounts.forEach(({ type, count }) => {
-    // Find the base prefix (before the first underscore or the whole string)
-    const prefix = type.split('_')[0];
+    const candidatePrefix = type.split('_')[0];
+    const prefix = knownTypes.has(candidatePrefix) ? candidatePrefix : type;
 
     if (!groups.has(prefix)) {
       groups.set(prefix, { types: [], totalCount: 0 });


### PR DESCRIPTION
## Bug

On the Channels page, the filter tab for the only `opencode_go` channel renders as the raw i18n key `channels.types.opencode` (instead of "OpenCode Go"), even though `frontend/src/locales/{en,zh-CN}/channels.json` already define `channels.types.opencode_go = "OpenCode Go"`. The right-hand provider tag on the row itself renders correctly:

![screenshot](https://raw.githubusercontent.com/qinkangdeid/axonhub/assets/pr-screenshots/2026-05-28-opencode-go-i18n-bug.png)

## Root cause

`channels-type-tabs.tsx` `groupTypesByPrefix` always splits the channel type on `_` and groups by the bare prefix:

```ts
const prefix = type.split('_')[0];
```

This is by design — it collapses e.g. `deepseek` + `deepseek_anthropic` into a single `deepseek` tab. But the design assumes the bare prefix is **itself** a registered channel type with its own i18n entry.

`opencode_go` has no sibling `opencode`. After splitting, the tab is keyed on `opencode`, the i18n lookup misses, and the UI falls back to the raw key. Any future single-variant `<prefix>_<suffix>` type would hit the same trap (e.g. if someone added a `_pro`-only variant).

## Fix

Only fold a `<prefix>_<suffix>` type under `<prefix>` when `<prefix>` is itself present in the same batch as a known channel type. Otherwise keep the full type name as the group key so the existing i18n entry is used.

- `opencode_go` (no sibling `opencode`) → group key stays `opencode_go` → uses existing `channels.types.opencode_go = "OpenCode Go"` ✅
- `deepseek` + `deepseek_anthropic` (both present) → both fold to `deepseek` → existing behaviour preserved ✅
- `anthropic` + `anthropic_aws` + `anthropic_gcp` + `anthropic_fake` → all fold to `anthropic` → existing behaviour preserved ✅

One-file, eight-line change in `frontend/src/features/channels/components/channels-type-tabs.tsx`.

## Test plan

- [x] Verified the i18n entries for `channels.types.opencode_go` are already present in both `en` and `zh-CN` (no locale changes needed)
- [x] Manually traced the grouping logic with the new rule against the 52 channel types in `frontend/src/locales/zh-CN/channels.json` — no regressions in the other multi-variant groups (`anthropic_*`, `deepseek_*`, `doubao_*`, `gemini_*`, `github_*`, `longcat_*`, `minimax_*`, `moonshot_*`, `nanogpt_*`, `openai_*`, `zai_*`, `zhipu_*`, `bailian_*`)
- [ ] CI green