### PR TITLE
fix(trace): include instruction content in system_instruction span key

### DIFF
--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -1502,6 +1502,10 @@ func spanToKey(span Span) string {
 	}
 
 	switch span.Type {
+	case "system_instruction":
+		if span.Value.SystemInstruction != nil {
+			return fmt.Sprintf("%s:%s", span.Type, span.Value.SystemInstruction.Instruction)
+		}
 	case "user_query":
 		if span.Value.UserQuery != nil {
 			return fmt.Sprintf("%s:%s", span.Type, span.Value.UserQuery.Text)


### PR DESCRIPTION
## 问题描述

在追踪 OpenCode、Claude Code 等 agent 会话时，发现追踪页面只显示一个系统提示词，即使多个请求都有不同的系统提示词（如生成标题的系统提示词和主 agent 的系统提示词）。

## 根因分析

`spanToKey` 函数为每个 span 生成唯一 key 用于去重比较。但该函数缺少对 `system_instruction` 类型的处理，导致所有系统提示词 span 都返回相同的空字符串 key，无法区分不同内容，被错误去重。

## 修复方案

在 `spanToKey` 中添加 `system_instruction` 的处理，将指令内容纳入 key 的生成。

这样：
- 不同内容的系统提示词会生成不同的 key，不会被错误去重
- 相同内容的系统提示词仍然会生成相同的 key，保持正确的去重行为

## 影响范围

- 仅修改 `spanToKey` 函数，不影响其他去重逻辑
- 修复后所有使用 OpenAI/Anthropic 格式的 agent 追踪都能正确显示多个系统提示词
