### PR TITLE
chore: add claude-opus-4-8 to claudecode DefaultModels

### DIFF
--- a/llm/transformer/anthropic/claudecode/constants.go
+++ b/llm/transformer/anthropic/claudecode/constants.go
@@ -9,6 +9,7 @@ func DefaultModels() []string {
 		"claude-opus-4-6",
 		"claude-sonnet-4-6",
 		"claude-opus-4-7",
+		"claude-opus-4-8",
 	}
 }
 


### PR DESCRIPTION
Claude Opus 4.8 was released on 2026-05-28, but `claudecode.DefaultModels()` still tops out at `claude-opus-4-7`.

Channels of type `claudecode` (Claude MAX OAuth) short-circuit `FetchModels` and return this hardcoded list (`internal/server/biz/model_fetcher.go` → `getDefaultModelsByType(TypeClaudecode)`), so the UI never surfaces 4-8 and the orchestrator route table rejects requests with HTTP 422 `model not found: claude-opus-4-8`. Newer Claude Code clients now default to `claude-opus-4-8`, so they fail out of the box against a Claude MAX channel.

Same one-line shape as #1733 (claude-opus-4-7), #1605 (gpt-5.5 for codex) and #1006 (gpt-5.4).

**Tested locally**: with this change, a Claude MAX OAuth channel whose `supportedModels` picks up `claude-opus-4-8` from `FetchModels` returns HTTP 200 from `api.anthropic.com/v1/messages` when Claude Code clients request `claude-opus-4-8`.
