### PR TITLE
fix: allow third-party Codex channels to edit Base URL

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -913,12 +913,14 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       setResponsesTransport(transport);
 
       const channelType = selectedProvider === 'codex' ? 'codex' : selectedType || derivedChannelType;
+      // Third-party Codex channels use custom endpoints — don't overwrite them on transport switch
+      if (isCodexType && authMode === 'third-party') return;
       const baseURL = transport === 'websocket' ? getResponsesWebSocketBaseURL(channelType) : getDefaultBaseURL(channelType);
       if (baseURL) {
         form.setValue('baseURL', baseURL, { shouldDirty: true });
       }
     },
-    [derivedChannelType, form, isOAuthChannel, selectedProvider, selectedType]
+    [authMode, derivedChannelType, form, isCodexType, isOAuthChannel, selectedProvider, selectedType]
   );
 
   const handleGeminiVertexChange = useCallback(
@@ -2105,7 +2107,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                 aria-invalid={!!fieldState.error}
                                 data-testid='channel-base-url-input'
                                 disabled={
-                                  isCodexType || (isClaudeCodeType && authMode === 'official') || selectedProvider === 'antigravity'
+                                  (isCodexType && authMode !== 'third-party') || (isClaudeCodeType && authMode === 'official') || selectedProvider === 'antigravity'
                                 }
                                 {...field}
                               />


### PR DESCRIPTION
## Problem

PR #1808 changed the Base URL input `disabled` condition from:

```tsx
(isCodexType && (authMode === 'official' || authMode === 'auth-json'))
```

to just:

```tsx
isCodexType
```

This unconditionally disables the Base URL field for **all** Codex channels, including third-party ones. Third-party Codex channels require a custom Base URL by definition — without it, the third-party option is functionally useless.

Additionally, `handleResponsesTransportChange` would overwrite a third-party channel's custom endpoint when the user switches the Responses transport protocol.

## Fix

1. **Base URL `disabled` condition**: Changed `isCodexType` to `(isCodexType && authMode !== 'third-party')`, restoring the ability for third-party Codex channels to edit their Base URL.

2. **Transport switch protection**: Added an early return in `handleResponsesTransportChange` when `isCodexType && authMode === 'third-party'`, preventing the official default URL from overwriting the user's custom endpoint on protocol switch.

## Testing

- Official Codex: Base URL remains disabled (auto-controlled by protocol)
- Auth-JSON Codex: Base URL remains disabled
- Third-party Codex: Base URL is now editable ✅
- Switching Responses transport on third-party Codex: preserves custom URL ✅

Fixes regression from #1808