### PR TITLE
fix: isolate upstream X-Request-ID per request

### DIFF
--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -270,6 +270,9 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		// User-Agent value (either from client pass-through or default "axonhub/1.0").
 		// This allows override headers to modify the User-Agent if configured.
 		applyUserAgentPassThrough(outbound, processor.SystemService),
+		// Replace a client-provided X-Request-Id with AxonHub's unique per-request
+		// identifier. Header overrides run afterwards and can still opt out.
+		applyUpstreamRequestID(),
 		applyOverrideRequestHeaders(outbound),
 
 		// Unified performance tracking middleware.

--- a/internal/server/orchestrator/request_id.go
+++ b/internal/server/orchestrator/request_id.go
@@ -1,0 +1,32 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/looplj/axonhub/internal/contexts"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+)
+
+const upstreamRequestIDHeader = "X-Request-Id"
+
+// applyUpstreamRequestID replaces any client-provided request ID with AxonHub's
+// per-request ID. Trace IDs may intentionally span multiple agent calls, while
+// X-Request-Id identifies one HTTP request and must remain unique downstream.
+func applyUpstreamRequestID() pipeline.Middleware {
+	return pipeline.OnRawRequest("upstream-request-id", func(ctx context.Context, request *httpclient.Request) (*httpclient.Request, error) {
+		requestID, ok := contexts.GetRequestID(ctx)
+		if !ok || strings.TrimSpace(requestID) == "" {
+			return request, nil
+		}
+
+		if request.Headers == nil {
+			request.Headers = make(http.Header)
+		}
+		request.Headers.Set(upstreamRequestIDHeader, requestID)
+
+		return request, nil
+	})
+}

--- a/internal/server/orchestrator/request_id_test.go
+++ b/internal/server/orchestrator/request_id_test.go
@@ -1,0 +1,54 @@
+package orchestrator
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/contexts"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestApplyUpstreamRequestID_ReusedClientIDGetsUniqueUpstreamIDs(t *testing.T) {
+	middleware := applyUpstreamRequestID()
+
+	first, err := middleware.OnOutboundRawRequest(
+		contexts.WithRequestID(t.Context(), "ar-first-request"),
+		&httpclient.Request{Headers: http.Header{
+			upstreamRequestIDHeader: []string{"shared-agent-trace"},
+		}},
+	)
+	require.NoError(t, err)
+
+	second, err := middleware.OnOutboundRawRequest(
+		contexts.WithRequestID(t.Context(), "ar-second-request"),
+		&httpclient.Request{Headers: http.Header{
+			upstreamRequestIDHeader: []string{"shared-agent-trace"},
+		}},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ar-first-request", first.Headers.Get(upstreamRequestIDHeader))
+	assert.Equal(t, "ar-second-request", second.Headers.Get(upstreamRequestIDHeader))
+	assert.NotEqual(t, first.Headers.Get(upstreamRequestIDHeader), second.Headers.Get(upstreamRequestIDHeader))
+}
+
+func TestApplyUpstreamRequestID_InitializesHeaders(t *testing.T) {
+	ctx := contexts.WithRequestID(t.Context(), "ar-unique-request")
+
+	got, err := applyUpstreamRequestID().OnOutboundRawRequest(ctx, &httpclient.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, "ar-unique-request", got.Headers.Get(upstreamRequestIDHeader))
+}
+
+func TestApplyUpstreamRequestID_PreservesHeaderWithoutContextID(t *testing.T) {
+	request := &httpclient.Request{Headers: http.Header{
+		upstreamRequestIDHeader: []string{"client-request-id"},
+	}}
+
+	got, err := applyUpstreamRequestID().OnOutboundRawRequest(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, "client-request-id", got.Headers.Get(upstreamRequestIDHeader))
+}


### PR DESCRIPTION
## Summary

- replace a client-provided `X-Request-Id` on outbound calls with AxonHub's unique per-request `ar-*` ID
- keep the ID stable for retry attempts belonging to the same inbound request
- keep channel header overrides authoritative by applying them after the generated request ID
- add regression coverage for multiple inbound requests that reuse one client request ID

## Problem

AxonHub trace IDs can intentionally span multiple agent calls, while an HTTP request ID must identify one request. The generic inbound-header merge currently forwards `X-Request-Id` unchanged. If a client reuses that value to group an agent trace, independent outbound calls receive the same request ID.

Downstream gateways that use `X-Request-Id` for usage idempotency or deduplication can then collapse unrelated requests into one record, mixing models, statuses, token usage, and charges.

AxonHub already generates a unique `ar-*` request ID for every inbound HTTP request in `WithLoggingTracing`; it was not previously applied to the outbound provider request.

## Fix

Add an outbound raw-request middleware that sets `X-Request-Id` from AxonHub's request context after inbound headers are merged. Different inbound requests therefore get different downstream IDs even when the client reuses its own value. Retries for one request keep the same ID, and explicit channel header overrides can still replace it.

## Verification

- `go test ./...`
- `cd llm && go test ./...`
