### PR TITLE
fix: preserve filter state when navigating to request detail page

### DIFF
--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -148,6 +148,10 @@ export function DataTableToolbar<TData>({
       value: 'failed' as RequestStatus,
       label: t('requests.status.failed'),
     },
+    {
+      value: 'canceled' as RequestStatus,
+      label: t('requests.status.canceled'),
+    },
   ];
 
   const requestSources = [

--- a/frontend/src/features/requests/components/request-detail-global-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-global-page.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { useParams, useNavigate } from '@tanstack/react-router';
+import { useParams, useNavigate, useRouterState } from '@tanstack/react-router';
 import { ArrowLeft, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { extractNumberID } from '@/lib/utils';
@@ -14,13 +14,16 @@ export default function RequestDetailGlobalPage() {
   const { t } = useTranslation();
   const { requestId } = useParams({ from: '/_authenticated/requests/$requestId' });
   const navigate = useNavigate();
+  const currentSearch = useRouterState({
+    select: (state) => (state.location.search ?? {}) as Record<string, unknown>,
+  });
   const { data: request } = useRequest(requestId, { projectId: null });
 
   return (
     <div className='flex h-screen flex-col'>
       <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur'>
         <div className='flex items-center space-x-4'>
-          <Button variant='ghost' size='sm' onClick={() => navigate({ to: '/requests' })} className='hover:bg-accent'>
+          <Button variant='ghost' size='sm' onClick={() => navigate({ to: '/requests', search: currentSearch })} className='hover:bg-accent'>
             <ArrowLeft className='mr-2 h-4 w-4' />
             {t('common.back')}
           </Button>

--- a/frontend/src/features/requests/components/request-detail-global-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-global-page.tsx
@@ -20,7 +20,7 @@ export default function RequestDetailGlobalPage() {
     <div className='flex h-screen flex-col'>
       <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur'>
         <div className='flex items-center space-x-4'>
-          <Button variant='ghost' size='sm' onClick={() => navigate({ to: '/channels' })} className='hover:bg-accent'>
+          <Button variant='ghost' size='sm' onClick={() => navigate({ to: '/requests' })} className='hover:bg-accent'>
             <ArrowLeft className='mr-2 h-4 w-4' />
             {t('common.back')}
           </Button>

--- a/frontend/src/hooks/use-pagination-search.ts
+++ b/frontend/src/hooks/use-pagination-search.ts
@@ -303,13 +303,15 @@ export function usePaginationSearch(options: UsePaginationSearchOptions = {}): U
 
   const navigateWithSearch = useCallback(
     (options: { to: string; params?: Record<string, any> }) => {
+      // Merge current URL search params (including filters) with pagination params
+      // to preserve all state when navigating to detail pages and back
       navigate({
         to: options.to as any,
         params: options.params,
-        search: getSearchParams(),
+        search: { ...search, ...getSearchParams() } as Record<string, unknown>,
       } as any);
     },
-    [navigate, getSearchParams]
+    [navigate, search, getSearchParams]
   );
 
   return {


### PR DESCRIPTION
fixed issues #1813 

- Add 'canceled' status to request status filter dropdown
- Fix navigateWithSearch to preserve all URL search params (filters + pagination)
- Fix incorrect back navigation path in global request detail page