### PR TITLE
fix: auto reasoning effort for qwen max, close #1751

### DIFF
--- a/internal/server/orchestrator/auto_reasoning_effort.go
+++ b/internal/server/orchestrator/auto_reasoning_effort.go
@@ -73,10 +73,27 @@ func splitAutoReasoningEffortModel(model string) (baseModel string, reasoningEff
 		return "", "", false
 	}
 
+	if effort == "max" && isQwenMaxModel(model) {
+		return "", "", false
+	}
+
 	base := model[:lastDash]
 	if base == "" {
 		return "", "", false
 	}
 
 	return base, effort, true
+}
+
+func isQwenMaxModel(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if !strings.HasSuffix(normalized, "-max") {
+		return false
+	}
+
+	if lastSlash := strings.LastIndex(normalized, "/"); lastSlash >= 0 {
+		normalized = normalized[lastSlash+1:]
+	}
+
+	return strings.HasPrefix(normalized, "qwen")
 }

--- a/internal/server/orchestrator/auto_reasoning_effort_test.go
+++ b/internal/server/orchestrator/auto_reasoning_effort_test.go
@@ -37,6 +37,16 @@ func TestSplitAutoReasoningEffortModel(t *testing.T) {
 			wantNormalized: true,
 		},
 		{
+			name:           "ignores qwen max model",
+			model:          "qwen3.7-max",
+			wantNormalized: false,
+		},
+		{
+			name:           "ignores namespaced qwen max model",
+			model:          "qwen/qwen3-max",
+			wantNormalized: false,
+		},
+		{
 			name:           "supports uppercase suffix",
 			model:          "gpt-5.4-HIGH",
 			wantBaseModel:  "gpt-5.4",
@@ -110,6 +120,17 @@ func TestAutoReasoningEffortMiddleware_OnInboundLlmRequest(t *testing.T) {
 			},
 			wantModel:  "gpt-5.4",
 			wantEffort: "max",
+		},
+		{
+			name: "enabled setting keeps qwen max model unchanged",
+			settings: biz.SystemModelSettings{
+				AutoReasoningEffort: true,
+			},
+			request: &llm.Request{
+				Model: "qwen3.7-max",
+			},
+			wantModel:  "qwen3.7-max",
+			wantEffort: "",
 		},
 		{
 			name: "suffix reasoning effort overrides explicit request value",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/looplj/axonhub/pull/1765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->