### PR TITLE
fix: default empty input_schema for Anthropic function tools with nil params

### DIFF
--- a/llm/pipeline/empty_response_test.go
+++ b/llm/pipeline/empty_response_test.go
@@ -238,8 +238,8 @@ func TestPipeline_Process_StreamEmptyResponseDetection(t *testing.T) {
 				if streamCalls == 1 {
 					return streams.SliceStream([]*llm.Response{
 						{
-							RequestType: llm.RequestTypeSpeech,
-							APIFormat:   llm.APIFormatOpenAISpeech,
+							RequestType:       llm.RequestTypeSpeech,
+							APIFormat:         llm.APIFormatOpenAISpeech,
 							SpeechStreamEvent: &llm.SpeechStreamEvent{Type: "speech.audio.done"},
 						},
 						llm.DoneResponse,

--- a/llm/pipeline/streaming_integration_test.go
+++ b/llm/pipeline/streaming_integration_test.go
@@ -669,7 +669,6 @@ func TestPipeline_NonStreaming_AutoAggregateUpgradedStream_EmptyAggregatedBody(t
 	require.ErrorContains(t, err, "empty aggregated body")
 }
 
-
 func TestPipeline_NonStreaming_AutoAggregateUpgradedStream_EmptyJSONObjectAggregatedBodyAllowed(t *testing.T) {
 	ctx := context.Background()
 

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -1,6 +1,8 @@
 package anthropic
 
 import (
+	"encoding/json"
+
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
@@ -225,10 +227,14 @@ func convertToolsAnthropic(tools []llm.Tool, config *Config) []Tool {
 	for _, tool := range tools {
 		switch tool.Type {
 		case llm.ToolTypeFunction:
+			inputSchema := tool.Function.Parameters
+			if len(inputSchema) == 0 {
+				inputSchema = json.RawMessage(`{"type":"object","properties":{}}`)
+			}
 			anthropicTools = append(anthropicTools, Tool{
 				Name:         tool.Function.Name,
 				Description:  tool.Function.Description,
-				InputSchema:  tool.Function.Parameters,
+				InputSchema:  inputSchema,
 				CacheControl: convertToAnthropicCacheControl(tool.CacheControl),
 			})
 		case llm.ToolTypeWebSearch:

--- a/llm/transformer/anthropic/outbound_convert_test.go
+++ b/llm/transformer/anthropic/outbound_convert_test.go
@@ -1115,3 +1115,62 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToolsAnthropic_NilParameters(t *testing.T) {
+	t.Run("nil parameters defaults to empty object schema", func(t *testing.T) {
+		tools := []llm.Tool{
+			{
+				Type: llm.ToolTypeFunction,
+				Function: llm.Function{
+					Name:        "web_search",
+					Description: "Search the web",
+					Parameters:  nil,
+				},
+			},
+		}
+		result := convertToolsAnthropic(tools, nil)
+		require.Len(t, result, 1)
+		require.Equal(t, "web_search", result[0].Name)
+		require.NotNil(t, result[0].InputSchema)
+		require.True(t, json.Valid(result[0].InputSchema))
+		var schema map[string]any
+		require.NoError(t, json.Unmarshal(result[0].InputSchema, &schema))
+		require.Equal(t, "object", schema["type"])
+		require.NotNil(t, schema["properties"])
+	})
+
+	t.Run("empty parameters defaults to empty object schema", func(t *testing.T) {
+		tools := []llm.Tool{
+			{
+				Type: llm.ToolTypeFunction,
+				Function: llm.Function{
+					Name:        "no_params_func",
+					Description: "A function with no parameters",
+					Parameters:  json.RawMessage{},
+				},
+			},
+		}
+		result := convertToolsAnthropic(tools, nil)
+		require.Len(t, result, 1)
+		require.NotNil(t, result[0].InputSchema)
+		var schema map[string]any
+		require.NoError(t, json.Unmarshal(result[0].InputSchema, &schema))
+		require.Equal(t, "object", schema["type"])
+	})
+
+	t.Run("explicit parameters are preserved unchanged", func(t *testing.T) {
+		params := json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`)
+		tools := []llm.Tool{
+			{
+				Type: llm.ToolTypeFunction,
+				Function: llm.Function{
+					Name:       "search",
+					Parameters: params,
+				},
+			},
+		}
+		result := convertToolsAnthropic(tools, nil)
+		require.Len(t, result, 1)
+		require.Equal(t, params, result[0].InputSchema)
+	})
+}

--- a/llm/transformer/anthropic/outbound_stream_server_tool_use_test.go
+++ b/llm/transformer/anthropic/outbound_stream_server_tool_use_test.go
@@ -30,10 +30,10 @@ func TestOutboundTransformer_ServerToolUse_NoPanic(t *testing.T) {
 		sseEvent(t, "message_start", map[string]any{
 			"type": "message_start",
 			"message": map[string]any{
-				"id":    "msg_01AEsGpin3gJumakZWMTyQp3",
-				"type":  "message",
-				"role":  "assistant",
-				"model": "claude-opus-4-7",
+				"id":      "msg_01AEsGpin3gJumakZWMTyQp3",
+				"type":    "message",
+				"role":    "assistant",
+				"model":   "claude-opus-4-7",
 				"content": []any{},
 				"usage": map[string]any{
 					"input_tokens":  6,


### PR DESCRIPTION
## Summary

- When converting function-type tools for the Anthropic Messages API, the `input_schema` field was omitted entirely when a tool had nil or empty `Parameters`, due to `json:",omitempty"` on the field.
- Anthropic now requires `input_schema` to be present (even if empty) for all `function`-type tools; omitting it causes HTTP 422.
- This fix defaults `InputSchema` to `{"type":"object","properties":{}}` when `tool.Function.Parameters` is nil or zero-length.

## Why this matters

Fixes #1843. After upgrading to v1.0.0-beta3, any Anthropic channel request containing a function tool with no parameters (e.g. a client sending a `web_search` function tool without a parameter schema) fails with HTTP 422 from the Anthropic API because `input_schema` is missing. The canonical empty JSON Schema object satisfies Anthropic's validation for no-argument tools.

## Testing

- Added `TestConvertToolsAnthropic_NilParameters` in `outbound_convert_test.go` covering:
  - nil `Parameters` produces valid `{"type":"object","properties":{}}` as `InputSchema`
  - empty `Parameters` (`json.RawMessage{}`) gets the same default
  - explicit `Parameters` with a schema are passed through unchanged
- All 539 existing tests in the `anthropic` package continue to pass.
- `gofmt`, `go vet`, and `go build` clean.

Fixes #1843