### PR TITLE
fix(model_fetcher): avoid duplicate /v1 for anthropic-like endpoints

### DIFF
--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -557,6 +557,10 @@ func (f *ModelFetcher) prepareModelsEndpoint(channelType channel.Type, baseURL s
 		baseURL = strings.TrimSuffix(baseURL, "/anthropic")
 		baseURL = strings.TrimSuffix(baseURL, "/claude")
 
+		if strings.HasSuffix(baseURL, "/v1") {
+			return baseURL + "/models", headers
+		}
+
 		return baseURL + "/v1/models", headers
 	case channelType.IsGemini():
 		if strings.Contains(baseURL, "/v1") {

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -277,6 +277,18 @@ func TestPrepareModelsEndpoint(t *testing.T) {
 			expectedURL: "https://api.moonshot.cn/v1/models",
 		},
 		{
+			name:        "OpencodeGoAnthropic with /v1 suffix",
+			channelType: channel.TypeOpencodeGoAnthropic,
+			baseURL:     "https://opencode.ai/zen/go/v1",
+			expectedURL: "https://opencode.ai/zen/go/v1/models",
+		},
+		{
+			name:        "OpencodeGoAnthropic without /v1 suffix",
+			channelType: channel.TypeOpencodeGoAnthropic,
+			baseURL:     "https://opencode.ai/zen/go",
+			expectedURL: "https://opencode.ai/zen/go/v1/models",
+		},
+		{
 			name:        "Gemini with /v1 suffix",
 			channelType: channel.TypeGemini,
 			baseURL:     "https://generativelanguage.googleapis.com/v1",


### PR DESCRIPTION
## Summary
- Fix anthropic-like model discovery when the configured Base URL already ends with `/v1`
- Avoid duplicating `/v1` for `*_anthropic` channels in `ModelFetcher.prepareModelsEndpoint()`
- Add regression coverage for `opencode_go_anthropic` model endpoint construction with and without a `/v1` suffix
- Keep the fix surgical to `ModelFetcher.prepareModelsEndpoint()` without changing auth headers or outbound request routing

## Problem
For `opencode_go_anthropic`, configuring a Base URL such as `https://opencode.ai/zen/go/v1` causes model discovery to request `.../v1/v1/models`, while `/messages` requests still work because they go through the Anthropic outbound transformer.

## Root cause
`ModelFetcher.prepareModelsEndpoint()` handled `TypeAnthropic` and `IsAnthropicLike()` differently: the official Anthropic branch already avoided duplicating `/v1`, while the anthropic-like branch always appended `/v1/models`.

## Fix
Add the missing `/v1` suffix handling to the `IsAnthropicLike()` branch only.

## Test Plan
- [x] `go test ./internal/server/biz -run TestPrepareModelsEndpoint -count=1`
- [x] `go test ./internal/server/biz -count=1`
