### PR TITLE
fix(channel): add missing optional() to modelMappings zod schema

### DIFF
--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -238,7 +238,7 @@ export type ChannelProviderQuotaSettings = z.infer<typeof channelProviderQuotaSe
 // Channel Settings
 export const channelSettingsSchema = z.object({
   extraModelPrefix: z.string().optional(),
-  modelMappings: z.array(modelMappingSchema).nullable(),
+  modelMappings: z.array(modelMappingSchema).optional().nullable(),
   autoTrimedModelPrefixes: z.array(z.string()).optional().nullable(),
   hideOriginalModels: z.boolean().optional(),
   hideMappedModels: z.boolean().optional(),


### PR DESCRIPTION
## Bug

创建 OpenCode Go 渠道时，表单校验失败，请求发不出去。

### 根因

`channelSettingsSchema` 中 `modelMappings` 字段只声明了 `.nullable()`，缺少 `.optional()`。

### 触发链条

1. edc1d26 为 OpenCode Go 新增了 `settings.providerQuota.opencodeGo.workspaceId` / `authCookie` 表单字段
2. 这两个字段注册在 `settings.*` 路径下，导致 react-hook-form 在提交时构建出非 `undefined` 的 `values.settings` 对象
3. 触发了 `channelSettingsSchema` 全量校验
4. `modelMappings` 不在表单数据中，值为 `undefined`，而 `.nullable()` 不接受 `undefined`（只接受 `null` 或数组）
5. 校验失败，请求终止

### 修复

`.nullable()` → `.optional().nullable()`