### PR TITLE
fix(datastorage): remove unbounded in-memory cache of request/response bodies (OOM)

### DIFF
--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -410,10 +410,13 @@ func (s *DataStorageService) createS3Fs(ctx context.Context, s3Config *objects.S
 		o.UsePathStyle = s3Config.PathStyle
 	})
 
-	baseFs := s3fs.NewFsFromClient(s3Config.BucketName, client)
-	cachedFs := afero.NewCacheOnReadFs(baseFs, afero.NewMemMapFs(), 5*time.Minute)
-
-	return cachedFs, nil
+	// NOTE: do NOT wrap baseFs in afero.NewCacheOnReadFs(..., afero.NewMemMapFs(), ...).
+	// That in-memory layer is never evicted (afero's cacheTime only re-checks
+	// freshness on read), so it retained a copy of every request/response body
+	// ever written and caused recurring OOMs. Request/response bodies are
+	// write-once and read rarely (admin request-detail view), so reads go
+	// directly to the object store instead of through an in-memory cache.
+	return s3fs.NewFsFromClient(s3Config.BucketName, client), nil
 }
 
 // createGcsFs creates a GCS filesystem using the afero gcsfs adapter.
@@ -436,11 +439,10 @@ func (s *DataStorageService) createGcsFs(ctx context.Context, gcsConfig *objects
 		return nil, fmt.Errorf("failed to create GCS filesystem: %w", err)
 	}
 
-	basePathFs := afero.NewBasePathFs(fs, gcsConfig.BucketName)
-
-	cachedFs := afero.NewCacheOnReadFs(basePathFs, afero.NewMemMapFs(), 5*time.Minute)
-
-	return cachedFs, nil
+	// NOTE: do NOT wrap in afero.NewCacheOnReadFs(..., afero.NewMemMapFs(), ...).
+	// The in-memory layer is never evicted and leaks every body forever (see
+	// createS3Fs). Reads go directly to the object store.
+	return afero.NewBasePathFs(fs, gcsConfig.BucketName), nil
 }
 
 // createWebDAVFs creates a WebDAV filesystem using the afero-webdav adapter.


### PR DESCRIPTION
## Problem

`DataStorageService` builds the S3 and GCS filesystems by wrapping the remote FS in
`afero.NewCacheOnReadFs(base, afero.NewMemMapFs(), 5*time.Minute)`
(`internal/server/biz/data_storage.go`, `createS3Fs` / `createGcsFs`).

The in-memory `MemMapFs` cache layer is **never evicted**: afero's `cacheTime`
is only a read-staleness check (it re-reads from base when a cached file is older
than the TTL) — it never removes entries from the layer. With `store_request_body` /
`store_response_body` enabled, every request writes body files keyed by a unique
request id, so the in-memory layer accumulates a copy of **every body ever written**
and grows without bound until the process is OOM-killed and restarts — repeatedly.

## Evidence

Heap profiling of an affected instance (`go tool pprof -inuse_space`) showed the
live heap dominated by this cache:

- `github.com/spf13/afero/mem.(*File).Write` ≈ **97%** of in-use heap, reached via
  `afero.(*UnionFile).Write` (the `CacheOnReadFs` layer) on the HTTP request path.
- Live heap grew monotonically (~10 MB/min under traffic) until the memory limit,
  then OOM — reproduced across multiple independent capture windows.
- Goroutine count was stable, ruling out a goroutine leak.

## Fix

`createS3Fs` / `createGcsFs` now return the base filesystem directly, with no
in-memory `CacheOnReadFs` layer. Request/response bodies are write-once and read
rarely (the admin request-detail view), so reads go straight to the object store.
This removes the unbounded retention entirely and keeps object storage
authoritative (no cache staleness on overwrite, delete, or storage reconfiguration).

A bounded in-memory LRU read cache was considered, but for a write-once /
read-rarely blob workload it provides marginal benefit while adding
cache-invalidation surface, so it was dropped in favor of the simpler, fully
correct approach.

## Verification

- Built and deployed the fixed image; UI and API healthy.
- Observed ~80 min under real traffic: live heap peaks at ~86 MB and oscillates
  around ~50 MB (vs. a monotonic climb to ~470 MB before the fix); **0 OOM kills,
  0 restarts** (previously OOM-killed every 25–80 min).
- `golangci-lint` reports no new issues.

Diff: `internal/server/biz/data_storage.go` only (+11 / −9).
