### PR TITLE
fix(frontend): avoid leaking "{{resource}}" placeholder in NOT_FOUND errors

### DIFF
--- a/frontend/src/hooks/use-error-handler.ts
+++ b/frontend/src/hooks/use-error-handler.ts
@@ -80,7 +80,15 @@ export function useErrorHandler() {
         // Get i18n key and params
         const i18nKey = getErrorI18nKey(code);
         const params = getErrorI18nParams(firstError);
-        
+
+        // Generic NOT_FOUND errors (e.g. relay node lookups) carry no
+        // `resource` extension, so the "{{resource}}" placeholder in
+        // `common.errors.notFound` would otherwise leak into the UI verbatim.
+        // Fall back to a generic noun so the message stays readable.
+        if (i18nKey === 'common.errors.notFound' && !params.resource) {
+          params.resource = t('common.errors.resourceFallback');
+        }
+
         // Build error message
         let message: string;
         try {

--- a/frontend/src/locales/en/base.json
+++ b/frontend/src/locales/en/base.json
@@ -159,6 +159,7 @@
   "common.errors.duplicateName": "Name '{{value}}' already exists. Please choose a different name.",
   "common.errors.duplicateKey": "This item already exists. Please use different values.",
   "common.errors.notFound": "{{resource}} not found",
+  "common.errors.resourceFallback": "Resource",
   "common.errors.forbidden": "You don't have permission to perform this action",
   "common.success.duplicated": "Duplicated successfully",
   "common.success.copiedToClipboard": "Copied to clipboard!",

--- a/frontend/src/locales/zh-CN/base.json
+++ b/frontend/src/locales/zh-CN/base.json
@@ -201,6 +201,7 @@
   "common.errors.duplicateName": "名称 '{{value}}' 已存在，请选择其他名称。",
   "common.errors.duplicateKey": "该项已存在，请使用不同的值。",
   "common.errors.notFound": "{{resource}} 未找到",
+  "common.errors.resourceFallback": "资源",
   "common.errors.forbidden": "您没有权限执行此操作",
   "common.success.duplicated": "复制成功",
   "common.success.copiedToClipboard": "已复制到剪贴板！",


### PR DESCRIPTION
## Problem

Generic `NOT_FOUND` GraphQL errors carry no `resource` extension — e.g. opening a `Request` detail whose record belongs to a different project than the active `x-project-id`, where the relay `node` resolver returns:

```json
{ "errors": [{ "message": "Could not resolve to a node with the global id of '8141'", "extensions": { "code": "NOT_FOUND" } }] }
```

`useErrorHandler` maps `NOT_FOUND` → `common.errors.notFound`, whose string interpolates `{{resource}}`. Since `getErrorI18nParams` only sets `params.resource` when `extensions.resource` is present, the placeholder gets no value and i18next leaves it verbatim, so the toast literally reads:

- `{{resource}} not found`
- `{{resource}} 未找到`

## Fix

Add a localized `common.errors.resourceFallback` (`Resource` / `资源`) and use it in `useErrorHandler` when a not-found error provides no resource name, so the message degrades to a readable `Resource not found` / `资源 未找到` instead of leaking the raw placeholder.

Targeted to the `common.errors.notFound` path only; errors that *do* carry `extensions.resource` are unchanged.

## Changes

- `frontend/src/hooks/use-error-handler.ts` — fallback when `resource` is absent
- `frontend/src/locales/{en,zh-CN}/base.json` — new `common.errors.resourceFallback` key (en/zh in sync)

## Testing

- `en` / `zh-CN` base.json validated as JSON; key sets remain in parity.
- Reproduced against a live v1.0.0-beta1 instance: opening a cross-project Request detail produced the `{{resource}}` toast; with this change it renders the fallback noun.