### PR TITLE
fix: enforce strict local channel RPM admission

### DIFF
--- a/internal/server/biz/quota.go
+++ b/internal/server/biz/quota.go
@@ -16,8 +16,9 @@ import (
 )
 
 type QuotaWindow struct {
-	Start *time.Time
-	End   *time.Time
+	Start        *time.Time
+	End          *time.Time
+	EndInclusive bool
 }
 
 type QuotaUsage struct {
@@ -197,7 +198,7 @@ func quotaWindow(now time.Time, period objects.APIKeyQuotaPeriod, loc *time.Loca
 	switch period.Type {
 	case objects.APIKeyQuotaPeriodTypeAllTime:
 		end := now
-		return QuotaWindow{End: &end}, nil
+		return QuotaWindow{End: &end, EndInclusive: true}, nil
 	case objects.APIKeyQuotaPeriodTypePastDuration:
 		if period.PastDuration == nil {
 			return QuotaWindow{}, fmt.Errorf("pastDuration is required")
@@ -223,7 +224,7 @@ func quotaWindow(now time.Time, period objects.APIKeyQuotaPeriod, loc *time.Loca
 		start := now.Add(-d)
 		end := now
 
-		return QuotaWindow{Start: &start, End: &end}, nil
+		return QuotaWindow{Start: &start, End: &end, EndInclusive: true}, nil
 	case objects.APIKeyQuotaPeriodTypeCalendarDuration:
 		if period.CalendarDuration == nil {
 			return QuotaWindow{}, fmt.Errorf("calendarDuration is required")
@@ -262,7 +263,11 @@ func (s *QuotaService) requestCount(ctx context.Context, apiKeyID int, window Qu
 	}
 
 	if window.End != nil {
-		q = q.Where(usagelog.CreatedAtLT(*window.End))
+		if window.EndInclusive {
+			q = q.Where(usagelog.CreatedAtLTE(*window.End))
+		} else {
+			q = q.Where(usagelog.CreatedAtLT(*window.End))
+		}
 	}
 
 	n, err := q.Count(ctx)
@@ -289,7 +294,11 @@ func (s *QuotaService) usageAgg(ctx context.Context, apiKeyID int, window QuotaW
 		}
 
 		if window.End != nil {
-			q = q.Where(usagelog.CreatedAtLT(*window.End))
+			if window.EndInclusive {
+				q = q.Where(usagelog.CreatedAtLTE(*window.End))
+			} else {
+				q = q.Where(usagelog.CreatedAtLT(*window.End))
+			}
 		}
 
 		switch {

--- a/internal/server/biz/quota_test.go
+++ b/internal/server/biz/quota_test.go
@@ -240,6 +240,64 @@ func TestQuotaService_PastDurationMinute_RequestCountExceeded(t *testing.T) {
 	require.Contains(t, res.Message, "requests quota exceeded")
 }
 
+func TestQuotaService_PastDurationMinute_IncludesUsageAtWindowEnd(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	p, err := client.Project.Create().
+		SetName("p").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	windowEnd := time.Now().UTC()
+	apiKeyID := 11
+
+	req, err := client.Request.Create().
+		SetProjectID(p.ID).
+		SetAPIKeyID(apiKeyID).
+		SetModelID("m").
+		SetFormat("openai/chat_completions").
+		SetStatus(request.StatusCompleted).
+		SetRequestBody(objects.JSONRawMessage([]byte(`{}`))).
+		SetCreatedAt(windowEnd).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.UsageLog.Create().
+		SetRequestID(req.ID).
+		SetAPIKeyID(apiKeyID).
+		SetProjectID(p.ID).
+		SetChannelID(1).
+		SetModelID("m").
+		SetTotalTokens(10).
+		SetTotalCost(1.0).
+		SetCreatedAt(windowEnd).
+		Save(ctx)
+	require.NoError(t, err)
+
+	systemService := NewSystemService(SystemServiceParams{Ent: client})
+	svc := NewQuotaService(client, systemService)
+	window := QuotaWindow{
+		Start:        lo.ToPtr(windowEnd.Add(-1 * time.Minute)),
+		End:          lo.ToPtr(windowEnd),
+		EndInclusive: true,
+	}
+
+	count, err := svc.requestCount(ctx, apiKeyID, window)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	usage, err := svc.usageAgg(ctx, apiKeyID, window, true, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), usage.TotalTokens)
+	require.True(t, usage.TotalCost.Equal(decimal.NewFromFloat(1.0)))
+}
+
 func TestQuotaWindow_PastDurationMinute(t *testing.T) {
 	now := time.Date(2026, 1, 20, 1, 2, 3, 0, time.UTC)
 	window, err := quotaWindow(now, objects.APIKeyQuotaPeriod{
@@ -254,6 +312,7 @@ func TestQuotaWindow_PastDurationMinute(t *testing.T) {
 	require.NotNil(t, window.End)
 	require.Equal(t, now.Add(-5*time.Minute), *window.Start)
 	require.Equal(t, now, *window.End)
+	require.True(t, window.EndInclusive)
 }
 
 func TestQuotaWindow_AllTime(t *testing.T) {
@@ -265,6 +324,7 @@ func TestQuotaWindow_AllTime(t *testing.T) {
 	require.Nil(t, window.Start)
 	require.NotNil(t, window.End)
 	require.Equal(t, now, *window.End)
+	require.True(t, window.EndInclusive)
 }
 
 func TestQuotaWindow_CalendarDay_Timezone(t *testing.T) {
@@ -284,6 +344,7 @@ func TestQuotaWindow_CalendarDay_Timezone(t *testing.T) {
 
 	require.Equal(t, time.Date(2026, 1, 19, 16, 0, 0, 0, time.UTC), *window.Start)
 	require.Equal(t, time.Date(2026, 1, 20, 16, 0, 0, 0, time.UTC), *window.End)
+	require.False(t, window.EndInclusive)
 }
 
 func TestQuotaWindow_CalendarMonth_Timezone(t *testing.T) {
@@ -303,6 +364,64 @@ func TestQuotaWindow_CalendarMonth_Timezone(t *testing.T) {
 
 	require.Equal(t, time.Date(2025, 12, 31, 16, 0, 0, 0, time.UTC), *window.Start)
 	require.Equal(t, time.Date(2026, 1, 31, 16, 0, 0, 0, time.UTC), *window.End)
+	require.False(t, window.EndInclusive)
+}
+
+func TestQuotaService_CalendarDuration_ExcludesUsageAtWindowEnd(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	p, err := client.Project.Create().
+		SetName("p").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	windowEnd := time.Date(2026, 1, 21, 0, 0, 0, 0, time.UTC)
+	apiKeyID := 12
+
+	req, err := client.Request.Create().
+		SetProjectID(p.ID).
+		SetAPIKeyID(apiKeyID).
+		SetModelID("m").
+		SetFormat("openai/chat_completions").
+		SetStatus(request.StatusCompleted).
+		SetRequestBody(objects.JSONRawMessage([]byte(`{}`))).
+		SetCreatedAt(windowEnd).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.UsageLog.Create().
+		SetRequestID(req.ID).
+		SetAPIKeyID(apiKeyID).
+		SetProjectID(p.ID).
+		SetChannelID(1).
+		SetModelID("m").
+		SetTotalTokens(10).
+		SetTotalCost(1.0).
+		SetCreatedAt(windowEnd).
+		Save(ctx)
+	require.NoError(t, err)
+
+	systemService := NewSystemService(SystemServiceParams{Ent: client})
+	svc := NewQuotaService(client, systemService)
+	window := QuotaWindow{
+		Start: lo.ToPtr(windowEnd.Add(-24 * time.Hour)),
+		End:   lo.ToPtr(windowEnd),
+	}
+
+	count, err := svc.requestCount(ctx, apiKeyID, window)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+
+	usage, err := svc.usageAgg(ctx, apiKeyID, window, true, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), usage.TotalTokens)
+	require.True(t, usage.TotalCost.Equal(decimal.Zero))
 }
 
 func TestQuotaService_CalendarDay_CostExceeded(t *testing.T) {

--- a/internal/server/orchestrator/candidates_cache_test.go
+++ b/internal/server/orchestrator/candidates_cache_test.go
@@ -115,16 +115,24 @@ func TestDefaultSelector_SelectModelCandidates_Cache(t *testing.T) {
 	})
 
 	t.Run("cache invalidated when channel updated", func(t *testing.T) {
+		selector.cacheMu.RLock()
+		initialEntry := selector.associationCache[modelID]
+		selector.cacheMu.RUnlock()
+
 		// Update a channel's timestamp
-		_, err := client.Channel.UpdateOneID(channels[0].ID).
+		updatedChannel, err := client.Channel.UpdateOneID(channels[0].ID).
 			SetUpdatedAt(now.Add(1 * time.Hour)).
 			Save(ctx)
 		require.NoError(t, err)
 
-		// Clear cache to force refresh
-		selector.cacheMu.Lock()
-		selector.associationCache = make(map[string]*associationCacheEntry)
-		selector.cacheMu.Unlock()
+		enabledChannels := append([]*biz.Channel(nil), channelService.GetEnabledChannels()...)
+		for i, ch := range enabledChannels {
+			if ch.ID == updatedChannel.ID {
+				enabledChannels[i] = &biz.Channel{Channel: updatedChannel}
+				break
+			}
+		}
+		channelService.SetEnabledChannelsForTest(enabledChannels)
 
 		req := &llm.Request{Model: modelID}
 		candidates, err := selector.selectModelCandidates(ctx, req)
@@ -137,6 +145,7 @@ func TestDefaultSelector_SelectModelCandidates_Cache(t *testing.T) {
 		selector.cacheMu.RUnlock()
 
 		require.NotNil(t, entry)
+		require.NotSame(t, initialEntry, entry, "cache entry should be refreshed when channel is updated")
 		require.True(t, entry.latestChannelUpdateTime.After(now), "cache should reflect new update time")
 	})
 

--- a/internal/server/orchestrator/channel_help_test.go
+++ b/internal/server/orchestrator/channel_help_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -183,11 +184,13 @@ type mockExecutor struct {
 	streamEvents  []*httpclient.StreamEvent
 	err           error
 	requestCalled bool
+	requestCalls  atomic.Int64
 	lastRequest   *httpclient.Request
 }
 
 func (m *mockExecutor) Do(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
 	m.requestCalled = true
+	m.requestCalls.Add(1)
 
 	m.lastRequest = request
 	if m.err != nil {
@@ -199,6 +202,7 @@ func (m *mockExecutor) Do(ctx context.Context, request *httpclient.Request) (*ht
 
 func (m *mockExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	m.requestCalled = true
+	m.requestCalls.Add(1)
 
 	m.lastRequest = request
 	if m.err != nil {
@@ -359,16 +363,16 @@ func newTestOrchestrator(
 	channelService, requestService, systemService, usageLogService := setupTestServices(t, client)
 
 	orchestrator := &ChatCompletionOrchestrator{
-		channelSelector:   channelSelector,
-		Inbound:           openai.NewInboundTransformer(),
-		RequestService:    requestService,
-		ChannelService:    channelService,
-		PromptProvider:    &stubPromptProvider{},
-		SystemService:     systemService,
-		UsageLogService:   usageLogService,
-		PipelineFactory:   pipeline.NewFactory(executor),
-		ModelMapper:       NewModelMapper(),
-		channelLimiterManager:      NewChannelLimiterManager(),
+		channelSelector:       channelSelector,
+		Inbound:               openai.NewInboundTransformer(),
+		RequestService:        requestService,
+		ChannelService:        channelService,
+		PromptProvider:        &stubPromptProvider{},
+		SystemService:         systemService,
+		UsageLogService:       usageLogService,
+		PipelineFactory:       pipeline.NewFactory(executor),
+		ModelMapper:           NewModelMapper(),
+		channelLimiterManager: NewChannelLimiterManager(),
 		Middlewares: []pipeline.Middleware{
 			stream.EnsureUsage(),
 		},

--- a/internal/server/orchestrator/channel_request_tracker.go
+++ b/internal/server/orchestrator/channel_request_tracker.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ChannelRequestTracker tracks per-channel request and token counts
-// within a fixed 1-minute sliding window for rate limiting.
+// within fixed natural-minute buckets for rate limiting.
 // It also manages cooldown periods for channels that received 429 errors.
 type ChannelRequestTracker struct {
 	mu        sync.RWMutex
@@ -42,13 +42,25 @@ func (t *ChannelRequestTracker) getOrResetWindow(channelID int) *rateLimitWindow
 	return w
 }
 
-// IncrementRequest increments the request count for a channel.
-func (t *ChannelRequestTracker) IncrementRequest(channelID int) {
+// TryAcquireRequest atomically checks and consumes one request slot for a
+// channel in the current fixed minute bucket. A non-positive limit means the
+// caller has no RPM limit configured, so no slot is consumed.
+func (t *ChannelRequestTracker) TryAcquireRequest(channelID int, limit int64) bool {
+	if limit <= 0 {
+		return true
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	w := t.getOrResetWindow(channelID)
+	if w.requests >= limit {
+		return false
+	}
+
 	w.requests++
+
+	return true
 }
 
 // AddTokens adds token count for a channel.

--- a/internal/server/orchestrator/channel_request_tracker_test.go
+++ b/internal/server/orchestrator/channel_request_tracker_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,14 +15,24 @@ func TestNewChannelRequestTracker(t *testing.T) {
 	assert.NotNil(t, tracker.counters)
 }
 
-func TestChannelRequestTracker_IncrementRequest(t *testing.T) {
+func TestChannelRequestTracker_TryAcquireRequestIncrementsCount(t *testing.T) {
 	tracker := NewChannelRequestTracker()
 
-	tracker.IncrementRequest(1)
-	tracker.IncrementRequest(1)
-	tracker.IncrementRequest(1)
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
 
 	assert.Equal(t, int64(3), tracker.GetRequestCount(1))
+}
+
+func TestChannelRequestTracker_TryAcquireRequestRejectsWhenLimitReached(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+
+	assert.True(t, tracker.TryAcquireRequest(1, 2))
+	assert.True(t, tracker.TryAcquireRequest(1, 2))
+	assert.False(t, tracker.TryAcquireRequest(1, 2))
+
+	assert.Equal(t, int64(2), tracker.GetRequestCount(1))
 }
 
 func TestChannelRequestTracker_AddTokens(t *testing.T) {
@@ -55,9 +66,9 @@ func TestChannelRequestTracker_GetTokenCount_UnknownChannel(t *testing.T) {
 func TestChannelRequestTracker_MultipleChannels(t *testing.T) {
 	tracker := NewChannelRequestTracker()
 
-	tracker.IncrementRequest(1)
-	tracker.IncrementRequest(1)
-	tracker.IncrementRequest(2)
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
+	assert.True(t, tracker.TryAcquireRequest(2, 10))
 	tracker.AddTokens(1, 100)
 	tracker.AddTokens(2, 500)
 
@@ -84,7 +95,7 @@ func TestChannelRequestTracker_WindowReset(t *testing.T) {
 	assert.Equal(t, int64(0), tracker.GetTokenCount(1))
 
 	// Writes should create a new window
-	tracker.IncrementRequest(1)
+	assert.True(t, tracker.TryAcquireRequest(1, 10))
 	assert.Equal(t, int64(1), tracker.GetRequestCount(1))
 	assert.Equal(t, int64(0), tracker.GetTokenCount(1))
 }
@@ -118,13 +129,13 @@ func TestChannelRequestTracker_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines * 2)
 
-	// Concurrent IncrementRequest
+	// Concurrent TryAcquireRequest
 	for range goroutines {
 		go func() {
 			defer wg.Done()
 
 			for range opsPerGoroutine {
-				tracker.IncrementRequest(1)
+				tracker.TryAcquireRequest(1, int64(goroutines*opsPerGoroutine))
 			}
 		}()
 	}
@@ -157,7 +168,7 @@ func TestChannelRequestTracker_ConcurrentReadWrite(t *testing.T) {
 		defer wg.Done()
 
 		for range 1000 {
-			tracker.IncrementRequest(1)
+			tracker.TryAcquireRequest(1, 1000)
 		}
 	}()
 
@@ -182,6 +193,54 @@ func TestChannelRequestTracker_ConcurrentReadWrite(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, int64(1000), tracker.GetRequestCount(1))
+}
+
+func TestChannelRequestTracker_TryAcquireRequestStrictlyCapsConcurrentBurst(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+
+	const (
+		channelID  = 42
+		limit      = int64(2)
+		goroutines = 50
+	)
+
+	start := make(chan struct{})
+	var successes atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+
+			if tracker.TryAcquireRequest(channelID, limit) {
+				successes.Add(1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, limit, successes.Load())
+	assert.Equal(t, limit, tracker.GetRequestCount(channelID))
+}
+
+func TestChannelRequestTracker_TryAcquireRequestResetsExpiredWindow(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+
+	tracker.mu.Lock()
+	tracker.counters[1] = &rateLimitWindow{
+		requests:    10,
+		tokens:      500,
+		windowStart: time.Now().Truncate(time.Minute).Add(-time.Minute),
+	}
+	tracker.mu.Unlock()
+
+	assert.True(t, tracker.TryAcquireRequest(1, 1))
+	assert.Equal(t, int64(1), tracker.GetRequestCount(1))
+	assert.Equal(t, int64(0), tracker.GetTokenCount(1))
 }
 
 // ========== Cooldown Tests ==========

--- a/internal/server/orchestrator/lb_strategy_rate_limit_test.go
+++ b/internal/server/orchestrator/lb_strategy_rate_limit_test.go
@@ -64,7 +64,7 @@ func TestRateLimitAwareStrategy_Score_RPMExhausted(t *testing.T) {
 	}
 
 	for range rpm {
-		tracker.IncrementRequest(channel.ID)
+		tracker.TryAcquireRequest(channel.ID, rpm)
 	}
 
 	ctx := context.Background()
@@ -108,7 +108,7 @@ func TestRateLimitAwareStrategy_Score_CooldownTakesPriority(t *testing.T) {
 	}
 
 	tracker.SetCooldown(channel.ID, time.Now().Add(30*time.Second))
-	tracker.IncrementRequest(channel.ID)
+	tracker.TryAcquireRequest(channel.ID, rpm)
 
 	ctx := context.Background()
 	assert.Equal(t, float64(rateLimitExhaustedScore), strategy.Score(ctx, channel))
@@ -130,8 +130,8 @@ func TestRateLimitAwareStrategy_Score_NormalUsage(t *testing.T) {
 		},
 	}
 
-	tracker.IncrementRequest(channel.ID)
-	tracker.IncrementRequest(channel.ID)
+	tracker.TryAcquireRequest(channel.ID, rpm)
+	tracker.TryAcquireRequest(channel.ID, rpm)
 	tracker.AddTokens(channel.ID, 500)
 
 	// maxRatio = max(2/100, 500/1000) = 0.5 -> score 50
@@ -337,7 +337,7 @@ func TestRateLimitAwareStrategy_Score_MinOfRPMAndConcurrency(t *testing.T) {
 
 	// 30% RPM (score 70) and 80% inFlight (score 20) -> min = 20.
 	for range 30 {
-		tracker.IncrementRequest(channel.ID)
+		tracker.TryAcquireRequest(channel.ID, rpm)
 	}
 
 	lim := mgr.GetOrCreate(channel)
@@ -391,7 +391,7 @@ func TestRateLimitAwareStrategy_ScoreWithDebug_RPMExhausted(t *testing.T) {
 	}
 
 	for range rpm {
-		tracker.IncrementRequest(channel.ID)
+		tracker.TryAcquireRequest(channel.ID, rpm)
 	}
 
 	ctx := context.Background()

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -273,11 +273,13 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		// Forward the events to the live streaming.
 		withLivePreview(state, processor.SystemService, processor.LiveStreamRegistry),
 
-		// Per-channel admission control. Must run before rate-limit tracking so a
-		// locally rejected (queue full / queue timeout) request does not consume
-		// RPM budget for a request that never reached upstream.
+		// Per-channel concurrency admission runs before RPM admission so a locally
+		// rejected queue attempt does not consume RPM for a request that never
+		// reached upstream.
 		withChannelLimiter(outbound, processor.channelLimiterManager, processor.channelLimiterMetrics),
-		// Rate limit tracking middleware for load balancing.
+		// Strict single-instance RPM admission for every outbound attempt.
+		withRateLimitAdmission(outbound, processor.rateLimitTracker),
+		// Rate limit tracking middleware for TPM and provider cooldown signals.
 		withRateLimitTracking(outbound, processor.rateLimitTracker),
 
 		// Response pass-through capture middlewares must be last in the outbound list

--- a/internal/server/orchestrator/orchestrator_streaming_test.go
+++ b/internal/server/orchestrator/orchestrator_streaming_test.go
@@ -832,6 +832,87 @@ func TestChatCompletionOrchestrator_Process_QueueRejectionDoesNotConsumeRPM(t *t
 		"queue rejection must not consume RPM budget — middleware order regression")
 }
 
+func TestChatCompletionOrchestrator_Process_RPMAdmissionBlocksBeforeUpstream(t *testing.T) {
+	ctx := context.Background()
+	ctx = authz.WithTestBypass(ctx)
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx = ent.NewContext(ctx, client)
+
+	project := createTestProject(t, ctx, client)
+	ch := createTestChannel(t, ctx, client)
+	channelService, requestService, systemService, usageLogService := setupTestServices(t, client)
+
+	mockResp := buildMockOpenAIResponse("chatcmpl-rpm", "gpt-4", "rpm test", 5, 10)
+	executor := &mockExecutor{
+		response: &httpclient.Response{
+			StatusCode: 200,
+			Body:       mockResp,
+			Headers:    http.Header{"Content-Type": []string{"application/json"}},
+		},
+	}
+
+	outbound, err := openai.NewOutboundTransformer(ch.BaseURL, ch.Credentials.APIKey)
+	require.NoError(t, err)
+
+	rpm := int64(1)
+	bizChannel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:               ch.ID,
+			Name:             ch.Name,
+			BaseURL:          ch.BaseURL,
+			Credentials:      ch.Credentials,
+			SupportedModels:  ch.SupportedModels,
+			DefaultTestModel: ch.DefaultTestModel,
+			Status:           ch.Status,
+			Settings: &objects.ChannelSettings{
+				RateLimit: &objects.ChannelRateLimit{RPM: &rpm},
+			},
+		},
+		Outbound: outbound,
+	}
+
+	channelSelector := &staticChannelSelector{candidates: channelsToTestCandidates([]*biz.Channel{bizChannel}, "gpt-4")}
+	rateLimitTracker := NewChannelRequestTracker()
+
+	orchestrator := &ChatCompletionOrchestrator{
+		channelSelector:       channelSelector,
+		Inbound:               openai.NewInboundTransformer(),
+		RequestService:        requestService,
+		ChannelService:        channelService,
+		PromptProvider:        &stubPromptProvider{},
+		SystemService:         systemService,
+		UsageLogService:       usageLogService,
+		PipelineFactory:       pipeline.NewFactory(executor),
+		ModelMapper:           NewModelMapper(),
+		channelLimiterManager: NewChannelLimiterManager(),
+		rateLimitTracker:      rateLimitTracker,
+		Middlewares: []pipeline.Middleware{
+			stream.EnsureUsage(),
+		},
+	}
+
+	ctx = contexts.WithProjectID(ctx, project.ID)
+
+	firstRequest := buildTestRequest("gpt-4", "rpm test", false)
+	result, err := orchestrator.Process(ctx, firstRequest)
+	require.NoError(t, err)
+	require.NotNil(t, result.ChatCompletion)
+
+	secondRequest := buildTestRequest("gpt-4", "rpm test", false)
+	_, err = orchestrator.Process(ctx, secondRequest)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrLocalRPMExhausted)
+
+	var rpmErr *LocalRPMExhaustedError
+	require.ErrorAs(t, err, &rpmErr)
+	assert.Equal(t, ch.ID, rpmErr.ChannelID)
+	assert.Equal(t, int64(1), rateLimitTracker.GetRequestCount(ch.ID))
+	assert.Equal(t, int64(1), executor.requestCalls.Load(), "RPM rejection must not reach upstream")
+}
+
 // TestChatCompletionOrchestrator_Process_ChannelLimiter exercises the channel admission
 // middleware end-to-end: configure a channel with MaxConcurrent + QueueSize, run a
 // request through the orchestrator, and confirm the limiter slot is released after

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -567,9 +567,9 @@ func (p *PersistentOutboundTransformer) CanRetry(err error) bool {
 		return false
 	}
 
-	// Local queue rejection: same channel is full or timed out — bounce immediately
-	// to the next channel rather than retrying.
-	if isChannelQueueError(err) {
+	// Local admission rejection: the same channel cannot make progress until the
+	// local queue/RPM state changes, so bounce immediately to the next channel.
+	if isChannelQueueError(err) || isLocalRPMExhaustedError(err) {
 		return false
 	}
 

--- a/internal/server/orchestrator/rate_limit_admission.go
+++ b/internal/server/orchestrator/rate_limit_admission.go
@@ -1,0 +1,74 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/looplj/axonhub/internal/log"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+)
+
+// withRateLimitAdmission enforces strict per-instance RPM before an attempt is
+// sent upstream. It intentionally runs after channel concurrency admission so
+// queue rejections never consume RPM.
+func withRateLimitAdmission(outbound *PersistentOutboundTransformer, tracker *ChannelRequestTracker) pipeline.Middleware {
+	if tracker == nil {
+		return &noopRateLimitAdmission{}
+	}
+
+	return &rateLimitAdmissionMiddleware{
+		outbound: outbound,
+		tracker:  tracker,
+	}
+}
+
+type rateLimitAdmissionMiddleware struct {
+	pipeline.DummyMiddleware
+
+	outbound *PersistentOutboundTransformer
+	tracker  *ChannelRequestTracker
+}
+
+func (m *rateLimitAdmissionMiddleware) Name() string {
+	return "rate-limit-admission"
+}
+
+func (m *rateLimitAdmissionMiddleware) OnOutboundRawRequest(ctx context.Context, request *httpclient.Request) (*httpclient.Request, error) {
+	channel := m.outbound.GetCurrentChannel()
+	if channel == nil || channel.Settings == nil || channel.Settings.RateLimit == nil {
+		return request, nil
+	}
+
+	limit := channel.Settings.RateLimit.RPM
+	if limit == nil || *limit <= 0 {
+		return request, nil
+	}
+
+	if !m.tracker.TryAcquireRequest(channel.ID, *limit) {
+		log.Debug(ctx, "channel local RPM admission rejected",
+			log.Int("channel_id", channel.ID),
+			log.String("channel_name", channel.Name),
+			log.Int64("rpm_limit", *limit),
+		)
+
+		return nil, newLocalRPMExhaustedError(channel, *limit)
+	}
+
+	if log.DebugEnabled(ctx) {
+		log.Debug(ctx, "channel local RPM admission acquired",
+			log.Int("channel_id", channel.ID),
+			log.String("channel_name", channel.Name),
+			log.Int64("rpm_limit", *limit),
+		)
+	}
+
+	return request, nil
+}
+
+type noopRateLimitAdmission struct {
+	pipeline.DummyMiddleware
+}
+
+func (m *noopRateLimitAdmission) Name() string {
+	return "rate-limit-admission-noop"
+}

--- a/internal/server/orchestrator/rate_limit_admission_error.go
+++ b/internal/server/orchestrator/rate_limit_admission_error.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+var ErrLocalRPMExhausted = errors.New("local channel rpm exhausted")
+
+// LocalRPMExhaustedError represents a local per-channel RPM admission failure.
+//
+// The embedded synthetic 429 lets existing response transformation produce a
+// rate-limit-shaped client error, while the typed wrapper lets retry and
+// cooldown code distinguish it from provider 429 responses.
+type LocalRPMExhaustedError struct {
+	ChannelID   int
+	ChannelName string
+	Limit       int64
+
+	httpErr *httpclient.Error
+}
+
+func newLocalRPMExhaustedError(ch *biz.Channel, limit int64) *LocalRPMExhaustedError {
+	message := fmt.Sprintf("channel %s exhausted local RPM limit %d; please retry shortly", ch.Name, limit)
+	body := []byte(fmt.Sprintf(
+		`{"error":{"code":"channel_rpm_exhausted","message":%s,"type":"rate_limit_error"}}`,
+		strconv.Quote(message),
+	))
+
+	return &LocalRPMExhaustedError{
+		ChannelID:   ch.ID,
+		ChannelName: ch.Name,
+		Limit:       limit,
+		httpErr: &httpclient.Error{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     http.StatusText(http.StatusTooManyRequests),
+			Body:       body,
+		},
+	}
+}
+
+func (e *LocalRPMExhaustedError) Error() string {
+	return fmt.Sprintf("channel %q (id=%d) local rpm exhausted", e.ChannelName, e.ChannelID)
+}
+
+func (e *LocalRPMExhaustedError) Unwrap() []error {
+	return []error{ErrLocalRPMExhausted, e.httpErr}
+}
+
+func isLocalRPMExhaustedError(err error) bool {
+	var rpmErr *LocalRPMExhaustedError
+	return errors.As(err, &rpmErr)
+}

--- a/internal/server/orchestrator/rate_limit_admission_error.go
+++ b/internal/server/orchestrator/rate_limit_admission_error.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -27,10 +26,7 @@ type LocalRPMExhaustedError struct {
 
 func newLocalRPMExhaustedError(ch *biz.Channel, limit int64) *LocalRPMExhaustedError {
 	message := fmt.Sprintf("channel %s exhausted local RPM limit %d; please retry shortly", ch.Name, limit)
-	body := []byte(fmt.Sprintf(
-		`{"error":{"code":"channel_rpm_exhausted","message":%s,"type":"rate_limit_error"}}`,
-		strconv.Quote(message),
-	))
+	body := fmt.Appendf(nil, `{"error":{"code":"channel_rpm_exhausted","message":%q,"type":"rate_limit_error"}}`, message)
 
 	return &LocalRPMExhaustedError{
 		ChannelID:   ch.ID,

--- a/internal/server/orchestrator/rate_limit_admission_test.go
+++ b/internal/server/orchestrator/rate_limit_admission_test.go
@@ -1,0 +1,108 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func channelWithRPM(id int, name string, rpm int64) *biz.Channel {
+	rl := &objects.ChannelRateLimit{}
+	if rpm > 0 {
+		rl.RPM = lo.ToPtr(rpm)
+	}
+
+	return &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   id,
+			Name: name,
+			Settings: &objects.ChannelSettings{
+				RateLimit: rl,
+			},
+		},
+	}
+}
+
+func TestRateLimitAdmission_AllowsOnlyConfiguredRPM(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+	channel := channelWithRPM(1, "strict-rpm", 2)
+	outbound := newTestOutbound(channel)
+	middleware := withRateLimitAdmission(outbound, tracker).(*rateLimitAdmissionMiddleware)
+
+	_, err := middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+
+	_, err = middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+
+	_, err = middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+	require.Error(t, err)
+
+	var rpmErr *LocalRPMExhaustedError
+	require.ErrorAs(t, err, &rpmErr)
+	assert.Equal(t, channel.ID, rpmErr.ChannelID)
+	assert.Equal(t, int64(2), rpmErr.Limit)
+	assert.Equal(t, int64(2), tracker.GetRequestCount(channel.ID))
+}
+
+func TestRateLimitAdmission_NoRPMBypasses(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+	channel := channelWithRPM(2, "no-rpm", 0)
+	outbound := newTestOutbound(channel)
+	middleware := withRateLimitAdmission(outbound, tracker).(*rateLimitAdmissionMiddleware)
+
+	for range 3 {
+		_, err := middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(0), tracker.GetRequestCount(channel.ID))
+}
+
+func TestRateLimitAdmission_SameChannelRetryCannotBypassRPM(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+	channel := channelWithRPM(5, "retry-rpm", 1)
+	outbound := newTestOutbound(channel)
+	middleware := withRateLimitAdmission(outbound, tracker).(*rateLimitAdmissionMiddleware)
+
+	_, err := middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+
+	_, err = middleware.OnOutboundRawRequest(t.Context(), &httpclient.Request{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLocalRPMExhausted)
+	assert.Equal(t, int64(1), tracker.GetRequestCount(channel.ID))
+}
+
+func TestRateLimitTracking_OnOutboundRawError_LocalRPMExhaustedIgnored(t *testing.T) {
+	tracker := NewChannelRequestTracker()
+	channel := channelWithRPM(3, "strict-rpm", 1)
+	outbound := newTestOutbound(channel)
+	middleware := &rateLimitTracking{
+		outbound: outbound,
+		tracker:  tracker,
+	}
+
+	middleware.OnOutboundRawError(context.Background(), newLocalRPMExhaustedError(channel, 1))
+
+	assert.False(t, tracker.IsCoolingDown(channel.ID),
+		"local RPM rejection must not trigger upstream-style cooldown")
+}
+
+func TestPersistentOutboundTransformer_CanRetry_LocalRPMExhausted(t *testing.T) {
+	channel := channelWithRPM(4, "strict-rpm", 1)
+	outbound := newTestOutbound(channel)
+	err := newLocalRPMExhaustedError(channel, 1)
+
+	assert.False(t, outbound.CanRetry(err))
+	assert.True(t, errors.Is(err, ErrLocalRPMExhausted))
+}

--- a/internal/server/orchestrator/rate_limit_tracking.go
+++ b/internal/server/orchestrator/rate_limit_tracking.go
@@ -11,7 +11,8 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
-// withRateLimitTracking creates a middleware that tracks request counts per channel for rate limiting.
+// withRateLimitTracking creates a middleware that tracks token usage and
+// provider cooldown signals for rate limiting.
 func withRateLimitTracking(outbound *PersistentOutboundTransformer, tracker *ChannelRequestTracker) pipeline.Middleware {
 	if tracker == nil {
 		return &noopRateLimitTracking{}
@@ -23,7 +24,9 @@ func withRateLimitTracking(outbound *PersistentOutboundTransformer, tracker *Cha
 	}
 }
 
-// rateLimitTracking is a middleware that increments request count for rate limiting.
+// rateLimitTracking records TPM usage and provider Retry-After cooldowns. RPM
+// accounting is owned by rateLimitAdmissionMiddleware so request slots are
+// consumed atomically before an attempt reaches upstream.
 type rateLimitTracking struct {
 	pipeline.DummyMiddleware
 
@@ -33,25 +36,6 @@ type rateLimitTracking struct {
 
 func (m *rateLimitTracking) Name() string {
 	return "track-rate-limit"
-}
-
-func (m *rateLimitTracking) OnOutboundRawRequest(ctx context.Context, request *httpclient.Request) (*httpclient.Request, error) {
-	channel := m.outbound.GetCurrentChannel()
-	if channel == nil {
-		return request, nil
-	}
-
-	m.tracker.IncrementRequest(channel.ID)
-
-	if log.DebugEnabled(ctx) {
-		log.Debug(ctx, "Incremented rate limit request count",
-			log.Int("channel_id", channel.ID),
-			log.String("channel_name", channel.Name),
-			log.Int64("current_rpm", m.tracker.GetRequestCount(channel.ID)),
-		)
-	}
-
-	return request, nil
 }
 
 func (m *rateLimitTracking) OnOutboundLlmResponse(ctx context.Context, response *llm.Response) (*llm.Response, error) {
@@ -93,8 +77,8 @@ func (m *rateLimitTracking) OnOutboundRawError(ctx context.Context, err error) {
 		return
 	}
 
-	// Local queue rejections never reached upstream — they must not trigger cooldown.
-	if isChannelQueueError(err) {
+	// Local admission rejections never reached upstream — they must not trigger cooldown.
+	if isChannelQueueError(err) || isLocalRPMExhaustedError(err) {
 		return
 	}
 

--- a/internal/server/orchestrator/rate_limit_tracking_test.go
+++ b/internal/server/orchestrator/rate_limit_tracking_test.go
@@ -175,7 +175,7 @@ func TestRateLimitTracking_OnOutboundLlmStream(t *testing.T) {
 	assert.Equal(t, int64(250), tracker.GetTokenCount(channel.ID))
 }
 
-func TestRateLimitTracking_OnOutboundRawRequest(t *testing.T) {
+func TestRateLimitTracking_OnOutboundRawRequest_DoesNotIncrementRequests(t *testing.T) {
 	tracker := NewChannelRequestTracker()
 
 	entChannel := &ent.Channel{ID: 1, Name: "test-channel"}
@@ -193,16 +193,15 @@ func TestRateLimitTracking_OnOutboundRawRequest(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Increment request count multiple times
 	for range 5 {
 		_, err := middleware.OnOutboundRawRequest(ctx, nil)
 		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, int64(5), tracker.GetRequestCount(channel.ID))
+	assert.Equal(t, int64(0), tracker.GetRequestCount(channel.ID))
 }
 
-func TestRateLimitTracking_Combined(t *testing.T) {
+func TestRateLimitTracking_CombinedTokenOnly(t *testing.T) {
 	tracker := NewChannelRequestTracker()
 
 	entChannel := &ent.Channel{ID: 1, Name: "test-channel"}
@@ -220,26 +219,22 @@ func TestRateLimitTracking_Combined(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Simulate a request flow
-	// 1. Request starts
+	// Simulate a request flow. RPM admission is handled before this middleware;
+	// tracking only records TPM and upstream cooldown signals.
 	_, _ = middleware.OnOutboundRawRequest(ctx, nil)
 	_, _ = middleware.OnOutboundRawRequest(ctx, nil)
 
-	// 2. Response with tokens
 	_, _ = middleware.OnOutboundLlmResponse(ctx, &llm.Response{
 		Usage: &llm.Usage{TotalTokens: 100},
 	})
 
-	// 3. Another request
 	_, _ = middleware.OnOutboundRawRequest(ctx, nil)
 
-	// 4. Another response with tokens
 	_, _ = middleware.OnOutboundLlmResponse(ctx, &llm.Response{
 		Usage: &llm.Usage{TotalTokens: 50},
 	})
 
-	// Verify both RPM and TPM are tracked
-	assert.Equal(t, int64(3), tracker.GetRequestCount(channel.ID))
+	assert.Equal(t, int64(0), tracker.GetRequestCount(channel.ID))
 	assert.Equal(t, int64(150), tracker.GetTokenCount(channel.ID))
 }
 


### PR DESCRIPTION
## Summary
- enforce per-channel RPM admission locally before an outbound attempt reaches upstream
- keep queue admission before RPM admission so queue rejections do not consume RPM
- prevent local RPM exhaustion from same-channel retry/cooldown handling
- fix quota window end-boundary counting and stabilize related cache tests

## Validation
- go test ./internal/server/orchestrator -run 'TestChatCompletionOrchestrator_Process_RPMAdmissionBlocksBeforeUpstream|TestChatCompletionOrchestrator_Process_QueueRejectionDoesNotConsumeRPM|TestRateLimitAdmission|TestRateLimitTracking|TestPersistentOutboundTransformer_CanRetry_LocalRPMExhausted|TestChannelRequestTracker|TestRateLimitAwareStrategy|TestDefaultSelector_SelectModelCandidates_Cache' -count=3 -timeout 60s
- go test ./internal/server/orchestrator -count=1 -timeout 120s
- go test ./internal/server/biz -count=1 -timeout 120s
- go test ./... -count=1 -timeout 120s
- git diff --check