### PR TITLE
feat: expose prompt cache key to override templates

### DIFF
--- a/docs/en/guides/request-override.md
+++ b/docs/en/guides/request-override.md
@@ -19,6 +19,7 @@ AxonHub uses Go templates for dynamic value rendering. You can access the follow
 | `.ReasoningEffort` | The `reasoning_effort` value (none, low, medium, high). | `{{.ReasoningEffort}}` |
 | `.Metadata` | Custom metadata map passed in the request. | `{{index .Metadata "user_id"}}` |
 | `.RequestHeader` | Filtered inbound client headers. Supports canonical/lowercase lookup and returns the first value. | `{{index .RequestHeader "X-Trace-Id"}}` |
+| `.PromptCacheKey` | The `prompt_cache_key` from the inbound request. It is an empty string when omitted. | `{{.PromptCacheKey}}` |
 
 ## Override Operation Types
 
@@ -288,6 +289,12 @@ Override headers use the same operation format as override parameters:
     "op": "set",
     "path": "X-Trace-Id",
     "value": "{{index .RequestHeader \"x-trace-id\"}}"
+  },
+  {
+    "op": "set",
+    "path": "Extra",
+    "value": "{\"session_id\":\"{{.PromptCacheKey}}\"}",
+    "condition": "{{if .PromptCacheKey}}true{{end}}"
   },
   {
     "op": "delete",

--- a/docs/en/guides/request-override.md
+++ b/docs/en/guides/request-override.md
@@ -21,6 +21,8 @@ AxonHub uses Go templates for dynamic value rendering. You can access the follow
 | `.RequestHeader` | Filtered inbound client headers. Supports canonical/lowercase lookup and returns the first value. | `{{index .RequestHeader "X-Trace-Id"}}` |
 | `.PromptCacheKey` | The `prompt_cache_key` from the inbound request. It is an empty string when omitted. | `{{.PromptCacheKey}}` |
 
+When embedding a template value inside JSON, use `toJSON` so quotes and other special characters are escaped correctly. For example: `{"session_id":{{toJSON .PromptCacheKey}}}`.
+
 ## Override Operation Types
 
 AxonHub supports the following override operations:
@@ -293,7 +295,7 @@ Override headers use the same operation format as override parameters:
   {
     "op": "set",
     "path": "Extra",
-    "value": "{\"session_id\":\"{{.PromptCacheKey}}\"}",
+    "value": "{\"session_id\":{{toJSON .PromptCacheKey}}}",
     "condition": "{{if .PromptCacheKey}}true{{end}}"
   },
   {

--- a/docs/zh/guides/request-override.md
+++ b/docs/zh/guides/request-override.md
@@ -21,6 +21,8 @@ AxonHub 使用 Go 模板 (Go templates) 进行动态值渲染。你可以在模�
 | `.RequestHeader` | 过滤后的客户端入站请求头。支持规范写法/小写查找，并返回第一个值。 | `{{index .RequestHeader "X-Trace-Id"}}` |
 | `.PromptCacheKey` | 入站请求中的 `prompt_cache_key`；未提供时为空字符串。 | `{{.PromptCacheKey}}` |
 
+在 JSON 中嵌入模板值时，请使用 `toJSON`，以正确转义引号等特殊字符。例如：`{"session_id":{{toJSON .PromptCacheKey}}}`。
+
 ## 重写操作类型
 
 AxonHub 支持以下重写操作：
@@ -293,7 +295,7 @@ AxonHub 支持以下重写操作：
   {
     "op": "set",
     "path": "Extra",
-    "value": "{\"session_id\":\"{{.PromptCacheKey}}\"}",
+    "value": "{\"session_id\":{{toJSON .PromptCacheKey}}}",
     "condition": "{{if .PromptCacheKey}}true{{end}}"
   },
   {

--- a/docs/zh/guides/request-override.md
+++ b/docs/zh/guides/request-override.md
@@ -19,6 +19,7 @@ AxonHub 使用 Go 模板 (Go templates) 进行动态值渲染。你可以在模�
 | `.ReasoningEffort` | `reasoning_effort` 的值 (none, low, medium, high)。 | `{{.ReasoningEffort}}` |
 | `.Metadata` | 请求中传递的自定义元数据 Map。 | `{{index .Metadata "user_id"}}` |
 | `.RequestHeader` | 过滤后的客户端入站请求头。支持规范写法/小写查找，并返回第一个值。 | `{{index .RequestHeader "X-Trace-Id"}}` |
+| `.PromptCacheKey` | 入站请求中的 `prompt_cache_key`；未提供时为空字符串。 | `{{.PromptCacheKey}}` |
 
 ## 重写操作类型
 
@@ -288,6 +289,12 @@ AxonHub 支持以下重写操作：
     "op": "set",
     "path": "X-Trace-Id",
     "value": "{{index .RequestHeader \"x-trace-id\"}}"
+  },
+  {
+    "op": "set",
+    "path": "Extra",
+    "value": "{\"session_id\":\"{{.PromptCacheKey}}\"}",
+    "condition": "{{if .PromptCacheKey}}true{{end}}"
   },
   {
     "op": "delete",

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -29,6 +29,8 @@ type RenderContext struct {
 	Metadata map[string]string `json:"metadata"`
 	// RequestHeader is the filtered request headers used in the current request.
 	RequestHeader map[string]string `json:"request_header"`
+	// PromptCacheKey is the prompt cache key provided by the original request.
+	PromptCacheKey string `json:"prompt_cache_key"`
 	// ReasoningEffort is the reasoning effort used in the current request.
 	ReasoningEffort string `json:"reasoning_effort"`
 }
@@ -58,13 +60,18 @@ func buildRequestHeaderMap(llmReq *llm.Request) map[string]string {
 }
 
 func buildRenderContext(llmReq *llm.Request, requestModel string) RenderContext {
-	return RenderContext{
+	renderCtx := RenderContext{
 		RequestModel:    requestModel,
 		Model:           llmReq.Model,
 		Metadata:        llmReq.Metadata,
 		RequestHeader:   buildRequestHeaderMap(llmReq),
 		ReasoningEffort: llmReq.ReasoningEffort,
 	}
+	if llmReq.PromptCacheKey != nil {
+		renderCtx.PromptCacheKey = *llmReq.PromptCacheKey
+	}
+
+	return renderCtx
 }
 
 // renderTemplate renders a Go template string against RenderContext. Returns the original value on error.

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -35,6 +35,16 @@ type RenderContext struct {
 	ReasoningEffort string `json:"reasoning_effort"`
 }
 
+var overrideTemplateFuncs = template.FuncMap{
+	"toJSON": func(value any) (string, error) {
+		data, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	},
+}
+
 func buildRequestHeaderMap(llmReq *llm.Request) map[string]string {
 	requestHeaders := make(map[string]string)
 	if llmReq == nil || llmReq.RawRequest == nil || llmReq.RawRequest.Headers == nil {
@@ -69,6 +79,8 @@ func buildRenderContext(llmReq *llm.Request, requestModel string) RenderContext 
 	}
 	if llmReq.PromptCacheKey != nil {
 		renderCtx.PromptCacheKey = *llmReq.PromptCacheKey
+	} else if llmReq.Compact != nil {
+		renderCtx.PromptCacheKey = llmReq.Compact.PromptCacheKey
 	}
 
 	return renderCtx
@@ -80,7 +92,7 @@ func renderTemplate(ctx context.Context, value string, renderCtx RenderContext) 
 		return value
 	}
 
-	tmpl, err := template.New("override").Funcs(template.FuncMap{}).Parse(value)
+	tmpl, err := template.New("override").Funcs(overrideTemplateFuncs).Parse(value)
 	if err != nil {
 		log.Warn(ctx, "failed to parse override template",
 			log.String("template", value),

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -393,6 +393,66 @@ func TestOverrideHeadersKeepJSONLikeString(t *testing.T) {
 	require.Equal(t, expectedValue, processedRequest.Headers.Get("Extra"))
 }
 
+func TestOverrideHeadersWithPromptCacheKeyTemplate(t *testing.T) {
+	ctx := context.Background()
+	promptCacheKey := "cache-key-123"
+
+	tests := []struct {
+		name           string
+		promptCacheKey *string
+		expectedHeader string
+	}{
+		{
+			name:           "sets header when prompt cache key is present",
+			promptCacheKey: &promptCacheKey,
+			expectedHeader: `{"session_id":"cache-key-123"}`,
+		},
+		{
+			name:           "skips header when prompt cache key is absent",
+			promptCacheKey: nil,
+			expectedHeader: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llmRequest := &llm.Request{
+				Model:          "gpt-5.5",
+				PromptCacheKey: tt.promptCacheKey,
+			}
+			channel := &biz.Channel{
+				Channel: &ent.Channel{
+					ID:   1,
+					Name: "prompt-cache-key-template-test",
+					Settings: &objects.ChannelSettings{
+						HeaderOverrideOperations: []objects.OverrideOperation{
+							{
+								Op:        objects.OverrideOpSet,
+								Path:      "Extra",
+								Value:     `{"session_id":"{{.PromptCacheKey}}"}`,
+								Condition: `{{if .PromptCacheKey}}true{{end}}`,
+							},
+						},
+					},
+				},
+				Outbound: &mockTransformer{},
+			}
+			outbound := &PersistentOutboundTransformer{
+				wrapped: &mockTransformer{},
+				state: &PersistenceState{
+					CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+					LlmRequest:       llmRequest,
+				},
+			}
+
+			headerMiddleware := applyOverrideRequestHeaders(outbound)
+			processedRequest, err := headerMiddleware.OnOutboundRawRequest(ctx, &httpclient.Request{Headers: make(http.Header)})
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedHeader, processedRequest.Headers.Get("Extra"))
+		})
+	}
+}
+
 func TestOverrideParametersWithRequestHeaderTemplate_NoRawRequest(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -395,31 +395,48 @@ func TestOverrideHeadersKeepJSONLikeString(t *testing.T) {
 
 func TestOverrideHeadersWithPromptCacheKeyTemplate(t *testing.T) {
 	ctx := context.Background()
-	promptCacheKey := "cache-key-123"
+	promptCacheKey := `cache-key-123","admin":true`
+	topLevelPromptCacheKey := "top-level-cache-key"
 
 	tests := []struct {
 		name           string
-		promptCacheKey *string
+		request        *llm.Request
 		expectedHeader string
 	}{
 		{
-			name:           "sets header when prompt cache key is present",
-			promptCacheKey: &promptCacheKey,
-			expectedHeader: `{"session_id":"cache-key-123"}`,
+			name: "JSON-escapes prompt cache key",
+			request: &llm.Request{
+				Model:          "gpt-5.5",
+				PromptCacheKey: &promptCacheKey,
+			},
+			expectedHeader: `{"session_id":"cache-key-123\",\"admin\":true"}`,
 		},
 		{
 			name:           "skips header when prompt cache key is absent",
-			promptCacheKey: nil,
+			request:        &llm.Request{Model: "gpt-5.5"},
 			expectedHeader: "",
+		},
+		{
+			name: "uses prompt cache key from compact request",
+			request: &llm.Request{
+				Model:   "gpt-5.5",
+				Compact: &llm.CompactRequest{PromptCacheKey: "compact-cache-key"},
+			},
+			expectedHeader: `{"session_id":"compact-cache-key"}`,
+		},
+		{
+			name: "prefers top-level prompt cache key",
+			request: &llm.Request{
+				Model:          "gpt-5.5",
+				PromptCacheKey: &topLevelPromptCacheKey,
+				Compact:        &llm.CompactRequest{PromptCacheKey: "compact-cache-key"},
+			},
+			expectedHeader: `{"session_id":"top-level-cache-key"}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			llmRequest := &llm.Request{
-				Model:          "gpt-5.5",
-				PromptCacheKey: tt.promptCacheKey,
-			}
 			channel := &biz.Channel{
 				Channel: &ent.Channel{
 					ID:   1,
@@ -429,7 +446,7 @@ func TestOverrideHeadersWithPromptCacheKeyTemplate(t *testing.T) {
 							{
 								Op:        objects.OverrideOpSet,
 								Path:      "Extra",
-								Value:     `{"session_id":"{{.PromptCacheKey}}"}`,
+								Value:     `{"session_id":{{toJSON .PromptCacheKey}}}`,
 								Condition: `{{if .PromptCacheKey}}true{{end}}`,
 							},
 						},
@@ -441,14 +458,20 @@ func TestOverrideHeadersWithPromptCacheKeyTemplate(t *testing.T) {
 				wrapped: &mockTransformer{},
 				state: &PersistenceState{
 					CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
-					LlmRequest:       llmRequest,
+					LlmRequest:       tt.request,
 				},
 			}
 
 			headerMiddleware := applyOverrideRequestHeaders(outbound)
 			processedRequest, err := headerMiddleware.OnOutboundRawRequest(ctx, &httpclient.Request{Headers: make(http.Header)})
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedHeader, processedRequest.Headers.Get("Extra"))
+			actualHeader := processedRequest.Headers.Get("Extra")
+			require.Equal(t, tt.expectedHeader, actualHeader)
+			if tt.expectedHeader != "" {
+				var headerValue map[string]any
+				require.NoError(t, json.Unmarshal([]byte(actualHeader), &headerValue))
+				require.Len(t, headerValue, 1)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- expose the inbound `prompt_cache_key` as `.PromptCacheKey` in request override templates
- render an empty string when the client omits the field, so templates can guard with `{{if .PromptCacheKey}}`
- document body/header usage in both English and Chinese

## Why

Header overrides can currently use request metadata and filtered inbound headers, but cannot use the parsed prompt cache key from the request body. Exposing the already-normalized `llm.Request.PromptCacheKey` allows provider-specific routing headers to stay aligned with the client's cache key without exposing the full request body to templates.

## Impact

Existing templates are unchanged. New templates can use `.PromptCacheKey` in values and conditions, including JSON-formatted header values.

## Checks

- `go test -mod=readonly ./internal/server/orchestrator`
