### PR TITLE
fix: copy model prices when duplicating channel

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -28,6 +28,7 @@ import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/syst
 import { antigravityOAuthExchange, antigravityOAuthStart } from '../data/antigravity';
 import {
   useCreateChannel,
+  useDuplicateChannel,
   useUpdateChannel,
   useFetchModels,
   useAllChannelNames,
@@ -266,6 +267,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const isDuplicate = !!duplicateFromRow && !isEdit;
   const initialRow: Channel | undefined = currentRow || duplicateFromRow;
   const createChannel = useCreateChannel();
+  const duplicateChannel = useDuplicateChannel();
   const updateChannel = useUpdateChannel();
   const fetchModels = useFetchModels();
   const syncChannelModels = useSyncChannelModels();
@@ -643,6 +645,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
   const apiKeys = form.watch('credentials.apiKeys');
   const apiKeysCount = useMemo(() => (apiKeys || []).filter((k) => k.trim().length > 0).length, [apiKeys]);
+  const isSubmitting = createChannel.isPending || duplicateChannel.isPending || updateChannel.isPending;
 
   const { data: disabledKeys = [] } = useChannelDisabledAPIKeys(currentRow?.id || '', {
     enabled: isEdit && !!currentRow?.id && showApiKeysPanel,
@@ -1138,10 +1141,19 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
           passThroughBody,
         });
 
-        await createChannel.mutateAsync({
+        const createInput = {
           ...(dataWithModels as z.infer<typeof createChannelInputSchema>),
           settings: nextSettings,
-        } as z.infer<typeof createChannelInputSchema>);
+        } as z.infer<typeof createChannelInputSchema>;
+
+        if (isDuplicate && duplicateFromRow) {
+          await duplicateChannel.mutateAsync({
+            sourceID: duplicateFromRow.id,
+            input: createInput,
+          });
+        } else {
+          await createChannel.mutateAsync(createInput);
+        }
 
         // Auto-save proxy preset (preserve existing name if available)
         if (proxyType === ProxyType.URL && proxyUrl) {
@@ -2940,10 +2952,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
             <Button
               type='submit'
               form='channel-form'
-              disabled={createChannel.isPending || updateChannel.isPending || supportedModels.length === 0}
+              disabled={isSubmitting || supportedModels.length === 0}
               data-testid='channel-submit-button'
             >
-              {createChannel.isPending || updateChannel.isPending
+              {isSubmitting
                 ? isEdit
                   ? t('common.buttons.editing')
                   : t('common.buttons.creating')

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -124,6 +124,68 @@ const CREATE_CHANNEL_MUTATION = `
   }
 `;
 
+const DUPLICATE_CHANNEL_MUTATION = `
+  mutation DuplicateChannel($sourceID: ID!, $input: CreateChannelInput!) {
+    duplicateChannel(sourceID: $sourceID, input: $input) {
+      id
+      type
+      createdAt
+      updatedAt
+      type
+      baseURL
+      name
+      status
+      policies {
+        stream
+      }
+      supportedModels
+      autoSyncSupportedModels
+      autoSyncModelPattern
+      manualModels
+      tags
+      defaultTestModel
+        settings {
+          extraModelPrefix
+          modelMappings {
+            from
+            to
+          }
+          autoTrimedModelPrefixes
+          hideOriginalModels
+          hideMappedModels
+          lowercaseModelId
+          proxy {
+            type
+            url
+            username
+            password
+          }
+          transformOptions {
+            forceArrayInstructions
+            forceArrayInputs
+            replaceDeveloperRoleWithSystem
+          }
+          passThroughUserAgent
+          passThroughBody
+        }
+      orderingWeight
+      remark
+      defaultEndpoints {
+        apiFormat
+        path
+        baseURL
+        transport
+      }
+      endpoints {
+        apiFormat
+        path
+        baseURL
+        transport
+      }
+    }
+  }
+`;
+
 const BULK_CREATE_CHANNELS_MUTATION = `
   mutation BulkCreateChannels($input: BulkCreateChannelsInput!) {
     bulkCreateChannels(input: $input) {
@@ -919,6 +981,26 @@ export function useCreateChannel() {
     },
     onError: (error) => {
       handleError(error, { context: t('channels.dialogs.create.title') });
+    },
+  });
+}
+
+export function useDuplicateChannel() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  const { handleError } = useErrorHandler();
+
+  return useMutation({
+    mutationFn: async ({ sourceID, input }: { sourceID: string; input: CreateChannelInput }) => {
+      const data = await graphqlRequest<{ duplicateChannel: Channel }>(DUPLICATE_CHANNEL_MUTATION, { sourceID, input });
+      return channelSchema.parse(data.duplicateChannel);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['channels'] });
+      toast.success(t('common.success.duplicated'));
+    },
+    onError: (error) => {
+      handleError(error, { context: t('common.actions.duplicate') });
     },
   });
 }

--- a/internal/server/biz/channel_duplicate.go
+++ b/internal/server/biz/channel_duplicate.go
@@ -1,0 +1,92 @@
+package biz
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/channelmodelprice"
+	"github.com/looplj/axonhub/internal/ent/channelmodelpriceversion"
+	"github.com/looplj/axonhub/internal/pkg/xerrors"
+)
+
+// DuplicateChannel creates a new channel from input and copies current model prices
+// from the source channel in the same transaction.
+func (svc *ChannelService) DuplicateChannel(ctx context.Context, sourceID int, input ent.CreateChannelInput) (*ent.Channel, error) {
+	var duplicated *ent.Channel
+
+	err := svc.RunInTransaction(ctx, func(ctx context.Context) error {
+		db := svc.entFromContext(ctx)
+
+		if _, err := db.Channel.Get(ctx, sourceID); err != nil {
+			return fmt.Errorf("failed to get source channel: %w", err)
+		}
+
+		existing, err := db.Channel.Query().
+			Where(channel.Name(input.Name)).
+			First(ctx)
+		if err != nil && !ent.IsNotFound(err) {
+			return fmt.Errorf("failed to check channel name: %w", err)
+		}
+
+		if existing != nil {
+			return xerrors.DuplicateNameError("channel", input.Name)
+		}
+
+		ch, err := svc.createChannel(ctx, input)
+		if err != nil {
+			return err
+		}
+
+		prices, err := db.ChannelModelPrice.Query().
+			Where(
+				channelmodelprice.ChannelID(sourceID),
+				channelmodelprice.DeletedAtEQ(0),
+			).
+			All(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to query source channel model prices: %w", err)
+		}
+
+		now := time.Now()
+		for _, price := range prices {
+			refID := generateReferenceID()
+
+			copiedPrice, err := db.ChannelModelPrice.Create().
+				SetChannelID(ch.ID).
+				SetModelID(price.ModelID).
+				SetPrice(price.Price).
+				SetReferenceID(refID).
+				Save(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to copy channel model price: %w", err)
+			}
+
+			_, err = db.ChannelModelPriceVersion.Create().
+				SetChannelID(ch.ID).
+				SetModelID(price.ModelID).
+				SetChannelModelPriceID(copiedPrice.ID).
+				SetPrice(price.Price).
+				SetStatus(channelmodelpriceversion.StatusActive).
+				SetEffectiveStartAt(now).
+				SetReferenceID(refID).
+				Save(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to copy channel model price version: %w", err)
+			}
+		}
+
+		duplicated = ch
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	svc.asyncReloadChannels()
+
+	return duplicated, nil
+}

--- a/internal/server/biz/channel_price_test.go
+++ b/internal/server/biz/channel_price_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,6 +209,77 @@ func TestChannelService_SaveChannelModelPrices(t *testing.T) {
 func loToDecimalPtr(s string) *decimal.Decimal {
 	d, _ := decimal.NewFromString(s)
 	return &d
+}
+
+func TestChannelService_DuplicateChannelCopiesModelPrices(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	source, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Source Channel").
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key1"}).
+		SetSupportedModels([]string{"gpt-4", "gpt-4o"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	price := objects.ModelPrice{
+		Items: []objects.ModelPriceItem{
+			{
+				ItemCode: objects.PriceItemCodeUsage,
+				Pricing: objects.Pricing{
+					Mode:         objects.PricingModeUsagePerUnit,
+					UsagePerUnit: loToDecimalPtr("0.01"),
+				},
+			},
+		},
+	}
+
+	sourcePrices, err := svc.SaveChannelModelPrices(ctx, source.ID, []SaveChannelModelPriceInput{
+		{ModelID: "gpt-4", Price: price},
+	})
+	require.NoError(t, err)
+	require.Len(t, sourcePrices, 1)
+
+	duplicated, err := svc.DuplicateChannel(ctx, source.ID, ent.CreateChannelInput{
+		Type:             channel.TypeOpenai,
+		BaseURL:          lo.ToPtr("https://api.openai.com/v1"),
+		Name:             "Source Channel (1)",
+		Credentials:      objects.ChannelCredentials{APIKey: "key2"},
+		SupportedModels:  []string{"gpt-4", "gpt-4o"},
+		DefaultTestModel: "gpt-4",
+	})
+	require.NoError(t, err)
+
+	copiedPrices, err := client.ChannelModelPrice.Query().
+		Where(channelmodelprice.ChannelID(duplicated.ID)).
+		All(ctx)
+	require.NoError(t, err)
+	require.Len(t, copiedPrices, 1)
+
+	copiedPrice := copiedPrices[0]
+	require.Equal(t, "gpt-4", copiedPrice.ModelID)
+	require.Equal(t, price, copiedPrice.Price)
+	require.NotEqual(t, sourcePrices[0].ReferenceID, copiedPrice.ReferenceID)
+	require.Len(t, copiedPrice.ReferenceID, 8)
+
+	copiedVersion, err := client.ChannelModelPriceVersion.Query().
+		Where(channelmodelpriceversion.ChannelModelPriceID(copiedPrice.ID)).
+		Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, duplicated.ID, copiedVersion.ChannelID)
+	require.Equal(t, "gpt-4", copiedVersion.ModelID)
+	require.Equal(t, price, copiedVersion.Price)
+	require.Equal(t, channelmodelpriceversion.StatusActive, copiedVersion.Status)
+	require.Nil(t, copiedVersion.EffectiveEndAt)
+	require.Equal(t, copiedPrice.ReferenceID, copiedVersion.ReferenceID)
 }
 
 func TestCalculatePriceChanges(t *testing.T) {

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -756,6 +756,7 @@ type DeleteDisabledAPIKeysPayload {
 
 type Mutation {
   createChannel(input: CreateChannelInput!): Channel!
+  duplicateChannel(sourceID: ID!, input: CreateChannelInput!): Channel!
   bulkCreateChannels(input: BulkCreateChannelsInput!): [Channel!]!
   updateChannel(id: ID!, input: UpdateChannelInput!): Channel!
   saveChannelEndpoints(input: SaveChannelEndpointsInput!): Channel!

--- a/internal/server/gql/axonhub.resolvers.go
+++ b/internal/server/gql/axonhub.resolvers.go
@@ -157,6 +157,11 @@ func (r *mutationResolver) CreateChannel(ctx context.Context, input ent.CreateCh
 	return r.channelService.CreateChannel(ctx, input)
 }
 
+// DuplicateChannel is the resolver for the duplicateChannel field.
+func (r *mutationResolver) DuplicateChannel(ctx context.Context, sourceID objects.GUID, input ent.CreateChannelInput) (*ent.Channel, error) {
+	return r.channelService.DuplicateChannel(ctx, sourceID.ID, input)
+}
+
 // BulkCreateChannels is the resolver for the bulkCreateChannels field.
 func (r *mutationResolver) BulkCreateChannels(ctx context.Context, input biz.BulkCreateChannelsInput) ([]*ent.Channel, error) {
 	return r.channelService.BulkCreateChannels(ctx, input)

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -916,6 +916,7 @@ type ComplexityRoot struct {
 		DeleteRole                           func(childComplexity int, id objects.GUID) int
 		DeleteUser                           func(childComplexity int, id objects.GUID) int
 		DisableChannelAPIKey                 func(childComplexity int, channelID objects.GUID, key string) int
+		DuplicateChannel                     func(childComplexity int, sourceID objects.GUID, input ent.CreateChannelInput) int
 		EnableAllChannelAPIKeys              func(childComplexity int, channelID objects.GUID) int
 		EnableChannelAPIKey                  func(childComplexity int, channelID objects.GUID, key string) int
 		EnableSelectedChannelAPIKeys         func(childComplexity int, channelID objects.GUID, keys []string) int
@@ -2013,6 +2014,7 @@ type ModelResolver interface {
 }
 type MutationResolver interface {
 	CreateChannel(ctx context.Context, input ent.CreateChannelInput) (*ent.Channel, error)
+	DuplicateChannel(ctx context.Context, sourceID objects.GUID, input ent.CreateChannelInput) (*ent.Channel, error)
 	BulkCreateChannels(ctx context.Context, input biz.BulkCreateChannelsInput) ([]*ent.Channel, error)
 	UpdateChannel(ctx context.Context, id objects.GUID, input ent.UpdateChannelInput) (*ent.Channel, error)
 	SaveChannelEndpoints(ctx context.Context, input biz.SaveChannelEndpointsInput) (*ent.Channel, error)
@@ -5725,6 +5727,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DisableChannelAPIKey(childComplexity, args["channelID"].(objects.GUID), args["key"].(string)), true
+	case "Mutation.duplicateChannel":
+		if e.complexity.Mutation.DuplicateChannel == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_duplicateChannel_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DuplicateChannel(childComplexity, args["sourceID"].(objects.GUID), args["input"].(ent.CreateChannelInput)), true
 	case "Mutation.enableAllChannelAPIKeys":
 		if e.complexity.Mutation.EnableAllChannelAPIKeys == nil {
 			break
@@ -11660,6 +11673,22 @@ func (ec *executionContext) field_Mutation_disableChannelAPIKey_args(ctx context
 		return nil, err
 	}
 	args["key"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_duplicateChannel_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "sourceID", ec.unmarshalNID2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋobjectsᚐGUID)
+	if err != nil {
+		return nil, err
+	}
+	args["sourceID"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNCreateChannelInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋentᚐCreateChannelInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg1
 	return args, nil
 }
 
@@ -28861,6 +28890,109 @@ func (ec *executionContext) fieldContext_Mutation_createChannel(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createChannel_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_duplicateChannel(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_duplicateChannel,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().DuplicateChannel(ctx, fc.Args["sourceID"].(objects.GUID), fc.Args["input"].(ent.CreateChannelInput))
+		},
+		nil,
+		ec.marshalNChannel2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋentᚐChannel,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_duplicateChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Channel_id(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Channel_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Channel_updatedAt(ctx, field)
+			case "type":
+				return ec.fieldContext_Channel_type(ctx, field)
+			case "baseURL":
+				return ec.fieldContext_Channel_baseURL(ctx, field)
+			case "name":
+				return ec.fieldContext_Channel_name(ctx, field)
+			case "status":
+				return ec.fieldContext_Channel_status(ctx, field)
+			case "supportedModels":
+				return ec.fieldContext_Channel_supportedModels(ctx, field)
+			case "manualModels":
+				return ec.fieldContext_Channel_manualModels(ctx, field)
+			case "autoSyncSupportedModels":
+				return ec.fieldContext_Channel_autoSyncSupportedModels(ctx, field)
+			case "autoSyncModelPattern":
+				return ec.fieldContext_Channel_autoSyncModelPattern(ctx, field)
+			case "tags":
+				return ec.fieldContext_Channel_tags(ctx, field)
+			case "defaultTestModel":
+				return ec.fieldContext_Channel_defaultTestModel(ctx, field)
+			case "policies":
+				return ec.fieldContext_Channel_policies(ctx, field)
+			case "settings":
+				return ec.fieldContext_Channel_settings(ctx, field)
+			case "orderingWeight":
+				return ec.fieldContext_Channel_orderingWeight(ctx, field)
+			case "errorMessage":
+				return ec.fieldContext_Channel_errorMessage(ctx, field)
+			case "remark":
+				return ec.fieldContext_Channel_remark(ctx, field)
+			case "endpoints":
+				return ec.fieldContext_Channel_endpoints(ctx, field)
+			case "requests":
+				return ec.fieldContext_Channel_requests(ctx, field)
+			case "executions":
+				return ec.fieldContext_Channel_executions(ctx, field)
+			case "usageLogs":
+				return ec.fieldContext_Channel_usageLogs(ctx, field)
+			case "channelProbes":
+				return ec.fieldContext_Channel_channelProbes(ctx, field)
+			case "channelModelPrices":
+				return ec.fieldContext_Channel_channelModelPrices(ctx, field)
+			case "providerQuotaStatus":
+				return ec.fieldContext_Channel_providerQuotaStatus(ctx, field)
+			case "defaultEndpoints":
+				return ec.fieldContext_Channel_defaultEndpoints(ctx, field)
+			case "allModelEntries":
+				return ec.fieldContext_Channel_allModelEntries(ctx, field)
+			case "credentials":
+				return ec.fieldContext_Channel_credentials(ctx, field)
+			case "disabledAPIKeys":
+				return ec.fieldContext_Channel_disabledAPIKeys(ctx, field)
+			case "liveLimiterStats":
+				return ec.fieldContext_Channel_liveLimiterStats(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Channel", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_duplicateChannel_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -90266,6 +90398,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createChannel":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createChannel(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "duplicateChannel":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_duplicateChannel(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++


### PR DESCRIPTION
## Summary
- add a duplicateChannel mutation that creates the duplicated channel and copies model prices in one transaction
- copy active model prices with fresh reference IDs and active price versions
- route the channel duplicate dialog through the new mutation

## Tests
- go test ./internal/server/biz -run TestChannelService_DuplicateChannelCopiesModelPrices -count=1
- go test ./internal/server/gql -run TestDoesNotExist -count=1

## Notes
- The fork-only GHCR build workflow is on a separate build branch and is not included in this PR.