### PR TITLE
fix(httpclient): cap upstream error response body at 1 MB to prevent OOM

### DIFF
--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -17,6 +17,12 @@ import (
 
 	"github.com/looplj/axonhub/llm/streams"
 )
+// MaxErrorBodySize is the maximum number of bytes read from an upstream error
+// response body. Error bodies beyond this size are truncated to prevent OOM
+// from pathological upstream responses that echo large request payloads in
+// validation error messages, producing response bodies of 1+ GB.
+const MaxErrorBodySize = 1 << 20 // 1 MB
+
 
 // HttpClient implements the HttpClient interface.
 type HttpClient struct {
@@ -219,12 +225,17 @@ func (hc *HttpClient) Do(ctx context.Context, request *Request) (*Response, erro
 		}
 	}()
 
-	body, err := io.ReadAll(rawResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
+	var body []byte
+	// Cap error response bodies at 1 MB to prevent OOM from pathological
+	// upstream error bodies (e.g., vLLM echoing multi-MB input in validation
+	// errors). Successful responses are read in full because they are
+	// typically small JSON payloads.
 	if rawResp.StatusCode >= 400 {
+		body, err = io.ReadAll(io.LimitReader(rawResp.Body, MaxErrorBodySize))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response body: %w", err)
+		}
+
 		if slog.Default().Enabled(ctx, slog.LevelDebug) {
 			slog.DebugContext(ctx, "HTTP request failed",
 				slog.String("method", rawReq.Method),
@@ -241,6 +252,11 @@ func (hc *HttpClient) Do(ctx context.Context, request *Request) (*Response, erro
 			Body:       body,
 			Headers:    rawResp.Header,
 		}
+	}
+
+	body, err = io.ReadAll(rawResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
@@ -301,7 +317,7 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 		}()
 
 		// Read error body for streaming requests
-		body, err := io.ReadAll(rawResp.Body)
+		body, err := io.ReadAll(io.LimitReader(rawResp.Body, MaxErrorBodySize))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

`HttpClient.Do` and `HttpClient.DoStream` both used `io.ReadAll` without a size limit when reading upstream error response bodies. When a provider returns a large error body (e.g., a validation error that echoes the entire request payload including inline base64 image data), AxonHub allocates the full response into memory — potentially 1+ GB — causing CPU spikes and OOM kills.

## Spirit/Intent

Prevent unbounded memory allocation from pathological upstream error responses by capping error body reads at 1 MB.

## Key Changes

- Added `MaxErrorBodySize = 1 << 20` (1 MB) constant
- `Do()`: error response bodies (status >= 400) are now read via `io.LimitReader(rawResp.Body, MaxErrorBodySize)` instead of unbounded `io.ReadAll`
- `DoStream()`: same cap applied to streaming error response bodies
- Successful response bodies are still read in full (typically small JSON payloads)

## Risks

- The 1 MB cap may truncate very large error messages from some providers. This is an acceptable trade-off: the truncated error still contains the status code, headers, and the first 1 MB of the body, which is sufficient for debugging in virtually all cases.
- No impact on successful response paths — only the `status >= 400` branch is affected.
