### PR TITLE
fix(frontend): guard execution channel query by permission

### DIFF
--- a/frontend/src/features/requests/data/requests.ts
+++ b/frontend/src/features/requests/data/requests.ts
@@ -23,12 +23,20 @@ function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChann
           }`
     : '';
 
-  const channelFields = permissions.canViewChannels
+  const requestChannelFields = permissions.canViewChannels
     ? `
                 channel {
                   id
                   name
                 }`
+    : '';
+
+  const executionChannelFields = permissions.canViewChannels
+    ? `
+                  channel {
+                    id
+                    name
+                  }`
     : '';
 
   return `
@@ -45,7 +53,7 @@ function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChann
           node {
             id
             createdAt
-            updatedAt${apiKeyFields}${channelFields}
+            updatedAt${apiKeyFields}${requestChannelFields}
             source
             modelID
             format
@@ -60,11 +68,7 @@ function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChann
               edges {
                 node {
                   modelID
-                  status
-                  channel {
-                    id
-                    name
-                  }
+                  status${executionChannelFields}
                 }
                 cursor
               }


### PR DESCRIPTION
## Bug 现象

当用户只有 `read_requests` 权限、没有 `read_channels` 权限时，访问 `/project/requests` 请求日志页面会失败并提示无权限。预期行为是：该用户可以查看请求日志列表，但不显示渠道相关信息。

## 问题原因

`GetRequests` 前端 GraphQL 查询中，顶层 `request.channel` 已根据 `canViewChannels` 做了条件拼接，但 `executions` 子查询里的 `channel { id name }` 仍然是无条件请求。

后端 `Channel` 查询策略要求 `read_channels` 权限，因此只有 `read_requests` 的用户虽然可以查询 `Request`，但 GraphQL 展开 `RequestExecution.channel` 时会触发 `Channel` 权限校验并被拒绝。

## 修复方法

将请求列表查询中的 `executions.channel` 改为按 `canViewChannels` 条件拼接：

- 有 `read_channels` 权限时，继续请求并展示渠道信息。
- 没有 `read_channels` 权限时，不再请求 `channel` 字段，只保留 `modelID`、`status` 等非渠道字段。

这样可以保持后端权限模型不变，同时允许只有 `read_requests` 权限的用户正常查看请求日志。