### PR TITLE
fix: exclude DB/storage persistence time from TTFT measurement

### DIFF
--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -261,14 +261,17 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		applyUserAgentPassThrough(outbound, processor.SystemService),
 		applyOverrideRequestHeaders(outbound),
 
-		// Unified performance tracking middleware.
-		withPerformanceRecording(outbound),
+		// The request execution middleware must be the first outbound middleware
+		// to ensure that the request execution is created with the correct request body
+		// before performance tracking starts, so that DB/storage persistence time
+		// is not included in TTFT measurement.
+		persistRequestExecution(outbound),
 
 		withModelCircuitBreaker(outbound, processor.modelCircuitBreaker, strategy),
 
-		// The request execution middleware must be the final middleware
-		// to ensure that the request execution is created with the correct request bodys.
-		persistRequestExecution(outbound),
+		// Unified performance tracking middleware. Set StartTime after request execution
+		// persistence so TTFT only measures upstream provider latency.
+		withPerformanceRecording(outbound),
 
 		// Forward the events to the live streaming.
 		withLivePreview(state, processor.SystemService, processor.LiveStreamRegistry),


### PR DESCRIPTION
The performance recording middleware (`withPerformanceRecording`) ran before the request execution persistence middleware (`persistRequestExecution`), causing `StartTime` to be set before the DB insert and external storage save. This meant TTFT (Time to First Token) included middleware persistence overhead rather than just upstream provider latency.

**Fix:** Swap the order of the two middlewares so `persistRequestExecution` runs first, then `withPerformanceRecording` sets `StartTime` just before the HTTP call.

The two middlewares have no shared state dependencies:
- `persistRequestExecution.OnOutboundRawRequest` does not read `state.Perf`
- `withPerformanceRecording.OnOutboundRawRequest` does not read `state.RequestExec`
- Both independently read `state.CurrentCandidate.Channel` (already set by `TransformRequest`)