### PR TITLE
fix(anthropic): synthesize terminal stream events when upstream omits finish_reason

### DIFF
--- a/llm/transformer/anthropic/inbound_convert.go
+++ b/llm/transformer/anthropic/inbound_convert.go
@@ -691,6 +691,14 @@ func convertToAnthropicResponse(chatResp *llm.Response) *Message {
 			default:
 				resp.StopReason = choice.FinishReason
 			}
+		} else {
+			stopReason := "end_turn"
+			if lo.ContainsBy(resp.Content, func(block MessageContentBlock) bool {
+				return block.Type == "tool_use"
+			}) {
+				stopReason = "tool_use"
+			}
+			resp.StopReason = &stopReason
 		}
 	}
 

--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -391,8 +391,12 @@ func (s *anthropicInboundStream) Next() bool {
 
 		if s.stopReason == nil {
 			stopReason := "end_turn"
-			if len(s.toolCalls) > 0 {
-				stopReason = "tool_use"
+			for _, toolCall := range s.toolCalls {
+				anthropicType := getAnthropicType(toolCall.TransformerMetadata)
+				if anthropicType == "" || anthropicType == "tool_use" {
+					stopReason = "tool_use"
+					break
+				}
 			}
 			s.stopReason = &stopReason
 		}

--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -46,6 +46,7 @@ type anthropicInboundStream struct {
 	queueIndex                int
 	err                       error
 	stopReason                *string
+	pendingUsage              *Usage
 	// Tool call tracking
 	toolCalls            map[int]*llm.ToolCall // Track tool calls by index
 	currentToolCallIndex int
@@ -289,6 +290,62 @@ func (s *anthropicInboundStream) closeThinkingBlock() error {
 	return nil
 }
 
+func (s *anthropicInboundStream) closeOpenContentBlocks() error {
+	if err := s.closeThinkingBlock(); err != nil {
+		return fmt.Errorf("failed to close thinking block: %w", err)
+	}
+
+	if s.hasTextContentStarted {
+		if err := s.flushPendingTextCitations(); err != nil {
+			return fmt.Errorf("failed to flush text citations: %w", err)
+		}
+
+		s.hasTextContentStarted = false
+
+		if err := s.enqueEvent(&StreamEvent{
+			Type:  "content_block_stop",
+			Index: &s.contentIndex,
+		}); err != nil {
+			return fmt.Errorf("failed to enqueue content_block_stop event: %w", err)
+		}
+
+		s.contentIndex += 1
+	}
+
+	if s.hasToolContentStarted {
+		if err := s.closeToolBlock(); err != nil {
+			return fmt.Errorf("failed to close tool block: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *anthropicInboundStream) enqueueTerminalEvents() error {
+	streamEvent := StreamEvent{
+		Type:  "message_delta",
+		Usage: s.pendingUsage,
+	}
+
+	if s.stopReason != nil {
+		streamEvent.Delta = &StreamDelta{
+			StopReason: s.stopReason,
+		}
+	}
+
+	if err := s.enqueEvent(&streamEvent); err != nil {
+		return fmt.Errorf("failed to enqueue message_delta event: %w", err)
+	}
+
+	if err := s.enqueEvent(&StreamEvent{Type: "message_stop"}); err != nil {
+		return fmt.Errorf("failed to enqueue message_stop event: %w", err)
+	}
+
+	s.messageStoped = true
+
+	return nil
+}
+
 func (s *anthropicInboundStream) enqueEvent(ev *StreamEvent) error {
 	// Some providers have a bug that generates duplicate "content_block_stop" events. This check ignores the duplicate to ensure compatibility.
 	if s.lastEventType == "content_block_stop" && ev.Type == "content_block_stop" {
@@ -323,10 +380,36 @@ func (s *anthropicInboundStream) Next() bool {
 
 	// Try to get the next chunk from source
 	if !s.source.Next() {
-		return false
+		if s.source.Err() != nil || !s.hasStarted || s.messageStoped {
+			return false
+		}
+
+		if err := s.closeOpenContentBlocks(); err != nil {
+			s.err = fmt.Errorf("failed to close content blocks at stream end: %w", err)
+			return false
+		}
+
+		if s.stopReason == nil {
+			stopReason := "end_turn"
+			if len(s.toolCalls) > 0 {
+				stopReason = "tool_use"
+			}
+			s.stopReason = &stopReason
+		}
+
+		if err := s.enqueueTerminalEvents(); err != nil {
+			s.err = fmt.Errorf("failed to finalize message at stream end: %w", err)
+			return false
+		}
+
+		return s.Next()
 	}
 
 	chunk := s.source.Current()
+	if chunk != nil && chunk.Usage != nil {
+		s.pendingUsage = convertToAnthropicUsage(chunk.Usage)
+	}
+
 	if chunk == nil {
 		return s.Next() // Try next chunk
 	}
@@ -865,37 +948,11 @@ func (s *anthropicInboundStream) Next() bool {
 	}
 
 	if chunk.Usage != nil && s.hasFinished && !s.messageStoped {
-		// Usage-only chunk after finish_reason - generate message_delta with both stop reason and usage
-		streamEvent := StreamEvent{
-			Type: "message_delta",
-		}
-
-		if s.stopReason != nil {
-			streamEvent.Delta = &StreamDelta{
-				StopReason: s.stopReason,
-			}
-		}
-
-		streamEvent.Usage = convertToAnthropicUsage(chunk.Usage)
-
-		err := s.enqueEvent(&streamEvent)
-		if err != nil {
-			s.err = fmt.Errorf("failed to enqueue message_delta event: %w", err)
+		// Usage-only chunk after finish_reason - generate message_delta with both stop reason and usage.
+		if err := s.enqueueTerminalEvents(); err != nil {
+			s.err = err
 			return false
 		}
-
-		// Generate message_stop
-		stopEvent := StreamEvent{
-			Type: "message_stop",
-		}
-
-		err = s.enqueEvent(&stopEvent)
-		if err != nil {
-			s.err = fmt.Errorf("failed to enqueue message_stop event: %w", err)
-			return false
-		}
-
-		s.messageStoped = true
 	}
 
 	// Continue to the next event.

--- a/llm/transformer/anthropic/inbound_stream_test.go
+++ b/llm/transformer/anthropic/inbound_stream_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,6 +15,205 @@ import (
 	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
+
+type failingResponseStream struct {
+	items []*llm.Response
+	index int
+	err   error
+}
+
+func (s *failingResponseStream) Next() bool {
+	return s.index < len(s.items)
+}
+
+func (s *failingResponseStream) Current() *llm.Response {
+	item := s.items[s.index]
+	s.index++
+
+	return item
+}
+
+func (s *failingResponseStream) Err() error {
+	return s.err
+}
+
+func (s *failingResponseStream) Close() error {
+	return nil
+}
+
+func TestInboundStream_FinalizesOnCleanExhaustionWithoutFinishReason(t *testing.T) {
+	transformer := NewInboundTransformer()
+	text := "Done"
+	thinking := "Thinking"
+
+	tests := []struct {
+		name               string
+		delta              *llm.Message
+		usage              *llm.Usage
+		expectedStopReason string
+	}{
+		{
+			name: "tool call",
+			delta: &llm.Message{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{{
+					Index: 0,
+					ID:    "call_123",
+					Type:  "function",
+					Function: llm.FunctionCall{
+						Name:      "search",
+						Arguments: `{"query":"test"}`,
+					},
+				}},
+			},
+			usage: &llm.Usage{
+				CompletionTokens: 7,
+			},
+			expectedStopReason: "tool_use",
+		},
+		{
+			name: "text",
+			delta: &llm.Message{
+				Role: "assistant",
+				Content: llm.MessageContent{
+					Content: &text,
+				},
+			},
+			expectedStopReason: "end_turn",
+		},
+		{
+			name: "thinking",
+			delta: &llm.Message{
+				Role:             "assistant",
+				ReasoningContent: &thinking,
+			},
+			expectedStopReason: "end_turn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := []*llm.Response{
+				{
+					ID:     "msg_missing_finish_reason",
+					Object: "chat.completion.chunk",
+					Model:  "claude-sonnet-4-6",
+					Choices: []llm.Choice{{
+						Index: 0,
+						Delta: tt.delta,
+					}},
+				},
+				{
+					ID:      "msg_missing_finish_reason",
+					Object:  "chat.completion.chunk",
+					Model:   "claude-sonnet-4-6",
+					Choices: []llm.Choice{{Index: 0}},
+					Usage:   tt.usage,
+				},
+			}
+
+			events := collectInboundStreamEvents(t, transformer, input)
+			require.GreaterOrEqual(t, len(events), 3)
+
+			terminalEvents := events[len(events)-3:]
+			require.Equal(t, "content_block_stop", terminalEvents[0].Type)
+			require.Equal(t, "message_delta", terminalEvents[1].Type)
+			require.NotNil(t, terminalEvents[1].Delta)
+			require.Equal(t, tt.expectedStopReason, *terminalEvents[1].Delta.StopReason)
+			if tt.usage == nil {
+				require.Nil(t, terminalEvents[1].Usage)
+			} else {
+				require.NotNil(t, terminalEvents[1].Usage)
+				require.Equal(t, int64(7), terminalEvents[1].Usage.OutputTokens)
+			}
+			require.Equal(t, "message_stop", terminalEvents[2].Type)
+		})
+	}
+}
+
+func TestInboundStream_DoesNotDuplicateTerminalEvents(t *testing.T) {
+	transformer := NewInboundTransformer()
+	text := "Done"
+	finishReason := "stop"
+
+	events := collectInboundStreamEvents(t, transformer, []*llm.Response{
+		{
+			ID:     "msg_with_finish_reason",
+			Object: "chat.completion.chunk",
+			Model:  "claude-sonnet-4-6",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{
+					Role: "assistant",
+					Content: llm.MessageContent{
+						Content: &text,
+					},
+				},
+			}},
+		},
+		{
+			ID:     "msg_with_finish_reason",
+			Object: "chat.completion.chunk",
+			Model:  "claude-sonnet-4-6",
+			Choices: []llm.Choice{{
+				Index:        0,
+				FinishReason: &finishReason,
+			}},
+			Usage: &llm.Usage{},
+		},
+	})
+
+	require.Equal(t, 1, countStreamEvents(events, "message_delta"))
+	require.Equal(t, 1, countStreamEvents(events, "message_stop"))
+}
+
+func TestInboundStream_DoesNotFinalizeOnSourceError(t *testing.T) {
+	transformer := NewInboundTransformer()
+	text := "Partial"
+	sourceErr := errors.New("upstream stream failed")
+	source := &failingResponseStream{
+		items: []*llm.Response{{
+			ID:     "msg_stream_error",
+			Object: "chat.completion.chunk",
+			Model:  "claude-sonnet-4-6",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{
+					Role: "assistant",
+					Content: llm.MessageContent{
+						Content: &text,
+					},
+				},
+			}},
+		}},
+		err: sourceErr,
+	}
+
+	stream, err := transformer.TransformStream(t.Context(), source)
+	require.NoError(t, err)
+
+	var events []StreamEvent
+	for stream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(stream.Current().Data, &event))
+		events = append(events, event)
+	}
+
+	require.ErrorIs(t, stream.Err(), sourceErr)
+	require.Zero(t, countStreamEvents(events, "message_delta"))
+	require.Zero(t, countStreamEvents(events, "message_stop"))
+}
+
+func countStreamEvents(events []StreamEvent, eventType string) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType {
+			count++
+		}
+	}
+
+	return count
+}
 
 func TestInboundStream_EmitsCitationsDeltaBeforeContentBlockStop(t *testing.T) {
 	transformer := NewInboundTransformer()

--- a/llm/transformer/anthropic/inbound_stream_test.go
+++ b/llm/transformer/anthropic/inbound_stream_test.go
@@ -72,6 +72,44 @@ func TestInboundStream_FinalizesOnCleanExhaustionWithoutFinishReason(t *testing.
 			expectedStopReason: "tool_use",
 		},
 		{
+			name: "server tool call",
+			delta: &llm.Message{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{{
+					Index: 0,
+					ID:    "server_tool_123",
+					Type:  "function",
+					Function: llm.FunctionCall{
+						Name:      "web_search",
+						Arguments: `{"query":"test"}`,
+					},
+					TransformerMetadata: map[string]any{
+						TransformerMetadataKeyAnthropicType: "server_tool_use",
+					},
+				}},
+			},
+			expectedStopReason: "end_turn",
+		},
+		{
+			name: "mcp tool call",
+			delta: &llm.Message{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{{
+					Index: 0,
+					ID:    "mcp_tool_123",
+					Type:  "function",
+					Function: llm.FunctionCall{
+						Name:      "mcp_search",
+						Arguments: `{"query":"test"}`,
+					},
+					TransformerMetadata: map[string]any{
+						TransformerMetadataKeyAnthropicType: "mcp_tool_use",
+					},
+				}},
+			},
+			expectedStopReason: "end_turn",
+		},
+		{
 			name: "text",
 			delta: &llm.Message{
 				Role: "assistant",

--- a/llm/transformer/anthropic/inbound_test.go
+++ b/llm/transformer/anthropic/inbound_test.go
@@ -2178,6 +2178,63 @@ func TestInboundTransformer_TransformResponse_EdgeCases(t *testing.T) {
 			},
 		},
 		{
+			name: "response with tool call and no finish reason",
+			chatResp: &llm.Response{
+				ID:      "msg_tool_without_finish_reason",
+				Object:  "chat.completion",
+				Model:   "claude-3-sonnet-20240229",
+				Created: 1234567890,
+				Choices: []llm.Choice{{
+					Index: 0,
+					Message: &llm.Message{
+						Role: "assistant",
+						ToolCalls: []llm.ToolCall{{
+							ID:   "call_without_finish_reason",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "search",
+								Arguments: `{"query":"test"}`,
+							},
+						}},
+					},
+				}},
+			},
+			expectError: false,
+			validate: func(t *testing.T, resp *Message) {
+				t.Helper()
+				require.Len(t, resp.Content, 1)
+				require.Equal(t, "tool_use", resp.Content[0].Type)
+				require.NotNil(t, resp.StopReason)
+				require.Equal(t, "tool_use", *resp.StopReason)
+			},
+		},
+		{
+			name: "response with text and no finish reason",
+			chatResp: &llm.Response{
+				ID:      "msg_text_without_finish_reason",
+				Object:  "chat.completion",
+				Model:   "claude-3-sonnet-20240229",
+				Created: 1234567890,
+				Choices: []llm.Choice{{
+					Index: 0,
+					Message: &llm.Message{
+						Role: "assistant",
+						Content: llm.MessageContent{
+							Content: lo.ToPtr("Done"),
+						},
+					},
+				}},
+			},
+			expectError: false,
+			validate: func(t *testing.T, resp *Message) {
+				t.Helper()
+				require.Len(t, resp.Content, 1)
+				require.Equal(t, "text", resp.Content[0].Type)
+				require.NotNil(t, resp.StopReason)
+				require.Equal(t, "end_turn", *resp.StopReason)
+			},
+		},
+		{
 			name: "response with empty thinking content",
 			chatResp: &llm.Response{
 				ID:      "msg_empty_thinking",


### PR DESCRIPTION
## Summary

When the Anthropic inbound transformer proxies an OpenAI-shaped upstream that ends a stream without ever sending a `finish_reason`, AxonHub never emitted the terminal `message_delta` / `message_stop` events. The Anthropic SSE stream was left unterminated, so downstream Anthropic-protocol clients treated the turn as aborted. This synthesizes the terminal events on clean stream exhaustion so every proxied turn closes properly.

## Why

The transformer only produced the closing `message_delta` (which carries `stop_reason`) and `message_stop` when the upstream supplied a `finish_reason`. Several OpenAI-compatible providers simply stop sending chunks instead, and in that path the stream ended mid-message. Because the Anthropic protocol requires an explicit terminal frame, a downstream Anthropic-protocol client waits for events that never arrive and gives up on the response.

On clean exhaustion of the source (no source error, and the message was started but not already stopped), the fix now closes any open thinking / text / tool content blocks, defaults `stop_reason` to `end_turn`, and emits `message_delta` + `message_stop`. When the turn produced client-executed tool calls the stop reason is `tool_use` instead; server-executed blocks (`server_tool_use` / `mcp_tool_use`) are deliberately excluded from that inference so they still close as `end_turn`, matching the non-streaming conversion path. Guards on `source.Err()`, `hasStarted`, and `messageStoped` ensure real upstream errors are preserved and terminal events are never duplicated. The non-streaming conversion path gets the same `stop_reason` default for consistency.

## Testing

`go test ./transformer/anthropic` (from the `llm` module) passes. New cases in `inbound_stream_test.go` and `inbound_test.go` cover: a text stream that exhausts without a finish reason (terminal events synthesized, `stop_reason: end_turn`), a client tool-call stream (`stop_reason: tool_use`), a server-side tool block that still closes as `end_turn`, preservation of an upstream error instead of a synthetic close, and no duplicate terminal events when the upstream already sent a finish reason.

Closes #1924
