### PR TITLE
refactor(neuralwatt): replace current_period_start/end with kwh_reset_date

### DIFF
--- a/frontend/src/features/system/data/quotas.ts
+++ b/frontend/src/features/system/data/quotas.ts
@@ -139,7 +139,7 @@ export type ProviderSyntheticQuotaData = ProviderQuotaDataCommon & {
 
 export type ProviderNeuralWattQuotaData = ProviderQuotaDataCommon & {
   balance?: { credits_remaining_usd?: number | null; total_credits_usd?: number | null } | null;
-  subscription?: { kwh_included?: number | null; kwh_used?: number | null; kwh_remaining?: number | null; in_overage?: boolean | null; status?: string | null; plan?: string | null } | null;
+  subscription?: { kwh_included?: number | null; kwh_used?: number | null; kwh_remaining?: number | null; in_overage?: boolean | null; status?: string | null; plan?: string | null; kwh_reset_date?: string | null } | null;
 }
 
 export type ProviderQuotaChannel = {

--- a/internal/server/biz/provider_quota/neuralwatt_checker.go
+++ b/internal/server/biz/provider_quota/neuralwatt_checker.go
@@ -23,14 +23,13 @@ type NeuralWattBalance struct {
 }
 
 type NeuralWattSubscription struct {
-	Plan               *string  `json:"plan,omitempty"`
-	Status             *string  `json:"status,omitempty"`
-	CurrentPeriodStart *string  `json:"current_period_start,omitempty"`
-	CurrentPeriodEnd   *string  `json:"current_period_end,omitempty"`
-	KwhIncluded        *float64 `json:"kwh_included,omitempty"`
-	KwhUsed            *float64 `json:"kwh_used,omitempty"`
-	KwhRemaining       *float64 `json:"kwh_remaining,omitempty"`
-	InOverage          *bool    `json:"in_overage,omitempty"`
+	Plan         *string  `json:"plan,omitempty"`
+	Status       *string  `json:"status,omitempty"`
+	KwhIncluded  *float64 `json:"kwh_included,omitempty"`
+	KwhUsed      *float64 `json:"kwh_used,omitempty"`
+	KwhRemaining *float64 `json:"kwh_remaining,omitempty"`
+	InOverage    *bool    `json:"in_overage,omitempty"`
+	KwhResetDate *string  `json:"kwh_reset_date,omitempty"`
 }
 
 type NeuralWattUsageResponse struct {
@@ -106,8 +105,8 @@ func (c *NeuralWattQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	}
 
 	var nextResetAt *time.Time
-	if response.Subscription != nil && response.Subscription.CurrentPeriodEnd != nil {
-		if t, err := time.Parse(time.RFC3339, *response.Subscription.CurrentPeriodEnd); err == nil {
+	if response.Subscription != nil && response.Subscription.KwhResetDate != nil {
+		if t, err := time.Parse(time.RFC3339, *response.Subscription.KwhResetDate); err == nil {
 			nextResetAt = &t
 		}
 	}
@@ -209,13 +208,6 @@ func convertNeuralWattSubscriptionToMap(sub *NeuralWattSubscription) map[string]
 		result["status"] = *sub.Status
 	}
 
-	if sub.CurrentPeriodStart != nil {
-		result["current_period_start"] = *sub.CurrentPeriodStart
-	}
-
-	if sub.CurrentPeriodEnd != nil {
-		result["current_period_end"] = *sub.CurrentPeriodEnd
-	}
 
 	if sub.KwhIncluded != nil {
 		result["kwh_included"] = *sub.KwhIncluded
@@ -231,6 +223,10 @@ func convertNeuralWattSubscriptionToMap(sub *NeuralWattSubscription) map[string]
 
 	if sub.InOverage != nil {
 		result["in_overage"] = *sub.InOverage
+	}
+
+	if sub.KwhResetDate != nil {
+		result["kwh_reset_date"] = *sub.KwhResetDate
 	}
 
 	return result

--- a/internal/server/biz/provider_quota/neuralwatt_checker_test.go
+++ b/internal/server/biz/provider_quota/neuralwatt_checker_test.go
@@ -31,8 +31,6 @@ func TestNeuralWatt_CheckQuota_HappyPath(t *testing.T) {
 				"subscription": {
 					"plan": "standard",
 					"status": "active",
-					"current_period_start": "2026-04-02T05:58:36Z",
-					"current_period_end": "2026-05-02T05:58:36Z",
 					"kwh_included": 20.0,
 					"kwh_used": 14.3126,
 					"kwh_remaining": 5.6874,
@@ -74,15 +72,12 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 				"subscription": {
 					"plan": "standard",
 					"status": "active",
-					"current_period_start": "2026-04-02T05:58:36Z",
-					"current_period_end": "2026-05-02T05:58:36Z",
 					"kwh_included": 20.0,
 					"kwh_used": 17.0,
 					"kwh_remaining": 3.0,
 					"in_overage": false
 				}
 			}`
-
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
@@ -104,7 +99,7 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_ExhaustedState(t *testing.T) {
-	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-05-02T05:58:36Z")
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -117,12 +112,11 @@ func TestNeuralWatt_CheckQuota_ExhaustedState(t *testing.T) {
 				"subscription": {
 					"plan": "standard",
 					"status": "active",
-					"current_period_start": "2026-04-02T05:58:36Z",
-					"current_period_end": "2026-05-02T05:58:36Z",
 					"kwh_included": 20.0,
 					"kwh_used": 22.5,
 					"kwh_remaining": 0.0,
-					"in_overage": true
+					"in_overage": true,
+					"kwh_reset_date": "2026-06-02T05:58:36Z"
 				}
 			}`
 
@@ -227,8 +221,6 @@ func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
 				"subscription": {
 					"plan": "standard",
 					"status": "active",
-					"current_period_start": "2026-04-02T05:58:36Z",
-					"current_period_end": "2026-05-02T05:58:36Z",
 					"kwh_included": 20.0,
 					"kwh_used": 20.0,
 					"kwh_remaining": 0.0,
@@ -304,8 +296,6 @@ func TestNeuralWatt_CheckQuota_CustomBaseURL(t *testing.T) {
 				"subscription": {
 					"plan": "standard",
 					"status": "active",
-					"current_period_start": "2026-04-02T05:58:36Z",
-					"current_period_end": "2026-05-02T05:58:36Z",
 					"kwh_included": 20.0,
 					"kwh_used": 10.0,
 					"kwh_remaining": 10.0,
@@ -332,6 +322,49 @@ func TestNeuralWatt_CheckQuota_CustomBaseURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
+}
+
+func TestNeuralWatt_CheckQuota_KwhResetDate(t *testing.T) {
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-26T19:25:50Z")
+
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{
+				"balance": {
+					"credits_remaining_usd": 120.01,
+					"total_credits_usd": 120.01,
+					"accounting_method": "energy"
+				},
+				"subscription": {
+					"plan": "pro",
+					"status": "active",
+					"kwh_included": 33.0,
+					"kwh_used": 8.7808,
+					"kwh_remaining": 24.2192,
+					"in_overage": false,
+					"kwh_reset_date": "2026-06-26T19:25:50Z"
+				}
+			}`
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewNeuralWattQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+	require.NotNil(t, quota.NextResetAt)
+	require.Equal(t, expectedResetAt, *quota.NextResetAt)
 }
 
 func TestNeuralWatt_SupportsChannel(t *testing.T) {

--- a/internal/server/biz/provider_quota/neuralwatt_checker_test.go
+++ b/internal/server/biz/provider_quota/neuralwatt_checker_test.go
@@ -60,6 +60,8 @@ func TestNeuralWatt_CheckQuota_HappyPath(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
+
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			// kwh_remaining = 3.0, kwh_included = 20.0 → 15% < 20% → warning
@@ -75,7 +77,8 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 					"kwh_included": 20.0,
 					"kwh_used": 17.0,
 					"kwh_remaining": 3.0,
-					"in_overage": false
+					"in_overage": false,
+					"kwh_reset_date": "2026-06-02T05:58:36Z"
 				}
 			}`
 			return &http.Response{
@@ -96,6 +99,8 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "warning", quota.Status)
 	require.True(t, quota.Ready)
+	require.NotNil(t, quota.NextResetAt)
+	require.Equal(t, expectedResetAt, *quota.NextResetAt)
 }
 
 func TestNeuralWatt_CheckQuota_ExhaustedState(t *testing.T) {
@@ -210,6 +215,8 @@ func TestNeuralWatt_CheckQuota_HTTPError(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
+
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			body := `{
@@ -224,7 +231,8 @@ func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
 					"kwh_included": 20.0,
 					"kwh_used": 20.0,
 					"kwh_remaining": 0.0,
-					"in_overage": false
+					"in_overage": false,
+					"kwh_reset_date": "2026-06-02T05:58:36Z"
 				}
 			}`
 
@@ -246,6 +254,8 @@ func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "exhausted", quota.Status)
 	require.False(t, quota.Ready)
+	require.NotNil(t, quota.NextResetAt)
+	require.Equal(t, expectedResetAt, *quota.NextResetAt)
 }
 
 func TestNeuralWatt_CheckQuota_SubscriptionWithoutKeyFields(t *testing.T) {


### PR DESCRIPTION
## Summary
Replaced `current_period_start` and `current_period_end` fields with `kwh_reset_date` in the NeuralWatt quota checker to better align with NeuralWatt's API subscription model and simplify quota reset date tracking.

## Spirit/Intent
Use a single `kwh_reset_date` field instead of period start/end dates for clearer quota reset tracking specific to NeuralWatt's kWh-based billing model.

## Key Changes
- **neuralwatt_checker.go**: Replaced `CurrentPeriodStart` and `CurrentPeriodEnd` with `KwhResetDate` in `NeuralWattSubscription` struct; updated `parseResponse()` to parse `kwh_reset_date` field
- **neuralwatt_checker_test.go**: Updated all test fixtures to use `kwh_reset_date` instead of `current_period_start`/`current_period_end`
- **quotas.ts**: Updated TypeScript type definitions to reflect the backend field changes

## Risks
- Breaking change for any frontend code relying on `current_period_start` or `current_period_end` - must ensure all consumers are updated to use `kwh_reset_date`
- Test coverage maintained but assumes API response format matches new structure
