### PR TITLE
fix(frontend): constrain API keys table scrolling

### DIFF
--- a/frontend/src/features/apikeys/components/apikeys-table.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-table.tsx
@@ -181,7 +181,7 @@ export function ApiKeysTable({
   }, [data, rowSelection]);
 
   return (
-    <div className='flex flex-1 flex-col'>
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
       <DataTableToolbar
         table={table}
         dateRange={dateRange}
@@ -189,7 +189,7 @@ export function ApiKeysTable({
         onResetFilters={onResetFilters}
         canViewCreators={canViewCreators}
       />
-      <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
+      <div className='shadow-soft relative mt-4 min-h-0 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
         <Table className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
           <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/frontend/src/features/apikeys/index.tsx
+++ b/frontend/src/features/apikeys/index.tsx
@@ -124,7 +124,7 @@ function ApiKeysContent() {
   );
 
   return (
-    <div className='flex flex-1 flex-col'>
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as ApiKeyTabKey)} className='w-full'>
         <TabsList className='shadow-soft border-border bg-background grid w-full grid-cols-4 rounded-2xl border'>
           <TabsTrigger value='all' data-value='all'>
@@ -141,7 +141,7 @@ function ApiKeysContent() {
           </TabsTrigger>
         </TabsList>
       </Tabs>
-      <div className='mt-6 flex-1'>
+      <div className='mt-6 flex min-h-0 flex-1 flex-col overflow-hidden'>
         <ApiKeysTable
           data={tableData}
           loading={isLoading}
@@ -184,7 +184,7 @@ export default function ApiKeysManagement() {
         </div>
       </Header>
 
-      <Main>
+      <Main fixed>
         <ApiKeysContent />
       </Main>
       <ApiKeysDialogs />


### PR DESCRIPTION
## Summary

Fixes double vertical scrolling and blank bottom space on the API Keys page by aligning it with the existing fixed table page layout.

## Before/After media

Before:

<img width="2560" height="1528" alt="API Keys page double scrolling before fix" src="https://github.com/user-attachments/assets/c184b834-2c0b-4874-bfa6-ec863dca5a17" />

After:

<img width="2560" height="1528" alt="API Keys page scrolling after fix" src="https://github.com/user-attachments/assets/2cbc08bd-c823-4901-b802-30cac071aa85" />

## Changes

- Render the API Keys page with the fixed `Main` layout.
- Constrain the page/table flex containers with `min-h-0` and hidden outer overflow.
- Keep scrolling inside the bordered table region as the single `overflow-auto` container.

## Validation

- Observed the API Keys page scrolling normally after the fix.
