### PR TITLE
ci: publish Helm chart to GHCR --issue=#1965

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,54 @@
+name: Publish Helm chart
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  helm-chart:
+    if: github.repository_owner == 'looplj'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-helm-chart-${{ github.ref }}
+      cancel-in-progress: false
+    env:
+      CHART_DIR: deploy/helm
+      OCI_REGISTRY: oci://ghcr.io/${{ github.repository_owner }}/charts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Sync chart metadata with release tag
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          chart_version="${tag_name#v}"
+
+          sed -i -E "s/^version:.*/version: ${chart_version}/" "$CHART_DIR/Chart.yaml"
+          sed -i -E "s/^appVersion:.*/appVersion: \"${tag_name}\"/" "$CHART_DIR/Chart.yaml"
+
+          echo "CHART_VERSION=${chart_version}" >> "$GITHUB_ENV"
+          echo "TAG_NAME=${tag_name}" >> "$GITHUB_ENV"
+
+      - name: Lint chart
+        run: helm lint "$CHART_DIR"
+
+      - name: Package chart
+        run: helm package "$CHART_DIR" --destination .chart-packages
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to GHCR
+        run: helm push ".chart-packages/axonhub-${CHART_VERSION}.tgz" "$OCI_REGISTRY"
+
+      - name: Verify published chart
+        run: helm show chart "$OCI_REGISTRY/axonhub" --version "$CHART_VERSION"

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the AxonHub chart and t
 |-----------|-------------|---------|
 | `axonhub.replicaCount` | Number of AxonHub replicas | `1` |
 | `axonhub.image.repository` | AxonHub image repository | `looplj/axonhub` |
-| `axonhub.image.tag` | AxonHub image tag | `latest` |
+| `axonhub.image.tag` | AxonHub image tag override. Defaults to chart `appVersion` when empty | `""` |
 | `axonhub.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `axonhub.dbPassword` | Database password | `axonhub_password` |
 | `axonhub.service.type` | Kubernetes service type | `ClusterIP` |

--- a/deploy/helm/values-production.yaml
+++ b/deploy/helm/values-production.yaml
@@ -13,7 +13,8 @@ axonhub:
   
   image:
     repository: looplj/axonhub
-    tag: "latest"  # Consider using specific version in production
+    # Overrides the image tag. Defaults to the chart appVersion when empty.
+    tag: ""
     pullPolicy: IfNotPresent
   
   # Environment variables - customize the database connection string for your environment

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -13,7 +13,8 @@ axonhub:
   image:
     repository: looplj/axonhub
     pullPolicy: IfNotPresent
-    tag: "latest"
+    # Overrides the image tag. Defaults to the chart appVersion when empty.
+    tag: ""
   
   # Environment variables for AxonHub
   env:


### PR DESCRIPTION
## 概述

为 AxonHub 增加 tag 驱动的 Helm chart 发布流程，将 `deploy/helm` chart 打包并发布到 GHCR OCI。同步修正 chart 默认镜像 tag，使 release chart 默认部署对应的 release image，而不是始终使用 `latest`。

## 变更内容

- **.github/workflows/helm-chart.yml**: 新增 `v*` tag 触发的 Helm chart 发布 workflow，执行 chart metadata 同步、`helm lint`、`helm package`、GHCR 登录、`helm push` 和 `helm show chart` 验证。
- **deploy/helm/values.yaml**: 将 `axonhub.image.tag` 默认值改为空，允许 deployment 模板回退到 `.Chart.AppVersion`。
- **deploy/helm/values-production.yaml**: 同步生产 values 的镜像 tag 默认行为。
- **deploy/helm/README.md**: 更新 `axonhub.image.tag` 配置说明，说明为空时默认使用 chart `appVersion`。

## 验证

- 已在本地模拟 tag `v1.2.3`，执行 Helm package/show，确认 chart name/version/appVersion 正确。
- 已通过 `helm template` 确认默认镜像渲染为 `looplj/axonhub:v1.2.3`，并包含匹配的 chart/version labels。
- 已对变更 YAML 文件执行 LSP diagnostics，未发现诊断错误。
- 未执行仓库 build/lint；仓库 AGENTS.md 约束要求除非明确请求，否则不运行 lint/build。

Related: #1965