### PR TITLE
fix: retry stream errors before first content

### DIFF
--- a/llm/pipeline/pipeline_retry_test.go
+++ b/llm/pipeline/pipeline_retry_test.go
@@ -579,6 +579,71 @@ func TestPipeline_Process_StreamDoesNotRetryAfterContent(t *testing.T) {
 	require.ErrorIs(t, res.EventStream.Err(), upstreamErr)
 }
 
+func TestPipeline_Process_StreamStopsPreCommitProbeAfterBound(t *testing.T) {
+	ctx := context.Background()
+	streamFlag := true
+	const nonContentEventsBeforeContent = 64
+
+	inbound := &mockInbound{
+		transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+			return &llm.Request{Stream: &streamFlag}, nil
+		},
+		transformStream: transformLlmContentToEvents,
+	}
+
+	attempts := 0
+	executor := &mockExecutor{
+		doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			attempts++
+			return streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("raw")}}), nil
+		},
+	}
+
+	var sourceStream *llmErrorAfterStream
+	outbound := &mockOutbound{
+		canRetry: func(err error) bool {
+			return true
+		},
+		transformStream: func(ctx context.Context, req *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+			items := make([]*llm.Response, 0, nonContentEventsBeforeContent+2)
+			for i := 0; i < nonContentEventsBeforeContent; i++ {
+				items = append(items, llmEmptyChunk())
+			}
+			items = append(items, llmContentChunk("ok"), llm.DoneResponse)
+
+			sourceStream = &llmErrorAfterStream{items: items}
+
+			return sourceStream, nil
+		},
+	}
+
+	p := NewFactory(executor).Pipeline(inbound, outbound, WithRetry(0, 1, 0))
+
+	res, err := p.Process(ctx, &httpclient.Request{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.Stream)
+	require.Equal(t, 1, attempts)
+	require.NotNil(t, sourceStream)
+	require.Equal(t, maxPreCommitRetryProbeEvents, sourceStream.index)
+
+	events, err := streams.All(res.EventStream)
+	require.NoError(t, err)
+	require.Len(t, events, nonContentEventsBeforeContent+2)
+	require.Equal(t, "metadata", string(events[0].Data))
+	require.Equal(t, "ok", string(events[nonContentEventsBeforeContent].Data))
+	require.Equal(t, "[DONE]", string(events[nonContentEventsBeforeContent+1].Data))
+}
+
+func llmEmptyChunk() *llm.Response {
+	return &llm.Response{
+		Object: "chat.completion.chunk",
+		Choices: []llm.Choice{{
+			Delta: &llm.Message{},
+		}},
+	}
+}
+
 func llmContentChunk(content string) *llm.Response {
 	return &llm.Response{
 		Object: "chat.completion.chunk",

--- a/llm/pipeline/pipeline_retry_test.go
+++ b/llm/pipeline/pipeline_retry_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/samber/lo"
@@ -148,6 +149,40 @@ func (m *mockExecutor) DoStream(ctx context.Context, req *httpclient.Request) (s
 	}
 
 	return nil, nil
+}
+
+type llmErrorAfterStream struct {
+	items   []*llm.Response
+	index   int
+	current *llm.Response
+	err     error
+}
+
+func (s *llmErrorAfterStream) Next() bool {
+	if s.index >= len(s.items) {
+		return false
+	}
+
+	s.current = s.items[s.index]
+	s.index++
+
+	return true
+}
+
+func (s *llmErrorAfterStream) Current() *llm.Response {
+	return s.current
+}
+
+func (s *llmErrorAfterStream) Err() error {
+	if s.index >= len(s.items) {
+		return s.err
+	}
+
+	return nil
+}
+
+func (s *llmErrorAfterStream) Close() error {
+	return nil
 }
 
 type mockMiddleware struct {
@@ -411,4 +446,162 @@ func TestPipeline_Process_RetryPreservesOriginalStreamIntent(t *testing.T) {
 	require.Equal(t, `{"ok":true}`, string(res.Response.Body))
 	require.Equal(t, 2, attempts)
 	require.Equal(t, 2, transformAttempts)
+}
+
+func TestPipeline_Process_StreamRetriesPreCommitError(t *testing.T) {
+	ctx := context.Background()
+	streamFlag := true
+	upstreamErr := &llm.ResponseError{
+		StatusCode: http.StatusInternalServerError,
+		Detail: llm.ErrorDetail{
+			Message: "upstream stream failed before content",
+			Type:    "server_error",
+		},
+	}
+
+	inbound := &mockInbound{
+		transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+			return &llm.Request{Stream: &streamFlag}, nil
+		},
+		transformStream: transformLlmContentToEvents,
+	}
+
+	attempts := 0
+	executor := &mockExecutor{
+		doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			attempts++
+			return streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("raw")}}), nil
+		},
+	}
+
+	prepareCalls := 0
+	outbound := &mockOutbound{
+		canRetry: func(err error) bool {
+			return errors.Is(err, upstreamErr)
+		},
+		prepareForRetry: func(ctx context.Context) error {
+			prepareCalls++
+			return nil
+		},
+		transformStream: func(ctx context.Context, req *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+			if attempts == 1 {
+				return &llmErrorAfterStream{
+					items: []*llm.Response{
+						{
+							Object: "chat.completion.chunk",
+							Choices: []llm.Choice{{
+								Delta: &llm.Message{},
+							}},
+						},
+					},
+					err: upstreamErr,
+				}, nil
+			}
+
+			return streams.SliceStream([]*llm.Response{
+				llmContentChunk("ok"),
+				llm.DoneResponse,
+			}), nil
+		},
+	}
+
+	p := NewFactory(executor).Pipeline(inbound, outbound, WithRetry(0, 1, 0))
+
+	res, err := p.Process(ctx, &httpclient.Request{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.Stream)
+	require.Equal(t, 2, attempts)
+	require.Equal(t, 1, prepareCalls)
+
+	events, err := streams.All(res.EventStream)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, "ok", string(events[0].Data))
+	require.Equal(t, "[DONE]", string(events[1].Data))
+}
+
+func TestPipeline_Process_StreamDoesNotRetryAfterContent(t *testing.T) {
+	ctx := context.Background()
+	streamFlag := true
+	upstreamErr := &llm.ResponseError{
+		StatusCode: http.StatusInternalServerError,
+		Detail: llm.ErrorDetail{
+			Message: "upstream stream failed after content",
+			Type:    "server_error",
+		},
+	}
+
+	inbound := &mockInbound{
+		transformRequest: func(ctx context.Context, req *httpclient.Request) (*llm.Request, error) {
+			return &llm.Request{Stream: &streamFlag}, nil
+		},
+		transformStream: transformLlmContentToEvents,
+	}
+
+	attempts := 0
+	executor := &mockExecutor{
+		doStream: func(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			attempts++
+			return streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("raw")}}), nil
+		},
+	}
+
+	prepareCalls := 0
+	outbound := &mockOutbound{
+		canRetry: func(err error) bool {
+			return true
+		},
+		prepareForRetry: func(ctx context.Context) error {
+			prepareCalls++
+			return nil
+		},
+		transformStream: func(ctx context.Context, req *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+			return &llmErrorAfterStream{
+				items: []*llm.Response{llmContentChunk("partial")},
+				err:   upstreamErr,
+			}, nil
+		},
+	}
+
+	p := NewFactory(executor).Pipeline(inbound, outbound, WithRetry(0, 1, 0))
+
+	res, err := p.Process(ctx, &httpclient.Request{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.Stream)
+	require.Equal(t, 1, attempts)
+	require.Equal(t, 0, prepareCalls)
+
+	require.True(t, res.EventStream.Next())
+	require.Equal(t, "partial", string(res.EventStream.Current().Data))
+	require.False(t, res.EventStream.Next())
+	require.ErrorIs(t, res.EventStream.Err(), upstreamErr)
+}
+
+func llmContentChunk(content string) *llm.Response {
+	return &llm.Response{
+		Object: "chat.completion.chunk",
+		Choices: []llm.Choice{{
+			Delta: &llm.Message{
+				Content: llm.MessageContent{Content: lo.ToPtr(content)},
+			},
+		}},
+	}
+}
+
+func transformLlmContentToEvents(_ context.Context, stream streams.Stream[*llm.Response]) (streams.Stream[*httpclient.StreamEvent], error) {
+	return streams.Map(stream, func(resp *llm.Response) *httpclient.StreamEvent {
+		if resp == llm.DoneResponse || (resp != nil && resp.Object == "[DONE]") {
+			return &httpclient.StreamEvent{Data: []byte("[DONE]")}
+		}
+
+		for _, choice := range resp.Choices {
+			if choice.Delta != nil && choice.Delta.Content.Content != nil {
+				return &httpclient.StreamEvent{Data: []byte(*choice.Delta.Content.Content)}
+			}
+		}
+
+		return &httpclient.StreamEvent{Data: []byte("metadata")}
+	}), nil
 }

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -27,6 +27,11 @@ const (
 	firstEventTimedOut
 )
 
+const (
+	maxPreReadEvents             = 3
+	maxPreCommitRetryProbeEvents = 16
+)
+
 func newFirstEventTimeoutGuard(ctx context.Context, timeout time.Duration) (context.Context, *firstEventTimeoutGuard) {
 	if timeout <= 0 {
 		return ctx, nil
@@ -171,8 +176,11 @@ func (p *pipeline) preReadLlmStream(
 	llmStream streams.Stream[*llm.Response],
 	firstEventGuard *firstEventTimeoutGuard,
 ) (streams.Stream[*llm.Response], error) {
-	const maxPreReadEvents = 3
 	preReadUntilContent := p.hasStreamRetryBudget()
+	probeLimit := maxPreReadEvents
+	if preReadUntilContent {
+		probeLimit = maxPreCommitRetryProbeEvents
+	}
 
 	var buffered []*llm.Response
 
@@ -218,7 +226,7 @@ func (p *pipeline) preReadLlmStream(
 			return nil, ErrEmptyResponse
 		}
 
-		if !preReadUntilContent && len(buffered) >= maxPreReadEvents {
+		if len(buffered) >= probeLimit {
 			break
 		}
 	}

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -146,8 +146,24 @@ func hasFinishReason(resp *llm.Response) bool {
 	return false
 }
 
+func isTerminalLlmStreamEvent(resp *llm.Response) bool {
+	return resp == llm.DoneResponse || (resp != nil && resp.Object == "[DONE]") || hasFinishReason(resp)
+}
+
+func (p *pipeline) hasStreamRetryBudget() bool {
+	return p.maxSameChannelRetries > 0 || p.maxChannelRetries > 0
+}
+
+func shouldWrapPreReadStreamError(err error) bool {
+	return !errors.Is(err, ErrStreamFirstEventTimeout) &&
+		!errors.Is(err, ErrEmptyResponse) &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
+}
+
 // preReadLlmStream reads the initial LLM stream events so the pipeline can
-// enforce first-event timeout and, when enabled, detect empty responses.
+// enforce first-event timeout, detect empty responses, and keep retryable stream
+// failures inside the pipeline until the first meaningful response content.
 // If the stream contains content, it returns a new stream with the pre-read events prepended.
 // If the stream is empty (finish reason reached without content), it returns ErrEmptyResponse.
 func (p *pipeline) preReadLlmStream(
@@ -156,14 +172,11 @@ func (p *pipeline) preReadLlmStream(
 	firstEventGuard *firstEventTimeoutGuard,
 ) (streams.Stream[*llm.Response], error) {
 	const maxPreReadEvents = 3
-	preReadLimit := maxPreReadEvents
-	if !p.emptyResponseDetection {
-		preReadLimit = 1
-	}
+	preReadUntilContent := p.hasStreamRetryBudget()
 
 	var buffered []*llm.Response
 
-	for i := range preReadLimit {
+	for i := 0; ; i++ {
 		hasNext, err := nextLlmStreamEvent(ctx, llmStream, i == 0, firstEventGuard)
 		if err != nil {
 			llmStream.Close()
@@ -177,12 +190,12 @@ func (p *pipeline) preReadLlmStream(
 		event := llmStream.Current()
 		buffered = append(buffered, event)
 
-		if !p.emptyResponseDetection {
+		if hasResponseContent(event) {
+			// Has content, not empty - prepend buffered events back
 			return streams.PrependStream(llmStream, buffered...), nil
 		}
 
-		if hasResponseContent(event) {
-			// Has content, not empty — prepend buffered events back
+		if !preReadUntilContent && !p.emptyResponseDetection {
 			return streams.PrependStream(llmStream, buffered...), nil
 		}
 
@@ -190,7 +203,11 @@ func (p *pipeline) preReadLlmStream(
 		// freshly-constructed "[DONE]" terminator: outbound transformers that emit
 		// terminal events as new *llm.Response (e.g. OpenAI TTS binary streams) must
 		// still trigger empty-response handling when no audio chunks were produced.
-		if event == llm.DoneResponse || (event != nil && event.Object == "[DONE]") || hasFinishReason(event) {
+		if isTerminalLlmStreamEvent(event) {
+			if !p.emptyResponseDetection {
+				return streams.PrependStream(llmStream, buffered...), nil
+			}
+
 			// Reached end without content — empty response
 			slog.WarnContext(ctx, "empty response detected",
 				slog.Int("events_read", len(buffered)),
@@ -200,6 +217,10 @@ func (p *pipeline) preReadLlmStream(
 
 			return nil, ErrEmptyResponse
 		}
+
+		if !preReadUntilContent && len(buffered) >= maxPreReadEvents {
+			break
+		}
 	}
 
 	if err := llmStream.Err(); err != nil {
@@ -208,7 +229,8 @@ func (p *pipeline) preReadLlmStream(
 		return nil, err
 	}
 
-	// Didn't find content or finish in 3 events — treat as non-empty (safe default)
+	// Didn't find content or finish in the bounded empty-response probe - treat
+	// as non-empty and let the handler consume the stream.
 	if len(buffered) > 0 {
 		return streams.PrependStream(llmStream, buffered...), nil
 	}
@@ -355,8 +377,9 @@ func (p *pipeline) stream(
 		})
 	}
 
-	// Check stream start for first-event timeout or empty response detection.
-	if p.emptyResponseDetection || firstEventTimeout > 0 {
+	// Check stream start before the handler commits the response. This enforces
+	// first-event timeout, empty-response detection, and pre-content retry.
+	if p.emptyResponseDetection || firstEventTimeout > 0 || p.hasStreamRetryBudget() {
 		rawLlmStream := llmStream
 
 		llmStream, err = p.preReadLlmStream(ctx, llmStream, firstEventGuard)
@@ -365,7 +388,11 @@ func (p *pipeline) stream(
 			err = firstEventGuard.finishBeforeFirstEvent(err)
 			p.applyRawErrorResponseMiddlewares(ctx, err)
 
-			return nil, err
+			if !shouldWrapPreReadStreamError(err) {
+				return nil, err
+			}
+
+			return nil, WrapUpstreamError(err)
 		}
 	} else if firstEventGuard != nil {
 		firstEventGuard.stop()


### PR DESCRIPTION
## Summary
- Pre-read streaming LLM responses until the first meaningful content when retry budget is available.
- Return pre-content upstream stream errors to the existing retry loop instead of committing the client stream early.
- Keep post-content stream failures on the stream path to avoid duplicate or mixed client output.

## Why
Streaming upstream connections can fail after the HTTP stream opens but before any useful model output is produced. In that case the API handler may already have committed the SSE response, so the existing retry loop never gets a chance to recover. This is especially visible for Responses API pass-through requests that fail with errors such as unexpected EOF or HTTP/2 stream INTERNAL_ERROR before any response chunks are persisted.

## Test Plan
- cd llm && go test ./pipeline -run "TestPipeline_Process_Stream(RetriesPreCommitError|DoesNotRetryAfterContent)|TestPipeline_Process_RetryLogic|TestPipeline_Process_StreamEmptyResponseDetection|TestPipeline_Process_RetryPreservesOriginalStreamIntent" -count=1 -timeout 60s
- cd llm && go test ./pipeline -count=1 -timeout 60s
- git diff --check
