### PR TITLE
opt: reduce S3 Class A operations with native ObjectStore

### DIFF
--- a/docs/solutions/s3-storage-refactor.md
+++ b/docs/solutions/s3-storage-refactor.md
@@ -1,0 +1,336 @@
+# 数据存储层重构方案：消除过量的 S3 Class A 操作
+
+> 状态：设计稿（待评审）
+> 范围：`internal/server/biz/data_storage.go`、`internal/server/gc/gc.go`、`internal/server/video_storage`、`internal/server/backup`、`internal/server/api/request_content.go`
+> 目标读者：后端工程师
+> 结论先行：采用 **务实混合架构（Pragmatic Hybrid）**——只为有 Class A 计费的后端（S3、GCS）引入原生 `ObjectStore` 接口，`Fs`/`WebDAV` 继续走 afero，`Database` 维持 no-op；分阶段落地，Phase 0 用极小改动先吃掉约 70% 的成本。
+
+---
+
+## 1. 背景与问题
+
+线上观测到 S3 出现大量 **Class A 操作**（`PutObject` / `ListObjectsV2` / multipart 三件套等）。经逐条对抗审查（读真实源码核实，结论全部成立），根因如下。
+
+> Class A 定义（本方案关注项）：`PutObject`、`ListObjects(V2)`、`CopyObject`、`CreateMultipartUpload`、`UploadPart`、`CompleteMultipartUpload` 等。`GetObject` / `HeadObject` 为 Class B；`DeleteObject` 不计费。
+
+### 1.1 根因：用 POSIX 文件系统抽象（afero）套在对象存储上
+
+存储层把所有后端统一抽象成 `afero.Fs`，S3 经 `github.com/looplj/afero-s3` 适配。POSIX 语义（`Create`/`Open`/`Write`/`Close`/`Stat`/`Mkdir`）与对象存储语义（`PutObject`/`GetObject`/`DeleteObject`/`ListObjects`）存在**阻抗失配**，适配器为"模拟文件语义"额外发起了大量 Class A 调用。
+
+### 1.2 已核实的六个放大源
+
+| # | 问题 | 位置 | 后果 |
+|---|------|------|------|
+| P1 | `SaveData` 一次逻辑写 = **3 个 PutObject** | `data_storage.go:542-553`（`fs.Create`+`f.Close`+`afero.WriteFile`） | `Create` 显式空 PutObject + 该句柄 `Close` 经 upload manager 再刷一个空 PutObject + `WriteFile` 真实 PutObject（应为 1） |
+| P2 | `SaveDataFromReader` = **2 个 PutObject** | `data_storage.go:589-595` | `fs.Create` 多余空 PutObject + 真实数据写入 |
+| P3 | 每请求 **4~6 次** `SaveData`（请求体/执行请求体/响应体/执行响应体 + chunks），且重试再叠加 | `request.go:246,365,447,632,716,926,1014` | 与 P1 叠乘 → **~12~18 PutObject/请求**（应为 ~4~6） |
+| P4 | GC 删除时 `Remove` 先 `Stat`；不存在的键 → `ListObjectsV2` | `gc.go:357,395` → `data_storage.go:628` → afero-s3 `Remove`/`Stat`/`statDirectory` | 3 个"目录标记键"对 S3 从不创建，每次删除**必然**触发 `ListObjectsV2`；未写入的文件键（如关闭 chunks 时）同样触发 |
+| P5 | 缺失键的读取升级为 `ListObjectsV2` | `data_storage.go:665`（`LoadData`）、`request_content.go:125`（下载） | 正常读是 Class B（Head+Get），但读不存在的键经 `statDirectory` 变成 Class A |
+| P6 | 未配置重试器 + 大对象 multipart | `createS3Fs`（`data_storage.go:388`）；video worker `worker.go:193-198`（512MB `io.LimitReader`，不可 seek → 强制 multipart） | SDK 默认重试 3 次：限流（503 SlowDown）下每个 Class A ×3，形成**限流-重试雪崩**；512MB 视频按默认 5MB 分片 ≈ 100+ 个 `UploadPart` |
+
+### 1.3 明确**不是**问题（不要为其设计）
+
+- `Rename`→`CopyObject`、`Chmod`→`PutObjectAcl`、`RemoveAll`→`ListObjectsV2`：全仓库**无调用方**。
+- 桶级操作 `ListBuckets`/`PutBucket*`/`HeadBucket`/`CreateBucket`：**零调用**（`createS3Fs` 仅构造 client）。
+- chunks **不是逐块写**——已批量 `json.Marshal` 成一个数组、一次 `SaveData`。
+- 每分钟的 `datastorage-fs-reload` cron **不发** S3 请求。
+
+---
+
+## 2. 设计目标与非目标
+
+**目标**
+
+1. 把每次逻辑写从 3（流式 2）降到 **1 个 PutObject**。
+2. GC 删除 **0 个 `ListObjectsV2`**：幂等单次 `DeleteObject`，并停止发送从不存在的目录标记键。
+3. 缺失键读取 **0 个 Class A**：`GetObject` 404 → `os.ErrNotExist`，无 List 回退。
+4. 配置自适应重试，消除限流-重试放大；大对象走可控分片。
+5. 五种后端（Database/Fs/S3/GCS/WebDAV）全部继续可用；**已存数据 0 迁移**。
+
+**非目标**
+
+- 不改变对外存储语义、键格式、`StoragePolicy` 门控、DB `{}` 哨兵。
+- 不重写无 Class A 计费的后端（Fs 本地、WebDAV 无原生流式 Writer）。
+- 不在本方案内合并"请求级 + 执行级"双份落盘（属产品决策，见 §9）。
+
+---
+
+## 3. 现状约束（迁移必须遵守）
+
+来自代码盘点的硬约束：
+
+- **抽象边界**：`DataStorageService` 的公开方法（`SaveData`、`SaveDataFromReader`、`LoadData`、`DeleteData`、`GetFileSystem` 等）被 5 个下游服务依赖，**签名不可变**。
+- **键格式不可变**：`/{proj}/requests/{id}/request_body.json` 等（`request.go:73-126`）必须保持字节一致，旧对象升级后仍可读/可删（缓存兼容规则 `.agent/rules/cache-compat.md`）。
+- **Database 后端 no-op**：`ds.Primary` / `Database` 类型下 Save/Load/Delete 维持现状（数据在 DB 列里）。
+- **三个 afero 逃逸口必须继续工作**（绕过了 `LoadData`/`DeleteData`）：
+  - `request_content.go:113,125` 直接 `GetFileSystem` + `fs.Open(key)` 做 HTTP 下载；
+  - `autobackup.go:129,134` `afero.ReadDir(fs, "/")` 列备份；
+  - `autobackup.go:155` `fs.Remove(name)` 删旧备份。
+- **路径规范化**：S3 PathStyle 去前导 `/`、WebDAV 去前导 `/` + 自定义 `mkdirAll`，均需保留。
+- **流式**：video worker 经 `SaveDataFromReader` 传最大 512MB 的非 seekable `io.LimitReader`，必须支持流式且不强制小分片。
+- **DI**：`NewDataStorageService` 经 FX 注入（`fx_module.go`），新依赖需进 `DataStorageServiceParams`。
+- **测试**：现有单测（`data_storage_test.go`、`gc_test.go`、`request_content_test.go`、`backup_test.go`、`restore_test.go`、`request_audio_test.go`）全部基于 `t.TempDir()` 的 FS 后端，必须保持绿。
+
+---
+
+## 4. 目标架构
+
+### 4.1 分层与取舍
+
+```
+            DataStorageService  (公开 API 不变，内部按 ds.Type 分发)
+            ┌───────────────────────────────────────────────────────┐
+            │  SaveData / SaveDataFromReader / LoadData / DeleteData │
+            └───────────────┬───────────────────────┬───────────────┘
+                            │ S3 / GCS              │ Fs / WebDAV / Database
+                            ▼                        ▼
+                   ObjectStore（原生）        afero.Fs（保留）        Database：no-op
+            ┌──────────────┴──────────────┐   ┌──────┴───────┐
+            │ s3ObjectStore  gcsObjectStore│   │ OsFs  WebDAVFs│
+            │ aws-sdk-go-v2  cloud storage │   └──────────────┘
+            └─────────────────────────────┘
+            GetFileSystem(): 对所有非 DB 后端仍返回 afero.Fs（保留逃逸口与 FS 下载快路径）
+```
+
+**为什么是混合而不是全量重写**：Class A 的真实成本只在 S3（GCS 次之）；Fs 是本地无计费，WebDAV 的 `gowebdav` 没有原生流式 Writer，重写它们只增加风险与测试负担、零收益。因此把原生代码**精确限定**在 S3+GCS。
+
+### 4.2 `ObjectStore` 接口（新文件 `internal/server/biz/objectstore.go`）
+
+```go
+// ObjectStore 是一个最小的对象存储 API，仅对有 Class A 计费的后端（S3、GCS）原生实现。
+// Fs/WebDAV 走 afero；Database 在本层之上为 no-op。key 由调用方完成规范化（去前导 '/'）。
+type ObjectStore interface {
+	// PutObject 单次写入。对内存 []byte 必须使用单次非 multipart 写
+	// （S3 PutObject / GCS Writer），绝不 Create+Close+Write。
+	PutObject(ctx context.Context, key string, data []byte) error
+
+	// PutObjectStream 从 r 流式写入；size<0 表示长度未知。
+	// 仅在确有必要时切到 multipart（S3 manager.Uploader，PartSize 经调优用于 512MB 视频）。
+	PutObjectStream(ctx context.Context, key string, r io.Reader, size int64) (written int64, err error)
+
+	// GetObject 读取对象。缺失键必须返回满足 errors.Is(err, os.ErrNotExist) 的错误，且无 List 回退。
+	GetObject(ctx context.Context, key string) ([]byte, error)
+
+	// OpenObject 返回流式 reader + size，用于下载路径（request_content）。缺失键 → os.ErrNotExist，无 List 回退。
+	OpenObject(ctx context.Context, key string) (body io.ReadCloser, size int64, err error)
+
+	// DeleteObject 删除单键。删除不存在的键（含从未创建的目录标记键、关闭 chunks 时的 chunk 键）
+	// 必须是幂等 no-op：单次 DeleteObject，无 HeadObject、无 ListObjectsV2。
+	DeleteObject(ctx context.Context, key string) error
+}
+```
+
+### 4.3 内部分发（`DataStorageService` 公开签名不变）
+
+```go
+// objectStoreFor 对 S3/GCS 返回原生 store；否则 (nil,false)，调用方回退到 afero 路径或 no-op。
+// store 按 ds.ID 缓存，与 fsCache 同生命周期、同步失效。
+func (s *DataStorageService) objectStoreFor(ctx context.Context, ds *ent.DataStorage) (ObjectStore, bool, error) {
+	switch ds.Type {
+	case datastorage.TypeS3:
+		return s.s3StoreFor(ctx, ds)
+	case datastorage.TypeGcs:
+		return s.gcsStoreFor(ctx, ds)
+	default:
+		return nil, false, nil // Database -> no-op；Fs/WebDAV -> afero
+	}
+}
+
+// SaveData:            store,ok := objectStoreFor(); ok → store.PutObject(ctx, normKey, data)；否则 afero（已删除 Create+Close）
+// SaveDataFromReader:  ok → store.PutObjectStream(...)；否则 afero OpenFile 路径
+// LoadData:            Database → []byte(key)；ok → store.GetObject(...)；否则 afero.ReadFile
+// DeleteData:          Database → nil；ok → store.DeleteObject(...)；否则 afero fs.Remove（isNotExist→nil）
+// GetFileSystem:       不变，所有非 DB 后端仍 afero（逃逸口 + FS 下载快路径）
+```
+
+### 4.4 S3 实现（`internal/server/biz/objectstore_s3.go`）
+
+```go
+type s3ObjectStore struct {
+	client   *awss3.Client
+	uploader *manager.Uploader // PartSize 调优（如 16~32MB），仅供 PutObjectStream 使用
+	bucket   string
+}
+
+func (o *s3ObjectStore) PutObject(ctx context.Context, key string, data []byte) error {
+	_, err := o.client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:        &o.bucket,
+		Key:           &key,
+		Body:          bytes.NewReader(data), // seekable → 单次 PutObject
+		ContentLength: aws.Int64(int64(len(data))),
+	})
+	return err
+}
+
+func (o *s3ObjectStore) DeleteObject(ctx context.Context, key string) error {
+	_, err := o.client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: &o.bucket, Key: &key})
+	return err // 幂等：缺失键返回 204，绝不 List
+}
+
+func (o *s3ObjectStore) GetObject(ctx context.Context, key string) ([]byte, error) {
+	out, err := o.client.GetObject(ctx, &awss3.GetObjectInput{Bucket: &o.bucket, Key: &key})
+	if err != nil {
+		if isS3NotFound(err) { // *types.NoSuchKey / *types.NotFound / smithy 404
+			return nil, fmt.Errorf("%w: %s", os.ErrNotExist, key)
+		}
+		return nil, err
+	}
+	defer out.Body.Close()
+	return io.ReadAll(out.Body)
+}
+
+// 客户端构造时安装自适应重试器（消除 503 限流-重试雪崩）：
+//   awsconfig.WithRetryer(func() aws.Retryer {
+//       return retry.AddWithMaxAttempts(retry.NewAdaptiveMode(), 3)
+//   })
+```
+
+### 4.5 GCS 实现（复用 `data_storage.go:431` 已创建的 `storage.Client`）
+
+```go
+type gcsObjectStore struct{ bucket *storage.BucketHandle }
+
+// PutObject:    w := bucket.Object(key).NewWriter(ctx); w.Write(data); w.Close()  // 单次写
+// GetObject:    r, err := bucket.Object(key).NewReader(ctx); ErrObjectNotExist → os.ErrNotExist
+// DeleteObject: err := bucket.Object(key).Delete(ctx); ErrObjectNotExist → nil   // 幂等
+```
+
+---
+
+## 5. 操作映射（Before / After）
+
+| 操作 | Before（afero-s3） | Before Class A | After（原生 ObjectStore） | After Class A |
+|------|--------------------|----------------|---------------------------|---------------|
+| `SaveData`（内存 body） | `Create`+`Close`+`WriteFile` | **3 PutObject** + 1 Head(B) | `PutObject(data)` | **1 PutObject** |
+| `SaveDataFromReader`（512MB 视频） | `Create`(空) + `io.Copy`（默认 5MB 分片强制 multipart） | 1 空 PutObject + Create/Upload×~100/Complete | `PutObjectStream`（调优 PartSize，<PartSize 单次） | 1 PutObject 或 1 Create + ⌈size/PartSize⌉ Upload + 1 Complete（更少分片、无空 Put） |
+| 整条成功请求（4~6 次 body 写，关 chunks） | 4~6 × 3 | **~12~18 PutObject** | 4~6 × 1 | **~4~6 PutObject** |
+| 删除目录标记键（从不存在） | `Remove`→`Stat`→NotFound→`statDirectory` | 1 ListObjectsV2（×3 限流重试） | GC 不再发送该键 | **0** |
+| 删除真实文件键 | `Remove`→Head + DeleteObject | 1 Head(B) + Delete | `DeleteObject` | **0**（仅 1 Delete） |
+| 删除未写入文件键（关 chunks） | `Remove`→Head NotFound→`statDirectory` | 1 ListObjectsV2 | `DeleteObject`（幂等） | **0** |
+| GC 清理 N 条请求 | ~5N DeleteData，~2N 升级 List | ~2N ListObjectsV2 | 只发真实键，逐个幂等 Delete | **0 ListObjectsV2** |
+| 读缺失键（详情/下载） | `ReadFile`/`Open`→Stat NotFound→`statDirectory` | 1 ListObjectsV2 | `GetObject`→404→`ErrNotExist` | **0**（404 属 Class B） |
+| 读存在键 | `ReadFile`（Head+Get） | 0 | `GetObject` | 0（1 GetObject，Class B） |
+
+---
+
+## 6. 次要修复清单（随阶段落地）
+
+| 问题 | 修复 |
+|------|------|
+| P4 目录标记键 | GC 删除列表移除 3 个目录键（`gc.go:353,390-391`）；原生 `DeleteObject` 对其余缺失键幂等 |
+| P5 缺失键读升级 | `GetObject`/`OpenObject` 将 404 映射为 `os.ErrNotExist`，**无 List 回退**；`LoadRequestBody` 等本就吞错返回空 JSON，行为不变 |
+| P6 限流重试雪崩 | S3 client 安装 `retry.NewAdaptiveMode()`（客户端限速 + 退避抖动） |
+| P6 视频 multipart 碎片 | `PutObjectStream` 用 `manager.Uploader` 显式 PartSize（16~32MB），512MB → ~16~32 分片而非 ~100+ |
+| 删除非存在键报错 | 统一 `isNotExist(err)` 助手（覆盖 `os.ErrNotExist` 与 smithy `NotFound`/`NoSuchKey`、GCS `ErrObjectNotExist`） |
+
+---
+
+## 7. 分阶段迁移计划
+
+### Phase 0 —— 极小改动快赢（✅ 已实现；沿用现有 afero 路径，近零风险，吃下约 70% 成本）
+
+> 不引入新接口，仅删除/替换冗余调用。可独立成 PR 先合。
+
+1. **`SaveData`**（`data_storage.go:535-553`）：保留 `isS3PathStyle` 去前导斜杠，**删除** `fs.Create(key)` + `f.Close()`，只保留 `afero.WriteFile`。
+   - afero `WriteFile` 自身只产生 1 个 PutObject → SaveData 3→1。
+2. **`SaveDataFromReader`**（`data_storage.go:589`）：把 `fs.Create(key)` 换成 `fs.OpenFile(key, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o777)`。
+   - 去掉 `Create` 的冗余空 PutObject → 2→1（大对象仍走 afero-s3 默认 5MB 分片，PartSize 调优留待 Phase 1）。
+3. **`createS3Fs`**（`data_storage.go:395-411`）：`LoadDefaultConfig` 增加 `awsconfig.WithRetryer(func() aws.Retryer { return retry.AddWithMaxAttempts(retry.NewAdaptiveMode(), 3) })`。
+4. **GC**（`gc.go`）：把 3 个目录标记键（`GenerateExecutionRequestDirKey`、`GenerateRequestExecutionsDirKey`、`GenerateRequestDirKey`）的删除改为**按后端条件执行**——仅对 `Fs`/`WebDAV` 这类有真实目录的后端追加，对象存储（S3/GCS）跳过。
+   - 原因：这些目录键在 S3/GCS 上从不作为对象存在，删除只会白费一次 `ListObjectsV2`；但在 FS/WebDAV 上它们是真实目录，GC 仍需清理（现有 `gc_test.go` 用 FS 存储并断言这些目录被删除）。因此**不能无条件删除**，否则会回归 FS/WebDAV 的目录清理并使测试失败。
+   - 实现：新增 `hasRealDirectories(t datastorage.Type) bool`（仅 `TypeFs`/`TypeWebdav` 为 true），用它门控目录键的追加。FS 测试无需改键列表；另加 `TestHasRealDirectories` 守护该意图。
+   - （可选）当 `policy.StoreChunks==false` 时，GC 跳过 chunk 键，进一步省去未写键的删除往返。
+
+**Phase 0 效果**：每请求 ~12 PutObject + 4 Head → **~4 PutObject**；GC 不再对目录标记键发 `ListObjectsV2`。仍残留：未写文件键删除/缺失键读取的 `ListObjectsV2`（afero `Remove`/`ReadFile` 仍先 `Stat`）——由 Phase 1 收尾。
+
+### Phase 1 —— S3 原生 `ObjectStore`（✅ 已实现）
+
+1. 新增 `internal/server/biz/objectstore.go`（`ObjectStore` 接口 + `objectStoreFor` 分发 + `normalizeObjectKey`）与 `objectstore_s3.go`（`s3ObjectStore` 实现 + `newS3ObjectStore` + `isS3NotFound` + `countingReader`）。
+2. `DataStorageService` 在 `SaveData`/`SaveDataFromReader`/`LoadData`/`DeleteData` 顶部加 `objectStoreFor` 分发：S3 走原生 store，其余（Fs/WebDAV/GCS）回退 afero、Database 仍 no-op。
+3. 抽出 `newS3Client`（含自适应重试器），由 afero 适配器（`createS3Fs`）与原生 store 共用；原生 client 按 `ds.ID` 缓存进 `objectStoreCache`，挂在 `fsCacheMu` 下、随 `refreshFileSystems`/`Invalidate*` 与 `fsCache` 同步失效；保留 `datastorage-fs-reload` cron 自愈。
+4. `GetFileSystem` 不动 → 三个逃逸口与 FS 下载快路径零改动。
+
+实现要点与决策：
+- **键兼容**：`normalizeObjectKey` 去前导 `/`，与 afero-s3 `sanitize` 一致（无论 PathStyle），故旧对象（写在 `2/requests/...`）仍可读/写/删。
+- **缺失键**：`GetObject`/`OpenObject` 把 `NoSuchKey`/`NotFound`/smithy 404 映射为 `os.ErrNotExist`，**无 List 回退**；`LoadRequestBody` 等本就吞错返回空 JSON，行为不变。
+- **删除幂等**：`DeleteObject` 不前置 `Stat`，缺失键返回成功，0 次 `ListObjectsV2`。
+- **multipart 受控**：流式上传用 `manager.Uploader` 且 `PartSize=16MiB`（常量 `s3UploadPartSize`），512MB 视频从 ~100 个 `UploadPart` 降到 ~32 个；小对象仍单次 `PutObject`。
+- **测试**：新增 `objectstore_s3_test.go` 覆盖 `isS3NotFound`（typed/smithy/negative）与 `normalizeObjectKey`。S3 往返建议后续加 MinIO/testcontainers（当前无在线 S3 harness）。
+- **GCS 暂仍走 afero**（留待 Phase 2 原生化）。`OpenObject` 已实现但下载路径（`request_content.go`）本阶段仍用 `GetFileSystem`（afero），与原生写读同键、可正常下载。
+
+**Phase 1 效果**：S3 的写=1、删=幂等单次、缺失读=0 Class A，multipart 受控。
+
+### Phase 2 —— GCS 原生 + 收尾（可选）
+
+1. 新增 `gcsObjectStore`，复用已建 `storage.Client`，纳入 `objectStoreFor`。
+2. （可选）下载路径 `request_content.go` 对 S3/GCS 改用 `OpenObject` 流式下载，减少一次额外 `Stat`。
+3. （可选）备份清理 `autobackup.go` 的 `ReadDir` 用 `ObjectStore.List`（如扩展接口）替代，避免逐项 Head。
+
+---
+
+## 8. 兼容性与风险
+
+| 维度 | 处理 |
+|------|------|
+| 键格式 | 全部 `Generate*Key` 不变，**字节一致**；S3 去前导斜杠规范化在分发前完成；旧对象 0 迁移即可读/删 |
+| 缓存兼容 | DB `{}` 哨兵、`shouldUseExternalStorage`/`StoragePolicy` 门控不变，满足 `.agent/rules/cache-compat.md` |
+| 公开 API | `DataStorageService` 全部签名不变 → 5 个下游服务**零改动编译通过** |
+| Database | 维持 no-op（分发命中 `default` 分支） |
+| 逃逸口 | `GetFileSystem` 仍 afero，`request_content.go`/`autobackup.go` 不动 |
+| 自愈 | 保留每分钟 fs-reload cron 与 `Invalidate*`（不像全量重写那样丢掉自愈，避免配置陈旧风险） |
+| DI | 若 GCS store 需新依赖，加入 `DataStorageServiceParams` 并更新 `fx_module.go` |
+
+**主要风险**：
+
+- **缺失键语义变化**：原生 `GetObject` 缺失返回 `os.ErrNotExist`（而非 afero 包装的 `*os.PathError`）。已核查 `LoadRequestBody` 等均吞错返回空值，行为不变；需在 Phase 1 单测覆盖 `errors.Is(err, os.ErrNotExist)`。
+- **无 S3 实测环境**：现有单测全为 FS。Phase 1 建议加 MinIO / testcontainers 冒烟测试（见 §9）。
+- **S3 兼容存储（MinIO/Ceph）差异**：保留 `PathStyle` 与去斜杠逻辑；`isS3NotFound` 需覆盖 `NoSuchKey`/`NotFound`/404 多种错误形态。
+
+---
+
+## 9. 测试策略
+
+1. **现有 FS 单测保持绿**：`data_storage_test.go`、`gc_test.go`、`request_content_test.go`、`backup_test.go`、`restore_test.go`、`request_audio_test.go`（均 `t.TempDir()`）。Phase 0 仅需更新 `gc_test.go` 的删除键期望。
+2. **新增原生 S3 单测（Phase 1）**：用 MinIO/testcontainers 或 aws-sdk stub，断言：
+   - `SaveData` → 恰好 1 次 `PutObject`；
+   - `DeleteData` 缺失键 → 1 次 `DeleteObject`、0 次 `List`，且不报错；
+   - `LoadData` 缺失键 → `errors.Is(os.ErrNotExist)`、0 次 `List`；
+   - `PutObjectStream` 小对象单次 PutObject、大对象受控 multipart 分片数。
+3. **调用计数断言**：用 mock S3 client 记录方法名序列，回归"每请求 PutObject 数"。
+
+---
+
+## 10. 影响评估（量化）
+
+| 场景 | 现状 | Phase 0 后 | Phase 1/2 后 |
+|------|------|-----------|--------------|
+| 每请求写（4 次 body，关 chunks） | ~12 PutObject + 4 Head | **~4 PutObject** | ~4 PutObject |
+| GC 每请求 | ~3+ ListObjectsV2 | 0（目录键已移除；未写文件键仍残留） | **0 ListObjectsV2** |
+| 缺失键读（详情/下载） | 1 ListObjectsV2 | 1 ListObjectsV2（残留） | **0** |
+| 512MB 视频 | 1 空 Put + ~100+ UploadPart | ~100+ UploadPart（无空 Put） | **~16~32 UploadPart**（受控 PartSize） |
+| 限流场景 | 每 Class A ×3 重试 | 自适应退避，雪崩消除 | 同 |
+
+> 综合：写放大 3×→1×，GC 的 `ListObjectsV2` 归零，缺失读 Class A 归零，限流雪崩消除。Phase 0 即可拿下大头且风险极低。
+
+---
+
+## 11. 验收清单
+
+- [ ] Phase 0：`SaveData` 去 `Create+Close`；`SaveDataFromReader` 改 `OpenFile`；`createS3Fs` 装自适应重试器；GC 去 3 个目录键 + 更新 `gc_test.go`。
+- [ ] Phase 1：`ObjectStore` 接口 + S3 实现 + `objectStoreFor` 分发；S3 client 按 `ds.ID` 缓存并随 `Invalidate*` 失效。
+- [ ] 缺失键映射 `os.ErrNotExist`，全部 `Load*` 行为不变。
+- [ ] 键字节一致；DB/Fs/WebDAV/逃逸口/快路径全部不变。
+- [ ] 现有 FS 单测绿；新增原生 S3 计数断言测试。
+- [ ] Phase 2（可选）：GCS 原生；下载流式；备份 List。
+
+---
+
+## 12. 进一步可选优化（需产品确认，超出本次架构范围）
+
+- **削减"双份落盘"**：当前请求级与执行级各存一份 body（不同键），是"每请求多次写"的主因之一。若详情 UI 不需要双份，可在单执行场景下省去请求级落盘——但这会改变**存了什么**（非本方案的"怎么存"），且影响 GC/详情页，需单独评估。
+- **附录·关键文件**：
+  - `internal/server/biz/data_storage.go`（`SaveData` 508-559、`SaveDataFromReader` 564-604、`DeleteData` 608-640、`LoadData` 645-668、`createS3Fs` 387-420、`createGcsFs` 422-446）
+  - `internal/server/gc/gc.go`（349-364、386-403）
+  - `internal/server/api/request_content.go`（100-139）
+  - `internal/server/video_storage/worker.go`（193-198）
+  - `internal/server/backup/autobackup.go`（110、129-155）

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/fx"
 	"golang.org/x/oauth2/google"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -45,9 +47,12 @@ type DataStorageService struct {
 	Cache         xcache.Cache[ent.DataStorage]
 
 	// fsCache caches afero filesystem instances by data storage ID
-	fsCache      map[int]afero.Fs
-	fsCacheMu    sync.RWMutex
-	latestUpdate time.Time
+	fsCache map[int]afero.Fs
+	// objectStoreCache caches native object-store clients (S3) by data storage ID.
+	// Guarded by fsCacheMu and invalidated in lockstep with fsCache.
+	objectStoreCache map[int]ObjectStore
+	fsCacheMu        sync.RWMutex
+	latestUpdate     time.Time
 }
 
 // DataStorageServiceParams holds the dependencies for DataStorageService.
@@ -65,9 +70,10 @@ func NewDataStorageService(params DataStorageServiceParams) *DataStorageService 
 		AbstractService: &AbstractService{
 			db: params.Client,
 		},
-		SystemService: params.SystemService,
-		Cache:         xcache.NewFromConfig[ent.DataStorage](params.CacheConfig),
-		fsCache:       make(map[int]afero.Fs),
+		SystemService:    params.SystemService,
+		Cache:            xcache.NewFromConfig[ent.DataStorage](params.CacheConfig),
+		fsCache:          make(map[int]afero.Fs),
+		objectStoreCache: make(map[int]ObjectStore),
 	}
 	svc.reloadFileSystemsPeriodically(context.Background())
 
@@ -133,6 +139,8 @@ func (s *DataStorageService) refreshFileSystems(ctx context.Context) error {
 
 	s.fsCacheMu.Lock()
 	s.fsCache = newCache
+	// Drop cached native object-store clients so changed configs are rebuilt lazily.
+	s.objectStoreCache = make(map[int]ObjectStore)
 	s.fsCacheMu.Unlock()
 
 	log.Info(ctx, "refreshed data storage filesystems", log.Int("count", len(newCache)))
@@ -368,6 +376,7 @@ func (s *DataStorageService) InvalidateAllDataStorageCache(ctx context.Context) 
 	// Also clear filesystem cache
 	s.fsCacheMu.Lock()
 	s.fsCache = make(map[int]afero.Fs)
+	s.objectStoreCache = make(map[int]ObjectStore)
 	s.fsCacheMu.Unlock()
 
 	s.latestUpdate = time.Time{}
@@ -379,36 +388,50 @@ func (s *DataStorageService) InvalidateAllDataStorageCache(ctx context.Context) 
 func (s *DataStorageService) InvalidateFsCache(id int) error {
 	s.fsCacheMu.Lock()
 	delete(s.fsCache, id)
+	delete(s.objectStoreCache, id)
 	s.fsCacheMu.Unlock()
 
 	return nil
 }
 
-// createS3Fs creates an S3 filesystem using the afero-s3 adapter.
-func (s *DataStorageService) createS3Fs(ctx context.Context, s3Config *objects.S3) (afero.Fs, error) {
+// newS3Client builds an aws-sdk-go-v2 S3 client from the given config. It uses
+// an adaptive retryer (client-side rate limiting + backoff/jitter) so throttling
+// (HTTP 503 SlowDown) does not trigger a retry storm that multiplies Class A
+// operations under load. The client is shared by createS3Fs (the afero adapter
+// used by GetFileSystem) and the native s3ObjectStore (byte Save/Load/Delete).
+func newS3Client(ctx context.Context, s3Config *objects.S3) (*awss3.Client, error) {
 	credProvider := awscredentials.NewStaticCredentialsProvider(
 		s3Config.AccessKey,
 		s3Config.SecretKey,
 		"",
 	)
 
-	loadOptions := []func(*awsconfig.LoadOptions) error{
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(s3Config.Region),
 		awsconfig.WithCredentialsProvider(credProvider),
-	}
-
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+		awsconfig.WithRetryer(func() aws.Retryer {
+			return retry.AddWithMaxAttempts(retry.NewAdaptiveMode(), 3)
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
-	client := awss3.NewFromConfig(awsCfg, func(o *awss3.Options) {
+	return awss3.NewFromConfig(awsCfg, func(o *awss3.Options) {
 		if s3Config.Endpoint != "" {
 			o.BaseEndpoint = lo.ToPtr(s3Config.Endpoint)
 		}
 		// Enable Path Style access for S3 compatible storage services (e.g., MinIO, Ceph RGW)
 		o.UsePathStyle = s3Config.PathStyle
-	})
+	}), nil
+}
+
+// createS3Fs creates an S3 filesystem using the afero-s3 adapter.
+func (s *DataStorageService) createS3Fs(ctx context.Context, s3Config *objects.S3) (afero.Fs, error) {
+	client, err := newS3Client(ctx, s3Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create s3 client: %w", err)
+	}
 
 	// NOTE: do NOT wrap baseFs in afero.NewCacheOnReadFs(..., afero.NewMemMapFs(), ...).
 	// That in-memory layer is never evicted (afero's cacheTime only re-checks
@@ -510,6 +533,14 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 	case datastorage.TypeDatabase:
 		return nil
 	case datastorage.TypeFs, datastorage.TypeS3, datastorage.TypeGcs, datastorage.TypeWebdav:
+		// Object-store backends (S3) write in a single PutObject via a native
+		// client; other backends fall back to the afero filesystem path below.
+		if store, ok, err := s.objectStoreFor(ctx, ds); err != nil {
+			return err
+		} else if ok {
+			return store.PutObject(ctx, normalizeObjectKey(key), data)
+		}
+
 		// For file-based storage, write to file system
 		fs, err := s.GetFileSystem(ctx, ds)
 		if err != nil {
@@ -532,22 +563,16 @@ func (s *DataStorageService) SaveData(ctx context.Context, ds *ent.DataStorage, 
 			}
 		}
 
-		if ds.Type != datastorage.TypeFs {
-			// For S3 with PathStyle enabled, remove leading slash from key
-			// to avoid InvalidArgument error from S3 compatible storage services
-			if isS3PathStyle(ds) {
-				key = strings.TrimPrefix(key, "/")
-			}
-
-			f, err := fs.Create(key)
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w, key: %s", err, key)
-			}
-
-			_ = f.Close()
+		// For S3 with PathStyle enabled, remove leading slash from key
+		// to avoid InvalidArgument error from S3 compatible storage services
+		if isS3PathStyle(ds) {
+			key = strings.TrimPrefix(key, "/")
 		}
 
-		// Write data to file
+		// Write data to file. afero.WriteFile creates the object in a single
+		// write. We deliberately do NOT pre-create it with fs.Create()+Close():
+		// on object stores (afero-s3) that issued two extra empty PutObject
+		// (Class A) calls per save with no benefit.
 		if err := afero.WriteFile(fs, key, data, 0o777); err != nil {
 			return fmt.Errorf("failed to write file: %w, key: %s", err, key)
 		}
@@ -566,6 +591,21 @@ func (s *DataStorageService) SaveDataFromReader(ctx context.Context, ds *ent.Dat
 	case datastorage.TypeDatabase:
 		return "", 0, fmt.Errorf("database storage does not support streaming writes")
 	case datastorage.TypeFs, datastorage.TypeS3, datastorage.TypeGcs, datastorage.TypeWebdav:
+		// Object-store backends (S3) stream via a native uploader with a tuned
+		// part size; other backends fall back to the afero filesystem path below.
+		if store, ok, err := s.objectStoreFor(ctx, ds); err != nil {
+			return "", 0, err
+		} else if ok {
+			nk := normalizeObjectKey(key)
+
+			n, err := store.PutObjectStream(ctx, nk, r, -1)
+			if err != nil {
+				return "", 0, err
+			}
+
+			return nk, n, nil
+		}
+
 		fs, err := s.GetFileSystem(ctx, ds)
 		if err != nil {
 			return "", 0, fmt.Errorf("failed to get file system: %w", err)
@@ -586,7 +626,10 @@ func (s *DataStorageService) SaveDataFromReader(ctx context.Context, ds *ent.Dat
 			key = strings.TrimPrefix(key, "/")
 		}
 
-		f, err := fs.Create(key)
+		// Open for writing without pre-creating the object. On object stores,
+		// fs.Create() issues a redundant empty PutObject (Class A) before the
+		// real upload; OpenFile only sets up the write stream.
+		f, err := fs.OpenFile(key, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o777)
 		if err != nil {
 			return "", 0, fmt.Errorf("failed to create file: %w, key: %s", err, key)
 		}
@@ -612,6 +655,14 @@ func (s *DataStorageService) DeleteData(ctx context.Context, ds *ent.DataStorage
 	case datastorage.TypeDatabase:
 		return nil
 	case datastorage.TypeFs, datastorage.TypeS3, datastorage.TypeGcs, datastorage.TypeWebdav:
+		// Object-store backends (S3) delete with a single idempotent DeleteObject
+		// (no pre-Stat / ListObjectsV2); other backends fall back to afero below.
+		if store, ok, err := s.objectStoreFor(ctx, ds); err != nil {
+			return err
+		} else if ok {
+			return store.DeleteObject(ctx, normalizeObjectKey(key))
+		}
+
 		fs, err := s.GetFileSystem(ctx, ds)
 		if err != nil {
 			return fmt.Errorf("failed to get file system: %w", err)
@@ -648,6 +699,14 @@ func (s *DataStorageService) LoadData(ctx context.Context, ds *ent.DataStorage, 
 		// For database storage, the key is the data itself
 		return []byte(key), nil
 	case datastorage.TypeFs, datastorage.TypeS3, datastorage.TypeGcs, datastorage.TypeWebdav:
+		// Object-store backends (S3) read with a single GetObject; a missing key
+		// returns os.ErrNotExist (no ListObjectsV2). Others fall back to afero.
+		if store, ok, err := s.objectStoreFor(ctx, ds); err != nil {
+			return nil, err
+		} else if ok {
+			return store.GetObject(ctx, normalizeObjectKey(key))
+		}
+
 		// For file-based storage, read from file system
 		fs, err := s.GetFileSystem(ctx, ds)
 		if err != nil {

--- a/internal/server/biz/data_storage.go
+++ b/internal/server/biz/data_storage.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
 	"github.com/spf13/afero/gcsfs"
@@ -21,8 +23,6 @@ import (
 	"go.uber.org/fx"
 	"golang.org/x/oauth2/google"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"

--- a/internal/server/biz/objectstore.go
+++ b/internal/server/biz/objectstore.go
@@ -1,0 +1,85 @@
+package biz
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/datastorage"
+)
+
+// ObjectStore is a minimal object-oriented blob API used natively for backends
+// with real Class-A pricing (currently S3; GCS planned). Filesystem and WebDAV
+// backends keep the afero path; Database is a no-op above this layer.
+//
+// Keys passed to an ObjectStore are already normalized via normalizeObjectKey
+// (leading slash stripped), matching how the afero-s3 adapter sanitized keys so
+// that objects written before this refactor remain readable/deletable.
+type ObjectStore interface {
+	// PutObject writes data in a single operation (S3 PutObject for in-memory
+	// payloads), never Create+Close+Write.
+	PutObject(ctx context.Context, key string, data []byte) error
+
+	// PutObjectStream streams from r and returns the number of bytes written.
+	// size < 0 means the length is unknown. The implementation switches to
+	// multipart only when actually required (with a deliberate part size).
+	PutObjectStream(ctx context.Context, key string, r io.Reader, size int64) (written int64, err error)
+
+	// GetObject returns the object bytes. A missing key maps to an error
+	// satisfying errors.Is(err, os.ErrNotExist) with no List fallback.
+	GetObject(ctx context.Context, key string) ([]byte, error)
+
+	// OpenObject returns a streaming reader and size for download paths.
+	// A missing key maps to os.ErrNotExist with no List fallback.
+	OpenObject(ctx context.Context, key string) (body io.ReadCloser, size int64, err error)
+
+	// DeleteObject deletes one key. Deleting a non-existent key (including the
+	// directory-marker keys that were never created, or chunk keys when
+	// StoreChunks is off) is an idempotent no-op: a single DeleteObject with no
+	// HeadObject and no ListObjectsV2.
+	DeleteObject(ctx context.Context, key string) error
+}
+
+// normalizeObjectKey strips the leading slash from a storage key so native
+// object-store operations target the same keys the afero-s3 adapter wrote to
+// (its sanitize() stripped the leading slash regardless of PathStyle).
+func normalizeObjectKey(key string) string {
+	return strings.TrimPrefix(key, "/")
+}
+
+// objectStoreFor returns a native ObjectStore for backends that have one
+// (currently S3 only). For all other backends it returns (nil, false, nil) so
+// the caller falls back to the afero filesystem path or the Database no-op.
+//
+// Clients are cached by data storage ID alongside fsCache and invalidated in
+// lockstep (see InvalidateFsCache / InvalidateAllDataStorageCache /
+// refreshFileSystems). Building a client performs no S3 network call.
+func (s *DataStorageService) objectStoreFor(ctx context.Context, ds *ent.DataStorage) (ObjectStore, bool, error) {
+	if ds == nil || ds.Type != datastorage.TypeS3 {
+		return nil, false, nil
+	}
+
+	if ds.Settings == nil || ds.Settings.S3 == nil {
+		return nil, false, fmt.Errorf("s3 settings not configured")
+	}
+
+	s.fsCacheMu.RLock()
+	if store, ok := s.objectStoreCache[ds.ID]; ok {
+		s.fsCacheMu.RUnlock()
+		return store, true, nil
+	}
+	s.fsCacheMu.RUnlock()
+
+	store, err := newS3ObjectStore(ctx, ds.Settings.S3)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create s3 object store: %w", err)
+	}
+
+	s.fsCacheMu.Lock()
+	s.objectStoreCache[ds.ID] = store
+	s.fsCacheMu.Unlock()
+
+	return store, true, nil
+}

--- a/internal/server/biz/objectstore_s3.go
+++ b/internal/server/biz/objectstore_s3.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithy "github.com/aws/smithy-go"

--- a/internal/server/biz/objectstore_s3.go
+++ b/internal/server/biz/objectstore_s3.go
@@ -1,0 +1,170 @@
+package biz
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/looplj/axonhub/internal/objects"
+)
+
+// s3UploadPartSize is the multipart part size used for streaming uploads. The
+// afero-s3 adapter left this at the SDK default (5MB), so a 512MB video stream
+// fragmented into ~100 UploadPart (Class A) calls. A larger part size keeps the
+// part count (and Class A op count) low for big payloads while small payloads
+// still upload as a single PutObject.
+const s3UploadPartSize = 16 * 1024 * 1024 // 16 MiB
+
+// s3ObjectStore is the native (non-afero) ObjectStore implementation for S3 and
+// S3-compatible stores. It issues exactly one S3 call per logical operation.
+type s3ObjectStore struct {
+	client   *awss3.Client
+	uploader *manager.Uploader
+	bucket   string
+}
+
+func newS3ObjectStore(ctx context.Context, cfg *objects.S3) (*s3ObjectStore, error) {
+	client, err := newS3Client(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
+		u.PartSize = s3UploadPartSize
+	})
+
+	return &s3ObjectStore{
+		client:   client,
+		uploader: uploader,
+		bucket:   cfg.BucketName,
+	}, nil
+}
+
+func (o *s3ObjectStore) PutObject(ctx context.Context, key string, data []byte) error {
+	_, err := o.client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:        aws.String(o.bucket),
+		Key:           aws.String(key),
+		Body:          bytes.NewReader(data),
+		ContentLength: aws.Int64(int64(len(data))),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 put object %q: %w", key, err)
+	}
+
+	return nil
+}
+
+func (o *s3ObjectStore) PutObjectStream(ctx context.Context, key string, r io.Reader, _ int64) (int64, error) {
+	// Count bytes as they flow through the uploader; manager.Uploader does not
+	// report the written size directly.
+	cr := &countingReader{r: r}
+
+	_, err := o.uploader.Upload(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(key),
+		Body:   cr,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("s3 upload %q: %w", key, err)
+	}
+
+	return cr.n, nil
+}
+
+func (o *s3ObjectStore) GetObject(ctx context.Context, key string) ([]byte, error) {
+	out, err := o.client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isS3NotFound(err) {
+			return nil, fmt.Errorf("%w: %s", os.ErrNotExist, key)
+		}
+
+		return nil, fmt.Errorf("s3 get object %q: %w", key, err)
+	}
+	defer out.Body.Close()
+
+	return io.ReadAll(out.Body)
+}
+
+func (o *s3ObjectStore) OpenObject(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	out, err := o.client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isS3NotFound(err) {
+			return nil, 0, fmt.Errorf("%w: %s", os.ErrNotExist, key)
+		}
+
+		return nil, 0, fmt.Errorf("s3 open object %q: %w", key, err)
+	}
+
+	return out.Body, aws.ToInt64(out.ContentLength), nil
+}
+
+func (o *s3ObjectStore) DeleteObject(ctx context.Context, key string) error {
+	// DeleteObject is idempotent: deleting a missing key returns success (204),
+	// so we never pre-Stat and never escalate to a ListObjectsV2.
+	_, err := o.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 delete object %q: %w", key, err)
+	}
+
+	return nil
+}
+
+// isS3NotFound reports whether err represents a missing S3 object. GetObject
+// returns *types.NoSuchKey; HeadObject returns *types.NotFound; S3-compatible
+// stores may surface the code via a generic smithy.APIError.
+func isS3NotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var noSuchKey *s3types.NoSuchKey
+	if errors.As(err, &noSuchKey) {
+		return true
+	}
+
+	var notFound *s3types.NotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "NotFound", "404":
+			return true
+		}
+	}
+
+	return false
+}
+
+// countingReader counts the number of bytes read through it.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+
+	return n, err
+}

--- a/internal/server/biz/objectstore_s3_integration_test.go
+++ b/internal/server/biz/objectstore_s3_integration_test.go
@@ -1,0 +1,212 @@
+package biz
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3fs "github.com/looplj/afero-s3"
+	"github.com/spf13/afero"
+
+	"github.com/looplj/axonhub/internal/objects"
+)
+
+// TestS3ObjectStoreIntegration exercises the native S3 ObjectStore against a real
+// S3-compatible endpoint (e.g. MinIO). It is skipped unless AXONHUB_TEST_S3_ENDPOINT
+// is set, so it never runs during a normal `go test ./...`.
+//
+//	docker run -d --rm --name minio -p 9000:9000 \
+//	  -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+//	  minio/minio server /data
+//	AXONHUB_TEST_S3_ENDPOINT=http://localhost:9000 go test ./internal/server/biz/ -run TestS3ObjectStoreIntegration -v
+func TestS3ObjectStoreIntegration(t *testing.T) {
+	cfg := s3TestConfig(t)
+	ctx := context.Background()
+
+	ensureBucket(ctx, t, cfg)
+
+	store, err := newS3ObjectStore(ctx, cfg)
+	if err != nil {
+		t.Fatalf("newS3ObjectStore: %v", err)
+	}
+
+	t.Run("put/get round trip", func(t *testing.T) {
+		key := "2/requests/5/request_body.json"
+		data := []byte(`{"hello":"world"}`)
+
+		if err := store.PutObject(ctx, key, data); err != nil {
+			t.Fatalf("PutObject: %v", err)
+		}
+
+		got, err := store.GetObject(ctx, key)
+		if err != nil {
+			t.Fatalf("GetObject: %v", err)
+		}
+
+		if !bytes.Equal(got, data) {
+			t.Fatalf("GetObject = %q, want %q", got, data)
+		}
+	})
+
+	t.Run("get missing key maps to os.ErrNotExist", func(t *testing.T) {
+		_, err := store.GetObject(ctx, "2/requests/5/missing.json")
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("GetObject(missing) error = %v, want os.ErrNotExist", err)
+		}
+	})
+
+	t.Run("delete is idempotent (missing key + dir marker)", func(t *testing.T) {
+		key := "2/requests/5/to-delete.json"
+
+		if err := store.PutObject(ctx, key, []byte("x")); err != nil {
+			t.Fatalf("PutObject: %v", err)
+		}
+
+		if err := store.DeleteObject(ctx, key); err != nil {
+			t.Fatalf("DeleteObject: %v", err)
+		}
+		// Deleting again (now missing) must be a no-op, no error, no List.
+		if err := store.DeleteObject(ctx, key); err != nil {
+			t.Fatalf("DeleteObject(missing) = %v, want nil", err)
+		}
+		// Deleting a never-created directory-marker key must be a no-op.
+		if err := store.DeleteObject(ctx, "2/requests/5"); err != nil {
+			t.Fatalf("DeleteObject(dir marker) = %v, want nil", err)
+		}
+		// Confirm the object is actually gone.
+		if _, err := store.GetObject(ctx, key); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("GetObject after delete = %v, want os.ErrNotExist", err)
+		}
+	})
+
+	t.Run("stream round trip returns byte count", func(t *testing.T) {
+		key := "2/requests/5/stream.bin"
+		payload := bytes.Repeat([]byte("a"), 2<<20) // 2 MiB (single-part)
+
+		n, err := store.PutObjectStream(ctx, key, bytes.NewReader(payload), -1)
+		if err != nil {
+			t.Fatalf("PutObjectStream: %v", err)
+		}
+
+		if n != int64(len(payload)) {
+			t.Fatalf("PutObjectStream wrote %d bytes, want %d", n, len(payload))
+		}
+
+		got, err := store.GetObject(ctx, key)
+		if err != nil {
+			t.Fatalf("GetObject: %v", err)
+		}
+
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("stream payload mismatch (got %d bytes)", len(got))
+		}
+	})
+
+	t.Run("stream multipart (> part size) round trip", func(t *testing.T) {
+		key := "2/requests/5/big.bin"
+		payload := bytes.Repeat([]byte("b"), s3UploadPartSize+(1<<20)) // > 16 MiB -> multipart
+
+		n, err := store.PutObjectStream(ctx, key, bytes.NewReader(payload), -1)
+		if err != nil {
+			t.Fatalf("PutObjectStream(multipart): %v", err)
+		}
+
+		if n != int64(len(payload)) {
+			t.Fatalf("PutObjectStream wrote %d bytes, want %d", n, len(payload))
+		}
+
+		rc, size, err := store.OpenObject(ctx, key)
+		if err != nil {
+			t.Fatalf("OpenObject: %v", err)
+		}
+		defer rc.Close()
+
+		if size != int64(len(payload)) {
+			t.Fatalf("OpenObject size = %d, want %d", size, len(payload))
+		}
+
+		got, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read OpenObject: %v", err)
+		}
+
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("multipart payload mismatch (got %d bytes)", len(got))
+		}
+	})
+
+	t.Run("object written via old afero path is readable via native store", func(t *testing.T) {
+		client, err := newS3Client(ctx, cfg)
+		if err != nil {
+			t.Fatalf("newS3Client: %v", err)
+		}
+
+		afs := s3fs.NewFsFromClient(cfg.BucketName, client)
+
+		// The pre-refactor path passed leading-slash keys; afero-s3 sanitized
+		// them to no-leading-slash. The native store must hit the same object
+		// via normalizeObjectKey.
+		oldKey := "/2/requests/9/response_body.json"
+		data := []byte(`{"compat":true}`)
+
+		if err := afero.WriteFile(afs, oldKey, data, 0o777); err != nil {
+			t.Fatalf("afero.WriteFile: %v", err)
+		}
+
+		got, err := store.GetObject(ctx, normalizeObjectKey(oldKey))
+		if err != nil {
+			t.Fatalf("native GetObject of afero-written key: %v", err)
+		}
+
+		if !bytes.Equal(got, data) {
+			t.Fatalf("backward-compat read mismatch: got %q, want %q", got, data)
+		}
+	})
+}
+
+func s3TestConfig(t *testing.T) *objects.S3 {
+	t.Helper()
+
+	endpoint := os.Getenv("AXONHUB_TEST_S3_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("AXONHUB_TEST_S3_ENDPOINT not set; skipping S3 integration test")
+	}
+
+	return &objects.S3{
+		BucketName: getenvDefault("AXONHUB_TEST_S3_BUCKET", "axonhub-test"),
+		Endpoint:   endpoint,
+		Region:     getenvDefault("AXONHUB_TEST_S3_REGION", "us-east-1"),
+		AccessKey:  getenvDefault("AXONHUB_TEST_S3_ACCESS_KEY", "minioadmin"),
+		SecretKey:  getenvDefault("AXONHUB_TEST_S3_SECRET_KEY", "minioadmin"),
+		PathStyle:  true,
+	}
+}
+
+func getenvDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+
+	return def
+}
+
+func ensureBucket(ctx context.Context, t *testing.T, cfg *objects.S3) {
+	t.Helper()
+
+	client, err := newS3Client(ctx, cfg)
+	if err != nil {
+		t.Fatalf("newS3Client: %v", err)
+	}
+
+	_, err = client.CreateBucket(ctx, &awss3.CreateBucketInput{Bucket: &cfg.BucketName})
+	if err != nil &&
+		!strings.Contains(err.Error(), "BucketAlreadyOwnedByYou") &&
+		!strings.Contains(err.Error(), "BucketAlreadyExists") {
+		t.Logf("CreateBucket (continuing, may already exist): %v", err)
+	}
+}

--- a/internal/server/biz/objectstore_s3_integration_test.go
+++ b/internal/server/biz/objectstore_s3_integration_test.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3fs "github.com/looplj/afero-s3"
-	"github.com/spf13/afero"
 
 	"github.com/looplj/axonhub/internal/objects"
 )

--- a/internal/server/biz/objectstore_s3_test.go
+++ b/internal/server/biz/objectstore_s3_test.go
@@ -1,0 +1,53 @@
+package biz
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+func TestIsS3NotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"NoSuchKey (GetObject)", &s3types.NoSuchKey{}, true},
+		{"NotFound (HeadObject)", &s3types.NotFound{}, true},
+		{"wrapped NoSuchKey", fmt.Errorf("get: %w", &s3types.NoSuchKey{}), true},
+		{"smithy code NoSuchKey", &smithy.GenericAPIError{Code: "NoSuchKey"}, true},
+		{"smithy code NotFound", &smithy.GenericAPIError{Code: "NotFound"}, true},
+		{"smithy code 404", &smithy.GenericAPIError{Code: "404"}, true},
+		{"smithy other code", &smithy.GenericAPIError{Code: "AccessDenied"}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isS3NotFound(c.err); got != c.want {
+				t.Errorf("isS3NotFound(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeObjectKey(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/2/requests/5/request_body.json", "2/requests/5/request_body.json"},
+		{"2/requests/5/request_body.json", "2/requests/5/request_body.json"},
+		{"/", ""},
+		{"", ""},
+	}
+
+	for _, c := range cases {
+		if got := normalizeObjectKey(c.in); got != c.want {
+			t.Errorf("normalizeObjectKey(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/server/gc/gc.go
+++ b/internal/server/gc/gc.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channelprobe"
+	"github.com/looplj/axonhub/internal/ent/datastorage"
 	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/ent/schema/schematype"
@@ -350,7 +351,13 @@ func (w *Worker) cleanupExecutionExternalStorage(ctx context.Context, exec *ent.
 		biz.GenerateExecutionRequestBodyKey(exec.ProjectID, exec.RequestID, exec.ID),
 		biz.GenerateExecutionResponseBodyKey(exec.ProjectID, exec.RequestID, exec.ID),
 		biz.GenerateExecutionResponseChunksKey(exec.ProjectID, exec.RequestID, exec.ID),
-		biz.GenerateExecutionRequestDirKey(exec.ProjectID, exec.RequestID, exec.ID),
+	}
+
+	// Directory-marker keys only exist as real directories on filesystem-like
+	// backends. On object stores (S3/GCS) they were never created, so deleting
+	// them only wastes a ListObjectsV2 (Class A); skip them there.
+	if hasRealDirectories(ds.Type) {
+		keys = append(keys, biz.GenerateExecutionRequestDirKey(exec.ProjectID, exec.RequestID, exec.ID))
 	}
 
 	for _, key := range keys {
@@ -387,8 +394,15 @@ func (w *Worker) cleanupRequestExternalStorage(ctx context.Context, req *ent.Req
 		biz.GenerateRequestBodyKey(req.ProjectID, req.ID),
 		biz.GenerateResponseBodyKey(req.ProjectID, req.ID),
 		biz.GenerateResponseChunksKey(req.ProjectID, req.ID),
-		biz.GenerateRequestExecutionsDirKey(req.ProjectID, req.ID),
-		biz.GenerateRequestDirKey(req.ProjectID, req.ID),
+	}
+
+	// See cleanupExecutionExternalStorage: object stores have no real
+	// directories, so only attempt directory-marker deletes on FS/WebDAV.
+	if hasRealDirectories(ds.Type) {
+		keys = append(keys,
+			biz.GenerateRequestExecutionsDirKey(req.ProjectID, req.ID),
+			biz.GenerateRequestDirKey(req.ProjectID, req.ID),
+		)
 	}
 
 	for _, key := range keys {
@@ -400,6 +414,16 @@ func (w *Worker) cleanupRequestExternalStorage(ctx context.Context, req *ent.Req
 			)
 		}
 	}
+}
+
+// hasRealDirectories reports whether the storage backend materializes
+// directories as real entries that must be explicitly removed during cleanup.
+// Object stores (S3/GCS) have no real directories — the "*DirKey" paths are
+// never created, so attempting to delete them only costs a wasted
+// ListObjectsV2 (Class A). Filesystem and WebDAV backends do create real
+// directories that should be removed.
+func hasRealDirectories(t datastorage.Type) bool {
+	return t == datastorage.TypeFs || t == datastorage.TypeWebdav
 }
 
 func (w *Worker) getDataStorageCached(ctx context.Context, id int, cache map[int]*ent.DataStorage) (*ent.DataStorage, error) {

--- a/internal/server/gc/gc_test.go
+++ b/internal/server/gc/gc_test.go
@@ -122,6 +122,25 @@ func TestWorker_cleanupExecutionExternalStorageDeletesFsArtifacts(t *testing.T) 
 	}
 }
 
+func TestHasRealDirectories(t *testing.T) {
+	cases := []struct {
+		typ  datastorage.Type
+		want bool
+	}{
+		{datastorage.TypeFs, true},
+		{datastorage.TypeWebdav, true},
+		{datastorage.TypeS3, false},
+		{datastorage.TypeGcs, false},
+		{datastorage.TypeDatabase, false},
+	}
+
+	for _, c := range cases {
+		if got := hasRealDirectories(c.typ); got != c.want {
+			t.Errorf("hasRealDirectories(%s) = %v, want %v", c.typ, got, c.want)
+		}
+	}
+}
+
 func setupWorkerWithFSStorage(t *testing.T) (*Worker, context.Context, *ent.DataStorage, string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Reduces the volume of **S3 Class A operations** (`PutObject`, `ListObjectsV2`, `CreateMultipartUpload`/`UploadPart`/`CompleteMultipartUpload`) generated by the data-storage layer when an S3 backend is configured.

The root cause was the `afero.Fs` POSIX abstraction (`afero-s3`) sitting on top of an object store: each logical "save" turned into multiple S3 calls (`Create` open + write + close), every `Stat`/missing-key lookup could escalate to a `ListObjectsV2`, and GC blindly issued deletes for directory-marker keys that never exist on an object store.

This PR keeps `afero` for real filesystems (Fs/WebDAV) but routes S3 byte operations through a small native `ObjectStore` that talks to the AWS SDK directly. **Object keys are byte-identical**, so existing stored objects remain readable — no migration needed.

## Changes

### Phase 0 — trim the afero path (lower risk)
- `SaveData`: drop the redundant `fs.Create()` + `Close()` and keep only `afero.WriteFile` (**3 → 1** `PutObject`).
- `SaveDataFromReader`: `fs.Create` → `OpenFile(O_WRONLY|O_CREATE|O_TRUNC)` (**2 → 1**).
- Add an adaptive S3 retryer (`retry.NewAdaptiveMode` + bounded max attempts).
- GC: skip directory-marker delete keys on object stores via `hasRealDirectories()` (only Fs/WebDAV have real directories) — avoids wasted `DeleteObject`/`ListObjectsV2`.

### Phase 1 — native S3 ObjectStore
- New `ObjectStore` interface + `s3ObjectStore` implementation:
  - `PutObject`: single `PutObject` with `ContentLength`.
  - `PutObjectStream`: `manager.Uploader` with a 16 MiB part size (fewer parts → fewer `UploadPart` calls).
  - `GetObject`/`OpenObject`: map 404 → `os.ErrNotExist` with **no `ListObjectsV2` fallback**.
  - `DeleteObject`: single idempotent delete.
- `DataStorageService` dispatches S3 byte ops to the native store (cached per datastorage ID) while keeping `afero` for Fs/WebDAV and the `GetFileSystem` escape hatch. Public API unchanged.

## Class A operation impact

| Operation | Before (afero) | After (native S3) |
|---|---|---|
| `SaveData` | 3× `PutObject` | 1× `PutObject` |
| `SaveDataFromReader` | 2× `PutObject` | 1× `PutObject` (or multipart only when > 16 MiB) |
| `LoadData` missing key | `HeadObject` → `ListObjectsV2` | `GetObject` → 404 (Class B only) |
| `DeleteData` (object store) | delete + dir-marker deletes | 1× idempotent `DeleteObject` |

## Compatibility
- Keys are produced via `normalizeObjectKey` (matches afero-s3's leading-slash sanitization), so objects written by the old path are read by the new one. Verified by an explicit backward-compat integration test.
- No schema or config changes. Fs/WebDAV/Database backends are untouched.

## Testing
- `go build ./...`, `go vet ./...` — clean.
- Unit tests: `internal/server/biz` (`TestIsS3NotFound`, `TestNormalizeObjectKey`), `internal/server/gc` (`TestHasRealDirectories`).
- MinIO integration (`TestS3ObjectStoreIntegration`, env-gated by `AXONHUB_TEST_S3_ENDPOINT`): put/get round trip, missing-key → `ErrNotExist`, idempotent delete, single-part + multipart (>16 MiB) streaming with byte-count verification, and old-afero-write → native-read backward compat. 6/6 pass.
- `-race` clean; downstream consumers (orchestrator/api/backup) build & test green.
- Built and deployed to a staging host running PostgreSQL; healthy, `RestartCount=0`, `/health` 200, no errors.

## Notes
Design rationale and a Phase 2 outline (native GCS + download streaming) are in `docs/solutions/s3-storage-refactor.md`.
