### PR TITLE
feat(traces): add span statistics to trace detail page and filter pop…

### DIFF
--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -2,13 +2,15 @@ import { useMemo, useState, useEffect } from 'react';
 import { format } from 'date-fns';
 import { useParams, useNavigate } from '@tanstack/react-router';
 import { zhCN, enUS } from 'date-fns/locale';
-import { ArrowLeft, FileText, Activity, RefreshCw, List, GitBranch, Waypoints, Maximize2, X } from 'lucide-react';
+import { ArrowLeft, FileText, Activity, RefreshCw, List, GitBranch, Waypoints, Maximize2, X, Wrench, MessageSquare, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn, extractNumberID } from '@/lib/utils';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Header } from '@/components/layout/header';
@@ -43,6 +45,35 @@ export default function TraceDetailPage() {
     if (!trace?.rawRootSegment) return null;
     return parseRawRootSegment(trace.rawRootSegment);
   }, [trace]);
+
+  // Compute span statistics for overview cards
+  const spanStats = useMemo(() => {
+    if (!effectiveRootSegment) return { userQueryCount: 0, toolCallCount: 0, toolDetails: {} as Record<string, number> };
+
+    let userQueryCount = 0;
+    let toolCallCount = 0;
+    const toolDetails: Record<string, number> = {};
+
+    const traverse = (segment: Segment) => {
+      for (const span of [...(segment.requestSpans ?? []), ...(segment.responseSpans ?? [])]) {
+        if (span.type === 'user_query') {
+          userQueryCount++;
+        } else if (span.type === 'tool_use') {
+          toolCallCount++;
+          const toolName = span.value?.toolUse?.name;
+          if (toolName) {
+            toolDetails[toolName] = (toolDetails[toolName] ?? 0) + 1;
+          }
+        }
+      }
+      for (const child of segment.children ?? []) {
+        traverse(child);
+      }
+    };
+
+    traverse(effectiveRootSegment);
+    return { userQueryCount, toolCallCount, toolDetails };
+  }, [effectiveRootSegment]);
 
   // Auto-select first span when trace loads
   useEffect(() => {
@@ -201,6 +232,54 @@ export default function TraceDetailPage() {
                       <p className='text-muted-foreground text-base sm:text-lg font-semibold'>-</p>
                     )}
                   </div>
+                </div>
+              </div>
+            )}
+
+            {/* Top: Span Statistics */}
+            {!isFullscreen && (spanStats.userQueryCount > 0 || spanStats.toolCallCount > 0) && (
+              <div className='px-4 sm:px-6 py-3 border-b bg-background'>
+                <div className='grid grid-cols-2 gap-3 sm:gap-4'>
+                  {spanStats.userQueryCount > 0 && (
+                    <div className='bg-muted/30 rounded-lg px-3 py-2'>
+                      <div className='flex items-center gap-2'>
+                        <MessageSquare className='text-muted-foreground h-4 w-4' />
+                        <p className='text-muted-foreground text-xs sm:text-sm'>{t('traces.timeline.spanTypes.userQuery')}</p>
+                      </div>
+                      <p className='text-base sm:text-lg font-semibold mt-1'>{spanStats.userQueryCount}</p>
+                    </div>
+                  )}
+                  {spanStats.toolCallCount > 0 && (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <div className='bg-muted/30 rounded-lg px-3 py-2 cursor-pointer hover:bg-muted/50 transition-colors'>
+                          <div className='flex items-center gap-2'>
+                            <Wrench className='text-muted-foreground h-4 w-4' />
+                            <p className='text-muted-foreground text-xs sm:text-sm'>{t('traces.timeline.spanTypes.toolUse')}</p>
+                            {Object.keys(spanStats.toolDetails).length > 0 && (
+                              <ChevronDown className='text-muted-foreground h-3 w-3' />
+                            )}
+                          </div>
+                          <p className='text-base sm:text-lg font-semibold mt-1'>{spanStats.toolCallCount}</p>
+                        </div>
+                      </PopoverTrigger>
+                      {Object.keys(spanStats.toolDetails).length > 0 && (
+                        <PopoverContent className='w-64 p-3' align='start'>
+                          <p className='text-sm font-medium mb-2'>{t('traces.detail.spanStats.toolDetails')}</p>
+                          <div className='space-y-1.5'>
+                            {Object.entries(spanStats.toolDetails)
+                              .sort(([, a], [, b]) => b - a)
+                              .map(([name, count]) => (
+                                <div key={name} className='flex items-center justify-between'>
+                                  <span className='text-sm truncate mr-2'>{name}</span>
+                                  <Badge variant='secondary' className='text-xs tabular-nums shrink-0'>{count}</Badge>
+                                </div>
+                              ))}
+                          </div>
+                        </PopoverContent>
+                      )}
+                    </Popover>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/features/traces/components/trace-flat-timeline.tsx
+++ b/frontend/src/features/traces/components/trace-flat-timeline.tsx
@@ -12,7 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { formatDuration } from '../../../utils/format-duration';
 import type { Segment, RequestMetadata, Span } from '../data/schema';
-import { getSpanDisplayLabels, normalizeSpanType } from '../utils/span-display';
+import { getSpanDisplayLabels, getSpanTypeTranslationKey, normalizeSpanType } from '../utils/span-display';
 import { getSpanIcon } from './constant';
 
 type SpanKind = 'request' | 'response';
@@ -498,13 +498,13 @@ export function TraceFlatTimeline({ trace, onSelectSpan, selectedSpanId }: Trace
 
     const flatSegments = flattenSegments(rootNode, earliestStart);
 
-    // Collect all unique span types
-    const allSpanTypes = new Set<string>();
+    // Collect all unique span types with counts
+    const spanTypeCounts = new Map<string, number>();
     flatSegments.forEach((seg) => {
       seg.spans.forEach((span) => {
         if (span.source.type === 'span') {
           const normalizedType = normalizeSpanType(span.source.span.type);
-          allSpanTypes.add(normalizedType);
+          spanTypeCounts.set(normalizedType, (spanTypeCounts.get(normalizedType) ?? 0) + 1);
         }
       });
     });
@@ -541,7 +541,8 @@ export function TraceFlatTimeline({ trace, onSelectSpan, selectedSpanId }: Trace
       totalItems,
       totalTokens,
       totalCachedTokens,
-      allSpanTypes: Array.from(allSpanTypes).sort(),
+      spanTypeCounts,
+      allSpanTypes: Array.from(spanTypeCounts.keys()).sort(),
     };
   }, [trace]);
 
@@ -674,7 +675,7 @@ export function TraceFlatTimeline({ trace, onSelectSpan, selectedSpanId }: Trace
     );
   }
 
-  const { totalDuration, totalItems, totalTokens, totalCachedTokens, allSpanTypes } = timelineData;
+  const { totalDuration, totalItems, totalTokens, totalCachedTokens, spanTypeCounts, allSpanTypes } = timelineData;
   const activeFilterCount = selectedSpanTypes.size;
 
   return (
@@ -762,8 +763,9 @@ export function TraceFlatTimeline({ trace, onSelectSpan, selectedSpanId }: Trace
                             />
                             <SpanIcon className='text-muted-foreground h-4 w-4 flex-shrink-0' />
                             <span className='flex-1 text-sm'>
-                              {t(`traces.timeline.spanTypes.${spanType}`, spanType)}
+                              {t(`traces.timeline.spanTypes.${getSpanTypeTranslationKey(spanType)}`, spanType)}
                             </span>
+                            <span className='text-muted-foreground text-xs tabular-nums'>{spanTypeCounts.get(spanType) ?? 0}</span>
                           </label>
                         );
                       })}

--- a/frontend/src/features/traces/components/trace-tree-view.tsx
+++ b/frontend/src/features/traces/components/trace-tree-view.tsx
@@ -12,7 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { formatDuration } from '../../../utils/format-duration';
 import type { Segment, Span } from '../data/schema';
-import { normalizeSpanType, getSpanDisplayLabels } from '../utils/span-display';
+import { normalizeSpanType, getSpanTypeTranslationKey, getSpanDisplayLabels } from '../utils/span-display';
 import { getSpanIcon } from './constant';
 
 type SpanKind = 'request' | 'response';
@@ -419,10 +419,11 @@ function collectAllNodes(node: TreeNode, result: TreeNode[] = []) {
   return result;
 }
 
-// Collect all span types from the tree
-function collectSpanTypes(node: TreeNode, result: Set<string> = new Set()) {
+// Collect all span types from the tree with counts
+function collectSpanTypes(node: TreeNode, result: Map<string, number> = new Map()): Map<string, number> {
   node.spans.forEach(({ span }) => {
-    result.add(normalizeSpanType(span.type));
+    const key = normalizeSpanType(span.type);
+    result.set(key, (result.get(key) ?? 0) + 1);
   });
   node.children.forEach((child) => collectSpanTypes(child, result));
   return result;
@@ -466,7 +467,8 @@ export function TraceTreeTimeline(props: TraceTreeTimelineProps) {
     return Math.max(timeRange.end - timeRange.start, 1);
   }, [timeRange]);
 
-  const allSpanTypes = useMemo(() => Array.from(collectSpanTypes(treeData)).sort(), [treeData]);
+  const spanTypeCounts = useMemo(() => collectSpanTypes(treeData), [treeData]);
+  const allSpanTypes = useMemo(() => Array.from(spanTypeCounts.keys()).sort(), [spanTypeCounts]);
 
   const filteredTree = useMemo(() => {
     if (selectedSpanTypes.size === 0) return treeData;
@@ -667,7 +669,8 @@ export function TraceTreeTimeline(props: TraceTreeTimelineProps) {
                           >
                             <Checkbox checked={isChecked} onCheckedChange={() => handleToggleSpanType(spanType)} />
                             <SpanIcon className='text-muted-foreground h-4 w-4 flex-shrink-0' />
-                            <span className='flex-1 text-sm'>{t(`traces.timeline.spanTypes.${spanType}`, spanType)}</span>
+                            <span className='flex-1 text-sm'>{t(`traces.timeline.spanTypes.${getSpanTypeTranslationKey(spanType)}`, spanType)}</span>
+                            <span className='text-muted-foreground text-xs tabular-nums'>{spanTypeCounts.get(spanType) ?? 0}</span>
                           </label>
                         );
                       })}

--- a/frontend/src/locales/en/traces.json
+++ b/frontend/src/locales/en/traces.json
@@ -90,5 +90,6 @@
   "traces.detail.viewMode.flat": "Flat",
   "traces.detail.viewMode.flow": "Flow",
   "traces.detail.viewMode.tree": "Tree",
-  "traces.detail.spanDetail": "Span Detail"
+  "traces.detail.spanDetail": "Span Detail",
+  "traces.detail.spanStats.toolDetails": "Tool Details"
 }

--- a/frontend/src/locales/zh-CN/traces.json
+++ b/frontend/src/locales/zh-CN/traces.json
@@ -90,5 +90,6 @@
   "traces.detail.viewMode.flat": "平铺",
   "traces.detail.viewMode.flow": "流程",
   "traces.detail.viewMode.tree": "树形",
-  "traces.detail.spanDetail": "片段详情"
+  "traces.detail.spanDetail": "片段详情",
+  "traces.detail.spanStats.toolDetails": "工具详情"
 }


### PR DESCRIPTION
## 概述

在 Trace 详情页增加片段类型统计功能，方便快速了解请求执行流程中的事件分布。

## 改动内容

**顶部总览新增统计卡片：**
- 用户查询次数（`user_query` span 计数）
- 工具调用次数（`tool_use` span 计数），点击可展开查看每种工具名称及调用次数

**片段类型筛选 popover 增强：**
- Flat 视图和 Tree 视图的筛选弹窗中，每个片段类型右侧标注出现次数
- 修复片段类型名称未翻译的问题（snake_case → camelCase 映射）

## 涉及文件

| 文件 | 说明 |
|------|------|
| `trace-detail-page.tsx` | 顶部新增用户查询和工具调用统计卡片 |
| `trace-flat-timeline.tsx` | 筛选 popover 加数量统计 + 翻译修复 |
| `trace-tree-view.tsx` | 筛选 popover 加数量统计 + 翻译修复 |
| `locales/en/traces.json` | 新增 tool details 翻译 |
| `locales/zh-CN/traces.json` | 新增工具详情翻译 |

## 特性

- 纯前端实现，无需后端改动
- 统计数据从已有的 `rawRootSegment` 客户端遍历计算
- 全屏模式下自动隐藏统计区域
- 中英文翻译支持

## 效果
<img width="2249" height="728" alt="截图 2026-07-13 15-37-28" src="https://github.com/user-attachments/assets/64e608f1-395a-496d-a02e-6f6a6b1d711e" />

