### PR TITLE
fix(openai): normalize "xhigh" reasoning_effort to "max" for OpenAI-compatible APIs

### DIFF
--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -30,7 +30,7 @@ func RequestFromLLM(r *llm.Request, reasoningField ReasoningField) *Request {
 		LogitBias:           r.LogitBias,
 		Metadata:            r.Metadata,
 		Modalities:          r.Modalities,
-		ReasoningEffort:     r.ReasoningEffort,
+		ReasoningEffort:     normalizeReasoningEffort(r.ReasoningEffort),
 		ServiceTier:         r.ServiceTier,
 		Stream:              r.Stream,
 		ParallelToolCalls:   r.ParallelToolCalls,
@@ -365,4 +365,14 @@ func (c Choice) ToLLMChoice() llm.Choice {
 	}
 
 	return choice
+}
+
+// normalizeReasoningEffort converts internal "xhigh" back to "max" for OpenAI-compatible APIs.
+// Axonhub internally uses "xhigh" to represent Anthropic's "max" effort level, but most
+// OpenAI-compatible providers (ollama, opencode, etc.) expect the standard "max" value.
+func normalizeReasoningEffort(effort string) string {
+	if effort == "xhigh" {
+		return "max"
+	}
+	return effort
 }


### PR DESCRIPTION
Fixes #1892

### What / 改动内容

修复 OpenAI transformer 向 OpenAI 兼容 API（ollama、opencode 等）发送非标准 `"xhigh"` reasoning_effort 值导致 400 错误的问题。

### Why / 问题背景

Anthropic inbound transformer 将 `output_config.effort: "max"` 转换为内部值 `"xhigh"`（`inbound_convert.go:368`），但 OpenAI outbound transformer 直接传递此值，导致不识别 `"xhigh"` 的上游 API 拒绝请求。

**错误示例：**
```
ollama: invalid reasoning value: 'xhigh' (must be "high", "medium", "low", "max", or "none")
```

### How / 解决方案

在 `llm/transformer/openai/outbound_convert.go` 中添加 `normalizeReasoningEffort()` 函数，将内部 `"xhigh"` 归一化为标准 `"max"`。

### Testing / 测试验证

- ✅ 使用 Claude Code + GLM-5.2 + `output_config.effort: "max"`
- ✅ ollama channel 成功接收 `reasoning_effort: "max"`
- ✅ 不再出现 `invalid reasoning value: 'xhigh'` 错误