### PR TITLE
feat(codex): update models and default version

### DIFF
--- a/llm/transformer/openai/codex/constants.go
+++ b/llm/transformer/openai/codex/constants.go
@@ -20,6 +20,9 @@ func DefaultModels() []string {
 		"gpt-5.4",
 		"gpt-5.4-mini",
 		"gpt-5.5",
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.6-luna",
 	}
 }
 
@@ -34,5 +37,5 @@ const (
 	RedirectURI = "http://localhost:1455/auth/callback"
 	Scopes      = "openid profile email offline_access"
 
-	codexDefaultVersion = "0.142.5"
+	codexDefaultVersion = "0.144.1"
 )


### PR DESCRIPTION
## 概述

更新 Codex 渠道的静态模型列表和默认客户端版本，使 AxonHub 能识别新的 GPT-5.6 Codex 模型，并满足上游模型对 Codex 版本的要求。

## 变更内容

- 在 `codex.DefaultModels()` 中新增：
  - `gpt-5.6-sol`
  - `gpt-5.6-terra`
  - `gpt-5.6-luna`
- 将默认 Codex CLI 版本从 `0.142.5` 更新为 `0.144.1`。
- 保持客户端显式传入 `Version` header 时优先使用客户端值的现有行为。

## 关联变更

PR #1982 更新的是前端 bundled model catalog；本 PR 更新 Codex transformer 的专用静态模型 registry 和 outbound `Version` header，两者互补。

## 验证

- `git diff --check upstream/unstable...HEAD` 通过。
- 已确认当前分支相对最新 `upstream/unstable` 仅包含 1 个提交和 1 个文件变更。
- 按仓库 `AGENTS.md` 约束，未运行 build、lint 或 test。

closes #1984