### PR TITLE
fix: embed IANA timezone database for Windows compatibility

### DIFF
--- a/cmd/axonhub/main.go
+++ b/cmd/axonhub/main.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/fx/fxevent"
 	"gopkg.in/yaml.v3"
 
+	_ "time/tzdata"
+
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/looplj/axonhub/conf"


### PR DESCRIPTION
## 问题

Windows 上仪表盘和分析页面的日期分组不正确。Linux 上运行正常。

**根因**: `SystemService.TimeLocation()` 调用 `time.LoadLocation("Asia/Shanghai")` 时，Windows 缺少 IANA 时区数据库（Linux 从 `/usr/share/zoneinfo/` 读取），导致加载失败并静默回退到 `time.UTC`，`offsetSeconds` 变为 0，日期分组全部按 UTC 进行。

## 修复

在 `cmd/axonhub/main.go` 中导入 `time/tzdata`，将 IANA 时区数据库嵌入二进制文件，使 `time.LoadLocation` 在所有平台上行为一致。

## 影响

- 二进制文件增大约 450KB（标准库自带，无需安装额外依赖）
- Linux 行为无变化，Windows 时区加载恢复正常
