### PR TITLE
fix: retry stream errors before client commit

### DIFF
--- a/frontend/src/features/system/components/retry-settings.tsx
+++ b/frontend/src/features/system/components/retry-settings.tsx
@@ -27,6 +27,7 @@ export function RetrySettings() {
     nonStreamResponseTimeoutSeconds: 0,
     loadBalancerStrategy: 'adaptive',
     emptyResponseDetection: false,
+    streamProbeDurationMs: 0,
     upstreamErrorPolicy: {
       mode: 'passthrough',
       customMessage: '',
@@ -48,6 +49,7 @@ export function RetrySettings() {
         nonStreamResponseTimeoutSeconds: retryPolicy.nonStreamResponseTimeoutSeconds,
         loadBalancerStrategy: retryPolicy.loadBalancerStrategy,
         emptyResponseDetection: retryPolicy.emptyResponseDetection,
+        streamProbeDurationMs: retryPolicy.streamProbeDurationMs ?? 0,
         upstreamErrorPolicy: {
           mode: retryPolicy.upstreamErrorPolicy?.mode || 'passthrough',
           customMessage: retryPolicy.upstreamErrorPolicy?.customMessage || '',
@@ -318,6 +320,25 @@ export function RetrySettings() {
                   checked={formData.emptyResponseDetection || false}
                   onCheckedChange={(checked) => handleInputChange('emptyResponseDetection', checked)}
                 />
+              </div>
+
+              {/* Stream Probe Duration */}
+              <div className='space-y-2'>
+                <Label htmlFor='stream-probe-duration'>{t('system.retry.streamProbeDurationMs.label')}</Label>
+                <div className='text-muted-foreground mb-2 text-sm'>{t('system.retry.streamProbeDurationMs.description')}</div>
+                <div className='flex items-center space-x-2'>
+                  <Input
+                    id='stream-probe-duration'
+                    type='number'
+                    min='0'
+                    max='120000'
+                    step='500'
+                    value={formData.streamProbeDurationMs ?? 0}
+                    onChange={(e) => handleInputChange('streamProbeDurationMs', parseInt(e.target.value) || 0)}
+                    className='w-32'
+                  />
+                  <span className='text-muted-foreground text-sm'>ms</span>
+                </div>
               </div>
 
               <Separator />

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -101,6 +101,7 @@ const RETRY_POLICY_QUERY = `
       loadBalancerStrategy
       enabled
       emptyResponseDetection
+      streamProbeDurationMs
       upstreamErrorPolicy {
         mode
         customMessage
@@ -352,6 +353,7 @@ export interface RetryPolicy {
   enabled: boolean;
   autoDisableChannel: AutoDisableChannel;
   emptyResponseDetection: boolean;
+  streamProbeDurationMs: number;
   upstreamErrorPolicy: UpstreamErrorPolicy;
 }
 
@@ -380,6 +382,7 @@ export interface RetryPolicyInput {
   enabled?: boolean;
   autoDisableChannel?: AutoDisableChannelInput;
   emptyResponseDetection?: boolean;
+  streamProbeDurationMs?: number;
   upstreamErrorPolicy?: Partial<UpstreamErrorPolicy>;
 }
 

--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -150,6 +150,8 @@
   "system.retry.nonStreamResponseTimeoutSeconds.description": "Maximum seconds to wait for a non-streaming response to complete (0-600s). Set to 0 to disable.",
   "system.retry.emptyResponseDetection.label": "Empty Response Detection",
   "system.retry.emptyResponseDetection.description": "When enabled, the system pre-reads stream events to detect empty responses (no content generated). If detected, the empty response is treated as a failed attempt for subsequent retry handling.",
+  "system.retry.streamProbeDurationMs.label": "Stream Probe Duration",
+  "system.retry.streamProbeDurationMs.description": "Duration in ms to probe the stream for errors before returning it to the client (0-120000). If a retryable error occurs during the probe window before any data is sent, the request is transparently retried. Set to 0 to disable.",
   "system.retry.upstreamErrorPolicy.label": "Upstream Error Display",
   "system.retry.upstreamErrorPolicy.description": "Control whether API users see raw provider errors. Request traces still keep the original error for administrators.",
   "system.retry.upstreamErrorPolicy.placeholder": "Select display mode",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -150,6 +150,8 @@
   "system.retry.nonStreamResponseTimeoutSeconds.description": "等待非流式响应完成的最长秒数 (0-600s)。设为 0 时关闭。",
   "system.retry.emptyResponseDetection.label": "空回检测",
   "system.retry.emptyResponseDetection.description": "启用后，系统会预读流式响应事件来检测空回（未生成任何内容）。如果检测到空回，会将其视为一次失败尝试，供后续重试处理使用。",
+  "system.retry.streamProbeDurationMs.label": "流式探测时长",
+  "system.retry.streamProbeDurationMs.description": "在将流返回给客户端前，探测流中错误的时间窗口（毫秒，0-120000）。如果在此窗口内（数据尚未发送）发生可重试错误，请求会被透明重试。设为 0 时关闭。",
   "system.retry.upstreamErrorPolicy.label": "上游错误展示",
   "system.retry.upstreamErrorPolicy.description": "控制 API 用户是否能看到原始服务商报错。请求追踪仍会保留原始错误，方便管理员排查。",
   "system.retry.upstreamErrorPolicy.placeholder": "选择展示模式",

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	maxRetryResponseTimeoutSeconds = 600
+	maxStreamProbeDurationMs       = 120000
 )
 
 const (
@@ -338,6 +339,13 @@ type RetryPolicy struct {
 
 	// UpstreamErrorPolicy controls how provider errors are exposed to API users.
 	UpstreamErrorPolicy UpstreamErrorPolicy `json:"upstream_error_policy"`
+
+	// StreamProbeDurationMs controls the mid-stream probe duration in milliseconds.
+	// After the pipeline successfully establishes a stream, the probe reads events for this duration
+	// before returning the stream to the client. If a retryable error occurs during the probe window
+	// (before any data is flushed to the client), the orchestrator transparently retries.
+	// Set to 0 to disable mid-stream probing.
+	StreamProbeDurationMs int `json:"stream_probe_duration_ms"`
 }
 
 type UpstreamErrorPolicy struct {
@@ -1065,6 +1073,14 @@ func normalizeRetryPolicy(policy *RetryPolicy) {
 	if policy.UpstreamErrorPolicy.Mode == UpstreamErrorModeCustom &&
 		strings.TrimSpace(policy.UpstreamErrorPolicy.CustomMessage) == "" {
 		policy.UpstreamErrorPolicy.Mode = UpstreamErrorModeHidden
+	}
+
+	// Clamp stream probe duration to a safe range (0 = disabled, max 120s)
+	if policy.StreamProbeDurationMs < 0 {
+		policy.StreamProbeDurationMs = 0
+	}
+	if policy.StreamProbeDurationMs > maxStreamProbeDurationMs {
+		policy.StreamProbeDurationMs = maxStreamProbeDurationMs
 	}
 }
 

--- a/internal/server/biz/system_default.go
+++ b/internal/server/biz/system_default.go
@@ -25,6 +25,7 @@ var defaultRetryPolicy = RetryPolicy{
 	RetryDelayMs:            1000,
 	LoadBalancerStrategy:    "adaptive",
 	Enabled:                 true,
+	StreamProbeDurationMs:   0, // disabled by default; set >0 to enable mid-stream probe
 	UpstreamErrorPolicy: UpstreamErrorPolicy{
 		Mode: UpstreamErrorModePassthrough,
 	},

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -968,7 +968,7 @@ type ComplexityRoot struct {
 		UpdatePromptProtectionRuleStatus     func(childComplexity int, id objects.GUID, status promptprotectionrule.Status) int
 		UpdatePromptStatus                   func(childComplexity int, id objects.GUID, status prompt.Status) int
 		UpdateQuotaEnforcementSettings       func(childComplexity int, input UpdateQuotaEnforcementSettingsInput) int
-		UpdateRetryPolicy                    func(childComplexity int, input biz.RetryPolicy) int
+		UpdateRetryPolicy                    func(childComplexity int, input UpdateRetryPolicyInput) int
 		UpdateRole                           func(childComplexity int, id objects.GUID, input ent.UpdateRoleInput) int
 		UpdateSecuritySettings               func(childComplexity int, input UpdateSecuritySettingsInput) int
 		UpdateStoragePolicy                  func(childComplexity int, input biz.StoragePolicy) int
@@ -2105,7 +2105,7 @@ type MutationResolver interface {
 	UnlinkOIDCIdentity(ctx context.Context, id objects.GUID) (bool, error)
 	UpdateBrandSettings(ctx context.Context, input UpdateBrandSettingsInput) (bool, error)
 	UpdateStoragePolicy(ctx context.Context, input biz.StoragePolicy) (bool, error)
-	UpdateRetryPolicy(ctx context.Context, input biz.RetryPolicy) (bool, error)
+	UpdateRetryPolicy(ctx context.Context, input UpdateRetryPolicyInput) (bool, error)
 	UpdateWebhookNotifierConfig(ctx context.Context, input biz.WebhookNotifierConfig) (bool, error)
 	UpdateSystemModelSettings(ctx context.Context, input biz.SystemModelSettings) (bool, error)
 	UpdateDefaultDataStorage(ctx context.Context, input UpdateDefaultDataStorageInput) (bool, error)
@@ -6283,7 +6283,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateRetryPolicy(childComplexity, args["input"].(biz.RetryPolicy)), true
+		return e.complexity.Mutation.UpdateRetryPolicy(childComplexity, args["input"].(UpdateRetryPolicyInput)), true
 	case "Mutation.updateRole":
 		if e.complexity.Mutation.UpdateRole == nil {
 			break
@@ -12449,7 +12449,7 @@ func (ec *executionContext) field_Mutation_updateQuotaEnforcementSettings_args(c
 func (ec *executionContext) field_Mutation_updateRetryPolicy_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateRetryPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐRetryPolicy)
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateRetryPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpdateRetryPolicyInput)
 	if err != nil {
 		return nil, err
 	}
@@ -32877,7 +32877,7 @@ func (ec *executionContext) _Mutation_updateRetryPolicy(ctx context.Context, fie
 		ec.fieldContext_Mutation_updateRetryPolicy,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdateRetryPolicy(ctx, fc.Args["input"].(biz.RetryPolicy))
+			return ec.resolvers.Mutation().UpdateRetryPolicy(ctx, fc.Args["input"].(UpdateRetryPolicyInput))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -60393,8 +60393,8 @@ func (ec *executionContext) unmarshalInputApplyChannelOverrideTemplateInput(ctx 
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputAutoDisableChannelInput(ctx context.Context, obj any) (biz.AutoDisableChannel, error) {
-	var it biz.AutoDisableChannel
+func (ec *executionContext) unmarshalInputAutoDisableChannelInput(ctx context.Context, obj any) (AutoDisableChannelInput, error) {
+	var it AutoDisableChannelInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -60409,14 +60409,14 @@ func (ec *executionContext) unmarshalInputAutoDisableChannelInput(ctx context.Co
 		switch k {
 		case "enabled":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
-			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Enabled = data
 		case "statuses":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statuses"))
-			data, err := ec.unmarshalOAutoDisableChannelStatusInput2ᚕgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannelStatusᚄ(ctx, v)
+			data, err := ec.unmarshalOAutoDisableChannelStatusInput2ᚕᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelStatusInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -60427,8 +60427,8 @@ func (ec *executionContext) unmarshalInputAutoDisableChannelInput(ctx context.Co
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputAutoDisableChannelStatusInput(ctx context.Context, obj any) (biz.AutoDisableChannelStatus, error) {
-	var it biz.AutoDisableChannelStatus
+func (ec *executionContext) unmarshalInputAutoDisableChannelStatusInput(ctx context.Context, obj any) (AutoDisableChannelStatusInput, error) {
+	var it AutoDisableChannelStatusInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -80087,8 +80087,8 @@ func (ec *executionContext) unmarshalInputUpdateRequestInput(ctx context.Context
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Context, obj any) (biz.RetryPolicy, error) {
-	var it biz.RetryPolicy
+func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Context, obj any) (UpdateRetryPolicyInput, error) {
+	var it UpdateRetryPolicyInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -80103,77 +80103,77 @@ func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Con
 		switch k {
 		case "maxChannelRetries":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("maxChannelRetries"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.MaxChannelRetries = data
 		case "maxSingleChannelRetries":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("maxSingleChannelRetries"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.MaxSingleChannelRetries = data
 		case "retryDelayMs":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("retryDelayMs"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.RetryDelayMs = data
 		case "streamFirstEventTimeoutSeconds":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("streamFirstEventTimeoutSeconds"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.StreamFirstEventTimeoutSeconds = data
 		case "nonStreamResponseTimeoutSeconds":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("nonStreamResponseTimeoutSeconds"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.NonStreamResponseTimeoutSeconds = data
 		case "loadBalancerStrategy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("loadBalancerStrategy"))
-			data, err := ec.unmarshalOString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.LoadBalancerStrategy = data
 		case "enabled":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
-			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Enabled = data
 		case "autoDisableChannel":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("autoDisableChannel"))
-			data, err := ec.unmarshalOAutoDisableChannelInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannel(ctx, v)
+			data, err := ec.unmarshalOAutoDisableChannelInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.AutoDisableChannel = data
 		case "emptyResponseDetection":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emptyResponseDetection"))
-			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.EmptyResponseDetection = data
 		case "upstreamErrorPolicy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("upstreamErrorPolicy"))
-			data, err := ec.unmarshalOUpstreamErrorPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐUpstreamErrorPolicy(ctx, v)
+			data, err := ec.unmarshalOUpstreamErrorPolicyInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpstreamErrorPolicyInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.UpstreamErrorPolicy = data
 		case "streamProbeDurationMs":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("streamProbeDurationMs"))
-			data, err := ec.unmarshalOInt2int(ctx, v)
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -81039,8 +81039,8 @@ func (ec *executionContext) unmarshalInputUpdateVideoStorageSettingsInput(ctx co
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpstreamErrorPolicyInput(ctx context.Context, obj any) (biz.UpstreamErrorPolicy, error) {
-	var it biz.UpstreamErrorPolicy
+func (ec *executionContext) unmarshalInputUpstreamErrorPolicyInput(ctx context.Context, obj any) (UpstreamErrorPolicyInput, error) {
+	var it UpstreamErrorPolicyInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -81055,14 +81055,14 @@ func (ec *executionContext) unmarshalInputUpstreamErrorPolicyInput(ctx context.C
 		switch k {
 		case "mode":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mode"))
-			data, err := ec.unmarshalOString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Mode = data
 		case "customMessage":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("customMessage"))
-			data, err := ec.unmarshalOString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -104033,9 +104033,9 @@ func (ec *executionContext) marshalNAutoDisableChannelStatus2ᚕgithubᚗcomᚋl
 	return ret
 }
 
-func (ec *executionContext) unmarshalNAutoDisableChannelStatusInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannelStatus(ctx context.Context, v any) (biz.AutoDisableChannelStatus, error) {
+func (ec *executionContext) unmarshalNAutoDisableChannelStatusInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelStatusInput(ctx context.Context, v any) (*AutoDisableChannelStatusInput, error) {
 	res, err := ec.unmarshalInputAutoDisableChannelStatusInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNAutoSyncFrequency2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoSyncFrequency(ctx context.Context, v any) (biz.AutoSyncFrequency, error) {
@@ -108959,7 +108959,7 @@ func (ec *executionContext) unmarshalNUpdateQuotaEnforcementSettingsInput2github
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNUpdateRetryPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐRetryPolicy(ctx context.Context, v any) (biz.RetryPolicy, error) {
+func (ec *executionContext) unmarshalNUpdateRetryPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpdateRetryPolicyInput(ctx context.Context, v any) (UpdateRetryPolicyInput, error) {
 	res, err := ec.unmarshalInputUpdateRetryPolicyInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
@@ -110179,9 +110179,12 @@ func (ec *executionContext) marshalOAny2interface(ctx context.Context, sel ast.S
 	return res
 }
 
-func (ec *executionContext) unmarshalOAutoDisableChannelInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannel(ctx context.Context, v any) (biz.AutoDisableChannel, error) {
+func (ec *executionContext) unmarshalOAutoDisableChannelInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelInput(ctx context.Context, v any) (*AutoDisableChannelInput, error) {
+	if v == nil {
+		return nil, nil
+	}
 	res, err := ec.unmarshalInputAutoDisableChannelInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOAutoDisableChannelOnboarding2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelOnboarding(ctx context.Context, sel ast.SelectionSet, v *AutoDisableChannelOnboarding) graphql.Marshaler {
@@ -110191,17 +110194,17 @@ func (ec *executionContext) marshalOAutoDisableChannelOnboarding2ᚖgithubᚗcom
 	return ec._AutoDisableChannelOnboarding(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalOAutoDisableChannelStatusInput2ᚕgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannelStatusᚄ(ctx context.Context, v any) ([]biz.AutoDisableChannelStatus, error) {
+func (ec *executionContext) unmarshalOAutoDisableChannelStatusInput2ᚕᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelStatusInputᚄ(ctx context.Context, v any) ([]*AutoDisableChannelStatusInput, error) {
 	if v == nil {
 		return nil, nil
 	}
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
 	var err error
-	res := make([]biz.AutoDisableChannelStatus, len(vSlice))
+	res := make([]*AutoDisableChannelStatusInput, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNAutoDisableChannelStatusInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐAutoDisableChannelStatus(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNAutoDisableChannelStatusInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐAutoDisableChannelStatusInput(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -115377,9 +115380,12 @@ func (ec *executionContext) unmarshalOUpdateChannelProbeSettingInput2githubᚗco
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOUpstreamErrorPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐUpstreamErrorPolicy(ctx context.Context, v any) (biz.UpstreamErrorPolicy, error) {
+func (ec *executionContext) unmarshalOUpstreamErrorPolicyInput2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋgqlᚐUpstreamErrorPolicyInput(ctx context.Context, v any) (*UpstreamErrorPolicyInput, error) {
+	if v == nil {
+		return nil, nil
+	}
 	res, err := ec.unmarshalInputUpstreamErrorPolicyInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOUsageLog2ᚖgithubᚗcomᚋloopljᚋaxonhubᚋinternalᚋentᚐUsageLog(ctx context.Context, sel ast.SelectionSet, v *ent.UsageLog) graphql.Marshaler {

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1450,6 +1450,7 @@ type ComplexityRoot struct {
 		NonStreamResponseTimeoutSeconds func(childComplexity int) int
 		RetryDelayMs                    func(childComplexity int) int
 		StreamFirstEventTimeoutSeconds  func(childComplexity int) int
+		StreamProbeDurationMs           func(childComplexity int) int
 		UpstreamErrorPolicy             func(childComplexity int) int
 	}
 
@@ -8649,6 +8650,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.RetryPolicy.StreamFirstEventTimeoutSeconds(childComplexity), true
+	case "RetryPolicy.streamProbeDurationMs":
+		if e.complexity.RetryPolicy.StreamProbeDurationMs == nil {
+			break
+		}
+
+		return e.complexity.RetryPolicy.StreamProbeDurationMs(childComplexity), true
 	case "RetryPolicy.upstreamErrorPolicy":
 		if e.complexity.RetryPolicy.UpstreamErrorPolicy == nil {
 			break
@@ -42430,6 +42437,8 @@ func (ec *executionContext) fieldContext_Query_retryPolicy(_ context.Context, fi
 				return ec.fieldContext_RetryPolicy_emptyResponseDetection(ctx, field)
 			case "upstreamErrorPolicy":
 				return ec.fieldContext_RetryPolicy_upstreamErrorPolicy(ctx, field)
+			case "streamProbeDurationMs":
+				return ec.fieldContext_RetryPolicy_streamProbeDurationMs(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RetryPolicy", field.Name)
 		},
@@ -46893,6 +46902,35 @@ func (ec *executionContext) fieldContext_RetryPolicy_upstreamErrorPolicy(_ conte
 				return ec.fieldContext_UpstreamErrorPolicy_customMessage(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UpstreamErrorPolicy", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RetryPolicy_streamProbeDurationMs(ctx context.Context, field graphql.CollectedField, obj *biz.RetryPolicy) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RetryPolicy_streamProbeDurationMs,
+		func(ctx context.Context) (any, error) {
+			return obj.StreamProbeDurationMs, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RetryPolicy_streamProbeDurationMs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RetryPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -80056,7 +80094,7 @@ func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"maxChannelRetries", "maxSingleChannelRetries", "retryDelayMs", "streamFirstEventTimeoutSeconds", "nonStreamResponseTimeoutSeconds", "loadBalancerStrategy", "enabled", "autoDisableChannel", "emptyResponseDetection", "upstreamErrorPolicy"}
+	fieldsInOrder := [...]string{"maxChannelRetries", "maxSingleChannelRetries", "retryDelayMs", "streamFirstEventTimeoutSeconds", "nonStreamResponseTimeoutSeconds", "loadBalancerStrategy", "enabled", "autoDisableChannel", "emptyResponseDetection", "upstreamErrorPolicy", "streamProbeDurationMs"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -80133,6 +80171,13 @@ func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Con
 				return it, err
 			}
 			it.UpstreamErrorPolicy = data
+		case "streamProbeDurationMs":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("streamProbeDurationMs"))
+			data, err := ec.unmarshalOInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.StreamProbeDurationMs = data
 		}
 	}
 
@@ -97901,6 +97946,11 @@ func (ec *executionContext) _RetryPolicy(ctx context.Context, sel ast.SelectionS
 			}
 		case "upstreamErrorPolicy":
 			out.Values[i] = ec._RetryPolicy_upstreamErrorPolicy(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "streamProbeDurationMs":
+			out.Values[i] = ec._RetryPolicy_streamProbeDurationMs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/server/gql/gqlgen.yml
+++ b/internal/server/gql/gqlgen.yml
@@ -192,9 +192,6 @@ models:
   RetryPolicy:
     model:
       - github.com/looplj/axonhub/internal/server/biz.RetryPolicy
-  UpdateRetryPolicyInput:
-    model:
-      - github.com/looplj/axonhub/internal/server/biz.RetryPolicy
   WebhookNotifierConfig:
     model:
       - github.com/looplj/axonhub/internal/server/biz.WebhookNotifierConfig
@@ -219,16 +216,7 @@ models:
   AutoDisableChannelStatus:
     model:
       - github.com/looplj/axonhub/internal/server/biz.AutoDisableChannelStatus
-  AutoDisableChannelInput:
-    model:
-      - github.com/looplj/axonhub/internal/server/biz.AutoDisableChannel
-  AutoDisableChannelStatusInput:
-    model:
-      - github.com/looplj/axonhub/internal/server/biz.AutoDisableChannelStatus
   UpstreamErrorPolicy:
-    model:
-      - github.com/looplj/axonhub/internal/server/biz.UpstreamErrorPolicy
-  UpstreamErrorPolicyInput:
     model:
       - github.com/looplj/axonhub/internal/server/biz.UpstreamErrorPolicy
   UpdateAPIKeyProfilesInput:

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -80,9 +80,19 @@ type AutoDisableAPIKeyStatus struct {
 	Times  int `json:"times"`
 }
 
+type AutoDisableChannelInput struct {
+	Enabled  *bool                            `json:"enabled,omitempty"`
+	Statuses []*AutoDisableChannelStatusInput `json:"statuses,omitempty"`
+}
+
 type AutoDisableChannelOnboarding struct {
 	Onboarded   bool       `json:"onboarded"`
 	CompletedAt *time.Time `json:"completedAt,omitempty"`
+}
+
+type AutoDisableChannelStatusInput struct {
+	Status int `json:"status"`
+	Times  int `json:"times"`
 }
 
 type BackupPayload struct {
@@ -547,6 +557,20 @@ type UpdateQuotaEnforcementSettingsInput struct {
 	Mode    *biz.QuotaEnforcementMode `json:"mode,omitempty"`
 }
 
+type UpdateRetryPolicyInput struct {
+	MaxChannelRetries               *int                      `json:"maxChannelRetries,omitempty"`
+	MaxSingleChannelRetries         *int                      `json:"maxSingleChannelRetries,omitempty"`
+	RetryDelayMs                    *int                      `json:"retryDelayMs,omitempty"`
+	StreamFirstEventTimeoutSeconds  *int                      `json:"streamFirstEventTimeoutSeconds,omitempty"`
+	NonStreamResponseTimeoutSeconds *int                      `json:"nonStreamResponseTimeoutSeconds,omitempty"`
+	LoadBalancerStrategy            *string                   `json:"loadBalancerStrategy,omitempty"`
+	Enabled                         *bool                     `json:"enabled,omitempty"`
+	AutoDisableChannel              *AutoDisableChannelInput  `json:"autoDisableChannel,omitempty"`
+	EmptyResponseDetection          *bool                     `json:"emptyResponseDetection,omitempty"`
+	UpstreamErrorPolicy             *UpstreamErrorPolicyInput `json:"upstreamErrorPolicy,omitempty"`
+	StreamProbeDurationMs           *int                      `json:"streamProbeDurationMs,omitempty"`
+}
+
 type UpdateSecuritySettingsInput struct {
 	BlockedIPs              []string `json:"blockedIPs,omitempty"`
 	ShowRequestLogIPBanIcon *bool    `json:"showRequestLogIPBanIcon,omitempty"`
@@ -554,6 +578,11 @@ type UpdateSecuritySettingsInput struct {
 
 type UpdateUserAgentPassThroughSettingsInput struct {
 	Enabled bool `json:"enabled"`
+}
+
+type UpstreamErrorPolicyInput struct {
+	Mode          *string `json:"mode,omitempty"`
+	CustomMessage *string `json:"customMessage,omitempty"`
 }
 
 type UserAgentPassThroughSettings struct {

--- a/internal/server/gql/system.graphql
+++ b/internal/server/gql/system.graphql
@@ -129,6 +129,7 @@ type RetryPolicy {
   autoDisableChannel: AutoDisableChannel!
   emptyResponseDetection: Boolean!
   upstreamErrorPolicy: UpstreamErrorPolicy!
+  streamProbeDurationMs: Int!
 }
 
 type UpstreamErrorPolicy {
@@ -162,6 +163,7 @@ input UpdateRetryPolicyInput {
   autoDisableChannel: AutoDisableChannelInput
   emptyResponseDetection: Boolean
   upstreamErrorPolicy: UpstreamErrorPolicyInput
+  streamProbeDurationMs: Int
 }
 
 enum QuotaEnforcementMode {

--- a/internal/server/gql/system.resolvers.go
+++ b/internal/server/gql/system.resolvers.go
@@ -57,8 +57,68 @@ func (r *mutationResolver) UpdateStoragePolicy(ctx context.Context, input biz.St
 }
 
 // UpdateRetryPolicy is the resolver for the updateRetryPolicy field.
-func (r *mutationResolver) UpdateRetryPolicy(ctx context.Context, input biz.RetryPolicy) (bool, error) {
-	err := r.systemService.SetRetryPolicy(ctx, &input)
+func (r *mutationResolver) UpdateRetryPolicy(ctx context.Context, input UpdateRetryPolicyInput) (bool, error) {
+	current, err := r.systemService.RetryPolicy(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to read current retry policy: %w", err)
+	}
+
+	policy := *current
+	if input.MaxChannelRetries != nil {
+		policy.MaxChannelRetries = *input.MaxChannelRetries
+	}
+	if input.MaxSingleChannelRetries != nil {
+		policy.MaxSingleChannelRetries = *input.MaxSingleChannelRetries
+	}
+	if input.RetryDelayMs != nil {
+		policy.RetryDelayMs = *input.RetryDelayMs
+	}
+	if input.StreamFirstEventTimeoutSeconds != nil {
+		policy.StreamFirstEventTimeoutSeconds = *input.StreamFirstEventTimeoutSeconds
+	}
+	if input.NonStreamResponseTimeoutSeconds != nil {
+		policy.NonStreamResponseTimeoutSeconds = *input.NonStreamResponseTimeoutSeconds
+	}
+	if input.LoadBalancerStrategy != nil {
+		policy.LoadBalancerStrategy = *input.LoadBalancerStrategy
+	}
+	if input.Enabled != nil {
+		policy.Enabled = *input.Enabled
+	}
+	if input.AutoDisableChannel != nil {
+		if input.AutoDisableChannel.Enabled != nil {
+			policy.AutoDisableChannel.Enabled = *input.AutoDisableChannel.Enabled
+		}
+		if input.AutoDisableChannel.Statuses != nil {
+			statuses := make([]biz.AutoDisableChannelStatus, 0, len(input.AutoDisableChannel.Statuses))
+			for _, status := range input.AutoDisableChannel.Statuses {
+				if status == nil {
+					continue
+				}
+				statuses = append(statuses, biz.AutoDisableChannelStatus{
+					Status: status.Status,
+					Times:  status.Times,
+				})
+			}
+			policy.AutoDisableChannel.Statuses = statuses
+		}
+	}
+	if input.EmptyResponseDetection != nil {
+		policy.EmptyResponseDetection = *input.EmptyResponseDetection
+	}
+	if input.UpstreamErrorPolicy != nil {
+		if input.UpstreamErrorPolicy.Mode != nil {
+			policy.UpstreamErrorPolicy.Mode = *input.UpstreamErrorPolicy.Mode
+		}
+		if input.UpstreamErrorPolicy.CustomMessage != nil {
+			policy.UpstreamErrorPolicy.CustomMessage = *input.UpstreamErrorPolicy.CustomMessage
+		}
+	}
+	if input.StreamProbeDurationMs != nil {
+		policy.StreamProbeDurationMs = *input.StreamProbeDurationMs
+	}
+
+	err = r.systemService.SetRetryPolicy(ctx, &policy)
 	if err != nil {
 		return false, fmt.Errorf("failed to update retry policy: %w", err)
 	}

--- a/internal/server/gql/system.resolvers_test.go
+++ b/internal/server/gql/system.resolvers_test.go
@@ -1,9 +1,15 @@
 package gql
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
@@ -88,4 +94,77 @@ func TestMutationResolver_UpdateSystemChannelSettings_MergesProbeWithoutOverwrit
 	require.False(t, setting.Probe.Enabled)
 	require.Equal(t, biz.ProbeFrequency1Hour, setting.Probe.Frequency)
 	require.Equal(t, biz.AutoSyncFrequencySixHours, setting.AutoSync.Frequency)
+}
+
+func TestMutationResolver_UpdateRetryPolicy_PreservesOmittedFields(t *testing.T) {
+	resolver, ctx, client := setupTestSystemMutationResolver(t)
+	defer client.Close()
+
+	err := resolver.systemService.SetRetryPolicy(ctx, &biz.RetryPolicy{
+		Enabled:                         true,
+		MaxChannelRetries:               4,
+		MaxSingleChannelRetries:         2,
+		RetryDelayMs:                    300,
+		StreamFirstEventTimeoutSeconds:  10,
+		NonStreamResponseTimeoutSeconds: 20,
+		LoadBalancerStrategy:            biz.LoadBalancerStrategyAdaptive,
+		AutoDisableChannel: biz.AutoDisableChannel{
+			Enabled: true,
+			Statuses: []biz.AutoDisableChannelStatus{
+				{Status: http.StatusTooManyRequests, Times: 3},
+			},
+		},
+		EmptyResponseDetection: true,
+		UpstreamErrorPolicy: biz.UpstreamErrorPolicy{
+			Mode:          biz.UpstreamErrorModeCustom,
+			CustomMessage: "custom upstream failure",
+		},
+		StreamProbeDurationMs: 5000,
+	})
+	require.NoError(t, err)
+
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver.Resolver}))
+	srv.AddTransport(transport.POST{})
+	body, err := json.Marshal(map[string]any{
+		"query": `mutation($input: UpdateRetryPolicyInput!) {
+			updateRetryPolicy(input: $input)
+		}`,
+		"variables": map[string]any{
+			"input": map[string]any{
+				"maxChannelRetries": 5,
+				"autoDisableChannel": map[string]any{
+					"enabled": false,
+				},
+				"upstreamErrorPolicy": map[string]any{
+					"mode": biz.UpstreamErrorModeHidden,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), `"errors"`)
+
+	policy, err := resolver.systemService.RetryPolicy(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 5, policy.MaxChannelRetries)
+	require.Equal(t, 2, policy.MaxSingleChannelRetries)
+	require.Equal(t, 300, policy.RetryDelayMs)
+	require.Equal(t, 10, policy.StreamFirstEventTimeoutSeconds)
+	require.Equal(t, 20, policy.NonStreamResponseTimeoutSeconds)
+	require.Equal(t, biz.LoadBalancerStrategyAdaptive, policy.LoadBalancerStrategy)
+	require.False(t, policy.AutoDisableChannel.Enabled)
+	require.Equal(t, []biz.AutoDisableChannelStatus{
+		{Status: http.StatusTooManyRequests, Times: 3},
+	}, policy.AutoDisableChannel.Statuses)
+	require.True(t, policy.EmptyResponseDetection)
+	require.Equal(t, biz.UpstreamErrorModeHidden, policy.UpstreamErrorPolicy.Mode)
+	require.Equal(t, "custom upstream failure", policy.UpstreamErrorPolicy.CustomMessage)
+	require.Equal(t, 5000, policy.StreamProbeDurationMs)
 }

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -154,6 +154,33 @@ func (processor *ChatCompletionOrchestrator) WithProxy(proxy *httpclient.ProxyCo
 	return &c
 }
 
+func buildPipelineOpts(retryPolicy *biz.RetryPolicy) []pipeline.Option {
+	var opts []pipeline.Option
+
+	if retryPolicy.Enabled {
+		opts = append(opts, pipeline.WithRetry(
+			retryPolicy.MaxChannelRetries,
+			retryPolicy.MaxSingleChannelRetries,
+			time.Duration(retryPolicy.RetryDelayMs)*time.Millisecond,
+		))
+
+		if retryPolicy.EmptyResponseDetection {
+			opts = append(opts, pipeline.WithEmptyResponseDetection())
+		}
+
+		opts = append(opts, pipeline.WithResponseTimeouts(
+			time.Duration(retryPolicy.StreamFirstEventTimeoutSeconds)*time.Second,
+			time.Duration(retryPolicy.NonStreamResponseTimeoutSeconds)*time.Second,
+		))
+
+		opts = append(opts, pipeline.WithStreamProbeDuration(
+			time.Duration(retryPolicy.StreamProbeDurationMs)*time.Millisecond,
+		))
+	}
+
+	return opts
+}
+
 type ChatCompletionResult struct {
 	ChatCompletion       *httpclient.Response
 	ChatCompletionStream streams.Stream[*httpclient.StreamEvent]
@@ -207,32 +234,15 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		CurrentCandidateIndex: 0,
 	}
 
-	var pipelineOpts []pipeline.Option
+	pipelineOpts := buildPipelineOpts(retryPolicy)
 
-	// Only apply retry if policy is enabled
-	if retryPolicy.Enabled {
-		pipelineOpts = append(pipelineOpts, pipeline.WithRetry(
-			retryPolicy.MaxChannelRetries,
-			retryPolicy.MaxSingleChannelRetries,
-			time.Duration(retryPolicy.RetryDelayMs)*time.Millisecond,
-		))
+	inbound, outbound := NewPersistentTransformers(state, processor.Inbound)
 
-		if retryPolicy.EmptyResponseDetection {
-			pipelineOpts = append(pipelineOpts, pipeline.WithEmptyResponseDetection())
-		}
-
-		pipelineOpts = append(pipelineOpts, pipeline.WithResponseTimeouts(
-			time.Duration(retryPolicy.StreamFirstEventTimeoutSeconds)*time.Second,
-			time.Duration(retryPolicy.NonStreamResponseTimeoutSeconds)*time.Second,
-		))
-	}
-
+	// Build middleware stack
 	var middlewares []pipeline.Middleware
 
 	// Add global middlewares
 	middlewares = append(middlewares, processor.Middlewares...)
-
-	inbound, outbound := NewPersistentTransformers(state, processor.Inbound)
 
 	// Add inbound middlewares (executed after inbound.TransformRequest)
 	middlewares = append(middlewares,

--- a/llm/pipeline/pipeline.go
+++ b/llm/pipeline/pipeline.go
@@ -81,6 +81,15 @@ func WithResponseTimeouts(streamFirstEventTimeout, nonStreamTimeout time.Duratio
 	}
 }
 
+// WithStreamProbeDuration configures how long a streaming response is held before
+// it is committed to the client. Errors observed during this window are returned
+// to Process so the normal retry budget and channel switching logic applies.
+func WithStreamProbeDuration(duration time.Duration) Option {
+	return func(p *pipeline) {
+		p.streamProbeDuration = duration
+	}
+}
+
 // Factory creates pipeline instances.
 type Factory struct {
 	Executor Executor
@@ -124,6 +133,7 @@ type pipeline struct {
 	retryDelay              time.Duration
 	emptyResponseDetection  bool
 	streamFirstEventTimeout time.Duration
+	streamProbeDuration     time.Duration
 	nonStreamTimeout        time.Duration
 }
 

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -410,5 +410,19 @@ func (p *pipeline) stream(
 		}
 	}
 
+	if p.streamProbeDuration > 0 {
+		inboundStream, err = probeStreamBeforeCommit(ctx, inboundStream, p.streamProbeDuration)
+		if err != nil {
+			firstEventGuard.cancelStream()
+			p.applyRawErrorResponseMiddlewares(ctx, err)
+
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+
+			return nil, WrapUpstreamError(err)
+		}
+	}
+
 	return inboundStream, nil
 }

--- a/llm/pipeline/stream_probe.go
+++ b/llm/pipeline/stream_probe.go
@@ -11,6 +11,8 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
+const maxStreamProbeBufferedEvents = 256
+
 type streamProbeEvent struct {
 	event *httpclient.StreamEvent
 	err   error
@@ -61,6 +63,9 @@ func probeStreamBeforeCommit(
 			}
 
 			probed.buffer = append(probed.buffer, event.event)
+			if len(probed.buffer) >= maxStreamProbeBufferedEvents {
+				return probed, nil
+			}
 
 		case <-timer.C:
 			return probed, nil

--- a/llm/pipeline/stream_probe.go
+++ b/llm/pipeline/stream_probe.go
@@ -1,0 +1,212 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+type streamProbeEvent struct {
+	event *httpclient.StreamEvent
+	err   error
+	done  bool
+}
+
+// probeStreamBeforeCommit reads the final outbound stream for a bounded window
+// before any bytes are exposed to the client. If the stream errors during that
+// window, the error is returned to the pipeline retry loop. On success, buffered
+// events are replayed and a single reader goroutine continues owning the inner
+// stream, so timeout does not create concurrent calls to inner.Next().
+func probeStreamBeforeCommit(
+	ctx context.Context,
+	stream streams.Stream[*httpclient.StreamEvent],
+	duration time.Duration,
+) (streams.Stream[*httpclient.StreamEvent], error) {
+	if duration <= 0 {
+		return stream, nil
+	}
+
+	probed := newCommitProbeStream(ctx, stream)
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	for {
+		select {
+		case event, ok := <-probed.events:
+			if !ok {
+				if err := probed.Err(); err != nil {
+					_ = probed.Close()
+
+					return nil, fmt.Errorf("stream probe failed before client commit: %w", err)
+				}
+
+				return probed, nil
+			}
+
+			if event.done {
+				if event.err != nil {
+					_ = probed.Close()
+
+					return nil, fmt.Errorf("stream probe failed before client commit: %w", event.err)
+				}
+
+				probed.readerDone = true
+
+				return probed, nil
+			}
+
+			probed.buffer = append(probed.buffer, event.event)
+
+		case <-timer.C:
+			return probed, nil
+
+		case <-ctx.Done():
+			_ = probed.Close()
+
+			return nil, ctx.Err()
+		}
+	}
+}
+
+type commitProbeStream struct {
+	ctx    context.Context
+	inner  streams.Stream[*httpclient.StreamEvent]
+	events chan streamProbeEvent
+	stop   chan struct{}
+	once   sync.Once
+
+	buffer      []*httpclient.StreamEvent
+	bufferIndex int
+	readerDone  bool
+	current     *httpclient.StreamEvent
+	errMu       sync.Mutex
+	err         error
+}
+
+func newCommitProbeStream(ctx context.Context, inner streams.Stream[*httpclient.StreamEvent]) *commitProbeStream {
+	s := &commitProbeStream{
+		ctx:    ctx,
+		inner:  inner,
+		events: make(chan streamProbeEvent),
+		stop:   make(chan struct{}),
+	}
+	go s.readLoop()
+
+	return s
+}
+
+func (s *commitProbeStream) readLoop() {
+	defer func() {
+		if r := recover(); r != nil {
+			s.setErr(fmt.Errorf("stream probe reader panic: %v", r))
+			slog.WarnContext(s.ctx, "stream probe reader recovered panic", slog.Any("panic", r))
+		}
+		close(s.events)
+	}()
+
+	for {
+		if s.inner.Next() {
+			event := s.inner.Current()
+			if !s.send(streamProbeEvent{event: event}) {
+				return
+			}
+
+			continue
+		}
+
+		err := s.inner.Err()
+		s.setErr(err)
+		s.send(streamProbeEvent{err: err, done: true})
+
+		return
+	}
+}
+
+func (s *commitProbeStream) send(event streamProbeEvent) bool {
+	select {
+	case s.events <- event:
+		return true
+	case <-s.stop:
+		return false
+	case <-s.ctx.Done():
+		s.setErr(s.ctx.Err())
+		return false
+	}
+}
+
+func (s *commitProbeStream) Next() bool {
+	if s.bufferIndex < len(s.buffer) {
+		s.current = s.buffer[s.bufferIndex]
+		s.bufferIndex++
+
+		return true
+	}
+
+	if s.readerDone {
+		return false
+	}
+
+	select {
+	case event, ok := <-s.events:
+		if !ok {
+			s.readerDone = true
+
+			return false
+		}
+		if event.done {
+			s.setErr(event.err)
+			s.readerDone = true
+
+			return false
+		}
+
+		s.current = event.event
+
+		return true
+
+	case <-s.ctx.Done():
+		s.setErr(s.ctx.Err())
+		_ = s.Close()
+
+		return false
+	}
+}
+
+func (s *commitProbeStream) Current() *httpclient.StreamEvent {
+	return s.current
+}
+
+func (s *commitProbeStream) Err() error {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+
+	return s.err
+}
+
+func (s *commitProbeStream) setErr(err error) {
+	if err == nil {
+		return
+	}
+
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+
+	if s.err == nil {
+		s.err = err
+	}
+}
+
+func (s *commitProbeStream) Close() error {
+	var err error
+	s.once.Do(func() {
+		close(s.stop)
+		err = s.inner.Close()
+	})
+
+	return err
+}

--- a/llm/pipeline/stream_probe_test.go
+++ b/llm/pipeline/stream_probe_test.go
@@ -178,6 +178,49 @@ func TestProbeStreamBeforeCommit_TimeoutKeepsSingleInnerReader(t *testing.T) {
 	require.NoError(t, result.stream.Close())
 }
 
+func TestProbeStreamBeforeCommit_StopsBufferingAtEventCap(t *testing.T) {
+	const expectedMaxBufferedEvents = 256
+
+	events := make([]*httpclient.StreamEvent, expectedMaxBufferedEvents+1)
+	for i := range events {
+		events[i] = &httpclient.StreamEvent{Data: []byte("event")}
+	}
+
+	stream := newBlockingAfterEventsStream(events)
+
+	resultCh := make(chan struct {
+		stream streams.Stream[*httpclient.StreamEvent]
+		err    error
+	}, 1)
+	go func() {
+		defer recoverTestGoroutine(t)
+
+		probed, err := probeStreamBeforeCommit(context.Background(), stream, time.Hour)
+		resultCh <- struct {
+			stream streams.Stream[*httpclient.StreamEvent]
+			err    error
+		}{stream: probed, err: err}
+	}()
+
+	var result struct {
+		stream streams.Stream[*httpclient.StreamEvent]
+		err    error
+	}
+	select {
+	case result = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("probe did not stop buffering after reaching the event cap")
+	}
+	require.NoError(t, result.err)
+	require.NotNil(t, result.stream)
+	defer result.stream.Close()
+
+	for i := 0; i < expectedMaxBufferedEvents+1; i++ {
+		require.True(t, result.stream.Next(), "event %d should be replayed or delivered live", i)
+		require.Equal(t, "event", string(result.stream.Current().Data))
+	}
+}
+
 func rawToLlmObjectStream(
 	ctx context.Context,
 	req *httpclient.Request,
@@ -225,6 +268,48 @@ func recoverTestGoroutine(t *testing.T) {
 	if r := recover(); r != nil {
 		t.Errorf("test goroutine panic: %v", r)
 	}
+}
+
+type blockingAfterEventsStream struct {
+	events []*httpclient.StreamEvent
+	index  int
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingAfterEventsStream(events []*httpclient.StreamEvent) *blockingAfterEventsStream {
+	return &blockingAfterEventsStream{
+		events: events,
+		closed: make(chan struct{}),
+	}
+}
+
+func (s *blockingAfterEventsStream) Next() bool {
+	if s.index < len(s.events) {
+		return true
+	}
+
+	<-s.closed
+	return false
+}
+
+func (s *blockingAfterEventsStream) Current() *httpclient.StreamEvent {
+	event := s.events[s.index]
+	s.index++
+
+	return event
+}
+
+func (s *blockingAfterEventsStream) Err() error {
+	return nil
+}
+
+func (s *blockingAfterEventsStream) Close() error {
+	s.once.Do(func() {
+		close(s.closed)
+	})
+
+	return nil
 }
 
 type errorAfterEventsStream struct {

--- a/llm/pipeline/stream_probe_test.go
+++ b/llm/pipeline/stream_probe_test.go
@@ -1,0 +1,328 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+func TestPipeline_Process_StreamProbeErrorRetriesBeforeClientCommit(t *testing.T) {
+	ctx := context.Background()
+	streamErr := errors.New("stream error: stream ID 7; INTERNAL_ERROR; received from peer")
+	streamFlag := true
+
+	attempts := 0
+	executor := &mockExecutor{
+		doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			attempts++
+			if attempts == 1 {
+				return newErrorAfterEventsStream(
+					[]*httpclient.StreamEvent{{Data: []byte("partial")}},
+					streamErr,
+				), nil
+			}
+
+			return streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("ok")}}), nil
+		},
+	}
+
+	prepareCalls := 0
+	outbound := &mockOutbound{
+		transformStream: rawToLlmObjectStream,
+		canRetry: func(err error) bool {
+			return errors.Is(err, streamErr)
+		},
+		prepareForRetry: func(ctx context.Context) error {
+			prepareCalls++
+			return nil
+		},
+	}
+	inbound := &mockInbound{
+		transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+			return &llm.Request{Stream: &streamFlag}, nil
+		},
+		transformStream: llmObjectToRawStream,
+	}
+
+	p := &pipeline{
+		Executor:              executor,
+		Inbound:               inbound,
+		Outbound:              outbound,
+		maxSameChannelRetries: 1,
+		streamProbeDuration:   time.Second,
+	}
+
+	res, err := p.Process(ctx, &httpclient.Request{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.Stream)
+	require.Equal(t, 2, attempts)
+	require.Equal(t, 1, prepareCalls)
+
+	events := collectStreamEvents(t, res.EventStream)
+	require.Equal(t, []string{"ok"}, streamEventData(events))
+}
+
+func TestPipeline_Process_StreamProbeExhaustionMarksUpstreamError(t *testing.T) {
+	ctx := context.Background()
+	streamErr := errors.New("stream error: stream ID 7; INTERNAL_ERROR; received from peer")
+	streamFlag := true
+
+	executor := &mockExecutor{
+		doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			return newErrorAfterEventsStream(
+				[]*httpclient.StreamEvent{{Data: []byte("partial")}},
+				streamErr,
+			), nil
+		},
+	}
+	outbound := &mockOutbound{
+		transformStream: rawToLlmObjectStream,
+	}
+	inbound := &mockInbound{
+		transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+			return &llm.Request{Stream: &streamFlag}, nil
+		},
+		transformStream: llmObjectToRawStream,
+	}
+
+	p := &pipeline{
+		Executor:            executor,
+		Inbound:             inbound,
+		Outbound:            outbound,
+		streamProbeDuration: time.Second,
+	}
+
+	res, err := p.Process(ctx, &httpclient.Request{})
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.True(t, errors.Is(err, streamErr))
+	require.True(t, IsUpstreamError(err))
+}
+
+func TestProbeStreamBeforeCommit_ReplaysBufferedEventsAfterProbeWindow(t *testing.T) {
+	stream := streams.SliceStream([]*httpclient.StreamEvent{
+		{Data: []byte("one")},
+		{Data: []byte("two")},
+	})
+
+	probed, err := probeStreamBeforeCommit(context.Background(), stream, time.Second)
+	require.NoError(t, err)
+
+	events := collectStreamEvents(t, probed)
+	require.Equal(t, []string{"one", "two"}, streamEventData(events))
+}
+
+func TestProbeStreamBeforeCommit_TimeoutKeepsSingleInnerReader(t *testing.T) {
+	stream := newControlledStream([]*httpclient.StreamEvent{{Data: []byte("late")}})
+
+	resultCh := make(chan struct {
+		stream streams.Stream[*httpclient.StreamEvent]
+		err    error
+	}, 1)
+	go func() {
+		defer recoverTestGoroutine(t)
+
+		probed, err := probeStreamBeforeCommit(context.Background(), stream, 50*time.Millisecond)
+		resultCh <- struct {
+			stream streams.Stream[*httpclient.StreamEvent]
+			err    error
+		}{stream: probed, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return stream.nextCalls.Load() > 0
+	}, time.Second, 10*time.Millisecond)
+
+	var result struct {
+		stream streams.Stream[*httpclient.StreamEvent]
+		err    error
+	}
+	select {
+	case result = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("probe did not return after duration")
+	}
+	require.NoError(t, result.err)
+	require.NotNil(t, result.stream)
+
+	nextResult := make(chan bool, 1)
+	go func() {
+		defer recoverTestGoroutine(t)
+
+		nextResult <- result.stream.Next()
+	}()
+
+	require.Never(t, func() bool {
+		return stream.maxActive.Load() > 1
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	stream.releaseReads()
+
+	select {
+	case ok := <-nextResult:
+		require.True(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("probed stream did not deliver released event")
+	}
+	require.Equal(t, "late", string(result.stream.Current().Data))
+	require.NoError(t, result.stream.Close())
+}
+
+func rawToLlmObjectStream(
+	ctx context.Context,
+	req *httpclient.Request,
+	stream streams.Stream[*httpclient.StreamEvent],
+) (streams.Stream[*llm.Response], error) {
+	return streams.Map(stream, func(event *httpclient.StreamEvent) *llm.Response {
+		return &llm.Response{Object: string(event.Data)}
+	}), nil
+}
+
+func llmObjectToRawStream(
+	ctx context.Context,
+	stream streams.Stream[*llm.Response],
+) (streams.Stream[*httpclient.StreamEvent], error) {
+	return streams.Map(stream, func(resp *llm.Response) *httpclient.StreamEvent {
+		return &httpclient.StreamEvent{Data: []byte(resp.Object)}
+	}), nil
+}
+
+func collectStreamEvents(t *testing.T, stream streams.Stream[*httpclient.StreamEvent]) []*httpclient.StreamEvent {
+	t.Helper()
+	defer stream.Close()
+
+	var events []*httpclient.StreamEvent
+	for stream.Next() {
+		events = append(events, stream.Current())
+	}
+	require.NoError(t, stream.Err())
+
+	return events
+}
+
+func streamEventData(events []*httpclient.StreamEvent) []string {
+	data := make([]string, 0, len(events))
+	for _, event := range events {
+		data = append(data, string(event.Data))
+	}
+
+	return data
+}
+
+func recoverTestGoroutine(t *testing.T) {
+	t.Helper()
+
+	if r := recover(); r != nil {
+		t.Errorf("test goroutine panic: %v", r)
+	}
+}
+
+type errorAfterEventsStream struct {
+	events []*httpclient.StreamEvent
+	err    error
+	index  int
+}
+
+func newErrorAfterEventsStream(events []*httpclient.StreamEvent, err error) *errorAfterEventsStream {
+	return &errorAfterEventsStream{
+		events: events,
+		err:    err,
+	}
+}
+
+func (s *errorAfterEventsStream) Next() bool {
+	return s.index < len(s.events)
+}
+
+func (s *errorAfterEventsStream) Current() *httpclient.StreamEvent {
+	event := s.events[s.index]
+	s.index++
+
+	return event
+}
+
+func (s *errorAfterEventsStream) Err() error {
+	if s.index >= len(s.events) {
+		return s.err
+	}
+
+	return nil
+}
+
+func (s *errorAfterEventsStream) Close() error {
+	return nil
+}
+
+type controlledStream struct {
+	events    []*httpclient.StreamEvent
+	index     int
+	release   chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
+
+	active    atomic.Int32
+	maxActive atomic.Int32
+	nextCalls atomic.Int32
+}
+
+func newControlledStream(events []*httpclient.StreamEvent) *controlledStream {
+	return &controlledStream{
+		events:  events,
+		release: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+}
+
+func (s *controlledStream) Next() bool {
+	active := s.active.Add(1)
+	defer s.active.Add(-1)
+
+	for {
+		maxActive := s.maxActive.Load()
+		if active <= maxActive || s.maxActive.CompareAndSwap(maxActive, active) {
+			break
+		}
+	}
+	s.nextCalls.Add(1)
+
+	select {
+	case <-s.release:
+	case <-s.closed:
+		return false
+	}
+
+	return s.index < len(s.events)
+}
+
+func (s *controlledStream) Current() *httpclient.StreamEvent {
+	event := s.events[s.index]
+	s.index++
+
+	return event
+}
+
+func (s *controlledStream) Err() error {
+	return nil
+}
+
+func (s *controlledStream) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+	})
+
+	return nil
+}
+
+func (s *controlledStream) releaseReads() {
+	close(s.release)
+}

--- a/llm/transformer/openai/fake.go
+++ b/llm/transformer/openai/fake.go
@@ -7,7 +7,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -48,7 +48,7 @@ type fakeExecutor struct{}
 // Do returns a fixed HTTP response from testdata/openai-stop.response.json.
 func (e *fakeExecutor) Do(ctx context.Context, req *httpclient.Request) (*httpclient.Response, error) {
 	// Read the fixed response from testdata
-	testDataPath := filepath.Join("testdata", "openai-stop.response.json")
+	testDataPath := path.Join("testdata", "openai-stop.response.json")
 
 	responseData, err := testdataFS.ReadFile(testDataPath)
 	if err != nil {
@@ -68,7 +68,7 @@ func (e *fakeExecutor) Do(ctx context.Context, req *httpclient.Request) (*httpcl
 // DoStream returns a fixed stream response from testdata/openai-stop.stream.jsonl.
 func (e *fakeExecutor) DoStream(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	// Read the fixed stream response from testdata
-	testDataPath := filepath.Join("testdata", "openai-stop.stream.jsonl")
+	testDataPath := path.Join("testdata", "openai-stop.stream.jsonl")
 
 	streamData, err := testdataFS.ReadFile(testDataPath)
 	if err != nil {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1048,7 +1048,7 @@ func (s *webSocketStream) Next() bool {
 
 	_, msg, err := s.lease.conn.ReadMessage()
 	if err != nil {
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
+		if isWebSocketClosedError(err) {
 			if ctxErr := s.ctx.Err(); ctxErr != nil {
 				s.setErr(ctxErr)
 			} else if !s.hasSeenEvent() {
@@ -1089,6 +1089,16 @@ func (s *webSocketStream) Next() bool {
 	}
 
 	return true
+}
+
+func isWebSocketClosedError(err error) bool {
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		return true
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "An established connection was aborted")
 }
 
 func (s *webSocketStream) Current() *httpclient.StreamEvent {

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1051,8 +1051,13 @@ func (s *webSocketStream) Next() bool {
 		if isWebSocketClosedError(err) {
 			if ctxErr := s.ctx.Err(); ctxErr != nil {
 				s.setErr(ctxErr)
+			} else if s.isTerminal() {
+				// A terminal event already committed the final response state; a
+				// following close from the provider is the normal end of the stream.
 			} else if !s.hasSeenEvent() {
 				s.setErr(fmt.Errorf("websocket closed before response event"))
+			} else {
+				s.setErr(fmt.Errorf("websocket closed before terminal response event: %w", err))
 			}
 			s.finish(true)
 			return false
@@ -1160,6 +1165,12 @@ func (s *webSocketStream) markTerminal() {
 	s.mu.Lock()
 	s.terminal = true
 	s.mu.Unlock()
+}
+
+func (s *webSocketStream) isTerminal() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.terminal
 }
 
 func (s *webSocketStream) setErr(err error) {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -1,9 +1,14 @@
 package responses
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -751,6 +756,21 @@ func TestWebSocketStreamReturnsErrorWhenReusedConnectionClosesBeforeEvent(t *tes
 	require.ErrorContains(t, stream.Err(), "websocket closed before response event")
 }
 
+func TestWebSocketStreamReportsAbortAfterNonTerminalEvent(t *testing.T) {
+	conn := newAbortingWebSocketClientConn(t, []byte(`{"type":"response.output_text.delta","delta":"partial"}`))
+	stream := &webSocketStream{
+		ctx:   webSocketTestContext(),
+		lease: &webSocketLease{conn: conn},
+		done:  make(chan struct{}),
+	}
+
+	require.True(t, stream.Next())
+	require.Equal(t, "response.output_text.delta", stream.Current().Type)
+
+	require.False(t, stream.Next())
+	require.ErrorContains(t, stream.Err(), "websocket closed before terminal response event")
+}
+
 func TestWebSocketExecutorSeparatesPoolByOrganizationHeaders(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var upgrades atomic.Int32
@@ -1284,4 +1304,98 @@ func TestToWebSocketURL(t *testing.T) {
 	got, err = toWebSocketURL("http://localhost:8080/v1/responses")
 	require.NoError(t, err)
 	require.Equal(t, "ws://localhost:8080/v1/responses", got)
+}
+
+func newAbortingWebSocketClientConn(t *testing.T, event []byte) *websocket.Conn {
+	t.Helper()
+
+	rawConn := &scriptedAbortConn{
+		event:    event,
+		abortErr: errors.New("wsarecv: An established connection was aborted by the software in your host machine."),
+	}
+	conn, _, err := websocket.NewClient(rawConn, mustParseURL(t, "ws://example.test/v1/responses"), nil, 1024, 1024)
+	require.NoError(t, err)
+
+	return conn
+}
+
+type scriptedAbortConn struct {
+	readBuf  bytes.Buffer
+	event    []byte
+	abortErr error
+	closed   bool
+}
+
+func (c *scriptedAbortConn) Read(p []byte) (int, error) {
+	if c.readBuf.Len() > 0 {
+		return c.readBuf.Read(p)
+	}
+	if c.closed {
+		return 0, net.ErrClosed
+	}
+
+	return 0, c.abortErr
+}
+
+func (c *scriptedAbortConn) Write(p []byte) (int, error) {
+	if !strings.Contains(string(p), "Sec-WebSocket-Key:") {
+		return len(p), nil
+	}
+
+	key := secWebSocketKeyFromRequest(p)
+	c.readBuf.WriteString("HTTP/1.1 101 Switching Protocols\r\n")
+	c.readBuf.WriteString("Upgrade: websocket\r\n")
+	c.readBuf.WriteString("Connection: Upgrade\r\n")
+	c.readBuf.WriteString("Sec-WebSocket-Accept: " + secWebSocketAccept(key) + "\r\n\r\n")
+	c.readBuf.Write(webSocketTextFrame(c.event))
+
+	return len(p), nil
+}
+
+func (c *scriptedAbortConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *scriptedAbortConn) LocalAddr() net.Addr              { return scriptedAddr("local") }
+func (c *scriptedAbortConn) RemoteAddr() net.Addr             { return scriptedAddr("remote") }
+func (c *scriptedAbortConn) SetDeadline(time.Time) error      { return nil }
+func (c *scriptedAbortConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *scriptedAbortConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *scriptedAbortConn) NetConn() net.Conn                { return c }
+
+type scriptedAddr string
+
+func (a scriptedAddr) Network() string { return string(a) }
+func (a scriptedAddr) String() string  { return string(a) }
+
+func secWebSocketKeyFromRequest(req []byte) string {
+	for _, line := range strings.Split(string(req), "\r\n") {
+		header, value, ok := strings.Cut(line, ":")
+		if ok && strings.EqualFold(header, "Sec-WebSocket-Key") {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
+}
+
+func secWebSocketAccept(key string) string {
+	sum := sha1.Sum([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func webSocketTextFrame(payload []byte) []byte {
+	frame := []byte{0x80 | byte(websocket.TextMessage)}
+	switch {
+	case len(payload) < 126:
+		frame = append(frame, byte(len(payload)))
+	case len(payload) <= 0xffff:
+		frame = append(frame, 126, byte(len(payload)>>8), byte(len(payload)))
+	default:
+		panic("test websocket frame payload is too large")
+	}
+	frame = append(frame, payload...)
+
+	return frame
 }


### PR DESCRIPTION
## Summary
- Add a configurable streaming probe window before committing a stream to the client, so upstream stream errors seen during the window return to the pipeline retry loop.
- Wire the setting through retry policy GraphQL/API/frontend settings with a 0 ms default and 120000 ms clamp.
- Fix Windows test compatibility for embedded OpenAI fake responses and reused WebSocket close errors.

## Example
Request #29292 failed after the upstream stream had been established with stream error: stream ID 7; INTERNAL_ERROR; received from peer. Previously that error only surfaced from stream.Err() in the HTTP handler, after pipeline.Process had already returned, so retry was never attempted. With streamProbeDurationMs configured, the pipeline owns the stream during the probe window and returns retryable upstream errors before any client bytes are committed.

## Test Plan
- cd internal/server/gql && go generate
- go test -p 1 ./...
- cd llm && go test -p 1 ./...
- go build -p 1 -ldflags "-s -w" -tags=nomsgpack -o TEMP/axonhub-pr-check/axonhub.exe ./cmd/axonhub
- cd cmd/schema && go build -p 1 -o TEMP/axonhub-pr-check/schema.exe
- cd llm && go build -p 1 ./...
- go build -p 1 ./...
- cd frontend && CI=true corepack pnpm@10 install --frozen-lockfile
- cd frontend && corepack pnpm@10 build
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --timeout 10m --max-same-issues 50
- git diff --check
- JSON parse check for frontend/src/locales/en/system.json and frontend/src/locales/zh-CN/system.json