### PR TITLE
fix: 修复非管理员切换语言权限错误

### DIFF
--- a/internal/scopes/policy.go
+++ b/internal/scopes/policy.go
@@ -24,11 +24,19 @@ type Policy struct {
 
 // EvalQuery evaluates a query against the policy's query rules.
 func (p Policy) EvalQuery(ctx context.Context, q ent.Query) error {
+	if decision, ok := privacy.DecisionFromContext(ctx); ok {
+		return decision
+	}
+
 	return p.Query.EvalQuery(ctx, q)
 }
 
 // EvalMutation evaluates a mutation against the policy's mutation rules.
 func (p Policy) EvalMutation(ctx context.Context, m ent.Mutation) error {
+	if decision, ok := privacy.DecisionFromContext(ctx); ok {
+		return decision
+	}
+
 	return p.Mutation.EvalMutation(ctx, m)
 }
 

--- a/internal/scopes/policy_test.go
+++ b/internal/scopes/policy_test.go
@@ -460,3 +460,17 @@ func TestPolicy_Complete(t *testing.T) {
 	mutationErr := policy.EvalMutation(ctx, nil)
 	require.ErrorIs(t, mutationErr, privacy.Allow)
 }
+
+func TestPolicy_EvalQuery_UsesContextDecision(t *testing.T) {
+	ctx := privacy.DecisionContext(context.Background(), privacy.Allow)
+
+	err := (Policy{}).EvalQuery(ctx, nil)
+	require.NoError(t, err)
+}
+
+func TestPolicy_EvalMutation_UsesContextDecision(t *testing.T) {
+	ctx := privacy.DecisionContext(context.Background(), privacy.Allow)
+
+	err := (Policy{}).EvalMutation(ctx, nil)
+	require.NoError(t, err)
+}

--- a/internal/scopes/policy_test.go
+++ b/internal/scopes/policy_test.go
@@ -474,3 +474,17 @@ func TestPolicy_EvalMutation_UsesContextDecision(t *testing.T) {
 	err := (Policy{}).EvalMutation(ctx, nil)
 	require.NoError(t, err)
 }
+
+func TestPolicy_EvalQuery_PropagatesDenyContextDecision(t *testing.T) {
+	ctx := privacy.DecisionContext(context.Background(), privacy.Deny)
+
+	err := (Policy{}).EvalQuery(ctx, nil)
+	require.ErrorIs(t, err, privacy.Deny)
+}
+
+func TestPolicy_EvalMutation_PropagatesDenyContextDecision(t *testing.T) {
+	ctx := privacy.DecisionContext(context.Background(), privacy.Deny)
+
+	err := (Policy{}).EvalMutation(ctx, nil)
+	require.ErrorIs(t, err, privacy.Deny)
+}

--- a/internal/server/biz/user_test.go
+++ b/internal/server/biz/user_test.go
@@ -1473,3 +1473,39 @@ func TestUpdateProjectUser_UpdateIsOwner_PermissionDenied(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, userProject.IsOwner)
 }
+
+func TestUpdateOwnProfile_AllowsLanguageChangeWithoutUserScopes(t *testing.T) {
+	userService, client := setupTestUserService(t)
+	defer client.Close()
+
+	setupCtx := context.Background()
+	setupCtx = ent.NewContext(setupCtx, client)
+	setupCtx = authz.WithTestBypass(setupCtx)
+
+	regularUser, err := client.User.Create().
+		SetEmail("language-user@example.com").
+		SetPassword("password").
+		SetFirstName("Language").
+		SetLastName("User").
+		SetPreferLanguage("en").
+		SetStatus(user.StatusActivated).
+		SetScopes([]string{}).
+		Save(setupCtx)
+	require.NoError(t, err)
+
+	requestCtx := context.Background()
+	requestCtx = ent.NewContext(requestCtx, client)
+	requestCtx = authz.NewUserContext(requestCtx, regularUser.ID)
+	requestCtx = contexts.WithUser(requestCtx, regularUser)
+
+	language := "zh"
+	updatedUser, err := userService.UpdateOwnProfile(requestCtx, ent.UpdateUserInput{
+		PreferLanguage: &language,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "zh", updatedUser.PreferLanguage)
+
+	storedUser, err := client.User.Get(setupCtx, regularUser.ID)
+	require.NoError(t, err)
+	require.Equal(t, "zh", storedUser.PreferLanguage)
+}


### PR DESCRIPTION
## 变更说明

- 修复自定义 `scopes.Policy` 未尊重 Ent `privacy.DecisionContext` 的问题
- 让 `updateMe` / `UpdateOwnProfile` 使用的 system bypass 真正生效
- 增加非管理员、无用户权限时修改自己 `preferLanguage` 的回归测试

## 验证

- `go test ./internal/scopes ./internal/server/biz`
- `go test -count=1 ./internal/server/biz -run TestUpdateOwnProfile_AllowsLanguageChangeWithoutUserScopes`
- `go test -count=1 ./internal/scopes -run 'TestPolicy_Eval(Query|Mutation)_UsesContextDecision'`

## 影响

修复后，非管理员账号可以通过右上角语言切换或设置页保存自己的界面语言，不再需要 `read_users` / `write_users` 权限。
