### PR TITLE
feat(frontend): add GPT-5.6 models and pricing

### DIFF
--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -3528,6 +3528,403 @@
       "display_name": "OpenAI",
       "models": [
         {
+          "id": "gpt-5.6",
+          "name": "GPT-5.6",
+          "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+          "family": "gpt",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1050000,
+            "input": 922000,
+            "output": 128000
+          },
+          "experimental": {
+            "modes": {
+              "fast": {
+                "cost": {
+                  "input": 10,
+                  "output": 60,
+                  "cache_read": 1,
+                  "cache_write": 12.5
+                },
+                "provider": {
+                  "body": {
+                    "service_tier": "priority"
+                  }
+                }
+              },
+              "pro": {
+                "provider": {
+                  "body": {
+                    "reasoning": {
+                      "mode": "pro"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cost": {
+            "input": 5,
+            "output": 30,
+            "cache_read": 0.5,
+            "cache_write": 6.25,
+            "tiers": [
+              {
+                "input": 10,
+                "output": 45,
+                "cache_read": 1,
+                "cache_write": 12.5,
+                "tier": {
+                  "type": "context",
+                  "size": 272000
+                }
+              }
+            ],
+            "context_over_200k": {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "cache_write": 12.5
+            }
+          },
+          "display_name": "GPT-5.6",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6-sol",
+          "name": "GPT-5.6 Sol",
+          "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+          "family": "gpt",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1050000,
+            "input": 922000,
+            "output": 128000
+          },
+          "experimental": {
+            "modes": {
+              "fast": {
+                "cost": {
+                  "input": 10,
+                  "output": 60,
+                  "cache_read": 1,
+                  "cache_write": 12.5
+                },
+                "provider": {
+                  "body": {
+                    "service_tier": "priority"
+                  }
+                }
+              },
+              "pro": {
+                "provider": {
+                  "body": {
+                    "reasoning": {
+                      "mode": "pro"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cost": {
+            "input": 5,
+            "output": 30,
+            "cache_read": 0.5,
+            "cache_write": 6.25,
+            "tiers": [
+              {
+                "input": 10,
+                "output": 45,
+                "cache_read": 1,
+                "cache_write": 12.5,
+                "tier": {
+                  "type": "context",
+                  "size": 272000
+                }
+              }
+            ],
+            "context_over_200k": {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "cache_write": 12.5
+            }
+          },
+          "display_name": "GPT-5.6 Sol",
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6-terra",
+          "name": "GPT-5.6 Terra",
+          "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+          "family": "gpt-mini",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1050000,
+            "input": 922000,
+            "output": 128000
+          },
+          "experimental": {
+            "modes": {
+              "fast": {
+                "cost": {
+                  "input": 5,
+                  "output": 30,
+                  "cache_read": 0.5,
+                  "cache_write": 6.25
+                },
+                "provider": {
+                  "body": {
+                    "service_tier": "priority"
+                  }
+                }
+              },
+              "pro": {
+                "provider": {
+                  "body": {
+                    "reasoning": {
+                      "mode": "pro"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cost": {
+            "input": 2.5,
+            "output": 15,
+            "cache_read": 0.25,
+            "cache_write": 3.125,
+            "tiers": [
+              {
+                "input": 5,
+                "output": 22.5,
+                "cache_read": 0.5,
+                "cache_write": 6.25,
+                "tier": {
+                  "type": "context",
+                  "size": 272000
+                }
+              }
+            ],
+            "context_over_200k": {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
+              "cache_write": 6.25
+            }
+          },
+          "display_name": "GPT-5.6 Terra",
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6-luna",
+          "name": "GPT-5.6 Luna",
+          "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+          "family": "gpt-nano",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1050000,
+            "input": 922000,
+            "output": 128000
+          },
+          "experimental": {
+            "modes": {
+              "fast": {
+                "cost": {
+                  "input": 2,
+                  "output": 12,
+                  "cache_read": 0.2,
+                  "cache_write": 2.5
+                },
+                "provider": {
+                  "body": {
+                    "service_tier": "priority"
+                  }
+                }
+              },
+              "pro": {
+                "provider": {
+                  "body": {
+                    "reasoning": {
+                      "mode": "pro"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cost": {
+            "input": 1,
+            "output": 6,
+            "cache_read": 0.1,
+            "cache_write": 1.25,
+            "tiers": [
+              {
+                "input": 2,
+                "output": 9,
+                "cache_read": 0.2,
+                "cache_write": 2.5,
+                "tier": {
+                  "type": "context",
+                  "size": 272000
+                }
+              }
+            ],
+            "context_over_200k": {
+              "input": 2,
+              "output": 9,
+              "cache_read": 0.2,
+              "cache_write": 2.5
+            }
+          },
+          "display_name": "GPT-5.6 Luna",
+          "type": "chat"
+        },
+        {
           "id": "gpt-5.5-pro",
           "name": "GPT-5.5 Pro",
           "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",

--- a/frontend/src/features/models/data/providers.schema.ts
+++ b/frontend/src/features/models/data/providers.schema.ts
@@ -1,16 +1,33 @@
 import { z } from 'zod';
 
-// Model cost schema
-export const modelCostSchema = z.object({
+const modelTokenCostSchema = z.object({
   input: z.number().optional(),
   output: z.number().optional(),
   cache_read: z.number().optional(),
   cache_write: z.number().optional(),
 });
 
+const modelCostTierSchema = modelTokenCostSchema
+  .extend({
+    tier: z
+      .object({
+        type: z.string(),
+        size: z.number().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+// Model cost schema
+export const modelCostSchema = modelTokenCostSchema.extend({
+  tiers: z.array(modelCostTierSchema).optional(),
+  context_over_200k: modelTokenCostSchema.optional(),
+});
+
 // Model limit schema
 export const modelLimitSchema = z.object({
   context: z.number().optional().nullable(),
+  input: z.number().optional().nullable(),
   output: z.number().optional().nullable(),
 });
 
@@ -26,14 +43,37 @@ export const modelModalitiesSchema = z.object({
   output: z.array(z.string()).optional().nullable(),
 });
 
+const modelReasoningOptionSchema = z.object({
+  type: z.string(),
+  values: z.array(z.string().nullable()).optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+});
+
+const modelExperimentalModeSchema = z
+  .object({
+    cost: modelTokenCostSchema.optional(),
+    provider: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const modelExperimentalSchema = z
+  .object({
+    modes: z.record(z.string(), modelExperimentalModeSchema).optional(),
+  })
+  .passthrough();
+
 // Single model schema
 export const providerModelSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
+  description: z.string().optional(),
   family: z.string().optional(),
   attachment: z.boolean().optional(),
   reasoning: modelReasoningSchema.optional(),
+  reasoning_options: z.array(modelReasoningOptionSchema).optional(),
   tool_call: z.boolean().optional(),
+  structured_output: z.boolean().optional(),
   temperature: z.boolean().optional(),
   knowledge: z.string().optional(),
   release_date: z.string().optional(),
@@ -42,7 +82,9 @@ export const providerModelSchema = z.object({
   open_weights: z.boolean().optional(),
   cost: modelCostSchema.optional(),
   limit: modelLimitSchema.optional().nullable(),
+  experimental: modelExperimentalSchema.optional(),
   display_name: z.string().optional(),
+  extra_capabilities: z.record(z.string(), z.unknown()).optional(),
   vision: z.boolean().optional(),
   type: z.string().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
## Summary

- Add `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the bundled OpenAI model catalog.
- Include reasoning support, model families, release metadata, input modalities, 1.05M context windows, 922K input limits, and 128K maximum output.
- Include base pricing, cached-input pricing, cache-write pricing, long-context tier pricing, and fast/pro mode metadata in the provider catalog.
- Extend the provider schema so the bundled catalog preserves GPT-5.6 metadata such as structured output, tiered pricing, experimental modes, and extra capabilities.

## Why

The GPT-5.6 family is available from OpenAI and already present in the upstream provider-pricing source, but it is missing from AxonHub's bundled developer catalog. As a result, these model IDs are not available in the Add Model selector when the remote catalog has not yet been synchronized.

## Pricing

Base pricing in USD per 1M tokens:

| Model | Input | Cached input | Cache write | Output |
| --- | ---: | ---: | ---: | ---: |
| GPT-5.6 / GPT-5.6 Sol | $5.00 | $0.50 | $6.25 | $30.00 |
| GPT-5.6 Terra | $2.50 | $0.25 | $3.125 | $15.00 |
| GPT-5.6 Luna | $1.00 | $0.10 | $1.25 | $6.00 |

Long-context tier pricing metadata is included for contexts over 272K tokens:

| Model | Input | Cached input | Cache write | Output |
| --- | ---: | ---: | ---: | ---: |
| GPT-5.6 / GPT-5.6 Sol | $10.00 | $1.00 | $12.50 | $45.00 |
| GPT-5.6 Terra | $5.00 | $0.50 | $6.25 | $22.50 |
| GPT-5.6 Luna | $2.00 | $0.20 | $2.50 | $9.00 |

Cache writes are billed at 1.25x the uncached input-token rate.

Official reference: https://developers.openai.com/api/docs/models

## Validation

- Parsed `providers.json` successfully.
- Confirmed exactly one entry for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Confirmed base pricing, cached-input pricing, cache-write pricing, long-context tier pricing metadata, and fast/pro metadata.
- Confirmed provider schema preserves the newly added catalog metadata.
- Ran `git diff --check`.
