### PR TITLE
fix: reject service_account API keys from LLM endpoints

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -216,6 +216,29 @@ func WithSource(source request.Source) gin.HandlerFunc {
 	}
 }
 
+// RequireAPIKeyType 中间件用于限制 API key 的类型。
+// 只有类型在 allowed 列表中的 API key 才能通过，否则返回 403。
+// 需要配合 WithAPIKeyConfig / WithGeminiKeyAuth 等认证中间件使用。
+func RequireAPIKeyType(allowed ...apikey.Type) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		apiKey, ok := contexts.GetAPIKey(c.Request.Context())
+		if !ok || apiKey == nil {
+			// 没有 API key 在上下文中（例如走了 noauth fallback），直接通过
+			c.Next()
+			return
+		}
+
+		for _, t := range allowed {
+			if apiKey.Type == t {
+				c.Next()
+				return
+			}
+		}
+
+		AbortWithError(c, http.StatusForbidden, errors.New("Forbidden"))
+	}
+}
+
 func withSessionScopeForAPIKey(ctx context.Context, key *ent.APIKey) context.Context {
 	scope := "api_key:" + strconv.Itoa(key.ID)
 	if key.Edges.Project != nil {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/server/api"
 	"github.com/looplj/axonhub/internal/server/biz"
@@ -160,6 +161,7 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 		middleware.WithTimeout(server.Config.LLMRequestTimeout),
 		middleware.WithIPBlocklist(services.SystemService),
 		middleware.WithAPIKeyConfig(services.AuthService, nil),
+		middleware.RequireAPIKeyType(apikey.TypeUser),
 		middleware.WithSource(request.SourceAPI),
 		middleware.WithThread(server.Config.Trace, services.ThreadService),
 		middleware.WithTrace(server.Config.Trace, services.TraceService),
@@ -221,6 +223,7 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 			middleware.WithTimeout(server.Config.LLMRequestTimeout),
 			middleware.WithIPBlocklist(services.SystemService),
 			middleware.WithGeminiKeyAuth(services.AuthService),
+			middleware.RequireAPIKeyType(apikey.TypeUser),
 			middleware.WithSource(request.SourceAPI),
 			middleware.WithThread(server.Config.Trace, services.ThreadService),
 			middleware.WithTrace(server.Config.Trace, services.TraceService),
@@ -233,6 +236,7 @@ func SetupRoutes(server *Server, handlers Handlers, client *ent.Client, services
 			middleware.WithTimeout(server.Config.LLMRequestTimeout),
 			middleware.WithIPBlocklist(services.SystemService),
 			middleware.WithGeminiKeyAuth(services.AuthService),
+			middleware.RequireAPIKeyType(apikey.TypeUser),
 			middleware.WithSource(request.SourceAPI),
 			middleware.WithThread(server.Config.Trace, services.ThreadService),
 			middleware.WithTrace(server.Config.Trace, services.TraceService),


### PR DESCRIPTION
Service account API keys should only be allowed to access the OpenAPI GraphQL interface. Previously, WithAPIKeyConfig and WithGeminiKeyAuth middleware accepted all API key types, allowing service accounts to bypass this restriction and call LLM APIs directly.

Added type checks:
- WithAPIKeyConfig: reject apikey.TypeServiceAccount with 403 Forbidden
- WithGeminiKeyAuth: reject apikey.TypeServiceAccount with 403 Forbidden

WithOpenAPIAuth already correctly restricts to service_account only.