### PR TITLE
feat(requests): enable auto-refresh by default on request monitoring page

### DIFF
--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -186,7 +186,7 @@ function RequestsContent() {
     [currentSearch]
   );
   const debouncedModelIDFilter = useDebounce(modelIDFilter, 300);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefresh, setAutoRefresh] = useState(true);
 
   // Build where clause with filters
   const whereClause = (() => {


### PR DESCRIPTION
## What this PR does

Sets the auto-refresh toggle on the request monitoring page to enabled (`true`) by default.

## Why

Currently the auto-refresh toggle defaults to `false`, which means users have to manually enable it every time they visit the request monitoring page or after a page refresh. This is inconvenient for users who want continuous monitoring of their requests.

## Changes

- `frontend/src/features/requests/index.tsx`: Changed `useState(false)` to `useState(true)` for the `autoRefresh` state.

## Testing

1. Visit the request monitoring page
2. Verify the auto-refresh toggle is enabled by default
3. Refresh the page and confirm the toggle remains enabled
4. Navigate away and return to confirm the behavior persists