### PR TITLE
feat: display last name before first name in sidebar for Chinese locale

### DIFF
--- a/frontend/src/sidebar.ts
+++ b/frontend/src/sidebar.ts
@@ -22,7 +22,7 @@ import { useMe } from '@/features/auth/data/auth';
 import { type SidebarData, type NavGroup, type NavLink } from './components/layout/types';
 
 export function useSidebarData(): SidebarData {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user: authUser } = useAuthStore((state) => state.auth);
   const { data: meData } = useMe();
   const { filterNavGroups } = useRoutePermissions();
@@ -33,7 +33,9 @@ export function useSidebarData(): SidebarData {
   // Generate user initials for avatar
   const getInitials = (firstName?: string, lastName?: string, email?: string) => {
     if (firstName && lastName) {
-      return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+      const isZh = i18n.language?.startsWith('zh');
+      const [first, second] = isZh ? [lastName, firstName] : [firstName, lastName];
+      return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
     }
     if (firstName) {
       return firstName.slice(0, 2).toUpperCase();
@@ -47,7 +49,8 @@ export function useSidebarData(): SidebarData {
   // Generate user display name
   const getDisplayName = (firstName?: string, lastName?: string, email?: string) => {
     if (firstName && lastName) {
-      return `${firstName} ${lastName}`;
+      const isZh = i18n.language?.startsWith('zh');
+      return isZh ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
     }
     if (firstName) {
       return firstName;


### PR DESCRIPTION
## 摘要
- 中文环境下，侧边栏头像缩写和显示名称改为姓在前、名在后，符合中文命名习惯
- 使用 `i18n.language?.startsWith('zh')` 兼容 `zh-CN`、`zh-TW` 等中文区域变体