### PR TITLE
fix(openai): avoid stream aggregation nil panics

### DIFF
--- a/llm/transformer/openai/aggregator.go
+++ b/llm/transformer/openai/aggregator.go
@@ -269,9 +269,16 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 
 		var finalToolCalls []llm.ToolCall
 		if len(choiceAgg.toolCalls) > 0 {
-			finalToolCalls = make([]llm.ToolCall, len(choiceAgg.toolCalls))
-			for index := range finalToolCalls {
-				finalToolCalls[index] = *choiceAgg.toolCalls[index]
+			toolCallIndexes := make([]int, 0, len(choiceAgg.toolCalls))
+			for toolCallIndex := range choiceAgg.toolCalls {
+				toolCallIndexes = append(toolCallIndexes, toolCallIndex)
+			}
+			sort.Ints(toolCallIndexes)
+
+			finalToolCalls = make([]llm.ToolCall, 0, len(toolCallIndexes))
+			for _, toolCallIndex := range toolCallIndexes {
+				toolCall := choiceAgg.toolCalls[toolCallIndex]
+				finalToolCalls = append(finalToolCalls, *toolCall)
 			}
 		}
 
@@ -338,6 +345,11 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 	}
 
 	// Build the final response using llm.Response struct
+	var responseUsage *llm.Usage
+	if usage != nil {
+		responseUsage = usage.ToLLMUsage()
+	}
+
 	response := &llm.Response{
 		ID:                lastChunkResponse.ID,
 		Model:             lastChunkResponse.Model,
@@ -345,7 +357,7 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 		Created:           lastChunkResponse.Created,
 		SystemFingerprint: systemFingerprint,
 		Choices:           choices,
-		Usage:             usage.ToLLMUsage(),
+		Usage:             responseUsage,
 	}
 
 	// Add citations to response if any were collected
@@ -371,6 +383,6 @@ func AggregateStreamChunks(ctx context.Context, chunks []*httpclient.StreamEvent
 
 	return data, llm.ResponseMeta{
 		ID:    response.ID,
-		Usage: usage.ToLLMUsage(),
+		Usage: responseUsage,
 	}, nil
 }

--- a/llm/transformer/openai/aggregator_nonzero_index_test.go
+++ b/llm/transformer/openai/aggregator_nonzero_index_test.go
@@ -31,3 +31,43 @@ func TestAggregateStreamChunksNonZeroChoiceIndex(t *testing.T) {
 	require.NotNil(t, got.Choices[0].Message.Content.Content)
 	require.Equal(t, "hi", *got.Choices[0].Message.Content.Content)
 }
+
+func TestAggregateStreamChunksNoUsage(t *testing.T) {
+	chunk := `{"id":"chatcmpl-1","model":"gpt-4o-mini","object":"chat.completion.chunk","created":1,` +
+		`"choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`
+
+	gotBytes, meta, err := AggregateStreamChunks(context.Background(), []*httpclient.StreamEvent{{Data: []byte(chunk)}}, DefaultTransformChunk)
+	require.NoError(t, err)
+	require.Nil(t, meta.Usage)
+
+	var got llm.Response
+	require.NoError(t, json.Unmarshal(gotBytes, &got))
+	require.Nil(t, got.Usage)
+	require.Len(t, got.Choices, 1)
+	require.Equal(t, "hi", *got.Choices[0].Message.Content.Content)
+}
+
+func TestAggregateStreamChunksNonZeroToolCallIndex(t *testing.T) {
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-1","model":"gpt-4o-mini","object":"chat.completion.chunk","created":1,` +
+				`"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":1,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"q\":"}}]}}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-1","model":"gpt-4o-mini","object":"chat.completion.chunk","created":1,` +
+				`"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\"axonhub\"}"}}]},"finish_reason":"tool_calls"}]}`),
+		},
+	}
+
+	gotBytes, _, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	require.NoError(t, json.Unmarshal(gotBytes, &got))
+	require.Len(t, got.Choices, 1)
+	require.Len(t, got.Choices[0].Message.ToolCalls, 1)
+	require.Equal(t, 1, got.Choices[0].Message.ToolCalls[0].Index)
+	require.Equal(t, "call_1", got.Choices[0].Message.ToolCalls[0].ID)
+	require.Equal(t, "search", got.Choices[0].Message.ToolCalls[0].Function.Name)
+	require.Equal(t, `{"q":"axonhub"}`, got.Choices[0].Message.ToolCalls[0].Function.Arguments)
+}


### PR DESCRIPTION
## Summary

Fix a nil panic during OpenAI-compatible stream aggregation.

## Problem

When AxonHub finalizes a streamed response, it aggregates stream chunks into a complete response for persistence and usage logging. Some providers may emit sparse `tool_calls` indexes, for example only `tool_calls[1]`, or omit the final `usage` block.

The old code assumed tool call indexes were contiguous from `0` and called `usage.ToLLMUsage()` unconditionally, which could panic during stream finalization.

## Changes

- aggregate tool calls by actual sorted map keys instead of positional indexes
- keep response/meta usage nil when the stream does not include usage
- add regression tests for sparse tool call indexes and missing usage

## Validation

```bash
cd llm && go test ./transformer/openai
```
