### PR TITLE
fix: model association page throws Invalid input for channels without endpoints

### DIFF
--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -694,7 +694,7 @@ export const channelSummarySchema = z.object({
   baseURL: z.string(),
   orderingWeight: z.number(),
   tags: z.array(z.string()).optional().default([]).nullable(),
-  endpoints: z.array(channelEndpointSchema).optional().default([]),
+  endpoints: z.array(channelEndpointSchema).optional().default([]).nullable(),
   allModelEntries: z.array(channelModelEntrySchema).optional().default([]),
 });
 export type ChannelSummary = z.infer<typeof channelSummarySchema>;


### PR DESCRIPTION
## Summary
Allows `null` for `endpoints` field in `channelSummarySchema` to fix Zod validation error when backend returns `endpoints: null` for legacy channels without custom endpoints configured.

## Background
### Where it was introduced
Commit `74d223c6` ("feat(llm): support responses websocket sessions #1730") added the `endpoints` field to the `allChannelSummarys` GraphQL query. This query returns channel summaries for the model association settings page.

### What error it caused
When loading the model association page (`/settings/models`), the frontend queries `allChannelSummarys` which includes the `endpoints` field. For legacy channels that have no custom endpoint overrides configured, the backend returns:
```json
{
  "endpoints": null
}
```

The Zod schema previously defined:
```typescript
endpoints: z.array(channelEndpointSchema).optional().default([])
```

This doesn't allow `null`, causing Zod to throw "Invalid input" for each channel in the list:
```
Validation failed: edges.0.node.endpoints: Invalid input, edges.1.node.endpoints: Invalid input, ...
```

## Solution
Added `.nullable()` to the schema:
```typescript
endpoints: z.array(channelEndpointSchema).optional().default([]).nullable()
```

This allows the field to be `null` (from backend) while still defaulting to `[]` for new channels.

## Testing
- Verified schema accepts payload with `endpoints: null`
- Verified legacy channels without custom endpoints work correctly