### PR TITLE
fix(apikeys): avoid double-counting cached and reasoning tokens in total

### DIFF
--- a/frontend/src/features/apikeys/components/api-key-token-chart-dialog.tsx
+++ b/frontend/src/features/apikeys/components/api-key-token-chart-dialog.tsx
@@ -70,7 +70,7 @@ export function ApiKeyTokenChartDialog({ apiKey, open, onOpenChange }: ApiKeyTok
   );
 
   const stat = usageStats?.[0];
-  const totalTokens = stat ? stat.inputTokens + stat.outputTokens + stat.cachedTokens + stat.reasoningTokens : 0;
+  const totalTokens = stat ? stat.inputTokens + stat.outputTokens : 0;
   const hasTopModels = stat && stat.topModels && stat.topModels.length > 0;
 
   return (
@@ -153,7 +153,7 @@ export function ApiKeyTokenChartDialog({ apiKey, open, onOpenChange }: ApiKeyTok
                   <h3 className="mb-3 text-sm font-medium">{t('apikeys.tokenUsageChart.topModels')}</h3>
                   <div className="space-y-4">
                     {stat.topModels.map((model, index) => {
-                      const modelTotal = model.inputTokens + model.outputTokens + model.cachedTokens + model.reasoningTokens;
+                      const modelTotal = model.inputTokens + model.outputTokens;
                       return (
                         <div key={model.modelId} className="rounded-lg border">
                           <div className="bg-muted/30 px-4 py-2">

--- a/frontend/src/features/apikeys/components/api-key-token-chart-dialog.tsx
+++ b/frontend/src/features/apikeys/components/api-key-token-chart-dialog.tsx
@@ -124,17 +124,17 @@ export function ApiKeyTokenChartDialog({ apiKey, open, onOpenChange }: ApiKeyTok
                         </TableCell>
                       </TableRow>
                       <TableRow>
-                        <TableCell className="font-medium">{t('apikeys.columns.cachedTokens')}</TableCell>
+                        <TableCell className="font-medium">{t('apikeys.tokenUsageChart.cacheHitRate')}</TableCell>
                         <TableCell className="text-center tabular-nums">{formatNumber(stat.cachedTokens)}</TableCell>
                         <TableCell className="text-center tabular-nums">
-                          {pct(stat.cachedTokens, totalTokens)}%
+                          {pct(stat.cachedTokens, stat.inputTokens)}%
                         </TableCell>
                       </TableRow>
                       <TableRow>
-                        <TableCell className="font-medium">{t('apikeys.columns.reasoningTokens')}</TableCell>
+                        <TableCell className="font-medium">{t('apikeys.tokenUsageChart.reasoningRatio')}</TableCell>
                         <TableCell className="text-center tabular-nums">{formatNumber(stat.reasoningTokens)}</TableCell>
                         <TableCell className="text-center tabular-nums">
-                          {pct(stat.reasoningTokens, totalTokens)}%
+                          {pct(stat.reasoningTokens, stat.outputTokens)}%
                         </TableCell>
                       </TableRow>
                       <TableRow className="bg-muted/50 font-semibold">
@@ -184,17 +184,17 @@ export function ApiKeyTokenChartDialog({ apiKey, open, onOpenChange }: ApiKeyTok
                                   </TableCell>
                                 </TableRow>
                                 <TableRow>
-                                  <TableCell className="font-medium whitespace-nowrap">{t('apikeys.columns.cachedTokens')}</TableCell>
+                                  <TableCell className="font-medium whitespace-nowrap">{t('apikeys.tokenUsageChart.cacheHitRate')}</TableCell>
                                   <TableCell className="text-center tabular-nums">{formatNumber(model.cachedTokens)}</TableCell>
                                   <TableCell className="text-center tabular-nums whitespace-nowrap">
-                                    {pct(model.cachedTokens, modelTotal)}%
+                                    {pct(model.cachedTokens, model.inputTokens)}%
                                   </TableCell>
                                 </TableRow>
                                 <TableRow>
-                                  <TableCell className="font-medium whitespace-nowrap">{t('apikeys.columns.reasoningTokens')}</TableCell>
+                                  <TableCell className="font-medium whitespace-nowrap">{t('apikeys.tokenUsageChart.reasoningRatio')}</TableCell>
                                   <TableCell className="text-center tabular-nums">{formatNumber(model.reasoningTokens)}</TableCell>
                                   <TableCell className="text-center tabular-nums whitespace-nowrap">
-                                    {pct(model.reasoningTokens, modelTotal)}%
+                                    {pct(model.reasoningTokens, model.outputTokens)}%
                                   </TableCell>
                                 </TableRow>
                               </TableBody>

--- a/frontend/src/locales/en/apikeys.json
+++ b/frontend/src/locales/en/apikeys.json
@@ -35,6 +35,8 @@
   "apikeys.tokenUsageChart.overallUsage": "Overall Usage",
   "apikeys.tokenUsageChart.topModels": "Top 3 Models Usage",
   "apikeys.tokenUsageChart.totalTokens": "Total Tokens",
+  "apikeys.tokenUsageChart.cacheHitRate": "Cache Hit Rate",
+  "apikeys.tokenUsageChart.reasoningRatio": "Reasoning Ratio",
   "apikeys.dialogs.create.title": "Create API Key",
   "apikeys.dialogs.create.description": "Create a new API Key for system access.",
   "apikeys.dialogs.edit.title": "Edit API Key",

--- a/frontend/src/locales/zh-CN/apikeys.json
+++ b/frontend/src/locales/zh-CN/apikeys.json
@@ -35,6 +35,8 @@
   "apikeys.tokenUsageChart.overallUsage": "总体使用情况",
   "apikeys.tokenUsageChart.topModels": "Top 3 模型使用情况",
   "apikeys.tokenUsageChart.totalTokens": "总 Token 数",
+  "apikeys.tokenUsageChart.cacheHitRate": "缓存命中率",
+  "apikeys.tokenUsageChart.reasoningRatio": "推理占比",
   "apikeys.dialogs.create.title": "创建 API Key",
   "apikeys.dialogs.create.description": "创建一个新的 API Key 用于访问系统。",
   "apikeys.dialogs.edit.title": "编辑 API Key",


### PR DESCRIPTION
## Summary

修复 API 密钥 Token 使用统计对话框中，总计重复计算以及缓存/推理占比不正确的问题。

## Problem

1. **总计重复计算**：`totalTokens` 将四个分类直接相加，但 `cachedTokens` 是 `inputTokens` 的子集，`reasoningTokens` 是 `outputTokens` 的子集，导致总计虚高。
2. **缓存/推理百分比无意义**：缓存和推理的使用 `% of total` 作为分母，叠加导致百分比和超过 100%。

## Fix

1. **总计计算**：改为 `totalTokens = inputTokens + outputTokens`
2. **缓存行**：标签改为「缓存命中率 / Cache Hit Rate」，百分比改为 `cached / input × 100`
3. **推理行**：标签改为「推理占比 / Reasoning Ratio」，百分比改为 `reasoning / output × 100`

## Changes

- `frontend/src/features/apikeys/components/api-key-token-chart-dialog.tsx`: 修改 total、缓存、推理的行标签和百分比计算
- `frontend/src/locales/zh-CN/apikeys.json`: 新增「缓存命中率」「推理占比」
- `frontend/src/locales/en/apikeys.json`: 新增「Cache Hit Rate」「Reasoning Ratio」