### PR TITLE
fix(frontend): hide api key creator column without system user permission

### DIFF
--- a/frontend/src/features/apikeys/components/apikeys-columns.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-columns.tsx
@@ -41,7 +41,7 @@ function ApiKeyCell({ apiKey, fullApiKey }: { apiKey: string; fullApiKey: ApiKey
   );
 }
 
-export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrite: boolean = true, canViewUsers: boolean = false): ColumnDef<ApiKey>[] => [
+export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrite: boolean = true, canViewCreators: boolean = false): ColumnDef<ApiKey>[] => [
   ...(canWrite
     ? [
         {
@@ -94,7 +94,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       className: 'max-w-48',
     },
   },
-  ...(canViewUsers
+  ...(canViewCreators
     ? ([
         {
           accessorKey: 'creator',

--- a/frontend/src/features/apikeys/components/apikeys-columns.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-columns.tsx
@@ -41,7 +41,7 @@ function ApiKeyCell({ apiKey, fullApiKey }: { apiKey: string; fullApiKey: ApiKey
   );
 }
 
-export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrite: boolean = true): ColumnDef<ApiKey>[] => [
+export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrite: boolean = true, canViewUsers: boolean = false): ColumnDef<ApiKey>[] => [
   ...(canWrite
     ? [
         {
@@ -94,21 +94,25 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       className: 'max-w-48',
     },
   },
-  {
-    accessorKey: 'creator',
-    header: ({ column }) => <DataTableColumnHeader column={column} title={t('apikeys.columns.creator')} />,
-    cell: ({ row }) => {
-      const creator = row.original.user;
-      const displayName = creator ? `${creator.firstName} ${creator.lastName}` : t('apikeys.user.deleted');
-      return <LongText className='text-muted-foreground max-w-24'>{displayName}</LongText>;
-    },
-    filterFn: (row, _id, value) => {
-      const creator = row.original.user;
-      if (!creator) return false;
-      return value.includes(creator.id);
-    },
-    enableSorting: false,
-  },
+  ...(canViewUsers
+    ? ([
+        {
+          accessorKey: 'creator',
+          header: ({ column }) => <DataTableColumnHeader column={column} title={t('apikeys.columns.creator')} />,
+          cell: ({ row }) => {
+            const creator = row.original.user;
+            const displayName = creator ? `${creator.firstName} ${creator.lastName}` : t('apikeys.user.deleted');
+            return <LongText className='text-muted-foreground max-w-24'>{displayName}</LongText>;
+          },
+          filterFn: (row, _id, value) => {
+            const creator = row.original.user;
+            if (!creator) return false;
+            return value.includes(creator.id);
+          },
+          enableSorting: false,
+        },
+      ] as ColumnDef<ApiKey>[])
+    : []),
   {
     accessorKey: 'type',
     header: ({ column }) => <DataTableColumnHeader column={column} title={t('apikeys.columns.type')} />,

--- a/frontend/src/features/apikeys/components/apikeys-table.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-table.tsx
@@ -50,6 +50,7 @@ interface DataTableProps {
   onDateRangeChange: (value: DateTimeRangeValue | undefined) => void;
   onResetFilters?: () => void;
   canWrite?: boolean;
+  canViewCreators?: boolean;
 }
 
 export function ApiKeysTable({
@@ -72,6 +73,7 @@ export function ApiKeysTable({
   onDateRangeChange,
   onResetFilters,
   canWrite = true,
+  canViewCreators = false,
 }: DataTableProps) {
   const { t } = useTranslation();
   const { setResetRowSelection, setSelectedApiKeys, openDialog } = useApiKeysContext();
@@ -180,7 +182,13 @@ export function ApiKeysTable({
 
   return (
     <div className='flex flex-1 flex-col'>
-      <DataTableToolbar table={table} dateRange={dateRange} onDateRangeChange={onDateRangeChange} onResetFilters={onResetFilters} />
+      <DataTableToolbar
+        table={table}
+        dateRange={dateRange}
+        onDateRangeChange={onDateRangeChange}
+        onResetFilters={onResetFilters}
+        canViewCreators={canViewCreators}
+      />
       <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
         <Table className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
           <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>

--- a/frontend/src/features/apikeys/components/data-table-toolbar.tsx
+++ b/frontend/src/features/apikeys/components/data-table-toolbar.tsx
@@ -1,14 +1,12 @@
-import { useMemo } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { DateRangePicker } from '@/components/date-range-picker';
 import type { DateTimeRangeValue } from '@/utils/date-range';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
-import { useMe } from '@/features/auth/data/auth';
 import { useUsers } from '@/features/users/data/users';
 import { ApiKeyStatus } from '../data/schema';
 
@@ -17,20 +15,19 @@ interface DataTableToolbarProps<TData> {
   dateRange?: DateTimeRangeValue;
   onDateRangeChange?: (range: DateTimeRangeValue | undefined) => void;
   onResetFilters?: () => void;
+  canViewCreators?: boolean;
 }
 
-export function DataTableToolbar<TData>({ table, dateRange, onDateRangeChange, onResetFilters }: DataTableToolbarProps<TData>) {
+export function DataTableToolbar<TData>({
+  table,
+  dateRange,
+  onDateRangeChange,
+  onResetFilters,
+  canViewCreators = false,
+}: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
-
-  const { user: authUser } = useAuthStore((state) => state.auth);
-  const { data: meData } = useMe();
-  const user = meData || authUser;
-  const userScopes = user?.scopes || [];
-  const isOwner = user?.isOwner || false;
-
-  const canViewUsers = isOwner || userScopes.includes('*') || (userScopes.includes('read_users') && userScopes.includes('read_api_keys'));
 
   const { data: usersData } = useUsers(
     {
@@ -38,18 +35,18 @@ export function DataTableToolbar<TData>({ table, dateRange, onDateRangeChange, o
       orderBy: { field: 'CREATED_AT', direction: 'DESC' },
     },
     {
-      disableAutoFetch: !canViewUsers,
+      disableAutoFetch: !canViewCreators,
     }
   );
 
   const userOptions = useMemo(() => {
-    if (!canViewUsers || !usersData?.edges) return [];
+    if (!canViewCreators || !usersData?.edges) return [];
 
     return usersData.edges.map((edge) => ({
       value: edge.node.id,
       label: `${edge.node.firstName} ${edge.node.lastName} (${edge.node.email})`,
     }));
-  }, [canViewUsers, usersData]);
+  }, [canViewCreators, usersData]);
 
   const statusOptions = [
     {
@@ -78,7 +75,7 @@ export function DataTableToolbar<TData>({ table, dateRange, onDateRangeChange, o
         {table.getColumn('status') && (
           <DataTableFacetedFilter column={table.getColumn('status')} title={t('apikeys.filters.status')} options={statusOptions} />
         )}
-        {canViewUsers && table.getColumn('creator') && userOptions.length > 0 && usersData?.edges && (
+        {canViewCreators && table.getColumn('creator') && userOptions.length > 0 && usersData?.edges && (
           <DataTableFacetedFilter column={table.getColumn('creator')} title={t('apikeys.filters.creator')} options={userOptions} />
         )}
         <DateRangePicker value={dateRange} onChange={onDateRangeChange} />

--- a/frontend/src/features/apikeys/index.tsx
+++ b/frontend/src/features/apikeys/index.tsx
@@ -19,7 +19,7 @@ type ApiKeyTabKey = ApiKeyType | 'all';
 
 function ApiKeysContent() {
   const { t } = useTranslation();
-  const { apiKeyPermissions } = usePermissions();
+  const { apiKeyPermissions, hasSystemScope } = usePermissions();
   const { pageSize, setCursors, setPageSize, resetCursor, paginationArgs } = usePaginationSearch({
     defaultPageSize: 20,
     pageSizeStorageKey: 'apikeys-table-page-size',
@@ -116,7 +116,12 @@ function ApiKeysContent() {
     resetCursor();
   };
 
-  const columns = React.useMemo(() => createColumns(t, apiKeyPermissions.canWrite), [t, apiKeyPermissions.canWrite]);
+  const canViewCreators = hasSystemScope('read_users');
+
+  const columns = React.useMemo(
+    () => createColumns(t, apiKeyPermissions.canWrite, canViewCreators),
+    [t, apiKeyPermissions.canWrite, canViewCreators]
+  );
 
   return (
     <div className='flex flex-1 flex-col'>

--- a/frontend/src/features/apikeys/index.tsx
+++ b/frontend/src/features/apikeys/index.tsx
@@ -159,6 +159,7 @@ function ApiKeysContent() {
           onDateRangeChange={setDateRange}
           onResetFilters={handleResetFilters}
           canWrite={apiKeyPermissions.canWrite}
+          canViewCreators={canViewCreators}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Hide the API key Creator column unless the current user has system-level `read_users` access
- Avoid showing a misleading deleted-user fallback when creator data is not readable

## Problem
The API Keys table always rendered the Creator column, but `APIKey.user` can resolve to `null` when the related user is not readable under the current permission model.

In that case, the frontend fell back to the deleted-user label even though the creator might still exist and was simply not readable.

## Fix
Only add the Creator column when the current user has system-level `read_users` access.

This keeps the UI aligned with the current backend `User` privacy behavior without changing the underlying permission model.

## Test Plan
- [x] Verified by code inspection that the Creator column is now gated by system-level `read_users`
- [x] Verified by code inspection that the Creator column defaults to hidden when the new permission argument is omitted
- [ ] Not run (UI-only change)
