### PR TITLE
fix(metrics): accept published OTLP HTTP exporter spelling

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -118,7 +118,7 @@ log:
 metrics:
   enabled: false                 # Enable metrics collection (env: AXONHUB_METRICS_ENABLED)
   exporter: 
-    type: "oltphttp"          # Metrics exporter type: prometheus, console (env: AXONHUB_METRICS_EXPORTER_TYPE)
+    type: "otlphttp"          # Metrics exporter type: stdout, otlpgrpc, otlphttp (env: AXONHUB_METRICS_EXPORTER_TYPE)
     endpoint: "localhost:8080" # Metrics exporter endpoint (env: AXONHUB_METRICS_EXPORTER_ENDPOINT)
     insecure: true             # Enable insecure connection (env: AXONHUB_METRICS_EXPORTER_INSECURE)
     

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -191,7 +191,7 @@ log:
 metrics:
   enabled: false                 # Enable metrics collection
   exporter:
-    type: "oltphttp"            # prometheus, console
+    type: "otlphttp"            # stdout, otlpgrpc, otlphttp
     endpoint: "localhost:8080"  # Metrics exporter endpoint
     insecure: true              # Enable insecure connection
 ```
@@ -411,7 +411,7 @@ username:password@tcp(host:3306)/database?parseTime=True&multiStatements=true&ch
    metrics:
      enabled: true
      exporter:
-       type: "prometheus"
+       type: "otlphttp"
    ```
 
 ### Troubleshooting

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -191,7 +191,7 @@ log:
 metrics:
   enabled: false                 # 启用指标收集
   exporter:
-    type: "oltphttp"            # prometheus, console
+    type: "otlphttp"            # stdout, otlpgrpc, otlphttp
     endpoint: "localhost:8080"  # 指标导出器端点
     insecure: true              # 启用不安全连接
 ```
@@ -377,7 +377,7 @@ username.root:password@tcp(host:4000)/database?tls=true&parseTime=true&multiStat
    metrics:
      enabled: true
      exporter:
-       type: "prometheus"
+       type: "otlphttp"
    ```
 
 ### 故障排除

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -10,7 +10,7 @@ type Config struct {
 }
 
 type ExporterConfig struct {
-	Type     string `conf:"type" validate:"oneof=stdout otlpgrpc otlphttp" yaml:"type" json:"type"`
+	Type     string `conf:"type" validate:"oneof=stdout otlpgrpc otlphttp oltphttp" yaml:"type" json:"type"`
 	Endpoint string `conf:"endpoint" yaml:"endpoint" json:"endpoint"`
 	Insecure bool   `conf:"insecure" yaml:"insecure" json:"insecure"`
 }

--- a/internal/metrics/provider.go
+++ b/internal/metrics/provider.go
@@ -52,7 +52,7 @@ func NewProvider(config Config) (*sdk.MeterProvider, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create otlpgrpc exporter: %w", err)
 		}
-	case "otlphttp":
+	case "otlphttp", "oltphttp":
 		opts := []otlpmetrichttp.Option{
 			otlpmetrichttp.WithEndpoint(config.Exporter.Endpoint),
 		}

--- a/internal/metrics/provider_test.go
+++ b/internal/metrics/provider_test.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestNewProviderAcceptsPublishedOltpHTTPSpelling(t *testing.T) {
+	var sawMetricsPath atomic.Bool
+	var unexpectedPath atomic.Value
+
+	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/metrics" {
+			sawMetricsPath.Store(true)
+		} else {
+			unexpectedPath.Store(r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(collector.Close)
+
+	provider, err := NewProvider(Config{
+		Enabled: true,
+		Exporter: ExporterConfig{
+			Type:     "oltphttp",
+			Endpoint: strings.TrimPrefix(collector.URL, "http://"),
+			Insecure: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider should accept the published oltphttp spelling: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("NewProvider returned nil provider")
+	}
+
+	if err := provider.Shutdown(context.Background()); err != nil {
+		t.Fatalf("failed to shutdown provider: %v", err)
+	}
+	if path, ok := unexpectedPath.Load().(string); ok {
+		t.Fatalf("unexpected metrics export path: %s", path)
+	}
+	if !sawMetricsPath.Load() {
+		t.Fatal("metrics exporter did not call /v1/metrics")
+	}
+}


### PR DESCRIPTION
## Summary

- accept the previously published `oltphttp` metrics exporter spelling as a backward-compatible alias for `otlphttp`
- correct `config.example.yml` and EN/ZH deployment docs to show the canonical `otlphttp` value instead of unsupported exporter names
- keep config validation/schema tags consistent with the compatibility alias
- add a regression test covering the published spelling so metrics-enabled configs no longer fail during provider initialization

## Context

`config.example.yml` and the deployment docs currently show:

```yaml
metrics:
  enabled: false
  exporter:
    type: "oltphttp"
```

But the runtime only accepts `otlphttp`. When users copy the published config and enable metrics, provider initialization fails with `unsupported metrics exporter type: "oltphttp"`, so the server never reaches `/health`.

This should help the Docker unhealthy/startup path reported in #1903, where another user noted that disabling metrics worked around the issue. I kept the runtime alias for compatibility with already-copied configs, while updating the examples to the canonical spelling.

## Test Plan

- [x] `go test ./internal/metrics -run TestNewProviderAcceptsPublishedOltpHTTPSpelling -count=1 -v`
  - RED before the fix: `unsupported metrics exporter type: "oltphttp"`
  - GREEN after the fix: pass
- [x] `go test ./internal/metrics -count=1`
- [x] `AXONHUB_METRICS_ENABLED=true AXONHUB_METRICS_EXPORTER_TYPE=oltphttp go run ./cmd/axonhub config validate`
- [x] `make test-backend-all`
- [x] `git diff --check`

## Notes

- Target branch: `release/v0.9.x`, because #1903 reports `v0.9.43` after rollback and an earlier metrics PR (#997) was redirected by the maintainer to `release/v0.9.x` for release fixes.
- The issue body does not include full container logs, so this PR avoids claiming complete reproduction of the reporter's deployment. It fixes a concrete startup failure path that matches the metrics workaround comment.
