### PR TITLE
fix: add UserOwnedMutationRule to user schema policy

### DIFF
--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -107,6 +107,7 @@ func (User) Policy() ent.Policy {
 		Mutation: scopes.MutationPolicy{
 			scopes.OwnerRule(),
 			scopes.UserWriteScopeRule(scopes.ScopeWriteUsers),
+			scopes.UserOwnedMutationRule(),
 		},
 	}
 }


### PR DESCRIPTION
Non-owner users receive a "permission denied" error when switching language.