### PR TITLE
fix: improve error reporting for /v1/models endpoint

### DIFF
--- a/internal/server/api/anthropic.go
+++ b/internal/server/api/anthropic.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/looplj/axonhub/internal/contexts"
+	entprivacy "github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/server/orchestrator"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -83,13 +85,19 @@ func (handlers *AnthropicHandlers) ListModels(c *gin.Context) {
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
 		requestID, _ := contexts.GetRequestID(ctx)
+		status := http.StatusInternalServerError
+		errorType := "internal_server_error"
+		if errors.Is(err, entprivacy.Deny) {
+			status = http.StatusForbidden
+			errorType = "permission_error"
+		}
 		_ = c.Error(err)
-		c.JSON(http.StatusInternalServerError, anthropic.AnthropicError{
-			StatusCode: http.StatusInternalServerError,
-			Type:       "internal_server_error",
+		c.JSON(status, anthropic.AnthropicError{
+			StatusCode: status,
+			Type:       errorType,
 			RequestID:  requestID,
 			Error: anthropic.ErrorDetail{
-				Type:    "internal_server_error",
+				Type:    errorType,
 				Message: err.Error(),
 			},
 		})

--- a/internal/server/api/anthropic.go
+++ b/internal/server/api/anthropic.go
@@ -83,6 +83,7 @@ func (handlers *AnthropicHandlers) ListModels(c *gin.Context) {
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
 		requestID, _ := contexts.GetRequestID(ctx)
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, anthropic.AnthropicError{
 			StatusCode: http.StatusInternalServerError,
 			Type:       "internal_server_error",

--- a/internal/server/api/gemini.go
+++ b/internal/server/api/gemini.go
@@ -141,6 +141,7 @@ func (handlers *GeminiHandlers) ListModels(c *gin.Context) {
 
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gemini.GeminiError{
 			Error: gemini.ErrorDetail{
 				Message: err.Error(),

--- a/internal/server/api/gemini.go
+++ b/internal/server/api/gemini.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/fx"
 
+	entprivacy "github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/server/orchestrator"
@@ -141,12 +143,18 @@ func (handlers *GeminiHandlers) ListModels(c *gin.Context) {
 
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
+		status := http.StatusInternalServerError
+		errorStatus := "internal_server_error"
+		if errors.Is(err, entprivacy.Deny) {
+			status = http.StatusForbidden
+			errorStatus = "permission_error"
+		}
 		_ = c.Error(err)
-		c.JSON(http.StatusInternalServerError, gemini.GeminiError{
+		c.JSON(status, gemini.GeminiError{
 			Error: gemini.ErrorDetail{
 				Message: err.Error(),
-				Code:    http.StatusInternalServerError,
-				Status:  "internal_server_error",
+				Code:    status,
+				Status:  errorStatus,
 			},
 		})
 

--- a/internal/server/api/oidc.go
+++ b/internal/server/api/oidc.go
@@ -79,6 +79,7 @@ func (h *OIDCHandlers) GetAuthorizeURL(c *gin.Context) {
 
 	authURL, state, err := h.oidc.GetAuthorizeURL(c.Request.Context(), provider, baseURL)
 	if err != nil {
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -112,6 +113,7 @@ func (h *OIDCHandlers) GetLinkAuthorizeURL(c *gin.Context) {
 
 	authURL, state, err := h.oidc.GetLinkAuthorizeURL(c.Request.Context(), provider, baseURL, userID)
 	if err != nil {
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -205,6 +207,7 @@ func (h *OIDCHandlers) Exchange(c *gin.Context) {
 			return
 		}
 
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 
 		return
@@ -212,6 +215,7 @@ func (h *OIDCHandlers) Exchange(c *gin.Context) {
 
 	token, err := h.auth.GenerateJWTToken(c.Request.Context(), user)
 	if err != nil {
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token: " + err.Error()})
 		return
 	}

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -639,7 +639,7 @@ func convertModelToOpenAIExtended(m *ent.Model, include map[string]bool) OpenAIM
 }
 
 func (handlers *OpenAIHandlers) writeOpenAIInternalError(c *gin.Context, requestID string, err error) {
-	contexts.AddError(c.Request.Context(), err)
+	_ = c.Error(err)
 
 	c.JSON(http.StatusInternalServerError, openai.OpenAIError{
 		StatusCode: http.StatusInternalServerError,

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -14,6 +14,7 @@ import (
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/model"
+	entprivacy "github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/server/orchestrator"
@@ -652,6 +653,20 @@ func (handlers *OpenAIHandlers) writeOpenAIInternalError(c *gin.Context, request
 	})
 }
 
+func (handlers *OpenAIHandlers) writeOpenAIPermissionDeniedError(c *gin.Context, requestID string, err error) {
+	_ = c.Error(err)
+
+	c.JSON(http.StatusForbidden, openai.OpenAIError{
+		StatusCode: http.StatusForbidden,
+		Detail: llm.ErrorDetail{
+			Code:      "permission_denied",
+			Message:   "insufficient permissions to access this resource",
+			Type:      "authentication_error",
+			RequestID: requestID,
+		},
+	})
+}
+
 func (handlers *OpenAIHandlers) writeOpenAIModelNotFoundError(c *gin.Context, requestID, modelID string) {
 	message := "The model does not exist or you do not have access to it."
 	if modelID != "" {
@@ -686,7 +701,11 @@ func (handlers *OpenAIHandlers) RetrieveModel(c *gin.Context) {
 
 	models, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
-		handlers.writeOpenAIInternalError(c, requestID, err)
+		if errors.Is(err, entprivacy.Deny) {
+			handlers.writeOpenAIPermissionDeniedError(c, requestID, err)
+		} else {
+			handlers.writeOpenAIInternalError(c, requestID, err)
+		}
 		return
 	}
 
@@ -736,7 +755,11 @@ func (handlers *OpenAIHandlers) ListModels(c *gin.Context) {
 
 	visibleModels, err := handlers.ModelService.ListEnabledModels(ctx)
 	if err != nil {
-		handlers.writeOpenAIInternalError(c, requestID, err)
+		if errors.Is(err, entprivacy.Deny) {
+			handlers.writeOpenAIPermissionDeniedError(c, requestID, err)
+		} else {
+			handlers.writeOpenAIInternalError(c, requestID, err)
+		}
 		return
 	}
 

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -639,6 +639,8 @@ func convertModelToOpenAIExtended(m *ent.Model, include map[string]bool) OpenAIM
 }
 
 func (handlers *OpenAIHandlers) writeOpenAIInternalError(c *gin.Context, requestID string, err error) {
+	contexts.AddError(c.Request.Context(), err)
+
 	c.JSON(http.StatusInternalServerError, openai.OpenAIError{
 		StatusCode: http.StatusInternalServerError,
 		Detail: llm.ErrorDetail{

--- a/internal/server/api/system.go
+++ b/internal/server/api/system.go
@@ -169,6 +169,7 @@ func (h *SystemHandlers) InitializeSystem(c *gin.Context) {
 		PreferLanguage: req.PreferLanguage,
 	})
 	if err != nil {
+		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, InitializeSystemResponse{
 			Success: false,
 			Message: fmt.Sprintf("Failed to initialize system: %v", err),

--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,16 +11,15 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/fx"
 
-	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/model"
+	entprivacy "github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/internal/pkg/xregexp"
 	"github.com/looplj/axonhub/internal/pkg/xtime"
-	"github.com/looplj/axonhub/internal/scopes"
 )
 
 type ModelServiceParams struct {
@@ -596,8 +596,6 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		profile  *objects.APIKeyProfile
 	)
 
-	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadChannels)
-
 	if apiKey, ok := contexts.GetAPIKey(ctx); ok && apiKey != nil {
 		// Project-level profile filtering (upper boundary)
 		if projectProfile := apiKey.Edges.Project.GetActiveProfile(); projectProfile != nil {
@@ -635,9 +633,14 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		allowedModelIDs = profile.ModelIDs
 	}
 
-	// Query configured Model entities (used in both modes)
+	// Query configured Model entities (used in both modes).
+	// Privacy denial is handled gracefully: if the principal lacks
+	// read_channels scope, the query returns no configured models
+	// and the response may still include channel-derived models.
 	configuredModels, err := svc.queryConfiguredModelFacades(ctx, allowedModelIDs, channels)
-	if err != nil {
+	if errors.Is(err, entprivacy.Deny) {
+		configuredModels = nil
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -709,6 +712,10 @@ func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, allowe
 
 	enabledModels, err := query.All(ctx)
 	if err != nil {
+		if errors.Is(err, entprivacy.Deny) {
+			return nil, fmt.Errorf("insufficient permissions to list models (scope %s required): %w",
+				"read_channels", err)
+		}
 		return nil, fmt.Errorf("failed to list configured models: %w", err)
 	}
 

--- a/internal/server/biz/model.go
+++ b/internal/server/biz/model.go
@@ -3,7 +3,6 @@ package biz
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -11,15 +10,16 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/fx"
 
+	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/model"
-	entprivacy "github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xerrors"
 	"github.com/looplj/axonhub/internal/pkg/xregexp"
 	"github.com/looplj/axonhub/internal/pkg/xtime"
+	"github.com/looplj/axonhub/internal/scopes"
 )
 
 type ModelServiceParams struct {
@@ -596,6 +596,8 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		profile  *objects.APIKeyProfile
 	)
 
+	ctx = authz.WithScopeDecision(ctx, scopes.ScopeReadChannels)
+
 	if apiKey, ok := contexts.GetAPIKey(ctx); ok && apiKey != nil {
 		// Project-level profile filtering (upper boundary)
 		if projectProfile := apiKey.Edges.Project.GetActiveProfile(); projectProfile != nil {
@@ -633,14 +635,9 @@ func (svc *ModelService) ListEnabledModels(ctx context.Context) ([]ModelFacade, 
 		allowedModelIDs = profile.ModelIDs
 	}
 
-	// Query configured Model entities (used in both modes).
-	// Privacy denial is handled gracefully: if the principal lacks
-	// read_channels scope, the query returns no configured models
-	// and the response may still include channel-derived models.
+	// Query configured Model entities (used in both modes)
 	configuredModels, err := svc.queryConfiguredModelFacades(ctx, allowedModelIDs, channels)
-	if errors.Is(err, entprivacy.Deny) {
-		configuredModels = nil
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -712,10 +709,6 @@ func (svc *ModelService) queryConfiguredModelFacades(ctx context.Context, allowe
 
 	enabledModels, err := query.All(ctx)
 	if err != nil {
-		if errors.Is(err, entprivacy.Deny) {
-			return nil, fmt.Errorf("insufficient permissions to list models (scope %s required): %w",
-				"read_channels", err)
-		}
 		return nil, fmt.Errorf("failed to list configured models: %w", err)
 	}
 


### PR DESCRIPTION
## 问题

部分 API handler 返回 500 错误时存在两个问题：

1. **Access log 看不到错误**：直接调用 `c.JSON()` 没有走 `c.Error(err)`，导致 AccessLog 中间件的 errors 字段为空
2. **隐私拒绝返回 500**：`ent/privacy: deny rule` 是权限不足，应该是 403 而非 500

## 改动

### 1. 统一错误记录（+8/-1）
所有直接返回 500 的 handler 增加 `_ = c.Error(err)`，对齐已有的 `AbortWithError` / `JSONError` 模式：
- **openai.go**: `writeOpenAIInternalError`
- **anthropic.go**: `ListModels`
- **gemini.go**: `ListModels`
- **oidc.go**: 4 处
- **system.go**: `InitializeSystem`

### 2. Privacy deny 返回 403（+48/-9）
所有 `ListEnabledModels` 调用方用 `errors.Is(err, entprivacy.Deny)` 检测权限不足，返回 403：
- **openai.go**: `RetrieveModel`、`ListModels` + 新增 `writeOpenAIPermissionDeniedError`
- **anthropic.go**: `ListModels`
- **gemini.go**: `ListModels`

## 效果

| 场景 | 之前 | 之后 |
|------|------|------|
| 缺少 read_channels scope | 500 + access log 无错误 | 403 + access log 有错误 |
| 其他内部错误 | 500 + access log 无错误 | 500 + access log 有错误 |