### PR TITLE
docs: update Docker Compose command in Chinese quick start

### DIFF
--- a/docs/zh/getting-started/quick-start.md
+++ b/docs/zh/getting-started/quick-start.md
@@ -28,7 +28,7 @@
 
 3. **启动服务**
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 4. **访问应用程序**
@@ -374,7 +374,7 @@ log:
 ### 常见问题
 
 **无法连接到 AxonHub**
-- 检查服务是否正在运行：`docker-compose ps`
+- 检查服务是否正在运行：`docker compose ps`
 - 验证端口 8090 是否可用
 - 检查防火墙设置
 


### PR DESCRIPTION
## Summary
- update the Chinese quick start Docker Compose startup command to use `docker compose`
- keep the troubleshooting command on the same page consistent

## Testing
- not run; documentation-only change