### PR TITLE
feat: add GLM-5.2 to zai channel default models

### DIFF
--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -227,7 +227,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
   zai: {
     channelType: 'zai',
     baseURL: 'https://api.z.ai/api/paas/v4',
-    defaultModels: ['glm-4.7', 'glm-4.6', 'glm-4.5-air'],
+    defaultModels: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
     apiFormat: OPENAI_CHAT_COMPLETIONS,
     color: 'bg-cyan-100 text-cyan-800 border-cyan-200',
     icon: ZAI,
@@ -243,7 +243,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
   zai_anthropic: {
     channelType: 'zai_anthropic',
     baseURL: 'https://api.z.ai/api/anthropic',
-    defaultModels: ['glm-4.7', 'glm-4.6', 'glm-4.5-air'],
+    defaultModels: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
     apiFormat: ANTHROPIC_MESSAGES,
     color: 'bg-cyan-100 text-cyan-800 border-cyan-200',
     icon: ZAI,


### PR DESCRIPTION
## What

`#1829` added `glm-5.2` to the **zhipu** / **zhipu_anthropic** `defaultModels` lists, but **zai** / **zai_anthropic** were left on the older `['glm-4.7', 'glm-4.6', 'glm-4.5-air']` list (missing glm-5/glm-5.1/glm-5.2).

z.ai shipped **GLM-5.2 on 2026-06-13** on the same GLM Coding Plan as Zhipu, so the zai presets should mirror zhipu's. This aligns all four GLM provider presets.

```diff
  zai / zai_anthropic:
- defaultModels: ['glm-4.7', 'glm-4.6', 'glm-4.5-air']
+ defaultModels: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air']
```

## Verification

`glm-5.2` returns HTTP 200 on `https://api.z.ai/api/anthropic/v1/messages` (and full ~1M context confirmed via a 994K-token request). This only changes the UI's default-model presets shown when creating a zai channel; `supportedModels` remains user-editable as before.