### PR TITLE
fix(frontend): correct api key creator filter scope

### DIFF
--- a/frontend/src/features/apikeys/components/data-table-toolbar.tsx
+++ b/frontend/src/features/apikeys/components/data-table-toolbar.tsx
@@ -30,7 +30,7 @@ export function DataTableToolbar<TData>({ table, dateRange, onDateRangeChange, o
   const userScopes = user?.scopes || [];
   const isOwner = user?.isOwner || false;
 
-  const canViewUsers = isOwner || userScopes.includes('*') || (userScopes.includes('read_users') && userScopes.includes('read_apikeys'));
+  const canViewUsers = isOwner || userScopes.includes('*') || (userScopes.includes('read_users') && userScopes.includes('read_api_keys'));
 
   const { data: usersData } = useUsers(
     {


### PR DESCRIPTION
## Summary
- Fix misspelled scope (`read_apikeys` -> `read_api_keys`) in the API key table toolbar's permission check

## Test Plan
- [x] Verified `read_apikeys` no longer appears in the repository
- [x] Verified `read_api_keys` is the defined API key read scope in `internal/scopes/scopes.go`
