### PR TITLE
feat: add IBM model developer with Granite models

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -16,6 +16,7 @@ export const DEVELOPER_IDS = [
   'bytedance',
   'stepfun',
   'meta',
+  'ibm',
 ];
 
 export const DEVELOPER_ICONS: Record<string, string> = {
@@ -36,4 +37,5 @@ export const DEVELOPER_ICONS: Record<string, string> = {
   bytedance: 'Doubao',
   stepfun: 'Stepfun',
   meta: 'Meta',
+  ibm: 'IBM',
 };

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -305,6 +305,42 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
+	// Aggregate IBM Granite models from all providers
+	if (allowedIds.includes("ibm")) {
+		const graniteModels = [];
+		const seen = new Set();
+
+		for (const provider of Object.values(data.providers)) {
+			for (const model of provider.models || []) {
+				const id = model.id?.toLowerCase() || "";
+				if (seen.has(id)) continue;
+				if (!id.includes("granite") && !id.includes("ibm")) continue;
+
+				// Skip embedding models
+				if (id.includes("embedding")) continue;
+				// Skip guardian/guardrail models
+				if (id.includes("guardian")) continue;
+				// Skip Cloudflare-hosted duplicates (@cf/ or workers-ai/ prefixes)
+				if (id.startsWith("@cf/") || id.includes("workers-ai/")) continue;
+
+				seen.add(id);
+				graniteModels.push(model);
+			}
+		}
+
+		if (graniteModels.length > 0) {
+			filtered.ibm = {
+				id: "ibm",
+				name: "IBM",
+				display_name: "IBM",
+				models: graniteModels,
+			};
+			console.log(
+				`Aggregated ${graniteModels.length} Granite models to ibm developer`,
+			);
+		}
+	}
+
 	// Map doubao channel's doubao models to bytedance developer
 	if (allowedIds.includes("bytedance") && data.providers.doubao) {
 		const doubaoProvider = data.providers.doubao;


### PR DESCRIPTION
## Summary

Add IBM as a new model developer, aggregating Granite models from multiple providers into a unified IBM developer profile.

## Changes

- **`frontend/src/features/models/data/constants.ts`** — Register `ibm` in `DEVELOPER_IDS` and add corresponding icon entry.
- **`frontend/src/features/models/data/providers.json`** — Add IBM Granite model entries aggregated from providers across the ecosystem.
- **`scripts/sync/sync-model-developers.js`** — Add sync logic to aggregate IBM Granite models from all providers, deduplicating by unique ID.
- **`internal/pkg/xurl/dataurl_compact_test.go`** — Add 146 lines of test coverage for URL compact encoding.
- **`internal/server/biz/request_compact_test.go`** — Add 198 lines of test coverage for request compact encoding.