### PR TITLE
fix(openai): aggregate stream choices by index to avoid nil panic

### DIFF
--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -256,9 +256,15 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		return data, llm.ResponseMeta{}, err
 	}
 
-	choices := make([]llm.Choice, len(choicesAggs))
+	choiceIndexes := make([]int, 0, len(choicesAggs))
+	for choiceIndex := range choicesAggs {
+		choiceIndexes = append(choiceIndexes, choiceIndex)
+	}
+	sort.Ints(choiceIndexes)
 
-	for choiceIndex := range choices {
+	choices := make([]llm.Choice, len(choiceIndexes))
+
+	for i, choiceIndex := range choiceIndexes {
 		choiceAgg := choicesAggs[choiceIndex]
 
 		var finalToolCalls []llm.ToolCall
@@ -324,7 +330,7 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 			}
 		}
 
-		choices[choiceIndex] = llm.Choice{
+		choices[i] = llm.Choice{
 			Index:        choiceIndex,
 			Message:      message,
 			FinishReason: finishReason,

--- a/llm/transformer/openai/aggregator_nonzero_index_test.go
+++ b/llm/transformer/openai/aggregator_nonzero_index_test.go
@@ -1,0 +1,33 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// TestAggregateStreamChunksNonZeroChoiceIndex ensures that a stream whose only
+// choice carries a non-zero index aggregates without panicking. choicesAggs is
+// keyed by the choice index, so a sparse/non-zero-based index must not be
+// looked up positionally.
+func TestAggregateStreamChunksNonZeroChoiceIndex(t *testing.T) {
+	chunk := `{"id":"chatcmpl-1","model":"gpt-4o-mini","object":"chat.completion.chunk","created":1,` +
+		`"choices":[{"index":1,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`
+
+	chunks := []*httpclient.StreamEvent{{Data: []byte(chunk)}}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	require.NoError(t, json.Unmarshal(gotBytes, &got))
+	require.Len(t, got.Choices, 1)
+	require.Equal(t, 1, got.Choices[0].Index)
+	require.NotNil(t, got.Choices[0].Message.Content.Content)
+	require.Equal(t, "hi", *got.Choices[0].Message.Content.Content)
+}


### PR DESCRIPTION
## Problem

`AggregateStreamChunks` collects choices into `choicesAggs`, a `map[int]*choiceAggregator` keyed by each choice's `index`. When building the final response it allocated `choices := make([]llm.Choice, len(choicesAggs))` and then iterated `for choiceIndex := range choices`, using the positional slot (0..len-1) as the map key.

If a stream's choice indexes are not a contiguous 0-based range (for example an OpenAI-compatible upstream that emits a single choice at index 1), the map lookup misses, `choiceAgg` is nil, and the next line dereferences it:

```
panic: runtime error: invalid memory address or nil pointer dereference
.../llm/transformer/openai/aggregator.go: AggregateStreamChunks
```

This crashes the whole stream aggregation, leaving the request stuck in `processing`.

## Fix

Collect the actual choice indexes, sort them, and iterate over those, using the real index for both the map lookup and the output `Index`. For the common contiguous 0-based case the result is unchanged. Adds a regression test covering a non-zero choice index.

Fixes #1767.