### PR TITLE
ci: add nightly docker publish workflow

### DIFF
--- a/.github/workflows/docker-unstable.yml
+++ b/.github/workflows/docker-unstable.yml
@@ -1,0 +1,108 @@
+name: Publish Docker image (unstable)
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+
+jobs:
+  prepare:
+    name: Pin commit & date
+    runs-on: ubuntu-slim
+    outputs:
+      commit_sha: ${{ steps.pin.outputs.commit_sha }}
+      build_date: ${{ steps.pin.outputs.build_date }}
+    steps:
+      - name: Check out unstable
+        uses: actions/checkout@v4
+        with:
+          ref: unstable
+          fetch-depth: 1
+
+      - name: Pin commit SHA & date
+        id: pin
+        run: |
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "build_date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+
+  build_single_arch:
+    name: Build & push (${{ matrix.arch }}) [native]
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out pinned commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+          fetch-depth: 1
+
+      - name: Write VERSION
+        run: echo "unstable-${{ needs.prepare.outputs.build_date }}" > internal/build/VERSION
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            looplj/axonhub
+
+      - name: Build & push single-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: |
+            looplj/axonhub:unstable-${{ matrix.arch }}
+            looplj/axonhub:unstable-${{ needs.prepare.outputs.build_date }}-${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+  create_manifests:
+    name: Create multi-arch manifest (Docker Hub)
+    needs: [prepare, build_single_arch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create & push manifest (Docker Hub - unstable)
+        run: |
+          DATE=${{ needs.prepare.outputs.build_date }}
+          docker buildx imagetools create \
+            -t looplj/axonhub:unstable \
+            looplj/axonhub:unstable-amd64 \
+            looplj/axonhub:unstable-arm64
+          docker buildx imagetools create \
+            -t looplj/axonhub:unstable-${DATE} \
+            looplj/axonhub:unstable-${DATE}-amd64 \
+            looplj/axonhub:unstable-${DATE}-arm64


### PR DESCRIPTION
Push to `unstable` branch triggers multi-arch Docker build, publishing `looplj/axonhub:unstable` image to Docker Hub.

- Triggers on push to `unstable` branch
- Builds amd64 + arm64, creates multi-arch manifest
- Tags: `looplj/axonhub:unstable`
- VERSION file includes short commit SHA for debugging