### PR TITLE
feat: add IBM model developer with Granite models

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -16,6 +16,7 @@ export const DEVELOPER_IDS = [
   'bytedance',
   'stepfun',
   'meta',
+  'ibm',
 ];
 
 export const DEVELOPER_ICONS: Record<string, string> = {
@@ -36,4 +37,5 @@ export const DEVELOPER_ICONS: Record<string, string> = {
   bytedance: 'Doubao',
   stepfun: 'Stepfun',
   meta: 'Meta',
+  ibm: 'IBM',
 };

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -305,6 +305,42 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
+	// Aggregate IBM Granite models from all providers
+	if (allowedIds.includes("ibm")) {
+		const graniteModels = [];
+		const seen = new Set();
+
+		for (const provider of Object.values(data.providers)) {
+			for (const model of provider.models || []) {
+				const id = model.id?.toLowerCase() || "";
+				if (seen.has(id)) continue;
+				if (!id.includes("granite") && !id.includes("ibm")) continue;
+
+				// Skip embedding models
+				if (id.includes("embedding")) continue;
+				// Skip guardian/guardrail models
+				if (id.includes("guardian")) continue;
+				// Skip Cloudflare-hosted duplicates (@cf/ or workers-ai/ prefixes)
+				if (id.startsWith("@cf/") || id.includes("workers-ai/")) continue;
+
+				seen.add(id);
+				graniteModels.push(model);
+			}
+		}
+
+		if (graniteModels.length > 0) {
+			filtered.ibm = {
+				id: "ibm",
+				name: "IBM",
+				display_name: "IBM",
+				models: graniteModels,
+			};
+			console.log(
+				`Aggregated ${graniteModels.length} Granite models to ibm developer`,
+			);
+		}
+	}
+
 	// Map doubao channel's doubao models to bytedance developer
 	if (allowedIds.includes("bytedance") && data.providers.doubao) {
 		const doubaoProvider = data.providers.doubao;


### PR DESCRIPTION
## Summary

Add IBM as a supported model developer in the model data sync pipeline. The sync script aggregates Granite models from all upstream providers, filtering out embedding models, guardrails, and Cloudflare duplicates.

## Key Changes

- **constants.ts**: Added `ibm` to `DEVELOPER_IDS` and `DEVELOPER_ICONS`
- **sync-model-developers.js**: Added aggregation block that pulls Granite/IBM models from all providers, excluding embeddings, guardians, and `@cf/`/`workers-ai/` duplicates

## Risks

- New developer entry means IBM will appear as a selectable developer in the UI with no channel config until models are manually mapped