### PR TITLE
fix(provider-quota): use official Cline quota limits

### DIFF
--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -98,9 +98,33 @@ type clineUsageLimitsData struct {
 }
 
 type clineUsageLimit struct {
-	Type        string   `json:"type,omitempty"`
-	PercentUsed *float64 `json:"percentUsed,omitempty"`
-	ResetsAt    string   `json:"resetsAt,omitempty"`
+	Type        string
+	PercentUsed *float64
+	ResetsAt    string
+}
+
+func (l *clineUsageLimit) UnmarshalJSON(data []byte) error {
+	*l = clineUsageLimit{}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil
+	}
+
+	if raw, ok := fields["type"]; ok {
+		_ = json.Unmarshal(raw, &l.Type)
+	}
+	if raw, ok := fields["percentUsed"]; ok {
+		var value *float64
+		if err := json.Unmarshal(raw, &value); err == nil {
+			l.PercentUsed = value
+		}
+	}
+	if raw, ok := fields["resetsAt"]; ok {
+		_ = json.Unmarshal(raw, &l.ResetsAt)
+	}
+
+	return nil
 }
 
 type clineOfficialWindowLimit struct {

--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -195,6 +195,8 @@ func (c *ClineQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Channel) (Qu
 		return QuotaData{}, fmt.Errorf("Cline plans response does not include an active ClinePass threshold")
 	}
 
+	officialLimits, officialMeta := c.fetchUsageLimits(ctx, hc, ch.BaseURL, apiKey)
+
 	items, fetchMeta, err := c.fetchUsageItems(ctx, hc, ch.BaseURL, me.Data.ID, apiKey)
 	if err != nil {
 		return QuotaData{}, err
@@ -208,8 +210,8 @@ func (c *ClineQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Channel) (Qu
 		balance.Data.Balance,
 		items,
 		fetchMeta,
-		nil,
-		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
+		officialLimits,
+		officialMeta,
 	), nil
 }
 
@@ -365,6 +367,19 @@ func selectClinePassThreshold(plans []clinePlan) (clineInferenceCapThreshold, []
 	}
 
 	return selected, summaries, found
+}
+
+func (c *ClineQuotaChecker) fetchUsageLimits(
+	ctx context.Context,
+	hc *httpclient.HttpClient,
+	baseURL string,
+	apiKey string,
+) (map[string]clineOfficialWindowLimit, clineUsageLimitsFetchMeta) {
+	var response clineEnvelope[clineUsageLimitsData]
+	if err := c.getJSON(ctx, hc, baseURL, clineUsageLimitsPath, nil, apiKey, &response); err != nil {
+		return nil, clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable}
+	}
+	return parseClineUsageLimits(response.Data.Limits)
 }
 
 func (c *ClineQuotaChecker) fetchUsageItems(ctx context.Context, hc *httpclient.HttpClient, baseURL, userID, apiKey string) ([]clineUsageItem, clineUsageFetchMeta, error) {

--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -117,13 +117,17 @@ type clineUsageLimitsFetchMeta struct {
 }
 
 type clineWindow struct {
-	key         string
-	duration    time.Duration
-	limitUnits  int64
-	usedUnits   int64
-	creditsUsed int64
-	itemsCount  int
-	nextResetAt *time.Time
+	key            string
+	duration       time.Duration
+	limitUnits     int64
+	usedUnits      int64
+	creditsUsed    int64
+	itemsCount     int
+	usageRatio     *float64
+	costUsageRatio *float64
+	usageSource    string
+	nextResetAt    *time.Time
+	resetSource    string
 }
 
 type clineUsageFetchMeta struct {
@@ -196,7 +200,17 @@ func (c *ClineQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Channel) (Qu
 		return QuotaData{}, err
 	}
 
-	return buildClineQuotaData(c.now(), scope, threshold, planSummaries, balance.Data.Balance, items, fetchMeta), nil
+	return buildClineQuotaData(
+		c.now(),
+		scope,
+		threshold,
+		planSummaries,
+		balance.Data.Balance,
+		items,
+		fetchMeta,
+		nil,
+		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
+	), nil
 }
 
 func (c *ClineQuotaChecker) getJSON(ctx context.Context, hc *httpclient.HttpClient, baseURL, path string, query url.Values, apiKey string, out any) error {
@@ -481,31 +495,37 @@ func clineUsageLimitWindowKey(value string) (string, bool) {
 		return "", false
 	}
 }
-func buildClineQuotaData(now time.Time, scope clineModelScope, threshold clineInferenceCapThreshold, plans []map[string]any, balance *int64, items []clineUsageItem, fetchMeta clineUsageFetchMeta) QuotaData {
+func buildClineQuotaData(
+	now time.Time,
+	scope clineModelScope,
+	threshold clineInferenceCapThreshold,
+	plans []map[string]any,
+	balance *int64,
+	items []clineUsageItem,
+	usageFetchMeta clineUsageFetchMeta,
+	officialLimits map[string]clineOfficialWindowLimit,
+	officialMeta clineUsageLimitsFetchMeta,
+) QuotaData {
 	windows := []clineWindow{
-		buildClineWindow(now, "last5h", 5*time.Hour, threshold.Last5HoursUsageCostUSDPerUser, items),
-		buildClineWindow(now, "last7d", 7*24*time.Hour, threshold.Last7DaysUsageCostUSDPerUser, items),
-		buildClineWindow(now, "last30d", 30*24*time.Hour, threshold.Last30DaysUsageCostUSDPerUser, items),
+		buildClineWindow(now, "last5h", 5*time.Hour, threshold.Last5HoursUsageCostUSDPerUser, items, officialLimits["last5h"]),
+		buildClineWindow(now, "last7d", 7*24*time.Hour, threshold.Last7DaysUsageCostUSDPerUser, items, officialLimits["last7d"]),
+		buildClineWindow(now, "last30d", 30*24*time.Hour, threshold.Last30DaysUsageCostUSDPerUser, items, officialLimits["last30d"]),
 	}
 
 	passStatus := worstClineStatus(windows)
 	status := passStatus
 	statusBasis := "cline_pass_windows"
-
 	if scope != clineModelScopePassOnly && passStatus == "exhausted" {
 		status = "warning"
 		statusBasis = "mixed_pool_pass_exhausted"
 	}
 
-	limits := clineLimitStatuses(windows, scope == clineModelScopePassOnly)
-	nextResetAt := earliestClineWindowReset(windows)
-
 	return QuotaData{
 		Status:       status,
 		ProviderType: clineProviderType,
 		Ready:        IsReadyStatus(status),
-		NextResetAt:  nextResetAt,
-		Limits:       limits,
+		NextResetAt:  earliestClineWindowReset(windows),
+		Limits:       clineLimitStatuses(windows, scope == clineModelScopePassOnly),
 		RawData: map[string]any{
 			"model_scope":  string(scope),
 			"status_basis": statusBasis,
@@ -516,10 +536,11 @@ func buildClineQuotaData(now time.Time, scope clineModelScope, threshold clineIn
 			"plans":        plans,
 			"windows":      clineWindowsRawData(windows),
 			"usage_fetch": map[string]any{
-				"pages":      fetchMeta.Pages,
-				"items_seen": fetchMeta.ItemsSeen,
-				"truncated":  fetchMeta.Truncated,
+				"pages":      usageFetchMeta.Pages,
+				"items_seen": usageFetchMeta.ItemsSeen,
+				"truncated":  usageFetchMeta.Truncated,
 			},
+			"usage_limits_fetch": clineUsageLimitsFetchRawData(officialMeta),
 		},
 	}
 }
@@ -540,8 +561,21 @@ func buildClineDirectOnlyQuota(balance *int64, plans []map[string]any) QuotaData
 	}
 }
 
-func buildClineWindow(now time.Time, key string, duration time.Duration, limit int64, items []clineUsageItem) clineWindow {
-	window := clineWindow{key: key, duration: duration, limitUnits: limit}
+func buildClineWindow(
+	now time.Time,
+	key string,
+	duration time.Duration,
+	limit int64,
+	items []clineUsageItem,
+	official clineOfficialWindowLimit,
+) clineWindow {
+	window := clineWindow{
+		key:         key,
+		duration:    duration,
+		limitUnits:  limit,
+		usageSource: clineWindowSourceUnavailable,
+		resetSource: clineWindowSourceUnavailable,
+	}
 	start := now.Add(-duration)
 	var earliest *time.Time
 
@@ -559,27 +593,43 @@ func buildClineWindow(now time.Time, key string, duration time.Duration, limit i
 		}
 	}
 
+	if window.limitUnits > 0 {
+		costRatio := float64(window.usedUnits) / float64(window.limitUnits)
+		window.costUsageRatio = &costRatio
+		window.usageRatio = &costRatio
+		window.usageSource = clineWindowSourceEstimatedCost
+	}
 	if earliest != nil {
 		resetAt := earliest.Add(duration)
 		window.nextResetAt = &resetAt
+		window.resetSource = clineWindowSourceEstimatedUsage
+	}
+	if official.UsageRatio != nil {
+		ratio := *official.UsageRatio
+		window.usageRatio = &ratio
+		window.usageSource = clineWindowSourceOfficialUsageLimits
+	}
+	if official.NextResetAt != nil {
+		resetAt := *official.NextResetAt
+		window.nextResetAt = &resetAt
+		window.resetSource = clineWindowSourceOfficialUsageLimits
 	}
 
 	return window
 }
 
 func clineWindowStatus(window clineWindow) string {
-	if window.limitUnits <= 0 {
+	if window.usageRatio == nil {
 		return "unknown"
 	}
 
-	ratio := float64(window.usedUnits) / float64(window.limitUnits)
+	ratio := *window.usageRatio
 	if ratio >= 1.0 {
 		return "exhausted"
 	}
 	if ratio >= WarningThresholdRatio {
 		return "warning"
 	}
-
 	return "available"
 }
 
@@ -604,8 +654,8 @@ func clineLimitStatuses(windows []clineWindow, allowExhausted bool) []QuotaLimit
 
 	for _, window := range windows {
 		usageRatio := 0.0
-		if window.limitUnits > 0 {
-			usageRatio = float64(window.usedUnits) / float64(window.limitUnits)
+		if window.usageRatio != nil {
+			usageRatio = *window.usageRatio
 		}
 
 		status := clineWindowStatus(window)
@@ -651,11 +701,16 @@ func clineWindowsRawData(windows []clineWindow) map[string]any {
 			"limit_cost_units":     window.limitUnits,
 			"remaining_cost_units": window.limitUnits - window.usedUnits,
 			"credits_used":         window.creditsUsed,
+			"usage_source":         window.usageSource,
+			"reset_source":         window.resetSource,
 		}
-		if window.limitUnits > 0 {
-			ratio := float64(window.usedUnits) / float64(window.limitUnits)
-			entry["usage_ratio"] = ratio
-			entry["usage_percent"] = ratio * 100
+		if window.usageRatio != nil {
+			entry["usage_ratio"] = *window.usageRatio
+			entry["usage_percent"] = *window.usageRatio * 100
+		}
+		if window.costUsageRatio != nil {
+			entry["cost_usage_ratio"] = *window.costUsageRatio
+			entry["cost_usage_percent"] = *window.costUsageRatio * 100
 		}
 		if window.nextResetAt != nil {
 			entry["next_reset_at"] = window.nextResetAt.Format(time.RFC3339)
@@ -664,6 +719,16 @@ func clineWindowsRawData(windows []clineWindow) map[string]any {
 	}
 
 	return result
+}
+
+func clineUsageLimitsFetchRawData(meta clineUsageLimitsFetchMeta) map[string]any {
+	return map[string]any{
+		"status":             meta.Status,
+		"entries_seen":       meta.EntriesSeen,
+		"recognized_entries": meta.RecognizedEntries,
+		"usable_windows":     meta.UsableWindows,
+		"usable_fields":      meta.UsableFields,
+	}
 }
 
 func clineBalanceRawData(balance *int64) map[string]any {

--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -1,6 +1,7 @@
 package provider_quota
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,9 +107,17 @@ type clineUsageLimit struct {
 func (l *clineUsageLimit) UnmarshalJSON(data []byte) error {
 	*l = clineUsageLimit{}
 
+	data = bytes.TrimSpace(data)
+	if !json.Valid(data) {
+		return fmt.Errorf("invalid Cline usage limit JSON")
+	}
+	if len(data) == 0 || data[0] != '{' {
+		return nil
+	}
+
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
-		return nil
+		return fmt.Errorf("failed to parse Cline usage limit: %w", err)
 	}
 
 	if raw, ok := fields["type"]; ok {
@@ -534,6 +543,7 @@ func clineUsageLimitWindowKey(value string) (string, bool) {
 		return "", false
 	}
 }
+
 func buildClineQuotaData(
 	now time.Time,
 	scope clineModelScope,
@@ -648,7 +658,7 @@ func buildClineWindow(
 		window.usageRatio = &ratio
 		window.usageSource = clineWindowSourceOfficialUsageLimits
 	}
-	if official.NextResetAt != nil {
+	if official.NextResetAt != nil && official.NextResetAt.After(now) {
 		resetAt := *official.NextResetAt
 		window.nextResetAt = &resetAt
 		window.resetSource = clineWindowSourceOfficialUsageLimits

--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -23,6 +23,21 @@ const (
 	clineMaxUsagePages       = 100
 	clineCostUnitsPerUSD     = int64(100_000_000)
 	clineMaxResponseBodySize = 1 << 20
+	clineUsageLimitsPath     = "/api/v1/users/me/plan/usage-limits"
+
+	clineUsageLimitTypeFiveHour = "five_hour"
+	clineUsageLimitTypeWeekly   = "weekly"
+	clineUsageLimitTypeMonthly  = "monthly"
+
+	clineUsageLimitsFetchStatusComplete    = "complete"
+	clineUsageLimitsFetchStatusPartial     = "partial"
+	clineUsageLimitsFetchStatusUnusable    = "unusable"
+	clineUsageLimitsFetchStatusUnavailable = "unavailable"
+
+	clineWindowSourceOfficialUsageLimits = "official_usage_limits"
+	clineWindowSourceEstimatedCost       = "estimated_from_cost"
+	clineWindowSourceEstimatedUsage      = "estimated_from_usage_window"
+	clineWindowSourceUnavailable         = "unavailable"
 )
 
 type ClineQuotaChecker struct {
@@ -76,6 +91,29 @@ type clineUsageItem struct {
 	CreatedAt   string `json:"createdAt,omitempty"`
 	CostUSD     int64  `json:"costUsd,omitempty"`
 	CreditsUsed int64  `json:"creditsUsed,omitempty"`
+}
+
+type clineUsageLimitsData struct {
+	Limits []clineUsageLimit `json:"limits,omitempty"`
+}
+
+type clineUsageLimit struct {
+	Type        string   `json:"type,omitempty"`
+	PercentUsed *float64 `json:"percentUsed,omitempty"`
+	ResetsAt    string   `json:"resetsAt,omitempty"`
+}
+
+type clineOfficialWindowLimit struct {
+	UsageRatio  *float64
+	NextResetAt *time.Time
+}
+
+type clineUsageLimitsFetchMeta struct {
+	Status            string
+	EntriesSeen       int
+	RecognizedEntries int
+	UsableWindows     int
+	UsableFields      int
 }
 
 type clineWindow struct {
@@ -379,6 +417,70 @@ func parseClineTime(value string) (time.Time, bool) {
 	return parsed, true
 }
 
+func parseClineUsageLimits(items []clineUsageLimit) (map[string]clineOfficialWindowLimit, clineUsageLimitsFetchMeta) {
+	limits := make(map[string]clineOfficialWindowLimit, 3)
+	meta := clineUsageLimitsFetchMeta{
+		Status:      clineUsageLimitsFetchStatusUnusable,
+		EntriesSeen: len(items),
+	}
+
+	for _, item := range items {
+		key, ok := clineUsageLimitWindowKey(item.Type)
+		if !ok {
+			continue
+		}
+		meta.RecognizedEntries++
+
+		limit := limits[key]
+		if limit.UsageRatio == nil && item.PercentUsed != nil {
+			ratio := *item.PercentUsed / 100
+			if ratio < 0 {
+				ratio = 0
+			}
+			if ratio > 1 {
+				ratio = 1
+			}
+			limit.UsageRatio = &ratio
+			meta.UsableFields++
+		}
+
+		if limit.NextResetAt == nil {
+			if resetAt, valid := parseClineTime(item.ResetsAt); valid {
+				limit.NextResetAt = &resetAt
+				meta.UsableFields++
+			}
+		}
+
+		if limit.UsageRatio != nil || limit.NextResetAt != nil {
+			limits[key] = limit
+		}
+	}
+
+	meta.UsableWindows = len(limits)
+	switch {
+	case meta.UsableFields == 0:
+		meta.Status = clineUsageLimitsFetchStatusUnusable
+	case meta.UsableWindows == 3 && meta.UsableFields == 6:
+		meta.Status = clineUsageLimitsFetchStatusComplete
+	default:
+		meta.Status = clineUsageLimitsFetchStatusPartial
+	}
+
+	return limits, meta
+}
+
+func clineUsageLimitWindowKey(value string) (string, bool) {
+	switch strings.TrimSpace(value) {
+	case clineUsageLimitTypeFiveHour:
+		return "last5h", true
+	case clineUsageLimitTypeWeekly:
+		return "last7d", true
+	case clineUsageLimitTypeMonthly:
+		return "last30d", true
+	default:
+		return "", false
+	}
+}
 func buildClineQuotaData(now time.Time, scope clineModelScope, threshold clineInferenceCapThreshold, plans []map[string]any, balance *int64, items []clineUsageItem, fetchMeta clineUsageFetchMeta) QuotaData {
 	windows := []clineWindow{
 		buildClineWindow(now, "last5h", 5*time.Hour, threshold.Last5HoursUsageCostUSDPerUser, items),

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -281,6 +281,100 @@ func TestCline_CheckQuota_UsageLimitsFailureFallsBackWithoutLosingCostData(t *te
 	assertClineErrorOmitsSensitiveValues(t, fmt.Sprint(quota.RawData))
 }
 
+func TestCline_CheckQuota_PartialUsageLimitsFallbackIsPerFieldAndPerWindow(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	requestCount := 0
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"data":{"id":"user_test"}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"data":[{"type":"individual","interval":"Monthly","isActive":true,"entitlements":{"cline_pass":{"enabled":true,"inferenceCapThreshold":{"last5HoursUsageCostUSDPerUser":100,"last7daysUsageCostUSDPerUser":200,"last30daysUsageCostUSDPerUser":400}}}}]}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"data":{"balance":1000}}`), nil
+			case 4:
+				return jsonResponse(http.StatusOK, `{"data":{"limits":[{"type":"five_hour","percentUsed":80},{"type":"weekly","resetsAt":"2026-07-17T02:56:47Z"},{"type":"unrecognized","percentUsed":99}]}}`), nil
+			case 5:
+				return jsonResponse(http.StatusOK, `{"data":{"items":[{"createdAt":"2026-07-14T11:00:00Z","costUsd":50,"creditsUsed":3}]}}`), nil
+			default:
+				t.Fatalf("unexpected request %d", requestCount)
+				return nil, nil
+			}
+		}),
+	})
+
+	checker := NewClineQuotaChecker(httpClient)
+	checker.now = func() time.Time { return now }
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Type:            channel.TypeCline,
+		BaseURL:         "https://api.cline.bot/v1",
+		SupportedModels: []string{"cline-pass/test"},
+		Credentials:     objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+
+	require.NoError(t, err)
+	windows := quota.RawData["windows"].(map[string]any)
+	fiveHour := windows["last5h"].(map[string]any)
+	weekly := windows["last7d"].(map[string]any)
+	monthly := windows["last30d"].(map[string]any)
+
+	require.InDelta(t, 0.80, fiveHour["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, fiveHour["usage_source"])
+	require.Equal(t, clineWindowSourceEstimatedUsage, fiveHour["reset_source"])
+	require.Equal(t, "2026-07-14T16:00:00Z", fiveHour["next_reset_at"])
+
+	require.InDelta(t, 0.25, weekly["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceEstimatedCost, weekly["usage_source"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, weekly["reset_source"])
+	require.Equal(t, "2026-07-17T02:56:47Z", weekly["next_reset_at"])
+
+	require.InDelta(t, 0.125, monthly["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceEstimatedCost, monthly["usage_source"])
+	require.Equal(t, clineWindowSourceEstimatedUsage, monthly["reset_source"])
+
+	fetch := quota.RawData["usage_limits_fetch"].(map[string]any)
+	require.Equal(t, clineUsageLimitsFetchStatusPartial, fetch["status"])
+	require.Equal(t, 2, fetch["recognized_entries"])
+	require.Equal(t, 2, fetch["usable_windows"])
+	require.Equal(t, 2, fetch["usable_fields"])
+}
+
+func TestCline_CheckQuota_DirectOnlySkipsPassUsageLimitsAndHistory(t *testing.T) {
+	requestCount := 0
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"data":{"id":"user_test"}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"data":[{"type":"individual","interval":"Monthly","isActive":true,"entitlements":{}}]}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"data":{"balance":497582}}`), nil
+			default:
+				t.Fatalf("direct-only quota made unexpected request %d to %s", requestCount, req.URL.Path)
+				return nil, nil
+			}
+		}),
+	})
+
+	checker := NewClineQuotaChecker(httpClient)
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Type:            channel.TypeCline,
+		BaseURL:         "https://api.cline.bot/v1",
+		SupportedModels: []string{"anthropic/claude-sonnet-5"},
+		Credentials:     objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, requestCount)
+	require.Equal(t, "direct_only", quota.RawData["model_scope"])
+	require.NotContains(t, quota.RawData, "usage_limits_fetch")
+	require.Empty(t, quota.Limits)
+}
+
 func TestCline_CheckQuota_WarningAtEightyPercent(t *testing.T) {
 	quota := buildClineQuotaData(
 		time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC),
@@ -317,16 +411,29 @@ func TestCline_CheckQuota_ExhaustedWhenPassOnly(t *testing.T) {
 }
 
 func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *testing.T) {
+	officialRatio := 1.0
 	quota := buildClineQuotaData(
 		time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC),
 		clineModelScopeMixed,
-		clineInferenceCapThreshold{Last5HoursUsageCostUSDPerUser: 100, Last7DaysUsageCostUSDPerUser: 1000, Last30DaysUsageCostUSDPerUser: 2000},
+		clineInferenceCapThreshold{
+			Last5HoursUsageCostUSDPerUser: 100,
+			Last7DaysUsageCostUSDPerUser:  1000,
+			Last30DaysUsageCostUSDPerUser: 2000,
+		},
 		nil,
 		nil,
-		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 100}},
+		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 1}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
-		nil,
-		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
+		map[string]clineOfficialWindowLimit{
+			"last5h": {UsageRatio: &officialRatio},
+		},
+		clineUsageLimitsFetchMeta{
+			Status:            clineUsageLimitsFetchStatusPartial,
+			EntriesSeen:       1,
+			RecognizedEntries: 1,
+			UsableWindows:     1,
+			UsableFields:      1,
+		},
 	)
 
 	require.Equal(t, "warning", quota.Status)
@@ -340,6 +447,11 @@ func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *te
 		require.NotEqual(t, "exhausted", limit.Status)
 		require.True(t, limit.Ready)
 	}
+
+	windows := quota.RawData["windows"].(map[string]any)
+	fiveHour := windows["last5h"].(map[string]any)
+	require.InDelta(t, 1.0, fiveHour["usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 0.01, fiveHour["cost_usage_ratio"].(float64), 0.000001)
 }
 
 func TestCline_CheckQuota_DirectOnlyUsesBalanceInformationally(t *testing.T) {

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -54,6 +54,64 @@ func TestParseClineUsageLimits_MapsFieldsIndependentlyAndKeepsFirstValidValue(t 
 	require.NotNil(t, monthly.NextResetAt)
 }
 
+func TestBuildClineQuotaData_OfficialValuesDriveStatusAndResetWhileCostRemainsExact(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	fiveHourRatio := 0.20
+	weeklyRatio := 0.90
+	monthlyRatio := 0.40
+	fiveHourReset := time.Date(2026, 7, 14, 14, 0, 0, 0, time.UTC)
+	weeklyReset := time.Date(2026, 7, 17, 2, 56, 47, 0, time.UTC)
+	monthlyReset := time.Date(2026, 8, 1, 11, 13, 17, 0, time.UTC)
+
+	quota := buildClineQuotaData(
+		now,
+		clineModelScopePassOnly,
+		clineInferenceCapThreshold{
+			Last5HoursUsageCostUSDPerUser: 100,
+			Last7DaysUsageCostUSDPerUser:  100,
+			Last30DaysUsageCostUSDPerUser: 100,
+		},
+		nil,
+		nil,
+		[]clineUsageItem{{CreatedAt: "2026-07-14T11:00:00Z", CostUSD: 50, CreditsUsed: 7}},
+		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
+		map[string]clineOfficialWindowLimit{
+			"last5h":  {UsageRatio: &fiveHourRatio, NextResetAt: &fiveHourReset},
+			"last7d":  {UsageRatio: &weeklyRatio, NextResetAt: &weeklyReset},
+			"last30d": {UsageRatio: &monthlyRatio, NextResetAt: &monthlyReset},
+		},
+		clineUsageLimitsFetchMeta{
+			Status:            clineUsageLimitsFetchStatusComplete,
+			EntriesSeen:       3,
+			RecognizedEntries: 3,
+			UsableWindows:     3,
+			UsableFields:      6,
+		},
+	)
+
+	require.Equal(t, "warning", quota.Status)
+	require.True(t, quota.Ready)
+	require.NotNil(t, quota.NextResetAt)
+	require.Equal(t, fiveHourReset, *quota.NextResetAt)
+	require.Len(t, quota.Limits, 3)
+	require.InDelta(t, 0.90, quota.Limits[1].UsageRatio, 0.000001)
+	require.Equal(t, "warning", quota.Limits[1].Status)
+
+	windows := quota.RawData["windows"].(map[string]any)
+	weekly := windows["last7d"].(map[string]any)
+	require.Equal(t, int64(50), weekly["used_cost_units"])
+	require.Equal(t, int64(100), weekly["limit_cost_units"])
+	require.Equal(t, int64(50), weekly["remaining_cost_units"])
+	require.Equal(t, int64(7), weekly["credits_used"])
+	require.InDelta(t, 0.90, weekly["usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 90.0, weekly["usage_percent"].(float64), 0.000001)
+	require.InDelta(t, 0.50, weekly["cost_usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 50.0, weekly["cost_usage_percent"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, weekly["usage_source"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, weekly["reset_source"])
+	require.Equal(t, weeklyReset.Format(time.RFC3339), weekly["next_reset_at"])
+}
+
 func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 	now := time.Date(2026, 7, 7, 10, 30, 0, 0, time.UTC)
 	requestCount := 0
@@ -152,6 +210,8 @@ func TestCline_CheckQuota_WarningAtEightyPercent(t *testing.T) {
 		nil,
 		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 80}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
+		nil,
+		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
 	)
 
 	require.Equal(t, "warning", quota.Status)
@@ -168,6 +228,8 @@ func TestCline_CheckQuota_ExhaustedWhenPassOnly(t *testing.T) {
 		nil,
 		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 100}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
+		nil,
+		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
 	)
 
 	require.Equal(t, "exhausted", quota.Status)
@@ -183,6 +245,8 @@ func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *te
 		nil,
 		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 100}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
+		nil,
+		clineUsageLimitsFetchMeta{Status: clineUsageLimitsFetchStatusUnavailable},
 	)
 
 	require.Equal(t, "warning", quota.Status)

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -153,6 +153,18 @@ func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 				return jsonResponse(http.StatusOK, `{"data":{"balance":497582}}`), nil
 			case 4:
 				require.Equal(t, "GET", req.Method)
+				require.Equal(t, clineUsageLimitsPath, req.URL.Path)
+				return jsonResponse(http.StatusOK, `{
+					"data": {
+						"limits": [
+							{"type":"five_hour","percentUsed":10,"resetsAt":"2026-07-07T14:00:00Z"},
+							{"type":"weekly","percentUsed":79,"resetsAt":"2026-07-17T02:56:47Z"},
+							{"type":"monthly","percentUsed":49,"resetsAt":"2026-08-01T11:13:17Z"}
+						]
+					}
+				}`), nil
+			case 5:
+				require.Equal(t, "GET", req.Method)
 				require.Equal(t, "/api/v1/users/user_test/usages", req.URL.Path)
 				require.Equal(t, "100", req.URL.Query().Get("limit"))
 				return jsonResponse(http.StatusOK, `{
@@ -187,7 +199,7 @@ func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 	require.True(t, quota.Ready)
 	require.Equal(t, "cline", quota.ProviderType)
 	require.Len(t, quota.Limits, 3)
-	require.Equal(t, requestCount, 4)
+	require.Equal(t, 5, requestCount)
 
 	raw := quota.RawData
 	require.Equal(t, "cline_pass_only", raw["model_scope"])
@@ -197,8 +209,76 @@ func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 
 	windows := raw["windows"].(map[string]any)
 	last7d := windows["last7d"].(map[string]any)
-	require.InDelta(t, 0.19887379, last7d["usage_ratio"].(float64), 0.000001)
-	require.InDelta(t, 19.887379, last7d["usage_percent"].(float64), 0.0001)
+	require.InDelta(t, 0.79, last7d["usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 79.0, last7d["usage_percent"].(float64), 0.0001)
+	require.InDelta(t, 0.19887379, last7d["cost_usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 19.887379, last7d["cost_usage_percent"].(float64), 0.0001)
+	require.Equal(t, "2026-07-17T02:56:47Z", last7d["next_reset_at"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, last7d["usage_source"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, last7d["reset_source"])
+
+	usageLimitsFetch := raw["usage_limits_fetch"].(map[string]any)
+	require.Equal(t, clineUsageLimitsFetchStatusComplete, usageLimitsFetch["status"])
+	require.Equal(t, 3, usageLimitsFetch["usable_windows"])
+	require.Equal(t, 6, usageLimitsFetch["usable_fields"])
+}
+
+func TestCline_CheckQuota_UsageLimitsFailureFallsBackWithoutLosingCostData(t *testing.T) {
+	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	requestCount := 0
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"data":{"id":"user_sensitive_123"}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"data":[{"type":"individual","interval":"Monthly","isActive":true,"entitlements":{"cline_pass":{"enabled":true,"inferenceCapThreshold":{"last5HoursUsageCostUSDPerUser":100,"last7daysUsageCostUSDPerUser":200,"last30daysUsageCostUSDPerUser":400}}}}]}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"data":{"balance":497582}}`), nil
+			case 4:
+				require.Equal(t, clineUsageLimitsPath, req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusServiceUnavailable,
+					Status:     "503 Service Unavailable",
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"api_key":"sk-sensitive-test-key","email":"person@example.test","user_id":"user_sensitive_123"}`)),
+				}, nil
+			case 5:
+				return jsonResponse(http.StatusOK, `{"data":{"items":[{"createdAt":"2026-07-07T11:00:00Z","costUsd":50,"creditsUsed":7}]}}`), nil
+			default:
+				t.Fatalf("unexpected Cline quota request %d", requestCount)
+				return nil, nil
+			}
+		}),
+	})
+
+	checker := NewClineQuotaChecker(httpClient)
+	checker.now = func() time.Time { return now }
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Type:            channel.TypeCline,
+		BaseURL:         "https://api.cline.bot/v1",
+		SupportedModels: []string{"cline-pass/test"},
+		Credentials: objects.ChannelCredentials{
+			APIKey: "sk-sensitive-test-key",
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 5, requestCount)
+	windows := quota.RawData["windows"].(map[string]any)
+	last5h := windows["last5h"].(map[string]any)
+	require.Equal(t, int64(50), last5h["used_cost_units"])
+	require.Equal(t, int64(100), last5h["limit_cost_units"])
+	require.InDelta(t, 0.5, last5h["usage_ratio"].(float64), 0.000001)
+	require.InDelta(t, 0.5, last5h["cost_usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceEstimatedCost, last5h["usage_source"])
+	require.Equal(t, clineWindowSourceEstimatedUsage, last5h["reset_source"])
+	require.Equal(t, "2026-07-07T16:00:00Z", last5h["next_reset_at"])
+
+	fetch := quota.RawData["usage_limits_fetch"].(map[string]any)
+	require.Equal(t, clineUsageLimitsFetchStatusUnavailable, fetch["status"])
+	assertClineErrorOmitsSensitiveValues(t, fmt.Sprint(quota.RawData))
 }
 
 func TestCline_CheckQuota_WarningAtEightyPercent(t *testing.T) {
@@ -368,8 +448,10 @@ func TestCline_CheckQuota_UsageTransportErrorOmitsSensitiveValues(t *testing.T) 
 		case 3:
 			return jsonResponse(http.StatusOK, `{"data":{"balance":497582}}`), nil
 		case 4:
-			return jsonResponse(http.StatusOK, `{"data":{"items":[{"createdAt":"2026-07-07T11:00:00Z","costUsd":1}],"nextToken":"cursor_sensitive_456"}}`), nil
+			return jsonResponse(http.StatusOK, `{"data":{"limits":[]}}`), nil
 		case 5:
+			return jsonResponse(http.StatusOK, `{"data":{"items":[{"createdAt":"2026-07-07T11:00:00Z","costUsd":1}],"nextToken":"cursor_sensitive_456"}}`), nil
+		case 6:
 			return nil, fmt.Errorf("dial to %s failed with api key sk-sensitive-test-key for person@example.test account acct_sensitive_456 generation gen_sensitive_789 payment_id pay_sensitive_000", req.URL.String())
 		default:
 			t.Fatalf("unexpected Cline quota request %d", requestCount)

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -17,6 +17,43 @@ import (
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
+func TestParseClineUsageLimits_MapsFieldsIndependentlyAndKeepsFirstValidValue(t *testing.T) {
+	firstPercent := 25.0
+	duplicatePercent := 90.0
+	negativePercent := -5.0
+	overPercent := 150.0
+
+	limits, meta := parseClineUsageLimits([]clineUsageLimit{
+		{Type: "unknown", PercentUsed: &firstPercent, ResetsAt: "2026-07-14T13:00:00Z"},
+		{Type: "five_hour", PercentUsed: &firstPercent},
+		{Type: "five_hour", PercentUsed: &duplicatePercent, ResetsAt: "2026-07-14T15:00:00Z"},
+		{Type: "weekly", PercentUsed: &negativePercent, ResetsAt: "not-a-time"},
+		{Type: "monthly", PercentUsed: &overPercent, ResetsAt: "2026-08-01T11:13:17Z"},
+	})
+
+	require.Equal(t, clineUsageLimitsFetchStatusPartial, meta.Status)
+	require.Equal(t, 5, meta.EntriesSeen)
+	require.Equal(t, 4, meta.RecognizedEntries)
+	require.Equal(t, 3, meta.UsableWindows)
+	require.Equal(t, 5, meta.UsableFields)
+
+	fiveHour := limits["last5h"]
+	require.NotNil(t, fiveHour.UsageRatio)
+	require.InDelta(t, 0.25, *fiveHour.UsageRatio, 0.000001)
+	require.NotNil(t, fiveHour.NextResetAt)
+	require.Equal(t, "2026-07-14T15:00:00Z", fiveHour.NextResetAt.Format(time.RFC3339))
+
+	weekly := limits["last7d"]
+	require.NotNil(t, weekly.UsageRatio)
+	require.Zero(t, *weekly.UsageRatio)
+	require.Nil(t, weekly.NextResetAt)
+
+	monthly := limits["last30d"]
+	require.NotNil(t, monthly.UsageRatio)
+	require.Equal(t, 1.0, *monthly.UsageRatio)
+	require.NotNil(t, monthly.NextResetAt)
+}
+
 func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 	now := time.Date(2026, 7, 7, 10, 30, 0, 0, time.UTC)
 	requestCount := 0

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -341,6 +341,68 @@ func TestCline_CheckQuota_PartialUsageLimitsFallbackIsPerFieldAndPerWindow(t *te
 	require.Equal(t, 2, fetch["usable_fields"])
 }
 
+func TestCline_CheckQuota_MalformedUsageLimitFieldsPreserveOtherOfficialValues(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	requestCount := 0
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				return jsonResponse(http.StatusOK, `{"data":{"id":"user_test"}}`), nil
+			case 2:
+				return jsonResponse(http.StatusOK, `{"data":[{"type":"individual","interval":"Monthly","isActive":true,"entitlements":{"cline_pass":{"enabled":true,"inferenceCapThreshold":{"last5HoursUsageCostUSDPerUser":100,"last7daysUsageCostUSDPerUser":200,"last30daysUsageCostUSDPerUser":400}}}}]}`), nil
+			case 3:
+				return jsonResponse(http.StatusOK, `{"data":{"balance":1000}}`), nil
+			case 4:
+				return jsonResponse(http.StatusOK, `{"data":{"limits":[{"type":"five_hour","percentUsed":"unknown","resetsAt":"2026-07-14T15:00:00Z"},{"type":"weekly","percentUsed":90,"resetsAt":123},{"type":"monthly","percentUsed":40,"resetsAt":"2026-08-01T11:13:17Z"},false]}}`), nil
+			case 5:
+				return jsonResponse(http.StatusOK, `{"data":{"items":[{"createdAt":"2026-07-14T11:00:00Z","costUsd":50,"creditsUsed":3}]}}`), nil
+			default:
+				t.Fatalf("unexpected request %d", requestCount)
+				return nil, nil
+			}
+		}),
+	})
+
+	checker := NewClineQuotaChecker(httpClient)
+	checker.now = func() time.Time { return now }
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Type:            channel.TypeCline,
+		BaseURL:         "https://api.cline.bot/v1",
+		SupportedModels: []string{"cline-pass/test"},
+		Credentials:     objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+
+	require.NoError(t, err)
+	windows := quota.RawData["windows"].(map[string]any)
+	fiveHour := windows["last5h"].(map[string]any)
+	weekly := windows["last7d"].(map[string]any)
+	monthly := windows["last30d"].(map[string]any)
+
+	require.InDelta(t, 0.5, fiveHour["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceEstimatedCost, fiveHour["usage_source"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, fiveHour["reset_source"])
+	require.Equal(t, "2026-07-14T15:00:00Z", fiveHour["next_reset_at"])
+
+	require.InDelta(t, 0.9, weekly["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, weekly["usage_source"])
+	require.Equal(t, clineWindowSourceEstimatedUsage, weekly["reset_source"])
+	require.Equal(t, "2026-07-21T11:00:00Z", weekly["next_reset_at"])
+
+	require.InDelta(t, 0.4, monthly["usage_ratio"].(float64), 0.000001)
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, monthly["usage_source"])
+	require.Equal(t, clineWindowSourceOfficialUsageLimits, monthly["reset_source"])
+	require.Equal(t, "2026-08-01T11:13:17Z", monthly["next_reset_at"])
+
+	fetch := quota.RawData["usage_limits_fetch"].(map[string]any)
+	require.Equal(t, clineUsageLimitsFetchStatusPartial, fetch["status"])
+	require.Equal(t, 4, fetch["entries_seen"])
+	require.Equal(t, 3, fetch["recognized_entries"])
+	require.Equal(t, 3, fetch["usable_windows"])
+	require.Equal(t, 4, fetch["usable_fields"])
+}
+
 func TestCline_CheckQuota_DirectOnlySkipsPassUsageLimitsAndHistory(t *testing.T) {
 	requestCount := 0
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -112,6 +112,23 @@ func TestBuildClineQuotaData_OfficialValuesDriveStatusAndResetWhileCostRemainsEx
 	require.Equal(t, weeklyReset.Format(time.RFC3339), weekly["next_reset_at"])
 }
 
+func TestBuildClineWindow_StaleOfficialResetPreservesEstimate(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	staleReset := now.Add(-2 * time.Hour)
+
+	window := buildClineWindow(
+		now,
+		"last5h",
+		5*time.Hour,
+		100,
+		[]clineUsageItem{{CreatedAt: now.Add(-time.Hour).Format(time.RFC3339)}},
+		clineOfficialWindowLimit{NextResetAt: &staleReset},
+	)
+
+	require.Equal(t, now.Add(4*time.Hour), *window.nextResetAt)
+	require.Equal(t, clineWindowSourceEstimatedUsage, window.resetSource)
+}
+
 func TestCline_CheckQuota_HappyPathPassOnly(t *testing.T) {
 	now := time.Date(2026, 7, 7, 10, 30, 0, 0, time.UTC)
 	requestCount := 0


### PR DESCRIPTION
## Summary

Use Cline's official usage-limits endpoint for ClinePass percentages and reset timestamps while preserving precise USD usage details.

Previously, AxonHub calculated resets from usage records in local rolling windows, which could differ significantly from the reset shown by Cline's official Web application.

## Changes

- Fetch and parse Cline's official five-hour, weekly, and monthly usage limits from `/api/v1/users/me/plan/usage-limits`.
- Use official percentages and reset timestamps for quota progress, status, readiness, and reset display.
- Keep the existing `/plans` and `/usages` cost accounting separate from official utilization, preserving precise USD usage details.
- Fall back independently per field and per window when official data is unavailable, incomplete, or malformed.
- Add source metadata and coverage for official values, fallback behavior, malformed responses, and scope regressions.

## Validation

- Ran `go test ./internal/server/biz/provider_quota -count=1`.
- Verified official percentages and resets alongside independently calculated USD usage details with a live Cline quota response.
