### PR TITLE
fix(frontend): avoid logout on upstream auth errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write .",
     "prepare": "husky",
     "knip": "knip",
+    "test:unit": "node --test src/**/*.test.mjs",
     "test:e2e": "../scripts/e2e/e2e-test.sh",
     "test:e2e:headed": "../scripts/e2e/e2e-test.sh --headed",
     "test:e2e:ui": "../scripts/e2e/e2e-test.sh --ui",

--- a/frontend/src/gql/graphql.test.mjs
+++ b/frontend/src/gql/graphql.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import ts from 'typescript';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const sourcePath = join(import.meta.dirname, 'graphql.ts');
+const source = readFileSync(sourcePath, 'utf8');
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2023,
+  },
+}).outputText
+  .replaceAll("import { toast } from 'sonner';", 'const toast = { error() {} };')
+  .replaceAll("import { getTokenFromStorage, removeTokenFromStorage } from '@/stores/authStore';", 'const getTokenFromStorage = () => ""; const removeTokenFromStorage = () => {};')
+  .replaceAll("import i18n from '@/lib/i18n';", 'const i18n = { t: (key) => key };');
+
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString('base64')}`;
+const { isUnauthorizedGraphQLError } = await import(moduleUrl);
+
+test('does not classify upstream unauthorized provider failures as login expiration', () => {
+  const error = {
+    message: 'model fetch returned error: failed to fetch models: GET - https://provider.example/v1/models with status 401 Unauthorized',
+    path: ['syncChannelModels'],
+  };
+
+  assert.equal(isUnauthorizedGraphQLError(error), false);
+});
+
+test('classifies explicit GraphQL authentication codes as login expiration', () => {
+  assert.equal(isUnauthorizedGraphQLError({ extensions: { code: 'UNAUTHENTICATED' } }), true);
+});

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -41,10 +41,8 @@ function isForbiddenGraphQLError(error: any): boolean {
   return error?.extensions?.code === 'FORBIDDEN' || error?.message?.toLowerCase().includes('permission denied');
 }
 
-function isUnauthorizedGraphQLError(error: any): boolean {
-  const message = error?.message?.toLowerCase() ?? '';
-
-  return error?.extensions?.code === 'UNAUTHENTICATED' || message.includes('unauthorized') || message.includes('unauthenticated');
+export function isUnauthorizedGraphQLError(error: any): boolean {
+  return error?.extensions?.code === 'UNAUTHENTICATED';
 }
 
 // GraphQL client function with token support


### PR DESCRIPTION
## Summary
- Stop treating arbitrary GraphQL error message text containing "Unauthorized" as an admin session-expiration signal.
- Keep logout behavior for explicit HTTP 401/403 responses and GraphQL `UNAUTHENTICATED` extension codes.
- Add a small unit regression test for upstream provider 401 errors returned inside GraphQL business errors.

## Example
A channel model-sync request can return HTTP 200 with a GraphQL business error like:

```json
{
  "errors": [
    {
      "message": "model fetch returned error: failed to fetch models: GET - https://provider.example/v1/models with status 401 Unauthorized",
      "path": ["syncChannelModels"]
    }
  ],
  "data": null
}
```

The `Unauthorized` text here belongs to the upstream provider request, not the AxonHub admin JWT session. The frontend should show it as an operation error instead of clearing the admin token and redirecting to sign-in.

## Test Plan
- `node --test src/**/*.test.mjs` from `frontend/`