### PR TITLE
fix(traces): normalize tool_use arguments JSON to fix span dedup

### DIFF
--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -1495,6 +1495,22 @@ func deduplicateSpansWithParent(current, parent []Span) []Span {
 	return result
 }
 
+// normalizeJSON re-parses and re-serializes JSON to produce a canonical form,
+// eliminating whitespace differences between compact and pretty-printed JSON.
+func normalizeJSON(s string) string {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return s
+	}
+
+	return string(b)
+}
+
 // spanToKey generates a unique key for a span based on its content.
 func spanToKey(span Span) string {
 	if span.Value == nil {
@@ -1550,7 +1566,7 @@ func spanToKey(span Span) string {
 		if span.Value.ToolUse != nil {
 			args := ""
 			if span.Value.ToolUse.Arguments != nil {
-				args = *span.Value.ToolUse.Arguments
+				args = normalizeJSON(*span.Value.ToolUse.Arguments)
 			}
 
 			return fmt.Sprintf("%s:%s:%s:%s", span.Type, span.Value.ToolUse.ID, span.Value.ToolUse.Name, args)


### PR DESCRIPTION
## 问题

追踪页面中，连续工具调用的 `tool_use` span 出现重复显示。例如：

- 段N 显示：`bash工具调用、工具结果、write工具调用`
- 段N+1 显示：`write工具调用、工具结果、edit工具调用`

其中 `write工具调用` 在两个段里都出现了。

## 根因

`spanToKey` 函数生成去重 key 时，直接使用 `tool_use` span 的原始 arguments 字符串。但同一个 tool call 的 arguments 在两个地方的 JSON 格式不同：

| 来源 | 格式 | 示例 |
|------|------|------|
| 请求体（客户端发送） | 紧凑 JSON | `{"command":"pwd"}` |
| 响应体（流式聚合后） | 格式化 JSON | `{"command": "pwd"}` |

Go 的 `json.Marshal` 在冒号后加空格，与客户端的紧凑 JSON 不一致。导致同一个 tool call 生成了不同的 key，去重失败。

## 修复

在 `spanToKey` 的 `tool_use` 分支，对 arguments 调用 `normalizeJSON`（解析再重新序列化），消除 JSON 格式差异。
