### PR TITLE
fix(dashboard): fix daily chart X-axis date display using Date.UTC

### DIFF
--- a/frontend/src/features/dashboard/components/daily-requests-stats.tsx
+++ b/frontend/src/features/dashboard/components/daily-requests-stats.tsx
@@ -16,7 +16,6 @@ export function DailyRequestStats() {
   const isLoading = isStatsLoading || isSettingsLoading;
 
   const currencyCode = generalSettings?.currencyCode || 'USD';
-  const timezone = generalSettings?.timezone || 'UTC';
   const locale = i18n.language.startsWith('zh') ? 'zh-CN' : 'en-US';
 
   const formatCurrency = useCallback(
@@ -62,14 +61,13 @@ export function DailyRequestStats() {
   // Transform data for the chart
   const chartData =
     dailyStats?.map((stat) => {
-      // Parse YYYY-MM-DD as local date to avoid UTC interpretation
       const [year, month, day] = stat.date.split('-').map(Number);
-      const date = new Date(year, month - 1, day);
+      const date = new Date(Date.UTC(year, month - 1, day));
       return {
         name: date.toLocaleDateString(locale, {
           month: '2-digit',
           day: '2-digit',
-          timeZone: timezone,
+          timeZone: 'UTC',
         }),
         requests: stat.count,
         tokens: stat.tokens,


### PR DESCRIPTION
## Bug: 仪表盘每日趋势图 X 轴日期偏移

### 问题描述

仪表盘每日趋势图的 X 轴日期标签在浏览器时区与系统设置时区不一致时会出现偏移，导致数据显示在错误的日期下。

### 根因

前端代码将后端返回的 `YYYY-MM-DD` 字符串转成 `Date` 对象时，使用了浏览器本地时区：

```javascript
const date = new Date(year, month - 1, day); // 浏览器时区
date.toLocaleDateString(locale, { timeZone: timezone }) // 系统时区
```

### 复现示例

环境：浏览器 UTC+8，系统时区设为 UTC

用户在 `2026-07-10 22:00:00 UTC+8`（即 `2026-07-10 14:00:00 UTC`）发了一个请求，后端存储 `created_at = 2026-07-10 14:00:00 UTC`。

后端 GROUP BY（系统时区 UTC，偏移 0 秒）：
`datetime('2026-07-10 14:00:00', '+0秒') = 2026-07-10`

后端返回 `{ date: "2026-07-10", count: 1 }` ✅ 正确

前端旧代码：
`new Date(2026, 6, 10)` 浏览器 UTC+8 → `2026-07-09T16:00:00Z`
`.toLocaleDateString({ timeZone: 'UTC' })` → `"07/09"` ❌ 偏移到了 7.9

前端修复后：
`new Date(Date.UTC(2026, 6, 10))` → `2026-07-10T00:00:00Z`
`.toLocaleDateString({ timeZone: 'UTC' })` → `"07/10"` ✅

### 影响范围

- 仅影响每日趋势图 X 轴日期标签和悬浮提示
- 不影响实际数据值（Token 数量、请求数、成本）
- 不影响其他图表（性能分析图表已使用 `Date.UTC()` 方式，无此问题）

### 修复方案

使用 `Date.UTC()` 创建 UTC 时间对象，与 `timeZone: 'UTC'` 配合，确保不受浏览器时区影响：

`const date = new Date(Date.UTC(year, month - 1, day));`
`date.toLocaleDateString(locale, { timeZone: 'UTC' })`

此方式与 `performance-chart.tsx` 的处理方式一致。

### 验证

| 浏览器时区 | 系统时区 | 请求时间 | created_at | 后端日期 | 修复前显示 | 修复后显示 |
|-----------|---------|---------|-----------|---------|-----------|-----------|
| UTC+8 | UTC | 7.10 22:00 UTC+8 | 7.10 14:00 UTC | 07-10 | 07/09 ❌ | 07/10 ✅ |
| UTC+8 | UTC+8 | 7.10 22:00 UTC+8 | 7.10 14:00 UTC | 07-10 | 07/10 ✅ | 07/10 ✅ |
| UTC+8 | UTC | 7.10 03:00 UTC+8 | 7.09 19:00 UTC | 07-09 | 07/08 ❌ | 07/09 ✅ |
| UTC+8 | UTC+8 | 7.10 03:00 UTC+8 | 7.09 19:00 UTC | 07-10 | 07/10 ✅ | 07/10 ✅ |
