### PR TITLE
fix(oidc): avoid privacy-deny error on every sign-in

### DIFF
--- a/internal/server/biz/oidc.go
+++ b/internal/server/biz/oidc.go
@@ -477,7 +477,7 @@ func (s *OIDCService) IsUserRestrictedToOIDC(ctx context.Context, u *ent.User) b
 	// eager-loaded (it returns a NotLoadedError in that case), instead of relying on
 	// len()==0 which cannot tell "not loaded" from "loaded but the user has none".
 	identities, err := u.Edges.OidcIdentitiesOrErr()
-	if err != nil {
+	if ent.IsNotLoaded(err) {
 		// The edge was not loaded. This runs during pre-auth sign-in, where there is
 		// no viewer in the context yet, so the privacy policy on OIDCIdentity would
 		// deny a normal query ("no user in context"). Read the user's own OIDC links

--- a/internal/server/biz/oidc.go
+++ b/internal/server/biz/oidc.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/oidcidentity"
@@ -471,13 +472,22 @@ func (s *OIDCService) IsUserRestrictedToOIDC(ctx context.Context, u *ent.User) b
 	}
 
 	// 2. Check if any of the user's linked OIDC providers have OIDCLoginOnly enabled
-	identities := u.Edges.OidcIdentities
-	if len(identities) == 0 {
-		// Try to fetch them if not loaded
-		var err error
-		identities, err = s.entFromContext(ctx).OIDCIdentity.Query().
-			Where(oidcidentity.UserID(u.ID)).
-			All(ctx)
+	//
+	// Use OidcIdentitiesOrErr so we only re-query when the edge was genuinely not
+	// eager-loaded (it returns a NotLoadedError in that case), instead of relying on
+	// len()==0 which cannot tell "not loaded" from "loaded but the user has none".
+	identities, err := u.Edges.OidcIdentitiesOrErr()
+	if err != nil {
+		// The edge was not loaded. This runs during pre-auth sign-in, where there is
+		// no viewer in the context yet, so the privacy policy on OIDCIdentity would
+		// deny a normal query ("no user in context"). Read the user's own OIDC links
+		// under a system bypass, mirroring the user lookup in AuthService.AuthenticateUser.
+		identities, err = authz.RunWithSystemBypass(ctx, "oidc-restriction-check",
+			func(bypassCtx context.Context) ([]*ent.OIDCIdentity, error) {
+				return s.entFromContext(bypassCtx).OIDCIdentity.Query().
+					Where(oidcidentity.UserID(u.ID)).
+					All(bypassCtx)
+			})
 		if err != nil {
 			log.Error(ctx, "failed to query user OIDC identities", zap.Error(err), log.Int("user_id", u.ID))
 			return false


### PR DESCRIPTION
Every sign-in logs an error, even for plain password logins:

```
ERROR failed to query user OIDC identities: no user in context: ent/privacy: deny rule
```

The login still succeeds and the token is issued, so nothing breaks — but the line shows up on *every* `POST /admin/auth/signin`, which is noisy enough to drown real errors.

**What's happening**

`IsUserRestrictedToOIDC` runs in the pre-auth phase, before there's a viewer in the context. If the user's `OidcIdentities` edge wasn't eager-loaded, it falls back to a plain query — and the `OIDCIdentity` privacy policy rejects that query because there's no viewer yet.

`AuthService.AuthenticateUser` in the same flow already sidesteps this with `RunWithSystemBypass`. This one path just didn't, so it's really an oversight rather than a config problem on my side.

**The change** (one file, +17/−7)

- Switch from `len(identities) == 0` to `Edges.OidcIdentitiesOrErr()`, so we can tell "edge not loaded" apart from "loaded, user genuinely has none" — the former is the only case that needs a re-query.
- When it does need to re-query, wrap it in `RunWithSystemBypass`, the same way `AuthenticateUser` reads the user.

Sign-in behavior is unchanged; this only drops the bogus error log.

Verified with `go build` + `go vet` on `internal/server/biz`, and confirmed the line is gone after the fix.