### PR TITLE
fix: allow users to update language preference

### DIFF
--- a/internal/server/biz/user.go
+++ b/internal/server/biz/user.go
@@ -163,15 +163,13 @@ func (s *UserService) UpdateUser(ctx context.Context, id int, input ent.UpdateUs
 }
 
 // UpdateOwnProfile updates fields users are allowed to change for their own account.
-func (s *UserService) UpdateOwnProfile(ctx context.Context, id int, input ent.UpdateUserInput) (*ent.User, error) {
+func (s *UserService) UpdateOwnProfile(ctx context.Context, input ent.UpdateUserInput) (*ent.User, error) {
 	currentUser, ok := contexts.GetUser(ctx)
 	if !ok || currentUser == nil {
 		return nil, fmt.Errorf("user not found in context")
 	}
 
-	if currentUser.ID != id {
-		return nil, fmt.Errorf("permission denied: cannot update another user's profile")
-	}
+	id := currentUser.ID
 
 	return authz.RunWithSystemBypass(ctx, "update-own-profile", func(ctx context.Context) (*ent.User, error) {
 		client := s.entFromContext(ctx)

--- a/internal/server/biz/user.go
+++ b/internal/server/biz/user.go
@@ -8,6 +8,8 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/role"
 	"github.com/looplj/axonhub/internal/ent/user"
@@ -158,6 +160,52 @@ func (s *UserService) UpdateUser(ctx context.Context, id int, input ent.UpdateUs
 	s.invalidateUserCache(ctx, id)
 
 	return user, nil
+}
+
+// UpdateOwnProfile updates fields users are allowed to change for their own account.
+func (s *UserService) UpdateOwnProfile(ctx context.Context, id int, input ent.UpdateUserInput) (*ent.User, error) {
+	currentUser, ok := contexts.GetUser(ctx)
+	if !ok || currentUser == nil {
+		return nil, fmt.Errorf("user not found in context")
+	}
+
+	if currentUser.ID != id {
+		return nil, fmt.Errorf("permission denied: cannot update another user's profile")
+	}
+
+	return authz.RunWithSystemBypass(ctx, "update-own-profile", func(ctx context.Context) (*ent.User, error) {
+		client := s.entFromContext(ctx)
+
+		mut := client.User.UpdateOneID(id).
+			SetNillableFirstName(input.FirstName).
+			SetNillableLastName(input.LastName).
+			SetNillablePreferLanguage(input.PreferLanguage)
+
+		if input.ClearAvatar {
+			mut.ClearAvatar()
+		} else {
+			mut.SetNillableAvatar(input.Avatar)
+		}
+
+		if input.Password != nil {
+			hashedPassword, err := HashPassword(*input.Password)
+			if err != nil {
+				return nil, err
+			}
+
+			mut.SetPassword(hashedPassword)
+		}
+
+		user, err := mut.Save(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update user profile: %w", err)
+		}
+
+		// Invalidate cache
+		s.invalidateUserCache(ctx, id)
+
+		return user, nil
+	})
 }
 
 // UpdateUserStatus updates the status of a user.

--- a/internal/server/gql/me.resolvers.go
+++ b/internal/server/gql/me.resolvers.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) UpdateMe(ctx context.Context, input UpdateMeInput) (*
 		return nil, fmt.Errorf("user not found in context")
 	}
 
-	return r.userService.UpdateOwnProfile(ctx, user.ID, ent.UpdateUserInput{
+	return r.userService.UpdateOwnProfile(ctx, ent.UpdateUserInput{
 		FirstName:      input.FirstName,
 		LastName:       input.LastName,
 		PreferLanguage: input.PreferLanguage,
@@ -56,7 +56,7 @@ func (r *mutationResolver) UpdateMyPassword(ctx context.Context, input UpdateMyP
 		}
 	}
 
-	_, err := r.userService.UpdateOwnProfile(ctx, user.ID, ent.UpdateUserInput{
+	_, err := r.userService.UpdateOwnProfile(ctx, ent.UpdateUserInput{
 		Password: &input.NewPassword,
 	})
 	if err != nil {

--- a/internal/server/gql/me.resolvers.go
+++ b/internal/server/gql/me.resolvers.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) UpdateMe(ctx context.Context, input UpdateMeInput) (*
 		return nil, fmt.Errorf("user not found in context")
 	}
 
-	return r.userService.UpdateUser(ctx, user.ID, ent.UpdateUserInput{
+	return r.userService.UpdateOwnProfile(ctx, user.ID, ent.UpdateUserInput{
 		FirstName:      input.FirstName,
 		LastName:       input.LastName,
 		PreferLanguage: input.PreferLanguage,
@@ -56,7 +56,7 @@ func (r *mutationResolver) UpdateMyPassword(ctx context.Context, input UpdateMyP
 		}
 	}
 
-	_, err := r.userService.UpdateUser(ctx, user.ID, ent.UpdateUserInput{
+	_, err := r.userService.UpdateOwnProfile(ctx, user.ID, ent.UpdateUserInput{
 		Password: &input.NewPassword,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes a permission error that occurred when regular users changed their UI language.

## Changes

- Added a self-service profile update path for authenticated users.
- Updated the `updateMe` resolver to use the self-service profile update path.
- Ensured users can only update their own profile.
- Limited the self-service update path to profile fields such as `firstName`, `lastName`, `preferLanguage`, `avatar`, and `password`.
- Kept the existing admin `UpdateUser` permission checks unchanged.

## Motivation

Changing the language preference calls the `updateMe` mutation with `preferLanguage`.

Previously, `updateMe` reused the admin user update service, which requires user management permissions. Regular users do not have those permissions, so saving the language preference failed with `permission denied`.

This change separates self-profile updates from admin user management updates, allowing users to update their own language preference safely.

## Verification

Ran targeted backend tests:

```sh
go test ./internal/server/biz ./internal/server/gql
Both packages passed.