### PR TITLE
feat: support set-if-absent body overrides

### DIFF
--- a/docs/en/guides/request-override.md
+++ b/docs/en/guides/request-override.md
@@ -48,7 +48,7 @@ Override parameters are defined as an array of operations, each containing the f
 | `path` | string | Conditional | Target field path (required for `set`, `set_if_absent`, `delete`, and all array ops) |
 | `from` | string | Conditional | Source field path (required for `rename` and `copy`) |
 | `to` | string | Conditional | Target field path (required for `rename` and `copy`) |
-| `value` | string | Conditional | Field value (required for `set`, `set_if_absent`, `array_append`, `array_prepend`, and `array_insert`), supports templates |
+| `value` | string | Conditional | Field value (required for `set`, `array_append`, `array_prepend`, and `array_insert`; must be non-empty for `set_if_absent`), supports templates |
 | `condition` | string | No | Condition expression, executes when result is `"true"` |
 | `match` | object | Conditional | Match rule (required for `array_remove`), formatted as `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | Conditional | Insertion position (required for `array_insert`); negative values count from the end, out-of-range values are clamped to `[0, len]` |

--- a/docs/en/guides/request-override.md
+++ b/docs/en/guides/request-override.md
@@ -27,6 +27,7 @@ AxonHub supports the following override operations:
 | Operation Type | Description | Use Case |
 | :--- | :--- | :--- |
 | `set` | Set field value, create if field doesn't exist | Modify or add parameters |
+| `set_if_absent` | Set field value only when the target path does not exist | Provide a default that clients can override |
 | `delete` | Delete specified field | Remove unwanted parameters |
 | `rename` | Rename field (move from `from` to `to`) | Field name mapping conversion |
 | `copy` | Copy field value (copy from `from` to `to`) | Parameter reuse |
@@ -35,7 +36,7 @@ AxonHub supports the following override operations:
 | `array_insert` | Insert value(s) at a specific position in the array at `path` | Insert items at an arbitrary position |
 | `array_remove` | Remove matching items from the array at `path` | Filter tools or messages by a field inside each array item |
 
-> Array operations only apply to the body. Headers only support `set`, `delete`, `rename`, and `copy`.
+> `set_if_absent` and array operations only apply to the body. Headers only support `set`, `delete`, `rename`, and `copy`.
 
 ## Override Parameters
 
@@ -43,11 +44,11 @@ Override parameters are defined as an array of operations, each containing the f
 
 | Field | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `op` | string | Yes | Operation type: `set`, `delete`, `rename`, `copy`, `array_append`, `array_prepend`, `array_insert`, `array_remove` |
-| `path` | string | Conditional | Target field path (required for `set`, `delete`, and all array ops) |
+| `op` | string | Yes | Operation type: `set`, `set_if_absent`, `delete`, `rename`, `copy`, `array_append`, `array_prepend`, `array_insert`, `array_remove` |
+| `path` | string | Conditional | Target field path (required for `set`, `set_if_absent`, `delete`, and all array ops) |
 | `from` | string | Conditional | Source field path (required for `rename` and `copy`) |
 | `to` | string | Conditional | Target field path (required for `rename` and `copy`) |
-| `value` | string | Conditional | Field value (required for `set`, `array_append`, `array_prepend`, and `array_insert`), supports templates |
+| `value` | string | Conditional | Field value (required for `set`, `set_if_absent`, `array_append`, `array_prepend`, and `array_insert`), supports templates |
 | `condition` | string | No | Condition expression, executes when result is `"true"` |
 | `match` | object | Conditional | Match rule (required for `array_remove`), formatted as `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | Conditional | Insertion position (required for `array_insert`); negative values count from the end, out-of-range values are clamped to `[0, len]` |
@@ -73,6 +74,22 @@ Override parameters are defined as an array of operations, each containing the f
   }
 ]
 ```
+
+### Providing Client-Overridable Defaults
+
+Use `set_if_absent` when the channel should provide a default without replacing a value supplied by the client:
+
+```json
+[
+  {
+    "op": "set_if_absent",
+    "path": "max_output_tokens",
+    "value": "32000"
+  }
+]
+```
+
+For a request without `max_output_tokens`, AxonHub adds `"max_output_tokens": 32000`. If the client supplies the field, its value is preserved. Presence is determined by the JSON path, so `0`, `false`, an empty string, and explicit `null` all count as present.
 
 ### Using Templates
 

--- a/docs/en/guides/request-override.md
+++ b/docs/en/guides/request-override.md
@@ -48,7 +48,7 @@ Override parameters are defined as an array of operations, each containing the f
 | `path` | string | Conditional | Target field path (required for `set`, `set_if_absent`, `delete`, and all array ops) |
 | `from` | string | Conditional | Source field path (required for `rename` and `copy`) |
 | `to` | string | Conditional | Target field path (required for `rename` and `copy`) |
-| `value` | string | Conditional | Field value (required for `set`, `array_append`, `array_prepend`, and `array_insert`; must be non-empty for `set_if_absent`), supports templates |
+| `value` | string | Conditional | Field value (required for `set`, `array_append`, `array_prepend`, and `array_insert`; must not be empty or whitespace-only for `set_if_absent`), supports templates |
 | `condition` | string | No | Condition expression, executes when result is `"true"` |
 | `match` | object | Conditional | Match rule (required for `array_remove`), formatted as `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | Conditional | Insertion position (required for `array_insert`); negative values count from the end, out-of-range values are clamped to `[0, len]` |

--- a/docs/zh/guides/request-override.md
+++ b/docs/zh/guides/request-override.md
@@ -48,7 +48,7 @@ AxonHub 支持以下重写操作：
 | `path` | string | 条件 | 目标字段路径（`set`、`set_if_absent`、`delete` 以及所有数组操作必需） |
 | `from` | string | 条件 | 源字段路径（`rename` 和 `copy` 必需） |
 | `to` | string | 条件 | 目标字段路径（`rename` 和 `copy` 必需） |
-| `value` | string | 条件 | 字段值（`set`、`array_append`、`array_prepend`、`array_insert` 必需；`set_if_absent` 必须为非空值），支持模板 |
+| `value` | string | 条件 | 字段值（`set`、`array_append`、`array_prepend`、`array_insert` 必需；`set_if_absent` 不能是空值或仅包含空白字符），支持模板 |
 | `condition` | string | 否 | 条件表达式，结果为 `"true"` 时执行 |
 | `match` | object | 条件 | 匹配规则（`array_remove` 必需），格式为 `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | 条件 | 插入位置（`array_insert` 必需），支持负数表示从末尾倒数；越界会被夹紧到 `[0, len]` |

--- a/docs/zh/guides/request-override.md
+++ b/docs/zh/guides/request-override.md
@@ -27,6 +27,7 @@ AxonHub 支持以下重写操作：
 | 操作类型 | 描述 | 适用场景 |
 | :--- | :--- | :--- |
 | `set` | 设置字段值，如果字段不存在则创建 | 修改或添加参数 |
+| `set_if_absent` | 仅当目标路径不存在时设置字段值 | 提供可由客户端覆盖的默认值 |
 | `delete` | 删除指定字段 | 移除不需要的参数 |
 | `rename` | 重命名字段（从 `from` 移动到 `to`） | 字段名映射转换 |
 | `copy` | 复制字段值（从 `from` 复制到 `to`） | 参数复用 |
@@ -35,7 +36,7 @@ AxonHub 支持以下重写操作：
 | `array_insert` | 把值插入到 `path` 数组的指定位置 | 在任意位置插入元素 |
 | `array_remove` | 从 `path` 数组中移除匹配项 | 按数组项内的字段值过滤工具或消息 |
 
-> 数组操作仅适用于请求体。请求头只支持 `set`、`delete`、`rename`、`copy`。
+> `set_if_absent` 和数组操作仅适用于请求体。请求头只支持 `set`、`delete`、`rename`、`copy`。
 
 ## 重写参数 (Override Parameters)
 
@@ -43,11 +44,11 @@ AxonHub 支持以下重写操作：
 
 | 字段 | 类型 | 必需 | 描述 |
 | :--- | :--- | :--- | :--- |
-| `op` | string | 是 | 操作类型：`set`、`delete`、`rename`、`copy`、`array_append`、`array_prepend`、`array_insert`、`array_remove` |
-| `path` | string | 条件 | 目标字段路径（`set`、`delete` 以及所有数组操作必需） |
+| `op` | string | 是 | 操作类型：`set`、`set_if_absent`、`delete`、`rename`、`copy`、`array_append`、`array_prepend`、`array_insert`、`array_remove` |
+| `path` | string | 条件 | 目标字段路径（`set`、`set_if_absent`、`delete` 以及所有数组操作必需） |
 | `from` | string | 条件 | 源字段路径（`rename` 和 `copy` 必需） |
 | `to` | string | 条件 | 目标字段路径（`rename` 和 `copy` 必需） |
-| `value` | string | 条件 | 字段值（`set`、`array_append`、`array_prepend`、`array_insert` 必需），支持模板 |
+| `value` | string | 条件 | 字段值（`set`、`set_if_absent`、`array_append`、`array_prepend`、`array_insert` 必需），支持模板 |
 | `condition` | string | 否 | 条件表达式，结果为 `"true"` 时执行 |
 | `match` | object | 条件 | 匹配规则（`array_remove` 必需），格式为 `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | 条件 | 插入位置（`array_insert` 必需），支持负数表示从末尾倒数；越界会被夹紧到 `[0, len]` |
@@ -73,6 +74,22 @@ AxonHub 支持以下重写操作：
   }
 ]
 ```
+
+### 提供可由客户端覆盖的默认值
+
+当渠道需要提供默认值，同时保留下游客户端的覆盖权时，使用 `set_if_absent`：
+
+```json
+[
+  {
+    "op": "set_if_absent",
+    "path": "max_output_tokens",
+    "value": "32000"
+  }
+]
+```
+
+当请求未携带 `max_output_tokens` 时，AxonHub 会追加 `"max_output_tokens": 32000`；客户端已提供该字段时则保留原值。是否存在按 JSON path 判断，因此 `0`、`false`、空字符串和显式 `null` 都视为已存在。
 
 ### 使用模板
 

--- a/docs/zh/guides/request-override.md
+++ b/docs/zh/guides/request-override.md
@@ -48,7 +48,7 @@ AxonHub 支持以下重写操作：
 | `path` | string | 条件 | 目标字段路径（`set`、`set_if_absent`、`delete` 以及所有数组操作必需） |
 | `from` | string | 条件 | 源字段路径（`rename` 和 `copy` 必需） |
 | `to` | string | 条件 | 目标字段路径（`rename` 和 `copy` 必需） |
-| `value` | string | 条件 | 字段值（`set`、`set_if_absent`、`array_append`、`array_prepend`、`array_insert` 必需），支持模板 |
+| `value` | string | 条件 | 字段值（`set`、`array_append`、`array_prepend`、`array_insert` 必需；`set_if_absent` 必须为非空值），支持模板 |
 | `condition` | string | 否 | 条件表达式，结果为 `"true"` 时执行 |
 | `match` | object | 条件 | 匹配规则（`array_remove` 必需），格式为 `{"path":"function.name","eq":"web_search"}` |
 | `index` | number | 条件 | 插入位置（`array_insert` 必需），支持负数表示从末尾倒数；越界会被夹紧到 `[0, len]` |

--- a/frontend/src/features/channels-override-merge.test.mjs
+++ b/frontend/src/features/channels-override-merge.test.mjs
@@ -76,7 +76,7 @@ test('set_if_absent is exposed as a localized body-only operation', () => {
   assert.match(schema, /'set_if_absent'/);
   assert.match(bodyTypes, /'set_if_absent'/);
   assert.doesNotMatch(headerTypes, /set_if_absent/);
-  assert.match(dialog, /op\.op === 'set_if_absent' && parseValueForDisplay\(op\.value\) === ''/);
+  assert.match(dialog, /op\.op === 'set_if_absent' && parseValueForDisplay\(op\.value\)\.trim\(\) === ''/);
 
   for (const locale of ['en', 'zh-CN']) {
     const messages = JSON.parse(read(`locales/${locale}/channels.json`));

--- a/frontend/src/features/channels-override-merge.test.mjs
+++ b/frontend/src/features/channels-override-merge.test.mjs
@@ -34,6 +34,39 @@ test('set_if_absent participates in scalar body override replacement', () => {
   ]);
 });
 
+test('scalar body override replacement removes existing duplicates', () => {
+  const temperature = { op: 'set', path: 'temperature', value: '0.5' };
+
+  assert.deepEqual(
+    mergeOverrideOperations(
+      [
+        { op: 'set', path: 'max_output_tokens', value: '8000' },
+        temperature,
+        { op: 'set_if_absent', path: 'max_output_tokens', value: '32000' },
+        { op: 'delete', path: 'max_output_tokens' },
+      ],
+      [{ op: 'set_if_absent', path: 'max_output_tokens', value: '16000' }]
+    ),
+    [{ op: 'set_if_absent', path: 'max_output_tokens', value: '16000' }, temperature]
+  );
+});
+
+test('last template scalar body override at the same path wins', () => {
+  assert.deepEqual(
+    mergeOverrideOperations(
+      [{ op: 'set', path: 'temperature', value: '0.5' }],
+      [
+        { op: 'set_if_absent', path: 'max_output_tokens', value: '32000' },
+        { op: 'set', path: 'max_output_tokens', value: '16000' },
+      ]
+    ),
+    [
+      { op: 'set', path: 'temperature', value: '0.5' },
+      { op: 'set', path: 'max_output_tokens', value: '16000' },
+    ]
+  );
+});
+
 test('set_if_absent is exposed as a localized body-only operation', () => {
   const schema = read('features/channels/data/schema.ts');
   const dialog = read('features/channels/components/channels-override-dialog.tsx');
@@ -43,9 +76,11 @@ test('set_if_absent is exposed as a localized body-only operation', () => {
   assert.match(schema, /'set_if_absent'/);
   assert.match(bodyTypes, /'set_if_absent'/);
   assert.doesNotMatch(headerTypes, /set_if_absent/);
+  assert.match(dialog, /op\.op === 'set_if_absent' && parseValueForDisplay\(op\.value\) === ''/);
 
   for (const locale of ['en', 'zh-CN']) {
     const messages = JSON.parse(read(`locales/${locale}/channels.json`));
     assert.ok(messages['channels.dialogs.settings.overrides.body.opSetIfAbsent']);
+    assert.ok(messages['channels.dialogs.settings.overrides.validation.missingValue']);
   }
 });

--- a/frontend/src/features/channels-override-merge.test.mjs
+++ b/frontend/src/features/channels-override-merge.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+
+const srcRoot = join(import.meta.dirname, '..');
+
+function read(relativePath) {
+  return readFileSync(join(srcRoot, relativePath), 'utf8');
+}
+
+const mergeSource = read('features/channels/utils/merge.ts');
+const transpiledMerge = ts.transpileModule(mergeSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2023,
+  },
+}).outputText;
+const mergeModuleUrl = `data:text/javascript;base64,${Buffer.from(transpiledMerge).toString('base64')}`;
+const { mergeOverrideOperations } = await import(mergeModuleUrl);
+
+test('set_if_absent participates in scalar body override replacement', () => {
+  const setIfAbsent = { op: 'set_if_absent', path: 'max_output_tokens', value: '32000' };
+  const temperature = { op: 'set', path: 'temperature', value: '0.5' };
+
+  assert.deepEqual(mergeOverrideOperations([{ op: 'set', path: 'max_output_tokens', value: '8000' }, temperature], [setIfAbsent]), [
+    setIfAbsent,
+    temperature,
+  ]);
+
+  assert.deepEqual(mergeOverrideOperations([setIfAbsent], [{ op: 'delete', path: 'max_output_tokens' }]), [
+    { op: 'delete', path: 'max_output_tokens' },
+  ]);
+});
+
+test('set_if_absent is exposed as a localized body-only operation', () => {
+  const schema = read('features/channels/data/schema.ts');
+  const dialog = read('features/channels/components/channels-override-dialog.tsx');
+  const bodyTypes = dialog.match(/const BODY_OP_TYPES:[\s\S]*?\];/)?.[0] || '';
+  const headerTypes = dialog.match(/const HEADER_OP_TYPES:[^\n]+/)?.[0] || '';
+
+  assert.match(schema, /'set_if_absent'/);
+  assert.match(bodyTypes, /'set_if_absent'/);
+  assert.doesNotMatch(headerTypes, /set_if_absent/);
+
+  for (const locale of ['en', 'zh-CN']) {
+    const messages = JSON.parse(read(`locales/${locale}/channels.json`));
+    assert.ok(messages['channels.dialogs.settings.overrides.body.opSetIfAbsent']);
+  }
+});

--- a/frontend/src/features/channels/components/channels-override-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-override-dialog.tsx
@@ -163,7 +163,7 @@ function isArrayInsertOp(op: OpType | undefined): boolean {
 }
 
 function isValidBodyOp(b: OverrideOperation): boolean {
-  if (b.op === 'set_if_absent') return !!b.path?.trim() && parseValueForDisplay(b.value) !== '';
+  if (b.op === 'set_if_absent') return !!b.path?.trim() && parseValueForDisplay(b.value).trim() !== '';
   if (b.op === 'set' || b.op === 'delete') return !!b.path?.trim();
   if (b.op === 'rename' || b.op === 'copy') return !!b.from?.trim() && !!b.to?.trim();
   if (b.op === 'array_append' || b.op === 'array_prepend') return !!b.path?.trim();
@@ -625,7 +625,7 @@ export function ChannelsOverrideDialog({ open, onOpenChange, currentRow }: Props
           return;
         }
       }
-      if (op.op === 'set_if_absent' && parseValueForDisplay(op.value) === '') {
+      if (op.op === 'set_if_absent' && parseValueForDisplay(op.value).trim() === '') {
         toast.error(t('channels.dialogs.settings.overrides.validation.missingValue', { index: i + 1, op: op.op }));
         return;
       }

--- a/frontend/src/features/channels/components/channels-override-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-override-dialog.tsx
@@ -163,7 +163,8 @@ function isArrayInsertOp(op: OpType | undefined): boolean {
 }
 
 function isValidBodyOp(b: OverrideOperation): boolean {
-  if (b.op === 'set' || b.op === 'set_if_absent' || b.op === 'delete') return !!b.path?.trim();
+  if (b.op === 'set_if_absent') return !!b.path?.trim() && parseValueForDisplay(b.value) !== '';
+  if (b.op === 'set' || b.op === 'delete') return !!b.path?.trim();
   if (b.op === 'rename' || b.op === 'copy') return !!b.from?.trim() && !!b.to?.trim();
   if (b.op === 'array_append' || b.op === 'array_prepend') return !!b.path?.trim();
   if (b.op === 'array_insert') return !!b.path?.trim() && typeof b.index === 'number';
@@ -623,6 +624,10 @@ export function ChannelsOverrideDialog({ open, onOpenChange, currentRow }: Props
           toast.error(t('channels.dialogs.settings.overrides.validation.emptyPath', { index: i + 1, op: op.op }));
           return;
         }
+      }
+      if (op.op === 'set_if_absent' && parseValueForDisplay(op.value) === '') {
+        toast.error(t('channels.dialogs.settings.overrides.validation.missingValue', { index: i + 1, op: op.op }));
+        return;
       }
       if (op.op === 'rename' || op.op === 'copy') {
         if (!op.from?.trim() || !op.to?.trim()) {

--- a/frontend/src/features/channels/components/channels-override-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-override-dialog.tsx
@@ -127,6 +127,7 @@ type OverrideFormValues = z.infer<typeof overrideFormSchema>;
 
 const OP_LABELS: Record<OpType, string> = {
   set: 'channels.dialogs.settings.overrides.body.opSet',
+  set_if_absent: 'channels.dialogs.settings.overrides.body.opSetIfAbsent',
   delete: 'channels.dialogs.settings.overrides.body.opDelete',
   rename: 'channels.dialogs.settings.overrides.body.opRename',
   copy: 'channels.dialogs.settings.overrides.body.opCopy',
@@ -137,7 +138,17 @@ const OP_LABELS: Record<OpType, string> = {
 };
 
 // Body operations support array manipulation; headers only support scalar set/delete/rename/copy.
-const BODY_OP_TYPES: OpType[] = ['set', 'delete', 'rename', 'copy', 'array_append', 'array_prepend', 'array_insert', 'array_remove'];
+const BODY_OP_TYPES: OpType[] = [
+  'set',
+  'set_if_absent',
+  'delete',
+  'rename',
+  'copy',
+  'array_append',
+  'array_prepend',
+  'array_insert',
+  'array_remove',
+];
 const HEADER_OP_TYPES: OpType[] = ['set', 'delete', 'rename', 'copy'];
 
 const ARRAY_OPS: OpType[] = ['array_append', 'array_prepend', 'array_insert', 'array_remove'];
@@ -152,7 +163,7 @@ function isArrayInsertOp(op: OpType | undefined): boolean {
 }
 
 function isValidBodyOp(b: OverrideOperation): boolean {
-  if (b.op === 'set' || b.op === 'delete') return !!b.path?.trim();
+  if (b.op === 'set' || b.op === 'set_if_absent' || b.op === 'delete') return !!b.path?.trim();
   if (b.op === 'rename' || b.op === 'copy') return !!b.from?.trim() && !!b.to?.trim();
   if (b.op === 'array_append' || b.op === 'array_prepend') return !!b.path?.trim();
   if (b.op === 'array_insert') return !!b.path?.trim() && typeof b.index === 'number';
@@ -177,9 +188,9 @@ function OperationRow({ index, control, fieldName, onUpdate, onRemove }: Operati
 
   const arrayOp = isArrayOp(field.op);
   const arrayInsertOp = isArrayInsertOp(field.op);
-  const needsPathOnly = field.op === 'set' || field.op === 'delete' || arrayOp;
+  const needsPathOnly = field.op === 'set' || field.op === 'set_if_absent' || field.op === 'delete' || arrayOp;
   const needsFromTo = field.op === 'rename' || field.op === 'copy';
-  const needsValue = field.op === 'set' || arrayInsertOp;
+  const needsValue = field.op === 'set' || field.op === 'set_if_absent' || arrayInsertOp;
   const needsIndex = field.op === 'array_insert';
   const needsMatch = field.op === 'array_remove';
 
@@ -607,7 +618,7 @@ export function ChannelsOverrideDialog({ open, onOpenChange, currentRow }: Props
     // Validate body operations
     for (let i = 0; i < bodyOps.length; i++) {
       const op = bodyOps[i];
-      if (op.op === 'set' || op.op === 'delete' || isArrayOp(op.op)) {
+      if (op.op === 'set' || op.op === 'set_if_absent' || op.op === 'delete' || isArrayOp(op.op)) {
         if (!op.path?.trim()) {
           toast.error(t('channels.dialogs.settings.overrides.validation.emptyPath', { index: i + 1, op: op.op }));
           return;

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -150,7 +150,7 @@ export const overrideMatchSchema = z.object({
 export type OverrideMatch = z.infer<typeof overrideMatchSchema>;
 
 export const overrideOperationSchema = z.object({
-  op: z.enum(['set', 'delete', 'rename', 'copy', 'array_append', 'array_prepend', 'array_insert', 'array_remove']),
+  op: z.enum(['set', 'set_if_absent', 'delete', 'rename', 'copy', 'array_append', 'array_prepend', 'array_insert', 'array_remove']),
   path: z.string().optional(),
   from: z.string().optional(),
   to: z.string().optional(),

--- a/frontend/src/features/channels/utils/merge.ts
+++ b/frontend/src/features/channels/utils/merge.ts
@@ -51,36 +51,32 @@ export function mergeOverrideHeaders(existing: OverrideOperation[], template: Ov
 
 /**
  * Merges override body operations with template body operations.
- * - For `set` and `delete` ops: match by `path`, template overrides existing
+ * - For `set`, `set_if_absent`, and `delete` ops: match by `path`, template overrides existing
  * - For `rename`, `copy`, and array ops: always appended from template
  * - Existing ops not matched by template are preserved
  */
 export function mergeOverrideOperations(existing: OverrideOperation[], template: OverrideOperation[]): OverrideOperation[] {
-  const result: OverrideOperation[] = [];
-
-  const templateSetOpsByPath = new Map<string, number[]>();
-  template.forEach((op, index) => {
-    if ((op.op === 'set' || op.op === 'delete') && op.path) {
-      const indices = templateSetOpsByPath.get(op.path) || [];
-      indices.push(index);
-      templateSetOpsByPath.set(op.path, indices);
-    }
-  });
-
-  for (const existingOp of existing) {
-    if ((existingOp.op === 'set' || existingOp.op === 'delete') && existingOp.path) {
-      if (templateSetOpsByPath.has(existingOp.path)) {
-        continue;
-      }
-    }
-    result.push(existingOp);
-  }
+  const result: OverrideOperation[] = [...existing];
 
   for (const templateOp of template) {
-    result.push(templateOp);
+    if (!isReplacingBodyOverrideOperation(templateOp)) {
+      result.push(templateOp);
+      continue;
+    }
+
+    const existingIndex = result.findIndex((op) => isReplacingBodyOverrideOperation(op) && op.path === templateOp.path);
+    if (existingIndex >= 0) {
+      result[existingIndex] = templateOp;
+    } else {
+      result.push(templateOp);
+    }
   }
 
   return result;
+}
+
+function isReplacingBodyOverrideOperation(op: OverrideOperation): boolean {
+  return op.op === 'set' || op.op === 'set_if_absent' || op.op === 'delete';
 }
 
 export function mergeChannelSettingsForUpdate(

--- a/frontend/src/features/channels/utils/merge.ts
+++ b/frontend/src/features/channels/utils/merge.ts
@@ -67,6 +67,11 @@ export function mergeOverrideOperations(existing: OverrideOperation[], template:
     const existingIndex = result.findIndex((op) => isReplacingBodyOverrideOperation(op) && op.path === templateOp.path);
     if (existingIndex >= 0) {
       result[existingIndex] = templateOp;
+      for (let i = result.length - 1; i > existingIndex; i--) {
+        if (isReplacingBodyOverrideOperation(result[i]) && result[i].path === templateOp.path) {
+          result.splice(i, 1);
+        }
+      }
     } else {
       result.push(templateOp);
     }

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -443,6 +443,7 @@
   "channels.dialogs.settings.overrides.body.description": "Override the request body sent to the channel, including changing body content, adding, deleting, renaming fields, or removing matching array items.",
   "channels.dialogs.settings.overrides.body.op": "Operation",
   "channels.dialogs.settings.overrides.body.opSet": "Set",
+  "channels.dialogs.settings.overrides.body.opSetIfAbsent": "Set If Absent",
   "channels.dialogs.settings.overrides.body.opDelete": "Delete",
   "channels.dialogs.settings.overrides.body.opRename": "Rename",
   "channels.dialogs.settings.overrides.body.opCopy": "Copy",

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -482,6 +482,7 @@
   "channels.dialogs.settings.overrides.headers.toPlaceholder": "e.g. X-New-Header",
   "channels.dialogs.settings.overrides.headers.sensitiveWarning": "This header may contain authentication credentials. Double-check before saving.",
   "channels.dialogs.settings.overrides.validation.emptyPath": "Operation {{index}} ({{op}}): Path cannot be empty",
+  "channels.dialogs.settings.overrides.validation.missingValue": "Operation {{index}} ({{op}}): Value is required",
   "channels.dialogs.settings.overrides.validation.emptyFromTo": "Operation {{index}} ({{op}}): Both source and target paths are required",
   "channels.dialogs.settings.overrides.validation.emptyHeaderPath": "Header operation {{index}} ({{op}}): Key cannot be empty",
   "channels.dialogs.settings.overrides.validation.emptyHeaderFromTo": "Header operation {{index}} ({{op}}): Both source and target keys are required",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -440,6 +440,7 @@
   "channels.dialogs.settings.overrides.body.description": "覆盖发送到渠道的请求体，您可以更改请求体内容、添加、删除、重命名字段，或移除匹配的数组项。",
   "channels.dialogs.settings.overrides.body.op": "操作类型",
   "channels.dialogs.settings.overrides.body.opSet": "设置",
+  "channels.dialogs.settings.overrides.body.opSetIfAbsent": "不存在时设置",
   "channels.dialogs.settings.overrides.body.opDelete": "删除",
   "channels.dialogs.settings.overrides.body.opRename": "重命名",
   "channels.dialogs.settings.overrides.body.opCopy": "复制",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -479,6 +479,7 @@
   "channels.dialogs.settings.overrides.headers.toPlaceholder": "例如 X-New-Header",
   "channels.dialogs.settings.overrides.headers.sensitiveWarning": "该请求头可能包含认证凭据，请谨慎设置。",
   "channels.dialogs.settings.overrides.validation.emptyPath": "第 {{index}} 个操作 ({{op}}): 路径不能为空",
+  "channels.dialogs.settings.overrides.validation.missingValue": "第 {{index}} 个操作 ({{op}}): 值不能为空",
   "channels.dialogs.settings.overrides.validation.emptyFromTo": "第 {{index}} 个操作 ({{op}}): 源路径和目标路径都不能为空",
   "channels.dialogs.settings.overrides.validation.emptyHeaderPath": "第 {{index}} 个请求头操作 ({{op}}): 键名不能为空",
   "channels.dialogs.settings.overrides.validation.emptyHeaderFromTo": "第 {{index}} 个请求头操作 ({{op}}): 源键名和目标键名都不能为空",

--- a/internal/objects/channel.go
+++ b/internal/objects/channel.go
@@ -47,6 +47,7 @@ type HeaderEntry struct {
 // Override operation types.
 const (
 	OverrideOpSet          = "set"
+	OverrideOpSetIfAbsent  = "set_if_absent"
 	OverrideOpDelete       = "delete"
 	OverrideOpRename       = "rename"
 	OverrideOpCopy         = "copy"

--- a/internal/server/biz/channel_merge_test.go
+++ b/internal/server/biz/channel_merge_test.go
@@ -180,6 +180,26 @@ func TestMergeOverrideOperations(t *testing.T) {
 			template: []objects.OverrideOperation{renameOp("max_tokens", "max_output_tokens")},
 			expected: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000"), renameOp("max_tokens", "max_output_tokens")},
 		},
+		{
+			name: "template removes duplicate scalar operations at the same path",
+			existing: []objects.OverrideOperation{
+				setOp("max_output_tokens", "8000"),
+				setOp("temperature", "0.5"),
+				setIfAbsentOp("max_output_tokens", "32000"),
+				deleteOp("max_output_tokens"),
+			},
+			template: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "16000")},
+			expected: []objects.OverrideOperation{
+				setIfAbsentOp("max_output_tokens", "16000"),
+				setOp("temperature", "0.5"),
+			},
+		},
+		{
+			name:     "last template scalar operation at the same path wins",
+			existing: []objects.OverrideOperation{setOp("temperature", "0.5")},
+			template: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000"), setOp("max_output_tokens", "16000")},
+			expected: []objects.OverrideOperation{setOp("temperature", "0.5"), setOp("max_output_tokens", "16000")},
+		},
 	}
 
 	for _, tt := range tests {
@@ -347,6 +367,11 @@ func TestValidateBodyOverrideOperations(t *testing.T) {
 		{
 			name:        "set if absent requires path",
 			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Value: "32000"}},
+			expectError: true,
+		},
+		{
+			name:        "set if absent requires value",
+			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens"}},
 			expectError: true,
 		},
 		{

--- a/internal/server/biz/channel_merge_test.go
+++ b/internal/server/biz/channel_merge_test.go
@@ -136,6 +136,59 @@ func TestMergeOverrideHeaders(t *testing.T) {
 	}
 }
 
+func TestMergeOverrideOperations(t *testing.T) {
+	setOp := func(path, value string) objects.OverrideOperation {
+		return objects.OverrideOperation{Op: objects.OverrideOpSet, Path: path, Value: value}
+	}
+	setIfAbsentOp := func(path, value string) objects.OverrideOperation {
+		return objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: path, Value: value}
+	}
+	deleteOp := func(path string) objects.OverrideOperation {
+		return objects.OverrideOperation{Op: objects.OverrideOpDelete, Path: path}
+	}
+	renameOp := func(from, to string) objects.OverrideOperation {
+		return objects.OverrideOperation{Op: objects.OverrideOpRename, From: from, To: to}
+	}
+
+	tests := []struct {
+		name     string
+		existing []objects.OverrideOperation
+		template []objects.OverrideOperation
+		expected []objects.OverrideOperation
+	}{
+		{
+			name:     "set if absent replaces set at the same path",
+			existing: []objects.OverrideOperation{setOp("max_output_tokens", "8000"), setOp("temperature", "0.5")},
+			template: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000")},
+			expected: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000"), setOp("temperature", "0.5")},
+		},
+		{
+			name:     "set replaces set if absent at the same path",
+			existing: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000")},
+			template: []objects.OverrideOperation{setOp("max_output_tokens", "16000")},
+			expected: []objects.OverrideOperation{setOp("max_output_tokens", "16000")},
+		},
+		{
+			name:     "delete replaces set if absent at the same path",
+			existing: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000")},
+			template: []objects.OverrideOperation{deleteOp("max_output_tokens")},
+			expected: []objects.OverrideOperation{deleteOp("max_output_tokens")},
+		},
+		{
+			name:     "non-replacing operations remain ordered and are appended",
+			existing: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000")},
+			template: []objects.OverrideOperation{renameOp("max_tokens", "max_output_tokens")},
+			expected: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000"), renameOp("max_tokens", "max_output_tokens")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, MergeOverrideOperations(tt.existing, tt.template))
+		})
+	}
+}
+
 func TestMergeOverrideParameters(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -287,6 +340,21 @@ func TestValidateBodyOverrideOperations(t *testing.T) {
 		expectError bool
 	}{
 		{
+			name:        "valid set if absent op",
+			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000"}},
+			expectError: false,
+		},
+		{
+			name:        "set if absent requires path",
+			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Value: "32000"}},
+			expectError: true,
+		},
+		{
+			name:        "set if absent cannot target stream",
+			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Path: "stream", Value: "true"}},
+			expectError: true,
+		},
+		{
 			name:        "valid array remove op",
 			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpArrayRemove, Path: "tools", Match: &objects.OverrideMatch{Path: "function.name", Eq: "web_search"}}},
 			expectError: false,
@@ -360,6 +428,13 @@ func TestValidateOverrideHeaders(t *testing.T) {
 			name: "set with whitespace path",
 			ops: []objects.OverrideOperation{
 				{Op: objects.OverrideOpSet, Path: "   ", Value: "value"},
+			},
+			expectError: true,
+		},
+		{
+			name: "set if absent is rejected for headers",
+			ops: []objects.OverrideOperation{
+				{Op: objects.OverrideOpSetIfAbsent, Path: "X-Default", Value: "value"},
 			},
 			expectError: true,
 		},

--- a/internal/server/biz/channel_merge_test.go
+++ b/internal/server/biz/channel_merge_test.go
@@ -375,6 +375,11 @@ func TestValidateBodyOverrideOperations(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "set if absent rejects whitespace value",
+			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "   "}},
+			expectError: true,
+		},
+		{
 			name:        "set if absent cannot target stream",
 			ops:         []objects.OverrideOperation{{Op: objects.OverrideOpSetIfAbsent, Path: "stream", Value: "true"}},
 			expectError: true,

--- a/internal/server/biz/channel_override.go
+++ b/internal/server/biz/channel_override.go
@@ -172,6 +172,7 @@ func ValidateOverrideParameters(params string) error {
 
 // ValidateBodyOverrideOperations validates body override operations.
 // - set/set_if_absent/delete/array_*: require non-empty Path
+// - set_if_absent: requires a non-empty Value
 // - rename/copy: require non-empty From and To
 // - array_insert: requires Index
 // - array_remove: requires Match.Path and Match.Eq
@@ -182,6 +183,10 @@ func ValidateBodyOverrideOperations(ops []objects.OverrideOperation) error {
 		case objects.OverrideOpSet, objects.OverrideOpSetIfAbsent:
 			if strings.TrimSpace(op.Path) == "" {
 				return fmt.Errorf("body operation at index %d (%s) has an empty path", i, op.Op)
+			}
+
+			if op.Op == objects.OverrideOpSetIfAbsent && op.Value == "" {
+				return fmt.Errorf("body operation at index %d (set_if_absent) has an empty value", i)
 			}
 
 			if strings.EqualFold(op.Path, "stream") {

--- a/internal/server/biz/channel_override.go
+++ b/internal/server/biz/channel_override.go
@@ -185,7 +185,7 @@ func ValidateBodyOverrideOperations(ops []objects.OverrideOperation) error {
 				return fmt.Errorf("body operation at index %d (%s) has an empty path", i, op.Op)
 			}
 
-			if op.Op == objects.OverrideOpSetIfAbsent && op.Value == "" {
+			if op.Op == objects.OverrideOpSetIfAbsent && strings.TrimSpace(op.Value) == "" {
 				return fmt.Errorf("body operation at index %d (set_if_absent) has an empty value", i)
 			}
 

--- a/internal/server/biz/channel_override.go
+++ b/internal/server/biz/channel_override.go
@@ -162,7 +162,7 @@ func ValidateOverrideParameters(params string) error {
 	}
 
 	for _, op := range ops {
-		if op.Op == objects.OverrideOpSet && strings.EqualFold(op.Path, "stream") {
+		if (op.Op == objects.OverrideOpSet || op.Op == objects.OverrideOpSetIfAbsent) && strings.EqualFold(op.Path, "stream") {
 			return fmt.Errorf("override parameters cannot contain the field \"stream\"")
 		}
 	}
@@ -171,17 +171,17 @@ func ValidateOverrideParameters(params string) error {
 }
 
 // ValidateBodyOverrideOperations validates body override operations.
-// - set/delete/array_*: require non-empty Path
+// - set/set_if_absent/delete/array_*: require non-empty Path
 // - rename/copy: require non-empty From and To
 // - array_insert: requires Index
 // - array_remove: requires Match.Path and Match.Eq
-// - set/array_*: cannot target the "stream" field.
+// - set/set_if_absent/array_*: cannot target the "stream" field.
 func ValidateBodyOverrideOperations(ops []objects.OverrideOperation) error {
 	for i, op := range ops {
 		switch op.Op {
-		case objects.OverrideOpSet:
+		case objects.OverrideOpSet, objects.OverrideOpSetIfAbsent:
 			if strings.TrimSpace(op.Path) == "" {
-				return fmt.Errorf("body operation at index %d (set) has an empty path", i)
+				return fmt.Errorf("body operation at index %d (%s) has an empty path", i, op.Op)
 			}
 
 			if strings.EqualFold(op.Path, "stream") {
@@ -247,6 +247,8 @@ func ValidateOverrideHeaders(ops []objects.OverrideOperation) error {
 			if strings.TrimSpace(op.From) == "" || strings.TrimSpace(op.To) == "" {
 				return fmt.Errorf("header operation at index %d (%s) requires non-empty from and to", i, op.Op)
 			}
+		case objects.OverrideOpSetIfAbsent:
+			return fmt.Errorf("header operation at index %d (%s) is not supported on headers; it only applies to the body", i, op.Op)
 		case objects.OverrideOpArrayAppend, objects.OverrideOpArrayPrepend, objects.OverrideOpArrayInsert, objects.OverrideOpArrayRemove:
 			return fmt.Errorf("header operation at index %d (%s) is not supported on headers; array ops only apply to the body", i, op.Op)
 		default:

--- a/internal/server/biz/channel_override_template.go
+++ b/internal/server/biz/channel_override_template.go
@@ -343,20 +343,34 @@ func MergeOverrideOperations(existing, template []objects.OverrideOperation) []o
 			continue
 		}
 
-		found := false
+		result = replaceBodyOverrideOperation(result, op)
+	}
 
-		for i := range result {
-			if isReplacingBodyOverrideOperation(result[i].Op) && result[i].Path == op.Path {
-				result[i] = op
+	return result
+}
+
+func replaceBodyOverrideOperation(result []objects.OverrideOperation, replacement objects.OverrideOperation) []objects.OverrideOperation {
+	found := false
+	writeIndex := 0
+
+	for _, op := range result {
+		if isReplacingBodyOverrideOperation(op.Op) && op.Path == replacement.Path {
+			if !found {
+				result[writeIndex] = replacement
+				writeIndex++
 				found = true
-
-				break
 			}
+
+			continue
 		}
 
-		if !found {
-			result = append(result, op)
-		}
+		result[writeIndex] = op
+		writeIndex++
+	}
+
+	result = result[:writeIndex]
+	if !found {
+		result = append(result, replacement)
 	}
 
 	return result

--- a/internal/server/biz/channel_override_template.go
+++ b/internal/server/biz/channel_override_template.go
@@ -330,7 +330,7 @@ func getBodyOverrideOperations(settings *objects.ChannelSettings) []objects.Over
 }
 
 // MergeOverrideOperations merges existing body operations with template operations.
-// - For set/delete ops, matching is by Path. Template overrides existing.
+// - For set/set_if_absent/delete ops, matching is by Path. Template overrides existing.
 // - For rename/copy and array_* ops, they are always appended (multiple of the same path are meaningful).
 // - Existing ops not mentioned in the template are preserved.
 func MergeOverrideOperations(existing, template []objects.OverrideOperation) []objects.OverrideOperation {
@@ -338,9 +338,7 @@ func MergeOverrideOperations(existing, template []objects.OverrideOperation) []o
 	result = append(result, existing...)
 
 	for _, op := range template {
-		switch op.Op {
-		case objects.OverrideOpRename, objects.OverrideOpCopy,
-			objects.OverrideOpArrayAppend, objects.OverrideOpArrayPrepend, objects.OverrideOpArrayInsert:
+		if !isReplacingBodyOverrideOperation(op.Op) {
 			result = append(result, op)
 			continue
 		}
@@ -348,8 +346,7 @@ func MergeOverrideOperations(existing, template []objects.OverrideOperation) []o
 		found := false
 
 		for i := range result {
-			if (result[i].Op == objects.OverrideOpSet || result[i].Op == objects.OverrideOpDelete) &&
-				result[i].Path == op.Path {
+			if isReplacingBodyOverrideOperation(result[i].Op) && result[i].Path == op.Path {
 				result[i] = op
 				found = true
 
@@ -363,6 +360,10 @@ func MergeOverrideOperations(existing, template []objects.OverrideOperation) []o
 	}
 
 	return result
+}
+
+func isReplacingBodyOverrideOperation(op string) bool {
+	return op == objects.OverrideOpSet || op == objects.OverrideOpSetIfAbsent || op == objects.OverrideOpDelete
 }
 
 // QueryChannelOverrideTemplatesInput represents the input for querying templates.

--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -192,6 +192,8 @@ func applyBodyOperation(
 	switch op.Op {
 	case objects.OverrideOpSet:
 		return applyBodySet(ctx, body, op, renderCtx)
+	case objects.OverrideOpSetIfAbsent:
+		return applyBodySetIfAbsent(ctx, body, op, renderCtx)
 	case objects.OverrideOpDelete:
 		return applyBodyDelete(body, op)
 	case objects.OverrideOpRename:
@@ -228,6 +230,20 @@ func applyBodySet(
 	}
 
 	return sjson.SetBytes(body, op.Path, renderedValue)
+}
+
+func applyBodySetIfAbsent(
+	ctx context.Context,
+	body []byte,
+	op objects.OverrideOperation,
+	renderCtx RenderContext,
+) ([]byte, error) {
+	existing := gjson.GetBytes(body, op.Path)
+	if existing.Exists() || existing.Raw == "null" {
+		return body, nil
+	}
+
+	return applyBodySet(ctx, body, op, renderCtx)
 }
 
 func applyBodyDelete(body []byte, op objects.OverrideOperation) ([]byte, error) {

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -1849,6 +1849,109 @@ func TestOverrideLegacyFormatCompatibility(t *testing.T) {
 	require.Equal(t, "yes", gjson.Get(bodyStr, "keep").String())
 }
 
+func TestOverrideBodySetIfAbsent(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		body     string
+		op       objects.OverrideOperation
+		metadata map[string]string
+		expected string
+	}{
+		{
+			name:     "sets top-level default when path is absent",
+			body:     `{"model":"gpt-5.5"}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000"},
+			expected: `{"model":"gpt-5.5","max_output_tokens":32000}`,
+		},
+		{
+			name:     "preserves existing number",
+			body:     `{"max_output_tokens":8000}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000"},
+			expected: `{"max_output_tokens":8000}`,
+		},
+		{
+			name:     "preserves zero",
+			body:     `{"max_output_tokens":0}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000"},
+			expected: `{"max_output_tokens":0}`,
+		},
+		{
+			name:     "preserves false",
+			body:     `{"feature":{"enabled":false}}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "feature.enabled", Value: "true"},
+			expected: `{"feature":{"enabled":false}}`,
+		},
+		{
+			name:     "preserves empty string",
+			body:     `{"label":""}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "label", Value: "fallback"},
+			expected: `{"label":""}`,
+		},
+		{
+			name:     "preserves explicit null",
+			body:     `{"max_output_tokens":null}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000"},
+			expected: `{"max_output_tokens":null}`,
+		},
+		{
+			name:     "sets nested default when path is absent",
+			body:     `{"generation":{}}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "generation.max_output_tokens", Value: "32000"},
+			expected: `{"generation":{"max_output_tokens":32000}}`,
+		},
+		{
+			name:     "preserves existing nested value",
+			body:     `{"generation":{"max_output_tokens":16000}}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "generation.max_output_tokens", Value: "32000"},
+			expected: `{"generation":{"max_output_tokens":16000}}`,
+		},
+		{
+			name:     "renders template when path is absent",
+			body:     `{}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: `{{index .Metadata "default_max"}}`},
+			metadata: map[string]string{"default_max": "64000"},
+			expected: `{"max_output_tokens":64000}`,
+		},
+		{
+			name:     "respects false condition",
+			body:     `{}`,
+			op:       objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: "max_output_tokens", Value: "32000", Condition: `{{eq .Model "other-model"}}`},
+			expected: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llmRequest := &llm.Request{Model: "gpt-5.5", Metadata: tt.metadata}
+			channel := &biz.Channel{
+				Channel: &ent.Channel{
+					ID:   1,
+					Name: "set-if-absent-test",
+					Settings: &objects.ChannelSettings{
+						BodyOverrideOperations: []objects.OverrideOperation{tt.op},
+					},
+				},
+				Outbound: &mockTransformer{},
+			}
+			outbound := &PersistentOutboundTransformer{
+				wrapped: &mockTransformer{},
+				state: &PersistenceState{
+					CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+					LlmRequest:       llmRequest,
+					OriginalModel:    llmRequest.Model,
+				},
+			}
+
+			middleware := applyOverrideRequestBody(outbound)
+			result, err := middleware.OnOutboundRawRequest(ctx, &httpclient.Request{Body: []byte(tt.body)})
+			require.NoError(t, err)
+			require.JSONEq(t, tt.expected, string(result.Body))
+		})
+	}
+}
+
 func TestParseOverrideOperations(t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
 		ops, err := objects.ParseOverrideOperations("")


### PR DESCRIPTION
## Summary

- add a body-only `set_if_absent` request override operation
- preserve client-provided values, including `0`, `false`, empty strings, and explicit `null`
- keep backend and frontend template-merge behavior consistent for `set`, `set_if_absent`, and `delete`
- add UI configuration, validation, localized labels, documentation, and focused tests

## Why

Channels sometimes need to provide provider-specific defaults such as `max_output_tokens` while still allowing clients to choose their own value. The existing `set` operation always replaces the client value, and template conditions cannot inspect arbitrary body paths.

## Impact

`set_if_absent` uses the existing GJSON/SJSON path syntax and only writes the rendered value when the target path is missing. Header overrides reject this operation. Existing operations and stored configurations remain compatible; no schema migration or GraphQL code generation is required.

## Checks

- `go test -mod=readonly ./internal/server/orchestrator ./internal/server/biz`
- `pnpm test:unit`
