### PR TITLE
fix(audio): 修复 TTS 流式 Accept、外部存储与持久化内存占用

### DIFF
--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-contrib/sse"
 	"github.com/gin-gonic/gin"
@@ -57,7 +58,13 @@ func (handlers *ChatCompletionHandlers) ChatCompletion(c *gin.Context) {
 		return
 	}
 
-	if len(genericReq.Body) == 0 {
+	handlers.ChatCompletionWithRequest(c, genericReq)
+}
+
+func (handlers *ChatCompletionHandlers) ChatCompletionWithRequest(c *gin.Context, genericReq *httpclient.Request) {
+	ctx := c.Request.Context()
+
+	if genericReq == nil || len(genericReq.Body) == 0 {
 		JSONError(c, http.StatusBadRequest, errors.New("Request body is empty"))
 		return
 	}
@@ -163,6 +170,91 @@ func WriteSSEStreamWithErrorFormatter(c *gin.Context, stream streams.Stream[*htt
 			}
 		}
 	}
+}
+
+// WriteBinaryStream writes raw bytes from stream events directly to the response body.
+// The first chunk type is treated as the stream Content-Type when present.
+func WriteBinaryStream(c *gin.Context, stream streams.Stream[*httpclient.StreamEvent]) {
+	ctx := c.Request.Context()
+	clientDisconnected := false
+	headersWritten := false
+	contentType := "application/octet-stream"
+
+	defer func() {
+		if clientDisconnected {
+			log.Warn(ctx, "Client disconnected")
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			clientDisconnected = true
+			log.Warn(ctx, "Context done, stopping binary stream")
+			return
+		default:
+			if !stream.Next() {
+				if stream.Err() != nil {
+					log.Error(ctx, "Error in binary stream", log.Cause(stream.Err()))
+					if !headersWritten {
+						c.JSON(streamErrorStatus(stream.Err()), FormatStreamError(ctx, stream.Err()))
+						return
+					}
+				}
+
+				c.Writer.Flush()
+				return
+			}
+
+			cur := stream.Current()
+			if cur != nil && cur.Type == httpclient.BinaryStreamDoneEventType {
+				continue
+			}
+
+			if cur == nil || len(cur.Data) == 0 {
+				continue
+			}
+
+			if !headersWritten {
+				if ct := strings.TrimSpace(cur.Type); ct != "" {
+					contentType = ct
+				}
+
+				c.Header("Content-Type", contentType)
+				c.Header("Cache-Control", "no-cache")
+				c.Header("Connection", "keep-alive")
+				c.Header("Access-Control-Allow-Origin", "*")
+				headersWritten = true
+			}
+
+			if _, err := c.Writer.Write(cur.Data); err != nil {
+				clientDisconnected = true
+				log.Warn(ctx, "Failed to write binary stream chunk", log.Cause(err))
+				return
+			}
+
+			c.Writer.Flush()
+		}
+	}
+}
+
+func streamErrorStatus(err error) int {
+	var quotaErr *orchestrator.QuotaExhaustedError
+	if errors.As(err, &quotaErr) {
+		return http.StatusServiceUnavailable
+	}
+
+	var respErr *llm.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode != 0 {
+		return respErr.StatusCode
+	}
+
+	var httpErr *httpclient.Error
+	if errors.As(err, &httpErr) && httpErr.StatusCode != 0 {
+		return httpErr.StatusCode
+	}
+
+	return http.StatusInternalServerError
 }
 
 // FormatStreamError formats a stream error into an OpenAI-compatible JSON error object.

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -83,6 +83,39 @@ func (s *errorAfterStream) Err() error {
 
 func (s *errorAfterStream) Close() error { return nil }
 
+type trackingStream struct {
+	items   []*httpclient.StreamEvent
+	idx     int
+	current *httpclient.StreamEvent
+}
+
+func (s *trackingStream) Next() bool {
+	if s.idx >= len(s.items) {
+		return false
+	}
+
+	s.current = s.items[s.idx]
+	s.idx++
+
+	return true
+}
+
+func (s *trackingStream) Current() *httpclient.StreamEvent { return s.current }
+func (s *trackingStream) Err() error                       { return nil }
+func (s *trackingStream) Close() error                     { return nil }
+
+type failingResponseWriter struct {
+	gin.ResponseWriter
+	err    error
+	writes int
+}
+
+func (w *failingResponseWriter) Write(_ []byte) (int, error) {
+	w.writes++
+
+	return 0, w.err
+}
+
 func TestWriteSSEStream_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -253,6 +286,74 @@ func TestWriteSSEStream_NoError(t *testing.T) {
 
 	body := w.Body.String()
 	assert.NotContains(t, body, "event:error")
+}
+
+func TestWriteBinaryStream(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := streams.SliceStream([]*httpclient.StreamEvent{
+		{Type: "audio/mpeg", Data: []byte{0x01, 0x02}},
+		{Type: "audio/mpeg", Data: []byte{0x03, 0x04, 0x05}},
+	})
+
+	WriteBinaryStream(c, stream)
+
+	require.Equal(t, "audio/mpeg", w.Header().Get("Content-Type"))
+	require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04, 0x05}, w.Body.Bytes())
+}
+
+func TestWriteBinaryStream_ErrorBeforeFirstChunkReturnsJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := &errorAfterStream{
+		err: &httpclient.Error{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       []byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit"},"request_id":"req_1"}`),
+		},
+	}
+
+	WriteBinaryStream(c, stream)
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	errorField, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "rate_limit_error", errorField["type"])
+	require.Equal(t, "rate_limit", errorField["code"])
+	require.Equal(t, "req_1", body["request_id"])
+}
+
+func TestWriteBinaryStream_WriteErrorStopsConsuming(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	failingWriter := &failingResponseWriter{
+		ResponseWriter: c.Writer,
+		err:            errors.New("broken pipe"),
+	}
+	c.Writer = failingWriter
+
+	stream := &trackingStream{
+		items: []*httpclient.StreamEvent{
+			{Type: "audio/mpeg", Data: []byte{0x01}},
+			{Type: "audio/mpeg", Data: []byte{0x02}},
+		},
+	}
+
+	WriteBinaryStream(c, stream)
+
+	require.Equal(t, 1, failingWriter.writes)
+	require.Equal(t, 1, stream.idx)
+	require.Empty(t, w.Body.Bytes())
 }
 
 func TestFormatStreamError_PlainError(t *testing.T) {

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -106,6 +106,7 @@ func (s *trackingStream) Close() error                     { return nil }
 
 type failingResponseWriter struct {
 	gin.ResponseWriter
+
 	err    error
 	writes int
 }

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -19,6 +19,7 @@ import (
 	"github.com/looplj/axonhub/internal/server/orchestrator"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
@@ -63,6 +64,10 @@ type OpenAIHandlers struct {
 	TranslationHandlers        *ChatCompletionHandlers
 	SpeechInboundTransformer   *openai.AudioInboundTransformer
 	EntClient                  *ent.Client
+}
+
+type speechRouteRequestBody struct {
+	StreamFormat string `json:"stream_format"`
 }
 
 func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
@@ -315,25 +320,43 @@ func (handlers *OpenAIHandlers) CreateSpeech(c *gin.Context) {
 		return
 	}
 
-	llmReq, err := handlers.SpeechInboundTransformer.TransformRequest(ctx, genericReq)
+	useBinaryStream, err := shouldUseBinarySpeechStream(genericReq)
 	if err != nil {
 		httpErr := handlers.SpeechHandlers.ChatCompletionOrchestrator.Inbound.TransformError(ctx, err)
 		c.JSON(httpErr.StatusCode, json.RawMessage(httpErr.Body))
 		return
 	}
 
-	isStream := llmReq.Stream != nil && *llmReq.Stream
-	if !isStream {
-		handlers.SpeechHandlers.ChatCompletionWithRequest(c, genericReq)
-		return
-	}
-
-	if llmReq.Speech != nil && llmReq.Speech.StreamFormat == "sse" {
+	if !useBinaryStream {
 		handlers.SpeechHandlers.ChatCompletionWithRequest(c, genericReq)
 		return
 	}
 
 	handlers.SpeechHandlers.WithStreamWriter(WriteBinaryStream).ChatCompletionWithRequest(c, genericReq)
+}
+
+func shouldUseBinarySpeechStream(genericReq *httpclient.Request) (bool, error) {
+	if genericReq == nil {
+		return false, fmt.Errorf("%w: http request is nil", transformer.ErrInvalidRequest)
+	}
+
+	if len(genericReq.Body) == 0 {
+		return false, fmt.Errorf("%w: request body is empty", transformer.ErrInvalidRequest)
+	}
+
+	contentType := strings.ToLower(genericReq.Headers.Get("Content-Type"))
+	if contentType != "" && !strings.Contains(contentType, "application/json") {
+		return false, nil
+	}
+
+	var body speechRouteRequestBody
+	if err := json.Unmarshal(genericReq.Body, &body); err != nil {
+		return false, fmt.Errorf("%w: failed to decode speech request: %w", transformer.ErrInvalidRequest, err)
+	}
+
+	streamFormat := strings.ToLower(strings.TrimSpace(body.StreamFormat))
+
+	return streamFormat != "" && streamFormat != "sse", nil
 }
 
 // CreateTranscription handles POST /v1/audio/transcriptions (speech-to-text).

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -61,11 +61,13 @@ type OpenAIHandlers struct {
 	SpeechHandlers             *ChatCompletionHandlers
 	TranscriptionHandlers      *ChatCompletionHandlers
 	TranslationHandlers        *ChatCompletionHandlers
+	SpeechInboundTransformer   *openai.AudioInboundTransformer
 	EntClient                  *ent.Client
 }
 
 func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 	videoInbound := openai.NewVideoInboundTransformer()
+	speechInbound := openai.NewSpeechInboundTransformer()
 
 	return &OpenAIHandlers{
 		ChatCompletionHandlers: &ChatCompletionHandlers{
@@ -233,7 +235,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.DefaultSelector,
 				params.RequestService,
 				params.HttpClient,
-				openai.NewSpeechInboundTransformer(),
+				speechInbound,
 				params.SystemService,
 				params.UsageLogService,
 				params.PromptService,
@@ -244,6 +246,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 				params.ProviderQuotaStatusProvider,
 			),
 		},
+		SpeechInboundTransformer: speechInbound,
 		TranscriptionHandlers: &ChatCompletionHandlers{
 			ChatCompletionOrchestrator: orchestrator.NewChatCompletionOrchestrator(
 				params.ChannelService,
@@ -303,7 +306,34 @@ func (handlers *OpenAIHandlers) CreateEmbedding(c *gin.Context) {
 
 // CreateSpeech handles POST /v1/audio/speech (text-to-speech). The response is binary audio.
 func (handlers *OpenAIHandlers) CreateSpeech(c *gin.Context) {
-	handlers.SpeechHandlers.ChatCompletion(c)
+	ctx := c.Request.Context()
+
+	genericReq, err := httpclient.ReadHTTPRequest(c.Request)
+	if err != nil {
+		httpErr := handlers.SpeechHandlers.ChatCompletionOrchestrator.Inbound.TransformError(ctx, err)
+		c.JSON(httpErr.StatusCode, json.RawMessage(httpErr.Body))
+		return
+	}
+
+	llmReq, err := handlers.SpeechInboundTransformer.TransformRequest(ctx, genericReq)
+	if err != nil {
+		httpErr := handlers.SpeechHandlers.ChatCompletionOrchestrator.Inbound.TransformError(ctx, err)
+		c.JSON(httpErr.StatusCode, json.RawMessage(httpErr.Body))
+		return
+	}
+
+	isStream := llmReq.Stream != nil && *llmReq.Stream
+	if !isStream {
+		handlers.SpeechHandlers.ChatCompletionWithRequest(c, genericReq)
+		return
+	}
+
+	if llmReq.Speech != nil && llmReq.Speech.StreamFormat == "sse" {
+		handlers.SpeechHandlers.ChatCompletionWithRequest(c, genericReq)
+		return
+	}
+
+	handlers.SpeechHandlers.WithStreamWriter(WriteBinaryStream).ChatCompletionWithRequest(c, genericReq)
 }
 
 // CreateTranscription handles POST /v1/audio/transcriptions (speech-to-text).

--- a/internal/server/api/openai_speech_test.go
+++ b/internal/server/api/openai_speech_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	entrequest "github.com/looplj/axonhub/internal/ent/request"
+	entrequestexecution "github.com/looplj/axonhub/internal/ent/requestexecution"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/orchestrator"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+type speechAPISelector struct {
+	candidates []*orchestrator.ChannelModelsCandidate
+}
+
+func (s *speechAPISelector) Select(context.Context, *llm.Request) ([]*orchestrator.ChannelModelsCandidate, error) {
+	return s.candidates, nil
+}
+
+type speechAPIExecutor struct {
+	streamEvents   []*httpclient.StreamEvent
+	doStreamCalled bool
+	lastRequest    *httpclient.Request
+}
+
+func (e *speechAPIExecutor) Do(context.Context, *httpclient.Request) (*httpclient.Response, error) {
+	return nil, errors.New("unexpected non-stream speech request")
+}
+
+func (e *speechAPIExecutor) DoStream(_ context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	e.doStreamCalled = true
+	e.lastRequest = request
+
+	return streams.SliceStream(e.streamEvents), nil
+}
+
+func setupSpeechAPITestServices(t *testing.T, client *ent.Client) (*biz.ChannelService, *biz.RequestService, *biz.SystemService, *biz.UsageLogService) {
+	t.Helper()
+
+	cacheConfig := xcache.Config{Mode: xcache.ModeMemory}
+	systemService := biz.NewSystemService(biz.SystemServiceParams{
+		CacheConfig: cacheConfig,
+		Ent:         client,
+	})
+	dataStorageService := &biz.DataStorageService{
+		AbstractService: &biz.AbstractService{},
+		SystemService:   systemService,
+		Cache:           xcache.NewFromConfig[ent.DataStorage](cacheConfig),
+	}
+	channelService := biz.NewChannelServiceForTest(client)
+	usageLogService := biz.NewUsageLogService(client, systemService, channelService)
+	requestService := biz.NewRequestService(client, systemService, usageLogService, dataStorageService, biz.NewLiveStreamRegistry())
+
+	return channelService, requestService, systemService, usageLogService
+}
+
+func TestOpenAIHandlers_CreateSpeech_AudioStreamEndToEnd(t *testing.T) {
+	ctx := ent.NewContext(authz.WithTestBypass(context.Background()), enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0"))
+	client := ent.FromContext(ctx)
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	modelID := "gpt-4o-mini-tts"
+	channelRow, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Speech Test Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-api-key"}).
+		SetSupportedModels([]string{modelID}).
+		SetDefaultTestModel(modelID).
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	channelService, requestService, systemService, usageLogService := setupSpeechAPITestServices(t, client)
+	require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+		StoreChunks:       true,
+		LivePreview:       false,
+		StoreRequestBody:  true,
+		StoreResponseBody: true,
+	}))
+
+	outbound, err := openai.NewOutboundTransformer(channelRow.BaseURL, channelRow.Credentials.APIKey)
+	require.NoError(t, err)
+
+	bizChannel := &biz.Channel{Channel: channelRow, Outbound: outbound}
+	selector := &speechAPISelector{
+		candidates: []*orchestrator.ChannelModelsCandidate{{
+			Channel: bizChannel,
+			Models: []biz.ChannelModelEntry{{
+				RequestModel: modelID,
+				ActualModel:  modelID,
+				Source:       "direct",
+			}},
+		}},
+	}
+	executor := &speechAPIExecutor{
+		streamEvents: []*httpclient.StreamEvent{
+			{Type: "audio/mpeg", Data: []byte{0x01, 0x02}},
+			{Type: "audio/mpeg", Data: []byte{0x03}},
+			{Type: httpclient.BinaryStreamDoneEventType},
+		},
+	}
+
+	speechInbound := openai.NewSpeechInboundTransformer()
+	promptProtectionService := biz.NewPromptProtectionRuleService(biz.PromptProtectionRuleServiceParams{
+		CacheConfig: xcache.Config{Mode: xcache.ModeMemory},
+		Ent:         client,
+	})
+	t.Cleanup(promptProtectionService.Stop)
+
+	speechOrchestrator := orchestrator.NewChatCompletionOrchestrator(
+		channelService,
+		nil,
+		requestService,
+		httpclient.NewHttpClient(),
+		speechInbound,
+		systemService,
+		usageLogService,
+		nil,
+		nil,
+		promptProtectionService,
+		biz.NewLiveStreamRegistry(),
+		orchestrator.NewChannelLimiterManager(),
+		nil,
+	).WithChannelSelector(selector)
+	speechOrchestrator.PipelineFactory = pipeline.NewFactory(executor)
+
+	handlers := &OpenAIHandlers{
+		SpeechHandlers:           NewChatCompletionHandlers(speechOrchestrator),
+		SpeechInboundTransformer: speechInbound,
+	}
+
+	body := `{"model":"gpt-4o-mini-tts","input":"Hi","voice":"alloy","stream_format":"audio"}`
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	c.Request = c.Request.WithContext(ctx)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handlers.CreateSpeech(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "audio/mpeg", w.Header().Get("Content-Type"))
+	require.Equal(t, []byte{0x01, 0x02, 0x03}, w.Body.Bytes())
+	require.True(t, executor.doStreamCalled)
+	require.NotNil(t, executor.lastRequest)
+	require.Equal(t, string(llm.APIFormatOpenAISpeech), executor.lastRequest.APIFormat)
+
+	var providerBody map[string]any
+	require.NoError(t, json.Unmarshal(executor.lastRequest.Body, &providerBody))
+	require.Equal(t, "audio", providerBody["stream_format"])
+	require.NotContains(t, providerBody, "stream")
+
+	requests, err := client.Request.Query().All(ctx)
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	require.Equal(t, entrequest.StatusCompleted, requests[0].Status)
+	require.True(t, requests[0].Stream)
+	require.Contains(t, string(requests[0].ResponseBody), `"object":"audio.speech.stream"`)
+	require.Contains(t, string(requests[0].ResponseBody), `"audio_bytes":3`)
+
+	executions, err := client.RequestExecution.Query().All(ctx)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+	require.Equal(t, entrequestexecution.StatusCompleted, executions[0].Status)
+	require.True(t, executions[0].Stream)
+	require.Contains(t, string(executions[0].ResponseBody), `"object":"audio.speech.stream"`)
+	require.Contains(t, string(executions[0].ResponseBody), `"audio_bytes":3`)
+}

--- a/internal/server/api/openai_speech_test.go
+++ b/internal/server/api/openai_speech_test.go
@@ -74,6 +74,62 @@ func setupSpeechAPITestServices(t *testing.T, client *ent.Client) (*biz.ChannelS
 	return channelService, requestService, systemService, usageLogService
 }
 
+func TestShouldUseBinarySpeechStream(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		want        bool
+		wantErr     bool
+	}{
+		{
+			name:        "audio stream format",
+			contentType: "application/json",
+			body:        `{"stream_format":"audio"}`,
+			want:        true,
+		},
+		{
+			name:        "sse stream format",
+			contentType: "application/json",
+			body:        `{"stream_format":"sse"}`,
+		},
+		{
+			name:        "default non-stream",
+			contentType: "application/json",
+			body:        `{}`,
+		},
+		{
+			name:        "non-json content type lets transformer report validation",
+			contentType: "multipart/form-data",
+			body:        `{"stream_format":"audio"}`,
+		},
+		{
+			name:        "invalid json",
+			contentType: "application/json",
+			body:        `{`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &httpclient.Request{
+				Headers: http.Header{"Content-Type": []string{tt.contentType}},
+				Body:    []byte(tt.body),
+			}
+
+			got, err := shouldUseBinarySpeechStream(req)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestOpenAIHandlers_CreateSpeech_AudioStreamEndToEnd(t *testing.T) {
 	ctx := ent.NewContext(authz.WithTestBypass(context.Background()), enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0"))
 	client := ent.FromContext(ctx)

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -795,6 +795,56 @@ type jsonStreamEvent struct {
 	Data        json.RawMessage `json:"data"`
 }
 
+type binaryStreamChunkSummary struct {
+	Object      string `json:"object"`
+	ContentType string `json:"content_type"`
+	Bytes       int    `json:"bytes"`
+}
+
+func isBinaryStreamChunk(chunk *httpclient.StreamEvent) bool {
+	if chunk == nil {
+		return false
+	}
+
+	eventType := strings.ToLower(strings.TrimSpace(chunk.Type))
+
+	return strings.HasPrefix(eventType, "audio/") || eventType == "application/octet-stream"
+}
+
+func shouldSkipStoredStreamChunk(chunk *httpclient.StreamEvent) bool {
+	return chunk == nil ||
+		(!isBinaryStreamChunk(chunk) && bytes.Equal(chunk.Data, llm.DoneStreamEvent.Data)) ||
+		chunk.Type == httpclient.BinaryStreamDoneEventType
+}
+
+func marshalStreamEventForStorage(chunk *httpclient.StreamEvent) (objects.JSONRawMessage, error) {
+	data := json.RawMessage(chunk.Data)
+	if isBinaryStreamChunk(chunk) {
+		// Prefer chunk.Size, which is set when the persistence layer summarized the
+		// raw audio chunk to avoid buffering audio bytes in memory.
+		byteCount := len(chunk.Data)
+		if byteCount == 0 {
+			byteCount = chunk.Size
+		}
+
+		var err error
+		data, err = json.Marshal(binaryStreamChunkSummary{
+			Object:      "binary.stream_chunk",
+			ContentType: strings.TrimSpace(chunk.Type),
+			Bytes:       byteCount,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return xjson.Marshal(jsonStreamEvent{
+		LastEventID: chunk.LastEventID,
+		Type:        chunk.Type,
+		Data:        data,
+	})
+}
+
 // SaveRequestExecutionChunks saves all response chunks to request execution at once.
 // Only stores chunks if the system StoreChunks setting is enabled.
 func (s *RequestService) SaveRequestExecutionChunks(
@@ -823,15 +873,11 @@ func (s *RequestService) SaveRequestExecutionChunks(
 	var chunkBytes []objects.JSONRawMessage
 
 	for _, chunk := range chunks {
-		if bytes.Equal(chunk.Data, llm.DoneStreamEvent.Data) {
+		if shouldSkipStoredStreamChunk(chunk) {
 			continue
 		}
 
-		b, err := xjson.Marshal(jsonStreamEvent{
-			LastEventID: chunk.LastEventID,
-			Type:        chunk.Type,
-			Data:        chunk.Data,
-		})
+		b, err := marshalStreamEventForStorage(chunk)
 		if err != nil {
 			log.Warn(ctx, "Failed to marshal chunk, skipping", log.Cause(err))
 
@@ -915,15 +961,11 @@ func (s *RequestService) SaveRequestChunks(
 	var chunkBytes []objects.JSONRawMessage
 
 	for _, chunk := range chunks {
-		if bytes.Equal(chunk.Data, llm.DoneStreamEvent.Data) {
+		if shouldSkipStoredStreamChunk(chunk) {
 			continue
 		}
 
-		b, err := xjson.Marshal(jsonStreamEvent{
-			LastEventID: chunk.LastEventID,
-			Type:        chunk.Type,
-			Data:        chunk.Data,
-		})
+		b, err := marshalStreamEventForStorage(chunk)
 		if err != nil {
 			log.Warn(ctx, "Failed to marshal chunk, skipping", log.Cause(err))
 

--- a/internal/server/biz/request_audio_test.go
+++ b/internal/server/biz/request_audio_test.go
@@ -2,6 +2,7 @@ package biz
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,8 @@ import (
 	entrequest "github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 )
 
 func TestRequestService_UpdateRequestCompletedWithAudio_ExternalStorage(t *testing.T) {
@@ -93,4 +96,54 @@ func TestRequestService_UpdateRequestCompletedWithAudio_ExternalStorage(t *testi
 	stored, err := dataStorageService.LoadData(ctx, ds, *updated.ContentStorageKey)
 	require.NoError(t, err)
 	require.Equal(t, audio, stored)
+}
+
+func TestMarshalStreamEventForStorage_BinaryAudioChunk(t *testing.T) {
+	raw, err := marshalStreamEventForStorage(&httpclient.StreamEvent{
+		Type: "audio/mpeg",
+		Data: []byte{0x7b, 0xff, 0x00},
+	})
+	require.NoError(t, err)
+
+	var got struct {
+		Event string `json:"event"`
+		Data  struct {
+			Object      string `json:"object"`
+			ContentType string `json:"content_type"`
+			Bytes       int    `json:"bytes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Equal(t, "audio/mpeg", got.Event)
+	require.Equal(t, "binary.stream_chunk", got.Data.Object)
+	require.Equal(t, "audio/mpeg", got.Data.ContentType)
+	require.Equal(t, 3, got.Data.Bytes)
+}
+
+func TestMarshalStreamEventForStorage_BinaryAudioChunkUsesSizeWhenDataElided(t *testing.T) {
+	// Persistence summarizes binary audio chunks by clearing Data and recording Size,
+	// so storage marshaling must fall back to Size for the byte count.
+	raw, err := marshalStreamEventForStorage(&httpclient.StreamEvent{
+		Type: "audio/mpeg",
+		Size: 4096,
+	})
+	require.NoError(t, err)
+
+	var got struct {
+		Event string `json:"event"`
+		Data  struct {
+			Bytes int `json:"bytes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Equal(t, "audio/mpeg", got.Event)
+	require.Equal(t, 4096, got.Data.Bytes)
+}
+
+func TestShouldSkipStoredStreamChunk_DoneSentinelDoesNotSkipBinaryAudio(t *testing.T) {
+	require.True(t, shouldSkipStoredStreamChunk(&httpclient.StreamEvent{Data: llm.DoneStreamEvent.Data}))
+	require.False(t, shouldSkipStoredStreamChunk(&httpclient.StreamEvent{
+		Type: "audio/mpeg",
+		Data: llm.DoneStreamEvent.Data,
+	}))
 }

--- a/internal/server/biz/stream_preview.go
+++ b/internal/server/biz/stream_preview.go
@@ -1,17 +1,13 @@
 package biz
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/chunkbuffer"
-	"github.com/looplj/axonhub/internal/pkg/xjson"
-	"github.com/looplj/axonhub/llm"
 )
 
 // LiveStreamRegistry provides read access to in-flight stream chunks
@@ -96,20 +92,11 @@ func marshalPreviewChunks(buffer *chunkbuffer.Buffer) []objects.JSONRawMessage {
 
 	var result []objects.JSONRawMessage
 	for _, chunk := range chunks {
-		// Skip terminal DONE events
-		if bytes.Equal(chunk.Data, llm.DoneStreamEvent.Data) {
+		if shouldSkipStoredStreamChunk(chunk) {
 			continue
 		}
 
-		b, err := xjson.Marshal(struct {
-			LastEventID string          `json:"last_event_id,omitempty"`
-			Type        string          `json:"event"`
-			Data        json.RawMessage `json:"data"`
-		}{
-			LastEventID: chunk.LastEventID,
-			Type:        chunk.Type,
-			Data:        chunk.Data,
-		})
+		b, err := marshalStreamEventForStorage(chunk)
 		if err != nil {
 			continue
 		}

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -67,7 +67,9 @@ func (ts *InboundPersistentStream) Next() bool {
 func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	event := ts.stream.Current()
 	if event != nil {
-		ts.responseChunks = append(ts.responseChunks, event)
+		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
+		// summary to avoid buffering the full audio payload in memory.
+		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
 		if isTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true
 		}
@@ -88,7 +90,8 @@ func isTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 		// For OpenAI audio APIs (TTS sse / STT stream) which have no [DONE] sentinel:
 		// rely on the terminal *.done event surfaced as StreamEvent.Type.
 		event.Type == "speech.audio.done" ||
-		event.Type == "transcript.text.done"
+		event.Type == "transcript.text.done" ||
+		event.Type == httpclient.BinaryStreamDoneEventType
 }
 
 func (ts *InboundPersistentStream) Err() error {

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -265,8 +265,10 @@ func TestIsTerminalStreamEvent_AudioDoneEvents(t *testing.T) {
 	// signaled by typed *.done events surfaced via StreamEvent.Type.
 	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.done"}))
 	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.done"}))
+	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: httpclient.BinaryStreamDoneEventType}))
 
 	// Other events must not be treated as terminal.
 	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.delta"}))
 	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.delta"}))
+	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "audio/mpeg"}))
 }

--- a/internal/server/orchestrator/live_streaming.go
+++ b/internal/server/orchestrator/live_streaming.go
@@ -149,7 +149,10 @@ func (s *liveRequestExecutionStream) Next() bool {
 
 	s.current = s.stream.Current()
 	if s.current != nil {
-		s.buffer.Append(s.current)
+		// Summarize raw binary audio chunks before buffering so the live preview
+		// path does not retain full TTS audio bytes in memory. Downstream
+		// consumers still receive the unmodified event via Current().
+		s.buffer.Append(httpclient.SummarizeBinaryChunk(s.current))
 	}
 
 	return true
@@ -192,7 +195,10 @@ func (s *liveRequestStream) Next() bool {
 
 	s.current = s.stream.Current()
 	if s.current != nil {
-		s.buffer.Append(s.current)
+		// Summarize raw binary audio chunks before buffering so the live preview
+		// path does not retain full TTS audio bytes in memory. Downstream
+		// consumers still receive the unmodified event via Current().
+		s.buffer.Append(httpclient.SummarizeBinaryChunk(s.current))
 	}
 
 	return true

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -79,7 +79,9 @@ func (ts *OutboundPersistentStream) Next() bool {
 func (ts *OutboundPersistentStream) Current() *httpclient.StreamEvent {
 	event := ts.stream.Current()
 	if event != nil {
-		ts.responseChunks = append(ts.responseChunks, event)
+		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
+		// summary to avoid buffering the full audio payload in memory.
+		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
 		// Check if this is a terminal event, which indicates the stream completed successfully.
 		// For Chat Completions API this is the raw [DONE] event; for Responses API this is
 		// response.completed; for Anthropic Messages API this is message_stop.
@@ -303,7 +305,8 @@ func (ts *OutboundPersistentStream) persistAggregatedResponse(ctx context.Contex
 }
 
 func isCompletedAggregated(meta llm.ResponseMeta) bool {
-	return meta.Usage != nil && meta.Usage.CompletionTokens > 0
+	return meta.Completed ||
+		(meta.Usage != nil && meta.Usage.CompletionTokens > 0)
 }
 
 var errSkipCandidateByCircuitBreaker = errors.New("skip candidate by circuit breaker")

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -574,6 +574,14 @@ func TestIsCompletedAggregatedOutboundResponse(t *testing.T) {
 		require.False(t, isCompletedAggregated(llm.ResponseMeta{ID: "resp_123"}))
 	})
 
+	t.Run("explicit completed flag is completed", func(t *testing.T) {
+		require.True(t, isCompletedAggregated(llm.ResponseMeta{ID: llm.SpeechStreamResponseID, Completed: true}))
+	})
+
+	t.Run("speech stream aggregate id alone is not completed", func(t *testing.T) {
+		require.False(t, isCompletedAggregated(llm.ResponseMeta{ID: llm.SpeechStreamResponseID}))
+	})
+
 	t.Run("missing usage and id is not completed", func(t *testing.T) {
 		require.False(t, isCompletedAggregated(llm.ResponseMeta{}))
 	})

--- a/llm/audio.go
+++ b/llm/audio.go
@@ -2,6 +2,10 @@ package llm
 
 import "encoding/json"
 
+// SpeechStreamResponseID is the synthetic response ID used for aggregated
+// streaming TTS metadata.
+const SpeechStreamResponseID = "audio.speech.stream"
+
 // SpeechRequest is the unified text-to-speech (TTS) request structure.
 // It maps to OpenAI's POST /v1/audio/speech API.
 // Note: Common fields like Model are in the parent Request struct, not here.
@@ -21,8 +25,7 @@ type SpeechRequest struct {
 	// Instructions controls the voice tone for supported models (e.g. gpt-4o-mini-tts).
 	Instructions string `json:"instructions,omitempty"`
 
-	// StreamFormat opts into SSE streaming for gpt-4o-mini-tts. Only "sse" is supported;
-	// the binary chunked stream (no stream_format) is not exposed by the gateway.
+	// StreamFormat selects streaming output for /audio/speech. OpenAI supports "sse" and "audio"; audio is the default.
 	StreamFormat string `json:"stream_format,omitempty"`
 }
 
@@ -37,6 +40,16 @@ type SpeechStreamEvent struct {
 
 	// Usage is populated on the terminal speech.audio.done event.
 	Usage *Usage `json:"usage,omitempty"`
+}
+
+// SpeechAudioChunk represents one binary audio chunk emitted by streaming TTS
+// when the provider returns raw chunked audio instead of SSE.
+type SpeechAudioChunk struct {
+	// Audio is the raw audio bytes for this chunk.
+	Audio []byte `json:"-"`
+
+	// ContentType is the MIME type returned by the provider for the stream.
+	ContentType string `json:"-"`
 }
 
 // SpeechResponse represents the unified TTS response.

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/looplj/axonhub/llm/streams"
@@ -272,8 +274,14 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 		return nil, fmt.Errorf("failed to build HTTP request: %w", err)
 	}
 
-	// Add streaming headers
-	rawReq.Header.Set("Accept", "text/event-stream")
+	// Add streaming headers. Force SSE Accept unless the outbound transformer
+	// explicitly opted into a non-JSON Accept (e.g. "*/*" for binary TTS chunks),
+	// so chat-style outbounds whose default Accept is application/json still
+	// negotiate SSE for streaming requests.
+	accept := rawReq.Header.Get("Accept")
+	if accept == "" || strings.EqualFold(accept, "application/json") {
+		rawReq.Header.Set("Accept", "text/event-stream")
+	}
 	rawReq.Header.Set("Cache-Control", "no-cache")
 	rawReq.Header.Set("Connection", "keep-alive")
 
@@ -324,6 +332,11 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 
 	// Try to get a registered decoder for the content type
 	decoderFactory, exists := GetDecoder(contentType)
+	if !exists {
+		if mediaType, _, err := mime.ParseMediaType(contentType); err == nil {
+			decoderFactory, exists = GetDecoder(mediaType)
+		}
+	}
 	if !exists {
 		// Fallback to default SSE decoder
 		slog.DebugContext(ctx, "no decoder found for content type, using default SSE", slog.String("content_type", contentType))

--- a/llm/httpclient/decoder.go
+++ b/llm/httpclient/decoder.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -196,4 +197,131 @@ func (s *defaultSSEDecoder) Close() error {
 func init() {
 	RegisterDecoder("text/event-stream", NewDefaultSSEDecoder)
 	RegisterDecoder("text/event-stream; charset=utf-8", NewDefaultSSEDecoder)
+	RegisterDecoder("audio/mpeg", NewBinaryChunkDecoder("audio/mpeg"))
+	RegisterDecoder("audio/mp3", NewBinaryChunkDecoder("audio/mpeg"))
+	RegisterDecoder("audio/wav", NewBinaryChunkDecoder("audio/wav"))
+	RegisterDecoder("audio/x-wav", NewBinaryChunkDecoder("audio/wav"))
+	RegisterDecoder("audio/opus", NewBinaryChunkDecoder("audio/opus"))
+	RegisterDecoder("audio/aac", NewBinaryChunkDecoder("audio/aac"))
+	RegisterDecoder("audio/flac", NewBinaryChunkDecoder("audio/flac"))
+	RegisterDecoder("audio/pcm", NewBinaryChunkDecoder("audio/pcm"))
+	RegisterDecoder("application/octet-stream", NewBinaryChunkDecoder("application/octet-stream"))
+}
+
+// NewBinaryChunkDecoder creates a decoder that yields raw bytes as stream events.
+// It is used for provider streams that do not use SSE framing, such as chunked TTS
+// audio responses.
+func NewBinaryChunkDecoder(contentType string) StreamDecoderFactory {
+	return func(ctx context.Context, rc io.ReadCloser) StreamDecoder {
+		return &binaryChunkDecoder{
+			ctx:         ctx,
+			reader:      rc,
+			contentType: contentType,
+		}
+	}
+}
+
+type binaryChunkDecoder struct {
+	ctx         context.Context
+	reader      io.ReadCloser
+	contentType string
+	current     *StreamEvent
+	err         error
+	pendingErr  error
+	doneSent    bool
+
+	closed    atomic.Bool
+	closeOnce sync.Once
+	closeErr  error
+}
+
+var _ StreamDecoder = (*binaryChunkDecoder)(nil)
+
+func (d *binaryChunkDecoder) Next() bool {
+	if d.err != nil {
+		return false
+	}
+
+	if d.pendingErr != nil {
+		d.err = d.pendingErr
+		d.pendingErr = nil
+
+		return false
+	}
+
+	if d.closed.Load() {
+		return false
+	}
+
+	select {
+	case <-d.ctx.Done():
+		d.err = d.ctx.Err()
+		return false
+	default:
+	}
+
+	buf := make([]byte, 32*1024)
+	n, err := d.reader.Read(buf)
+	if n > 0 {
+		if err != nil && !errors.Is(err, io.EOF) {
+			if ctxErr := d.ctx.Err(); ctxErr != nil {
+				d.pendingErr = ctxErr
+			} else {
+				d.pendingErr = err
+			}
+		}
+
+		payload := bytes.Clone(buf[:n])
+		d.current = &StreamEvent{
+			Type: d.contentType,
+			Data: payload,
+		}
+
+		return true
+	}
+
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, io.EOF) {
+		if !d.doneSent {
+			d.doneSent = true
+			d.current = &StreamEvent{Type: BinaryStreamDoneEventType}
+
+			return true
+		}
+
+		slog.DebugContext(d.ctx, "binary stream closed")
+		return false
+	}
+
+	if ctxErr := d.ctx.Err(); ctxErr != nil {
+		d.err = ctxErr
+	} else {
+		d.err = err
+	}
+
+	return false
+}
+
+func (d *binaryChunkDecoder) Current() *StreamEvent {
+	return d.current
+}
+
+func (d *binaryChunkDecoder) Err() error {
+	return d.err
+}
+
+func (d *binaryChunkDecoder) Close() error {
+	d.closeOnce.Do(func() {
+		d.closed.Store(true)
+		if d.reader != nil {
+			d.closeErr = d.reader.Close()
+		}
+
+		slog.DebugContext(d.ctx, "binary stream closed")
+	})
+
+	return d.closeErr
 }

--- a/llm/httpclient/decoder.go
+++ b/llm/httpclient/decoder.go
@@ -217,6 +217,7 @@ func NewBinaryChunkDecoder(contentType string) StreamDecoderFactory {
 			ctx:         ctx,
 			reader:      rc,
 			contentType: contentType,
+			buf:         make([]byte, 32*1024),
 		}
 	}
 }
@@ -225,6 +226,7 @@ type binaryChunkDecoder struct {
 	ctx         context.Context
 	reader      io.ReadCloser
 	contentType string
+	buf         []byte
 	current     *StreamEvent
 	err         error
 	pendingErr  error
@@ -260,8 +262,7 @@ func (d *binaryChunkDecoder) Next() bool {
 	default:
 	}
 
-	buf := make([]byte, 32*1024)
-	n, err := d.reader.Read(buf)
+	n, err := d.reader.Read(d.buf)
 	if n > 0 {
 		if err != nil && !errors.Is(err, io.EOF) {
 			if ctxErr := d.ctx.Err(); ctxErr != nil {
@@ -271,7 +272,7 @@ func (d *binaryChunkDecoder) Next() bool {
 			}
 		}
 
-		payload := bytes.Clone(buf[:n])
+		payload := bytes.Clone(d.buf[:n])
 		d.current = &StreamEvent{
 			Type: d.contentType,
 			Data: payload,

--- a/llm/httpclient/decoder_test.go
+++ b/llm/httpclient/decoder_test.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"maps"
 	"testing"
@@ -71,6 +72,27 @@ func newMockReadCloser(data []byte) *mockReadCloser {
 		Reader: bytes.NewReader(data),
 		closed: false,
 	}
+}
+
+type readChunkThenError struct {
+	data []byte
+	err  error
+	read bool
+}
+
+func (r *readChunkThenError) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+
+	r.read = true
+	n := copy(p, r.data)
+
+	return n, r.err
+}
+
+func (r *readChunkThenError) Close() error {
+	return nil
 }
 
 func TestRegisterDecoder(t *testing.T) {
@@ -178,6 +200,48 @@ func TestDefaultSSEDecoder_NextAfterClose(t *testing.T) {
 	hasNext := decoder.Next()
 	require.False(t, hasNext)
 	require.NoError(t, decoder.Err())
+}
+
+func TestBinaryChunkDecoder(t *testing.T) {
+	ctx := context.Background()
+	rc := newMockReadCloser([]byte("abcdefgh"))
+	decoder := NewBinaryChunkDecoder("audio/mpeg")(ctx, rc)
+
+	require.True(t, decoder.Next())
+	first := decoder.Current()
+	require.NotNil(t, first)
+	require.Equal(t, "audio/mpeg", first.Type)
+	require.Equal(t, []byte("abcdefgh"), first.Data)
+
+	require.True(t, decoder.Next())
+	done := decoder.Current()
+	require.NotNil(t, done)
+	require.Equal(t, BinaryStreamDoneEventType, done.Type)
+	require.Empty(t, done.Data)
+
+	require.False(t, decoder.Next())
+	require.NoError(t, decoder.Err())
+	require.NoError(t, decoder.Close())
+	require.True(t, rc.closed)
+}
+
+func TestBinaryChunkDecoder_PreservesReadErrorAfterChunk(t *testing.T) {
+	ctx := context.Background()
+	streamErr := errors.New("truncated audio stream")
+	decoder := NewBinaryChunkDecoder("audio/mpeg")(ctx, &readChunkThenError{
+		data: []byte("abc"),
+		err:  streamErr,
+	})
+
+	require.True(t, decoder.Next())
+	chunk := decoder.Current()
+	require.NotNil(t, chunk)
+	require.Equal(t, "audio/mpeg", chunk.Type)
+	require.Equal(t, []byte("abc"), chunk.Data)
+	require.NoError(t, decoder.Err())
+
+	require.False(t, decoder.Next())
+	require.ErrorIs(t, decoder.Err(), streamErr)
 }
 
 func TestStreamDecoderInterface(t *testing.T) {

--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/looplj/axonhub/llm/streams"
 )
@@ -73,6 +74,9 @@ type AuthConfig struct {
 const (
 	AuthTypeBearer = "bearer"
 	AuthTypeAPIKey = "api_key"
+
+	// BinaryStreamDoneEventType marks EOF for non-SSE streaming responses.
+	BinaryStreamDoneEventType = "binary.done"
 )
 
 // Response represents a generic HTTP response.
@@ -103,6 +107,39 @@ type StreamEvent struct {
 	LastEventID string `json:"last_event_id,omitempty"`
 	Type        string `json:"type"`
 	Data        []byte `json:"data"`
+	// Size optionally carries the byte size of a binary chunk that was elided
+	// from Data for persistence (e.g. raw TTS audio chunks). It lets stream
+	// aggregators report total bytes without retaining the audio payload.
+	Size int `json:"size,omitempty"`
+}
+
+// IsBinaryAudioChunk reports whether the event carries a raw binary audio payload
+// (e.g. TTS audio/* or application/octet-stream chunks) as opposed to an SSE event
+// or the binary.done sentinel.
+func (e *StreamEvent) IsBinaryAudioChunk() bool {
+	if e == nil || e.Type == "" || e.Type == BinaryStreamDoneEventType {
+		return false
+	}
+
+	t := strings.ToLower(strings.TrimSpace(e.Type))
+
+	return strings.HasPrefix(t, "audio/") || t == "application/octet-stream"
+}
+
+// SummarizeBinaryChunk returns a copy of the event suitable for persistence:
+// for raw binary audio chunks the audio bytes are dropped and only the byte
+// count is kept in Size, so persistence buffers never accumulate the full
+// audio payload. Non-binary events are returned as-is.
+func SummarizeBinaryChunk(event *StreamEvent) *StreamEvent {
+	if event == nil || !event.IsBinaryAudioChunk() {
+		return event
+	}
+
+	return &StreamEvent{
+		LastEventID: event.LastEventID,
+		Type:        event.Type,
+		Size:        len(event.Data),
+	}
 }
 
 // StreamDecoder defines the interface for decoding streaming responses.

--- a/llm/httpclient/model_test.go
+++ b/llm/httpclient/model_test.go
@@ -1,0 +1,48 @@
+package httpclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamEvent_IsBinaryAudioChunk(t *testing.T) {
+	require.True(t, (&StreamEvent{Type: "audio/mpeg"}).IsBinaryAudioChunk())
+	require.True(t, (&StreamEvent{Type: "application/octet-stream"}).IsBinaryAudioChunk())
+	require.False(t, (&StreamEvent{Type: BinaryStreamDoneEventType}).IsBinaryAudioChunk())
+	require.False(t, (&StreamEvent{Type: "text/event-stream"}).IsBinaryAudioChunk())
+	require.False(t, (&StreamEvent{}).IsBinaryAudioChunk())
+
+	var nilEvent *StreamEvent
+
+	require.False(t, nilEvent.IsBinaryAudioChunk())
+}
+
+func TestSummarizeBinaryChunk(t *testing.T) {
+	t.Run("audio chunk is summarized", func(t *testing.T) {
+		orig := &StreamEvent{Type: "audio/mpeg", Data: []byte{0x01, 0x02, 0x03}}
+		got := SummarizeBinaryChunk(orig)
+		require.NotSame(t, orig, got)
+		require.Equal(t, "audio/mpeg", got.Type)
+		require.Empty(t, got.Data)
+		require.Equal(t, 3, got.Size)
+		// Original is left untouched so downstream consumers still get the payload.
+		require.Equal(t, []byte{0x01, 0x02, 0x03}, orig.Data)
+	})
+
+	t.Run("non-binary chunk is returned as-is", func(t *testing.T) {
+		orig := &StreamEvent{Type: "transcript.text.delta", Data: []byte(`{"delta":"hi"}`)}
+		got := SummarizeBinaryChunk(orig)
+		require.Same(t, orig, got)
+	})
+
+	t.Run("binary done sentinel is returned as-is", func(t *testing.T) {
+		orig := &StreamEvent{Type: BinaryStreamDoneEventType}
+		got := SummarizeBinaryChunk(orig)
+		require.Same(t, orig, got)
+	})
+
+	t.Run("nil is returned as-is", func(t *testing.T) {
+		require.Nil(t, SummarizeBinaryChunk(nil))
+	})
+}

--- a/llm/model.go
+++ b/llm/model.go
@@ -689,6 +689,10 @@ type Response struct {
 	// SpeechStreamEvent carries one SSE event of a streaming TTS response (stream_format="sse").
 	SpeechStreamEvent *SpeechStreamEvent `json:"speech_stream_event,omitempty"`
 
+	// SpeechAudioChunk carries one raw binary chunk of a streaming TTS response
+	// when the provider returns chunked audio instead of SSE.
+	SpeechAudioChunk *SpeechAudioChunk `json:"-"`
+
 	// TranscriptionStreamEvent carries one SSE event of a streaming STT response (stream=true).
 	TranscriptionStreamEvent *TranscriptionStreamEvent `json:"transcription_stream_event,omitempty"`
 
@@ -751,8 +755,9 @@ type TopLogprob struct {
 }
 
 type ResponseMeta struct {
-	ID    string `json:"id"`
-	Usage *Usage `json:"usage"`
+	ID        string `json:"id"`
+	Usage     *Usage `json:"usage"`
+	Completed bool   `json:"completed,omitempty"`
 }
 
 // Usage Represents the total token usage per request to OpenAI.

--- a/llm/pipeline/empty_response.go
+++ b/llm/pipeline/empty_response.go
@@ -54,7 +54,7 @@ func hasMessageContent(msg *llm.Message) bool {
 
 // hasResponseContent checks if an llm.Response contains meaningful content.
 func hasResponseContent(resp *llm.Response) bool {
-	if resp == nil || resp == llm.DoneResponse {
+	if resp == nil || resp == llm.DoneResponse || resp.Object == "[DONE]" {
 		return false
 	}
 
@@ -87,7 +87,14 @@ func hasResponseContent(resp *llm.Response) bool {
 		return true
 	}
 
-	if resp.SpeechStreamEvent != nil && (resp.SpeechStreamEvent.AudioBase64 != "" || resp.SpeechStreamEvent.Type != "") {
+	// Only audio deltas count as content. A bare "speech.audio.done" event with
+	// no audio chunks must still be treated as empty so empty-response detection
+	// can retry instead of completing a request with audio_bytes=0.
+	if resp.SpeechStreamEvent != nil && resp.SpeechStreamEvent.AudioBase64 != "" {
+		return true
+	}
+
+	if resp.SpeechAudioChunk != nil && len(resp.SpeechAudioChunk.Audio) > 0 {
 		return true
 	}
 

--- a/llm/pipeline/empty_response_test.go
+++ b/llm/pipeline/empty_response_test.go
@@ -156,6 +156,137 @@ func TestPipeline_Process_StreamEmptyResponseDetection(t *testing.T) {
 		require.Equal(t, 1, prepareCalls)
 	})
 
+	t.Run("retries on empty binary speech stream", func(t *testing.T) {
+		// TTS binary streams emit a terminal *llm.Response{Object:"[DONE]"} that is
+		// not the shared llm.DoneResponse sentinel. Empty-response detection must
+		// still recognize it so providers returning 200 + zero audio chunks trigger
+		// a retry instead of being recorded as completed.
+		streamCalls := 0
+		executor := &mockExecutor{
+			doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+				streamCalls++
+				return streams.SliceStream([]*httpclient.StreamEvent{{}}), nil
+			},
+		}
+
+		prepareCalls := 0
+		outbound := &mockOutbound{
+			transformStream: func(ctx context.Context, req *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+				if streamCalls == 1 {
+					// Empty binary speech stream: only the [DONE] terminator, no SpeechAudioChunk.
+					return streams.SliceStream([]*llm.Response{
+						{Object: "[DONE]", RequestType: llm.RequestTypeSpeech, APIFormat: llm.APIFormatOpenAISpeech},
+					}), nil
+				}
+
+				return streams.SliceStream([]*llm.Response{
+					{
+						RequestType: llm.RequestTypeSpeech,
+						APIFormat:   llm.APIFormatOpenAISpeech,
+						SpeechAudioChunk: &llm.SpeechAudioChunk{
+							Audio:       []byte{0x01, 0x02},
+							ContentType: "audio/mpeg",
+						},
+					},
+					{Object: "[DONE]", RequestType: llm.RequestTypeSpeech, APIFormat: llm.APIFormatOpenAISpeech},
+				}), nil
+			},
+			canRetry: func(err error) bool { return errors.Is(err, ErrEmptyResponse) },
+			prepareForRetry: func(ctx context.Context) error {
+				prepareCalls++
+				return nil
+			},
+		}
+
+		streamFlag := true
+		streamInbound := &mockInbound{
+			transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+				return &llm.Request{Stream: &streamFlag}, nil
+			},
+		}
+
+		p := &pipeline{
+			Executor:               executor,
+			Inbound:                streamInbound,
+			Outbound:               outbound,
+			maxSameChannelRetries:  1,
+			emptyResponseDetection: true,
+		}
+
+		res, err := p.Process(ctx, &httpclient.Request{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, 2, streamCalls)
+		require.Equal(t, 1, prepareCalls)
+	})
+
+	t.Run("retries on empty TTS SSE stream with only done event", func(t *testing.T) {
+		// TTS stream_format=sse providers that emit only "speech.audio.done" (no
+		// speech.audio.delta) must still be treated as empty so empty-response
+		// detection retries instead of completing a request with audio_bytes=0.
+		streamCalls := 0
+		executor := &mockExecutor{
+			doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+				streamCalls++
+				return streams.SliceStream([]*httpclient.StreamEvent{{}}), nil
+			},
+		}
+
+		prepareCalls := 0
+		outbound := &mockOutbound{
+			transformStream: func(ctx context.Context, req *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+				if streamCalls == 1 {
+					return streams.SliceStream([]*llm.Response{
+						{
+							RequestType: llm.RequestTypeSpeech,
+							APIFormat:   llm.APIFormatOpenAISpeech,
+							SpeechStreamEvent: &llm.SpeechStreamEvent{Type: "speech.audio.done"},
+						},
+						llm.DoneResponse,
+					}), nil
+				}
+
+				return streams.SliceStream([]*llm.Response{
+					{
+						RequestType: llm.RequestTypeSpeech,
+						APIFormat:   llm.APIFormatOpenAISpeech,
+						SpeechStreamEvent: &llm.SpeechStreamEvent{
+							Type:        "speech.audio.delta",
+							AudioBase64: "YWJjZA==",
+						},
+					},
+					llm.DoneResponse,
+				}), nil
+			},
+			canRetry: func(err error) bool { return errors.Is(err, ErrEmptyResponse) },
+			prepareForRetry: func(ctx context.Context) error {
+				prepareCalls++
+				return nil
+			},
+		}
+
+		streamFlag := true
+		streamInbound := &mockInbound{
+			transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+				return &llm.Request{Stream: &streamFlag}, nil
+			},
+		}
+
+		p := &pipeline{
+			Executor:               executor,
+			Inbound:                streamInbound,
+			Outbound:               outbound,
+			maxSameChannelRetries:  1,
+			emptyResponseDetection: true,
+		}
+
+		res, err := p.Process(ctx, &httpclient.Request{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, 2, streamCalls)
+		require.Equal(t, 1, prepareCalls)
+	})
+
 	t.Run("accepts stream response with content", func(t *testing.T) {
 		streamCalls := 0
 		executor := &mockExecutor{

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -50,7 +50,11 @@ func (p *pipeline) checkEmptyResponse(
 			return streams.PrependStream(llmStream, buffered...), nil
 		}
 
-		if event == llm.DoneResponse || hasFinishReason(event) {
+		// Recognize both the shared sentinel pointer (llm.DoneResponse) and a
+		// freshly-constructed "[DONE]" terminator: outbound transformers that emit
+		// terminal events as new *llm.Response (e.g. OpenAI TTS binary streams) must
+		// still trigger empty-response handling when no audio chunks were produced.
+		if event == llm.DoneResponse || (event != nil && event.Object == "[DONE]") || hasFinishReason(event) {
 			// Reached end without content — empty response
 			slog.WarnContext(ctx, "empty response detected",
 				slog.Int("events_read", len(buffered)),

--- a/llm/transformer/openai/audio_inbound.go
+++ b/llm/transformer/openai/audio_inbound.go
@@ -99,15 +99,16 @@ func (t *AudioInboundTransformer) transformSpeechRequest(httpReq *httpclient.Req
 		return nil, fmt.Errorf("%w: voice is required", transformer.ErrInvalidRequest)
 	}
 
-	// Only SSE streaming is exposed. Binary chunked streams (the OpenAI default when
-	// no stream_format is set) require a non-SSE response carrier the gateway does
-	// not currently model; reject them up front rather than silently buffering.
+	// stream_format is opt-in. When the client omits it, OpenAI returns a single
+	// binary audio body (non-streaming) and we keep that path so the gateway can
+	// persist the audio bytes to external storage via UpdateRequestCompletedWithAudio.
+	// Only explicit "sse" or "audio" engages the streaming pipeline.
 	streamFormat := strings.ToLower(strings.TrimSpace(body.StreamFormat))
-	if streamFormat != "" && streamFormat != "sse" {
-		return nil, fmt.Errorf("%w: unsupported stream_format: %q (only \"sse\" is supported)", transformer.ErrInvalidRequest, body.StreamFormat)
+	if streamFormat != "" && streamFormat != "sse" && streamFormat != "audio" {
+		return nil, fmt.Errorf("%w: unsupported stream_format: %q (only \"sse\" and \"audio\" are supported)", transformer.ErrInvalidRequest, body.StreamFormat)
 	}
 
-	isStream := streamFormat == "sse"
+	isStream := streamFormat != ""
 
 	return &llm.Request{
 		Model:       body.Model,
@@ -295,8 +296,9 @@ func (t *AudioInboundTransformer) TransformResponse(ctx context.Context, llmResp
 	}, nil
 }
 
-// TransformStream converts unified streaming audio responses back into SSE events.
-// Supports gpt-4o-mini-tts speech (stream_format="sse") and gpt-4o-transcribe STT (stream=true).
+// TransformStream converts unified streaming audio responses back into client-facing
+// stream events. TTS supports both SSE and raw binary chunk streams; STT/translation
+// use SSE only.
 func (t *AudioInboundTransformer) TransformStream(ctx context.Context, stream streams.Stream[*llm.Response]) (streams.Stream[*httpclient.StreamEvent], error) {
 	return streams.NoNil(streams.MapErr(stream, func(resp *llm.Response) (*httpclient.StreamEvent, error) {
 		if resp == nil {
@@ -304,9 +306,14 @@ func (t *AudioInboundTransformer) TransformStream(ctx context.Context, stream st
 			return nil, nil
 		}
 
-		// The DoneResponse sentinel is the pipeline-level end marker; the audio SSE
-		// streams have their own "*.done" events, so swallow the sentinel.
+		// The DoneResponse sentinel is the pipeline-level end marker. SSE audio
+		// streams have their own "*.done" events; binary speech streams need a
+		// client-facing binary.done so persistence can mark the stream complete.
 		if resp == llm.DoneResponse || resp.Object == "[DONE]" {
+			if t.apiFormat == llm.APIFormatOpenAISpeech && resp.RequestType == llm.RequestTypeSpeech {
+				return &httpclient.StreamEvent{Type: httpclient.BinaryStreamDoneEventType}, nil
+			}
+
 			//nolint:nilnil // skip pipeline sentinel
 			return nil, nil
 		}
@@ -320,6 +327,13 @@ func (t *AudioInboundTransformer) TransformStream(ctx context.Context, stream st
 			// Propagate the event type so InboundPersistentStream.isTerminalStreamEvent
 			// can recognize speech.audio.done and mark the request as completed.
 			return &httpclient.StreamEvent{Type: resp.SpeechStreamEvent.Type, Data: data}, nil
+		}
+
+		if resp.SpeechAudioChunk != nil {
+			return &httpclient.StreamEvent{
+				Type: resp.SpeechAudioChunk.ContentType,
+				Data: resp.SpeechAudioChunk.Audio,
+			}, nil
 		}
 
 		if resp.TranscriptionStreamEvent != nil {
@@ -357,14 +371,37 @@ func aggregateSpeechStreamChunks(chunks []*httpclient.StreamEvent) ([]byte, llm.
 	var (
 		audioBytes int
 		usage      *llm.Usage
+		completed  bool
 	)
 
 	for _, chunk := range chunks {
-		if chunk == nil || len(chunk.Data) == 0 {
+		if chunk == nil {
+			continue
+		}
+
+		if chunk.Type == httpclient.BinaryStreamDoneEventType {
+			completed = true
+			continue
+		}
+
+		if isSpeechBinaryStreamEvent(chunk) {
+			// Persistence layer may have replaced the binary payload with a size
+			// summary; fall back to chunk.Size when Data is empty.
+			if n := len(chunk.Data); n > 0 {
+				audioBytes += n
+			} else {
+				audioBytes += chunk.Size
+			}
+
+			continue
+		}
+
+		if len(chunk.Data) == 0 {
 			continue
 		}
 
 		if bytes.HasPrefix(chunk.Data, []byte("[DONE]")) {
+			completed = true
 			continue
 		}
 
@@ -378,13 +415,17 @@ func aggregateSpeechStreamChunks(chunks []*httpclient.StreamEvent) ([]byte, llm.
 			audioBytes += base64DecodedLen(ev.AudioBase64)
 		}
 
+		if ev.Type == "speech.audio.done" {
+			completed = true
+		}
+
 		if ev.Usage != nil {
 			usage = ev.Usage
 		}
 	}
 
 	body, err := json.Marshal(map[string]any{
-		"object":      "audio.speech.stream",
+		"object":      llm.SpeechStreamResponseID,
 		"audio_bytes": audioBytes,
 		"chunks":      len(chunks),
 	})
@@ -392,7 +433,13 @@ func aggregateSpeechStreamChunks(chunks []*httpclient.StreamEvent) ([]byte, llm.
 		return nil, llm.ResponseMeta{}, fmt.Errorf("failed to marshal speech stream aggregate: %w", err)
 	}
 
-	return body, llm.ResponseMeta{Usage: usage}, nil
+	meta := llm.ResponseMeta{
+		ID:        llm.SpeechStreamResponseID,
+		Usage:     usage,
+		Completed: completed,
+	}
+
+	return body, meta, nil
 }
 
 func aggregateTranscriptionStreamChunks(chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {
@@ -400,6 +447,7 @@ func aggregateTranscriptionStreamChunks(chunks []*httpclient.StreamEvent) ([]byt
 		deltaBuilder strings.Builder
 		finalText    string
 		usage        *llm.Usage
+		completed    bool
 	)
 
 	for _, chunk := range chunks {
@@ -408,6 +456,7 @@ func aggregateTranscriptionStreamChunks(chunks []*httpclient.StreamEvent) ([]byt
 		}
 
 		if bytes.HasPrefix(chunk.Data, []byte("[DONE]")) {
+			completed = true
 			continue
 		}
 
@@ -420,6 +469,7 @@ func aggregateTranscriptionStreamChunks(chunks []*httpclient.StreamEvent) ([]byt
 		case "transcript.text.delta":
 			deltaBuilder.WriteString(ev.Delta)
 		case "transcript.text.done":
+			completed = true
 			if ev.Text != "" {
 				finalText = ev.Text
 			}
@@ -439,7 +489,7 @@ func aggregateTranscriptionStreamChunks(chunks []*httpclient.StreamEvent) ([]byt
 		return nil, llm.ResponseMeta{}, fmt.Errorf("failed to marshal transcription stream aggregate: %w", err)
 	}
 
-	return body, llm.ResponseMeta{Usage: usage}, nil
+	return body, llm.ResponseMeta{Usage: usage, Completed: completed}, nil
 }
 
 // base64DecodedLen returns the decoded byte length of a standard base64 string

--- a/llm/transformer/openai/audio_inbound_test.go
+++ b/llm/transformer/openai/audio_inbound_test.go
@@ -84,7 +84,7 @@ func TestAudioInboundTransformer_Speech(t *testing.T) {
 	t.Run("unsupported stream_format rejected", func(t *testing.T) {
 		body, _ := json.Marshal(map[string]any{
 			"model": "gpt-4o-mini-tts", "input": "hi", "voice": "alloy",
-			"stream_format": "audio",
+			"stream_format": "json",
 		})
 		_, err := tr.TransformRequest(context.Background(), &httpclient.Request{
 			Body:    body,
@@ -107,6 +107,35 @@ func TestAudioInboundTransformer_Speech(t *testing.T) {
 		require.NotNil(t, req.Stream)
 		require.True(t, *req.Stream)
 		require.Equal(t, "sse", req.Speech.StreamFormat)
+	})
+
+	t.Run("audio stream_format enables binary streaming", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"model": "gpt-4o-mini-tts", "input": "hi", "voice": "alloy",
+			"stream_format": "audio",
+		})
+		req, err := tr.TransformRequest(context.Background(), &httpclient.Request{
+			Body:    body,
+			Headers: http.Header{"Content-Type": []string{"application/json"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, req.Stream)
+		require.True(t, *req.Stream)
+		require.Equal(t, "audio", req.Speech.StreamFormat)
+	})
+
+	t.Run("missing stream_format stays non-streaming", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"model": "gpt-4o-mini-tts", "input": "hi", "voice": "alloy",
+		})
+		req, err := tr.TransformRequest(context.Background(), &httpclient.Request{
+			Body:    body,
+			Headers: http.Header{"Content-Type": []string{"application/json"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, req.Stream)
+		require.False(t, *req.Stream)
+		require.Empty(t, req.Speech.StreamFormat)
 	})
 }
 

--- a/llm/transformer/openai/audio_outbound.go
+++ b/llm/transformer/openai/audio_outbound.go
@@ -329,15 +329,8 @@ func transformSpeechBinaryChunk(event *httpclient.StreamEvent) (*llm.Response, e
 }
 
 func isSpeechBinaryStreamEvent(event *httpclient.StreamEvent) bool {
-	if event == nil {
-		return false
-	}
-
-	eventType := strings.ToLower(strings.TrimSpace(event.Type))
-
-	return eventType == httpclient.BinaryStreamDoneEventType ||
-		strings.HasPrefix(eventType, "audio/") ||
-		eventType == "application/octet-stream"
+	return event != nil &&
+		(event.Type == httpclient.BinaryStreamDoneEventType || event.IsBinaryAudioChunk())
 }
 
 // transformTranscriptionStreamChunkFor returns a decoder for streaming STT/translation SSE events.

--- a/llm/transformer/openai/audio_outbound.go
+++ b/llm/transformer/openai/audio_outbound.go
@@ -24,7 +24,7 @@ type SpeechRequestBody struct {
 	ResponseFormat string   `json:"response_format,omitempty"`
 	Speed          *float64 `json:"speed,omitempty"`
 	Instructions   string   `json:"instructions,omitempty"`
-	// StreamFormat="sse" requests an SSE stream from gpt-4o-mini-tts.
+	// StreamFormat selects streaming output from /audio/speech. OpenAI supports "sse" and "audio"; audio is the default.
 	StreamFormat string `json:"stream_format,omitempty"`
 }
 
@@ -299,6 +299,47 @@ func transformSpeechStreamChunk(event *httpclient.StreamEvent) (*llm.Response, e
 	}, nil
 }
 
+func transformSpeechBinaryChunk(event *httpclient.StreamEvent) (*llm.Response, error) {
+	if event != nil && event.Type == httpclient.BinaryStreamDoneEventType {
+		return &llm.Response{
+			Object:      "[DONE]",
+			RequestType: llm.RequestTypeSpeech,
+			APIFormat:   llm.APIFormatOpenAISpeech,
+		}, nil
+	}
+
+	if event == nil || len(event.Data) == 0 {
+		//nolint:nilnil // skip empty chunks
+		return nil, nil
+	}
+
+	contentType := strings.TrimSpace(event.Type)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return &llm.Response{
+		RequestType: llm.RequestTypeSpeech,
+		APIFormat:   llm.APIFormatOpenAISpeech,
+		SpeechAudioChunk: &llm.SpeechAudioChunk{
+			Audio:       bytes.Clone(event.Data),
+			ContentType: contentType,
+		},
+	}, nil
+}
+
+func isSpeechBinaryStreamEvent(event *httpclient.StreamEvent) bool {
+	if event == nil {
+		return false
+	}
+
+	eventType := strings.ToLower(strings.TrimSpace(event.Type))
+
+	return eventType == httpclient.BinaryStreamDoneEventType ||
+		strings.HasPrefix(eventType, "audio/") ||
+		eventType == "application/octet-stream"
+}
+
 // transformTranscriptionStreamChunkFor returns a decoder for streaming STT/translation SSE events.
 func transformTranscriptionStreamChunkFor(apiFormat llm.APIFormat) func(*httpclient.StreamEvent) (*llm.Response, error) {
 	requestType := requestTypeForAudioFormat(apiFormat)
@@ -328,6 +369,16 @@ func transformTranscriptionStreamChunkFor(apiFormat llm.APIFormat) func(*httpcli
 			TranscriptionStreamEvent: &ev,
 			Usage:                    ev.Usage,
 		}, nil
+	}
+}
+
+func speechStreamChunkTransformFor(_ *httpclient.Request) func(*httpclient.StreamEvent) (*llm.Response, error) {
+	return func(event *httpclient.StreamEvent) (*llm.Response, error) {
+		if isSpeechBinaryStreamEvent(event) {
+			return transformSpeechBinaryChunk(event)
+		}
+
+		return transformSpeechStreamChunk(event)
 	}
 }
 

--- a/llm/transformer/openai/audio_outbound_test.go
+++ b/llm/transformer/openai/audio_outbound_test.go
@@ -35,8 +35,10 @@ func TestOutbound_BuildSpeechRequest(t *testing.T) {
 	out := newAudioOutbound(t)
 
 	speed := 1.5
+	stream := false
 	llmReq := &llm.Request{
 		Model:       "tts-1",
+		Stream:      &stream,
 		RequestType: llm.RequestTypeSpeech,
 		APIFormat:   llm.APIFormatOpenAISpeech,
 		Speech: &llm.SpeechRequest{
@@ -62,6 +64,10 @@ func TestOutbound_BuildSpeechRequest(t *testing.T) {
 	require.Equal(t, "wav", body.ResponseFormat)
 	require.NotNil(t, body.Speed)
 	require.InDelta(t, 1.5, *body.Speed, 1e-9)
+
+	var rawBody map[string]any
+	require.NoError(t, json.Unmarshal(httpReq.Body, &rawBody))
+	require.NotContains(t, rawBody, "stream")
 }
 
 func TestOutbound_BuildTranscriptionRequest(t *testing.T) {
@@ -327,8 +333,8 @@ func TestAudioStreaming_Speech(t *testing.T) {
 
 	// Simulate the provider's SSE events flowing through the outbound transformer.
 	events := []*httpclient.StreamEvent{
-		{Data: []byte(`{"type":"speech.audio.delta","audio":"YWJjZA=="}`)},      // "abcd" → 4 bytes
-		{Data: []byte(`{"type":"speech.audio.delta","audio":"ZWZnaA=="}`)},      // "efgh" → 4 bytes
+		{Data: []byte(`{"type":"speech.audio.delta","audio":"YWJjZA=="}`)}, // "abcd" → 4 bytes
+		{Data: []byte(`{"type":"speech.audio.delta","audio":"ZWZnaA=="}`)}, // "efgh" → 4 bytes
 		{Data: []byte(`{"type":"speech.audio.done","usage":{"total_tokens":12}}`)},
 		{Data: []byte("[DONE]")},
 	}
@@ -365,8 +371,66 @@ func TestAudioStreaming_Speech(t *testing.T) {
 	body, meta, err := inbound.AggregateStreamChunks(context.Background(), events)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"audio_bytes":8`)
+	require.True(t, meta.Completed)
 	require.NotNil(t, meta.Usage)
 	require.EqualValues(t, 12, meta.Usage.TotalTokens)
+}
+
+func TestAudioStreaming_SpeechBinaryChunks(t *testing.T) {
+	inbound := NewSpeechInboundTransformer()
+	outbound := newAudioOutbound(t)
+
+	clientBody, _ := json.Marshal(map[string]any{
+		"model": "gpt-4o-mini-tts", "input": "Hi", "voice": "alloy",
+		"stream_format": "audio",
+	})
+
+	llmReq, err := inbound.TransformRequest(context.Background(), &httpclient.Request{
+		Body:    clientBody,
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, llmReq.Stream)
+	require.True(t, *llmReq.Stream)
+
+	providerReq, err := outbound.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+	require.Equal(t, "*/*", providerReq.Headers.Get("Accept"))
+
+	var providerBody map[string]any
+	require.NoError(t, json.Unmarshal(providerReq.Body, &providerBody))
+	require.Equal(t, "audio", providerBody["stream_format"])
+	require.NotContains(t, providerBody, "stream")
+
+	events := []*httpclient.StreamEvent{
+		{Type: "audio/mpeg", Data: []byte{0x7b, 0x01, 0x02}},
+		{Type: "audio/mpeg", Data: []byte{0x04, 0x05}},
+		{Type: httpclient.BinaryStreamDoneEventType},
+	}
+
+	llmStream, err := outbound.TransformStream(context.Background(), providerReq, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	clientStream, err := inbound.TransformStream(context.Background(), llmStream)
+	require.NoError(t, err)
+
+	var chunks []*httpclient.StreamEvent
+	for clientStream.Next() {
+		chunks = append(chunks, clientStream.Current())
+	}
+	require.NoError(t, clientStream.Err())
+	require.Len(t, chunks, 3)
+	require.Equal(t, "audio/mpeg", chunks[0].Type)
+	require.Equal(t, []byte{0x7b, 0x01, 0x02}, chunks[0].Data)
+	require.Equal(t, []byte{0x04, 0x05}, chunks[1].Data)
+	require.Equal(t, httpclient.BinaryStreamDoneEventType, chunks[2].Type)
+
+	body, meta, err := inbound.AggregateStreamChunks(context.Background(), chunks)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"audio_bytes":5`)
+	require.Equal(t, llm.SpeechStreamResponseID, meta.ID)
+	require.True(t, meta.Completed)
+	require.Nil(t, meta.Usage)
 }
 
 // TestAudioStreaming_Transcription verifies an end-to-end SSE streaming STT round trip.
@@ -434,6 +498,7 @@ func TestAudioStreaming_Transcription(t *testing.T) {
 	body, meta, err := inbound.AggregateStreamChunks(context.Background(), events)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"text":"hello world"`)
+	require.True(t, meta.Completed)
 	require.NotNil(t, meta.Usage)
 	require.EqualValues(t, 5, meta.Usage.TotalTokens)
 }

--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -285,7 +285,7 @@ func (t *OutboundTransformer) TransformStream(ctx context.Context, req *httpclie
 	if req != nil {
 		switch req.APIFormat {
 		case string(llm.APIFormatOpenAISpeech):
-			return streams.MapErr(stream, transformSpeechStreamChunk), nil
+			return streams.MapErr(stream, speechStreamChunkTransformFor(req)), nil
 		case string(llm.APIFormatOpenAITranscription):
 			return streams.MapErr(stream, transformTranscriptionStreamChunkFor(llm.APIFormatOpenAITranscription)), nil
 		case string(llm.APIFormatOpenAITranslation):


### PR DESCRIPTION
## 背景

`#1784` 引入 OpenAI Audio API 后，对 `/audio/speech` 默认走 `stream_format=audio` 流式路径，并放宽了 `DoStream` 的 Accept 设置，导致几个回归。本 PR 修复这些问题。

## 修复内容

### 1. `DoStream` 不再正确协商 SSE

`llm/httpclient/client.go` 之前改成只在 Accept 为空时才写 `text/event-stream`，但 OpenAI chat outbound 默认设 `Accept: application/json`，导致普通流式 chat 请求向上游声明的是 JSON 而非 SSE。

修复：Accept 为空 **或** 等于 `application/json` 时都强制改为 `text/event-stream`，保留 TTS 二进制流 `*/*` 和已显式 `text/event-stream` 的 outbound。

### 2. `/audio/speech` 默认走流式，绕过音频外部存储

`llm/transformer/openai/audio_inbound.go` 之前缺省 `stream_format` 时强制 `Stream=true`、`stream_format=audio`，会绕开 `UpdateRequestCompletedWithAudio` 的音频外部存储路径，只剩 `audio_bytes` 摘要，无法下载完整音频。

修复：缺省 `stream_format` 保持非流式（`Stream=false`），客户端必须显式 `sse` 或 `audio` 才进流式管线。OpenAI 官方该参数本就是可选的。

### 3. 空二进制 TTS 流被误判为完成

`transformSpeechBinaryChunk` 把 `binary.done` 转成新构造的 `*llm.Response{Object:"[DONE]"}`，但 `checkEmptyResponse` 只识别 `event == llm.DoneResponse` 指针。结果是 200 + 空 body 时不会触发 empty-response retry，最终保存 `audio_bytes:0` 的 completed 请求。

修复：空响应检测同时识别 `event.Object == "[DONE]"`；`hasResponseContent` 同步处理。

### 4. TTS SSE 仅 done、无 delta 时也未触发重试

`hasResponseContent` 中 `SpeechStreamEvent.Type != ""` 把纯 `speech.audio.done` 当成了有效内容。

修复：只把 `AudioBase64 != ""` 视为有内容，裸 `speech.audio.done` 不再算内容。

### 5. 流式音频在持久化缓冲里被全量保留

主持久化流和 LivePreview buffer 都把原始 `audio/mpeg` chunk append 到 buffer，长音频流在请求结束前会累积完整音频字节多份。

修复：
- 给 `httpclient.StreamEvent` 新增 `Size` 字段
- 新增 `SummarizeBinaryChunk()`：摘要二进制音频 chunk（清空 `Data`、保留 `Type` 与字节数）
- `InboundPersistentStream.Current`、`OutboundPersistentStream.Current`、`liveRequestStream.Next`、`liveRequestExecutionStream.Next` 均在写入持久化/preview buffer 前摘要化；下游消费者仍拿原始事件
- `aggregateSpeechStreamChunks` 与 `marshalStreamEventForStorage` 从 `chunk.Size` 兜底统计字节数

## 测试

- 新增/更新单测覆盖所有四个修复点（empty binary stream、empty SSE done、Accept 协商、外部存储路径、Size 兜底）
- 本地以 `tts-1` 非流式 + `gpt-4o-mini-tts` (`sse` / `audio`) 三条路径手动验证生成音频均正常
- `go test ./...` 全部通过