### PR TITLE
fix(codex): preserve Responses Lite request requirements

### DIFF
--- a/llm/provider_extensions.go
+++ b/llm/provider_extensions.go
@@ -13,10 +13,11 @@ type OpenAIResponsesProviderExtensions struct {
 }
 
 type OpenAIResponsesRequestExtensions struct {
-	RawTools       []OpenAIResponsesRawFragment `json:"-"`
-	ToolSignatures []string                     `json:"-"`
-	RawToolChoice  json.RawMessage              `json:"-"`
-	RawInputItems  []OpenAIResponsesRawFragment `json:"-"`
+	ReasoningContext string                       `json:"-"`
+	RawTools         []OpenAIResponsesRawFragment `json:"-"`
+	ToolSignatures   []string                     `json:"-"`
+	RawToolChoice    json.RawMessage              `json:"-"`
+	RawInputItems    []OpenAIResponsesRawFragment `json:"-"`
 }
 
 type OpenAIResponsesRawFragment struct {
@@ -53,10 +54,11 @@ func CloneProviderExtensions(src *ProviderExtensions) *ProviderExtensions {
 		cloned.OpenAIResponses = &OpenAIResponsesProviderExtensions{}
 		if src.OpenAIResponses.Request != nil {
 			cloned.OpenAIResponses.Request = &OpenAIResponsesRequestExtensions{
-				RawTools:       cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawTools),
-				ToolSignatures: append([]string(nil), src.OpenAIResponses.Request.ToolSignatures...),
-				RawToolChoice:  cloneRawMessage(src.OpenAIResponses.Request.RawToolChoice),
-				RawInputItems:  cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawInputItems),
+				ReasoningContext: src.OpenAIResponses.Request.ReasoningContext,
+				RawTools:         cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawTools),
+				ToolSignatures:   append([]string(nil), src.OpenAIResponses.Request.ToolSignatures...),
+				RawToolChoice:    cloneRawMessage(src.OpenAIResponses.Request.RawToolChoice),
+				RawInputItems:    cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawInputItems),
 			}
 		}
 	}

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -517,18 +517,19 @@ func TestCodexOutbound_ForcesArrayInputsForSingleMessage(t *testing.T) {
 	assert.Equal(t, "user", first["role"])
 }
 
-func TestCodexOutbound_PreservesResponsesLiteReasoningContext(t *testing.T) {
+func TestCodexOutbound_PreservesResponsesLiteRequirements(t *testing.T) {
 	ctx := context.Background()
 	outbound := newTestCodexOutbound(t)
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set(responses.ResponsesLiteHeader, "true")
 	inboundRequest := &httpclient.Request{
-		Headers: http.Header{
-			"Content-Type":                           []string{"application/json"},
-			"X-Openai-Internal-Codex-Responses-Lite": []string{"true"},
-		},
+		Headers: headers,
 		Body: []byte(`{
 			"model": "gpt-5.6-sol",
 			"input": "Hello",
 			"stream": true,
+			"parallel_tool_calls": false,
 			"reasoning": {
 				"effort": "xhigh",
 				"context": "all_turns"
@@ -544,9 +545,10 @@ func TestCodexOutbound_PreservesResponsesLiteReasoningContext(t *testing.T) {
 	require.NoError(t, err)
 	outboundRequest = httpclient.MergeInboundRequest(outboundRequest, inboundRequest)
 
-	assert.Equal(t, "true", outboundRequest.Headers.Get("X-Openai-Internal-Codex-Responses-Lite"))
+	assert.Equal(t, "true", outboundRequest.Headers.Get(responses.ResponsesLiteHeader))
 
 	body := decodeCodexRequestBody(t, outboundRequest)
+	assert.Equal(t, false, body["parallel_tool_calls"])
 	reasoning, ok := body["reasoning"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "all_turns", reasoning["context"])

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -517,6 +517,41 @@ func TestCodexOutbound_ForcesArrayInputsForSingleMessage(t *testing.T) {
 	assert.Equal(t, "user", first["role"])
 }
 
+func TestCodexOutbound_PreservesResponsesLiteReasoningContext(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+	inboundRequest := &httpclient.Request{
+		Headers: http.Header{
+			"Content-Type":                           []string{"application/json"},
+			"X-Openai-Internal-Codex-Responses-Lite": []string{"true"},
+		},
+		Body: []byte(`{
+			"model": "gpt-5.6-sol",
+			"input": "Hello",
+			"stream": true,
+			"reasoning": {
+				"effort": "xhigh",
+				"context": "all_turns"
+			}
+		}`),
+	}
+
+	llmRequest, err := responses.NewInboundTransformer().TransformRequest(ctx, inboundRequest)
+	require.NoError(t, err)
+	llmRequest.RawRequest = inboundRequest
+
+	outboundRequest, err := outbound.TransformRequest(ctx, llmRequest)
+	require.NoError(t, err)
+	outboundRequest = httpclient.MergeInboundRequest(outboundRequest, inboundRequest)
+
+	assert.Equal(t, "true", outboundRequest.Headers.Get("X-Openai-Internal-Codex-Responses-Lite"))
+
+	body := decodeCodexRequestBody(t, outboundRequest)
+	reasoning, ok := body["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "all_turns", reasoning["context"])
+}
+
 func newTestCodexOutbound(t *testing.T) *OutboundTransformer {
 	t.Helper()
 

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -164,6 +164,8 @@ type Prompt struct {
 
 // Reasoning represents configuration options for reasoning models.
 type Reasoning struct {
+	// The reasoning context scope requested by internal Responses features.
+	Context string `json:"context,omitempty"`
 	// The effort level for reasoning. Any of "low", "medium", "high".
 	Effort string `json:"effort,omitempty"`
 	// Whether to generate a summary of the reasoning. Any of "auto", "concise", "detailed".

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -28,8 +28,9 @@ var (
 
 // Config holds all configuration for the OpenAI Responses outbound transformer.
 const (
-	TransportHTTP      = "http"
-	TransportWebSocket = "websocket"
+	TransportHTTP       = "http"
+	TransportWebSocket  = "websocket"
+	ResponsesLiteHeader = "X-OpenAI-Internal-Codex-Responses-Lite"
 )
 
 type Config struct {
@@ -277,8 +278,11 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		}
 	}
 
-	// Clear `parallel_tool_calls` when no tools are sent (Responses API compatibility).
-	if len(payload.Tools) == 0 {
+	// Responses Lite requires an explicit false value, even when no top-level tools are sent.
+	if llmReq.RawRequest != nil && strings.EqualFold(strings.TrimSpace(llmReq.RawRequest.Headers.Get(ResponsesLiteHeader)), "true") {
+		payload.ParallelToolCalls = lo.ToPtr(false)
+	} else if len(payload.Tools) == 0 {
+		// Other Responses providers may reject parallel_tool_calls when tools are absent.
 		payload.ParallelToolCalls = nil
 	}
 

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -504,8 +504,14 @@ func convertStreamOptions(src *llm.StreamOptions, metadata map[string]any) *Stre
 // Only one of "reasoning.effort" and "reasoning.max_tokens" can be specified.
 // Priority is given to effort when both are present.
 func convertReasoning(req *llm.Request) *Reasoning {
+	reasoningContext := ""
+	if requestExt := openAIResponsesRequestExtensions(req); requestExt != nil {
+		reasoningContext = requestExt.ReasoningContext
+	}
+
 	// Check if any reasoning-related fields are present
-	hasReasoningFields := req.ReasoningEffort != "" ||
+	hasReasoningFields := reasoningContext != "" ||
+		req.ReasoningEffort != "" ||
 		req.ReasoningBudget != nil ||
 		req.ReasoningSummary != nil
 	if !hasReasoningFields {
@@ -513,6 +519,7 @@ func convertReasoning(req *llm.Request) *Reasoning {
 	}
 
 	reasoning := &Reasoning{
+		Context:   reasoningContext,
 		Effort:    req.ReasoningEffort,
 		MaxTokens: req.ReasoningBudget,
 	}

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -780,6 +780,21 @@ func TestConvertReasoning(t *testing.T) {
 				Summary: "concise",
 			},
 		},
+		{
+			name: "with only responses reasoning context",
+			req: &llm.Request{
+				ProviderExtensions: &llm.ProviderExtensions{
+					OpenAIResponses: &llm.OpenAIResponsesProviderExtensions{
+						Request: &llm.OpenAIResponsesRequestExtensions{
+							ReasoningContext: "all_turns",
+						},
+					},
+				},
+			},
+			expected: &Reasoning{
+				Context: "all_turns",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/llm/transformer/openai/responses/request_extensions.go
+++ b/llm/transformer/openai/responses/request_extensions.go
@@ -12,14 +12,19 @@ func attachOpenAIResponsesRequestExtensions(chatReq *llm.Request, req *Request, 
 	}
 
 	raw := parseRawRequestFragments(rawBody)
+	reasoningContext := ""
+	if req.Reasoning != nil {
+		reasoningContext = req.Reasoning.Context
+	}
 	requestExt := &llm.OpenAIResponsesRequestExtensions{
-		RawTools:       buildRawOnlyToolFragments(req.Tools, raw.Tools),
-		ToolSignatures: buildRepresentedToolSignatures(req.Tools),
-		RawToolChoice:  rawUnsupportedToolChoice(req.ToolChoice, raw.ToolChoice),
-		RawInputItems:  buildRawOnlyInputFragments(req.Input, raw.InputItems),
+		ReasoningContext: reasoningContext,
+		RawTools:         buildRawOnlyToolFragments(req.Tools, raw.Tools),
+		ToolSignatures:   buildRepresentedToolSignatures(req.Tools),
+		RawToolChoice:    rawUnsupportedToolChoice(req.ToolChoice, raw.ToolChoice),
+		RawInputItems:    buildRawOnlyInputFragments(req.Input, raw.InputItems),
 	}
 
-	if len(requestExt.RawTools) == 0 && len(requestExt.RawToolChoice) == 0 && len(requestExt.RawInputItems) == 0 {
+	if requestExt.ReasoningContext == "" && len(requestExt.RawTools) == 0 && len(requestExt.RawToolChoice) == 0 && len(requestExt.RawInputItems) == 0 {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- preserve `reasoning.context` across the normalized Responses request pipeline
- keep `parallel_tool_calls` explicitly `false` for Responses Lite requests, including requests without top-level tools
- centralize the Responses Lite header name and add regression coverage for both requirements

## Root cause

AxonHub forwarded `X-OpenAI-Internal-Codex-Responses-Lite`, but the normalized request path did not preserve the provider-specific `reasoning.context` field. It also removed `parallel_tool_calls` when no top-level tools were present. The Codex Responses Lite endpoint requires `reasoning.context=all_turns` and an explicit `parallel_tool_calls=false`, so the transformed request was rejected upstream.

## Impact

Codex clients using GPT-5.6 models through the non-pass-through Responses pipeline can keep the Lite request contract instead of receiving upstream `unsupported_value` errors for the missing constraints.

## Validation

- `cd llm && go test ./... -count=1`
- manual end-to-end verification against a Responses Lite request

Fixes #1983
