### PR TITLE
fix(openai): write image edit model before files

### DIFF
--- a/llm/transformer/openai/image_edit_outbound_test.go
+++ b/llm/transformer/openai/image_edit_outbound_test.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestImageEditRequestWritesModelBeforeImageFiles(t *testing.T) {
+	// Given
+	outbound, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	request := &llm.Request{
+		Model:       "gpt-image-2",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt: "Make this image brighter",
+			Images: [][]byte{[]byte("image-data")},
+		},
+	}
+
+	// When
+	httpRequest, err := outbound.TransformRequest(t.Context(), request)
+	require.NoError(t, err)
+
+	_, params, err := mime.ParseMediaType(httpRequest.Headers.Get("Content-Type"))
+	require.NoError(t, err)
+
+	part, err := multipart.NewReader(bytes.NewReader(httpRequest.Body), params["boundary"]).NextPart()
+	require.NoError(t, err)
+
+	value, err := io.ReadAll(part)
+	require.NoError(t, err)
+
+	// Then
+	require.Equal(t, "model", part.FormName())
+	require.Equal(t, "gpt-image-2", string(value))
+}

--- a/llm/transformer/openai/image_outbound.go
+++ b/llm/transformer/openai/image_outbound.go
@@ -220,6 +220,14 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
+	if model != "" {
+		if err := writer.WriteField("model", model); err != nil {
+			return nil, fmt.Errorf("failed to write model field: %w", err)
+		}
+
+		jsonBody["model"] = model
+	}
+
 	imageFieldName := "image"
 	if len(formFiles) > 1 {
 		imageFieldName = "image[]"
@@ -261,15 +269,6 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 	// Add prompt
 	if err := writer.WriteField("prompt", prompt); err != nil {
 		return nil, fmt.Errorf("failed to write prompt field: %w", err)
-	}
-
-	// Add model if specified
-	if model != "" {
-		if err := writer.WriteField("model", model); err != nil {
-			return nil, fmt.Errorf("failed to write model field: %w", err)
-		}
-
-		jsonBody["model"] = model
 	}
 
 	// Extract image edit parameters from Image field


### PR DESCRIPTION
## Summary

- serialize the `model` multipart field before image file parts for OpenAI image edits
- preserve all existing field names, values, and multi-image behavior
- add a regression test that locks the required wire order

## Root cause

Some OpenAI-compatible providers process multipart parts in stream order. AxonHub previously emitted image files before `model`, so ZenMux rejected otherwise valid `gpt-image-2` edit requests with `404 invalid_model` before it encountered the model field.

A controlled live comparison confirmed the ordering dependency:

- `image -> model`: HTTP 404 `invalid_model`
- `model -> image`: HTTP 200

## Verification

- `go test -race -shuffle=on -count=1 ./transformer/openai`
- post-fix transformer request against ZenMux returned a valid 1024x1024 edited PNG
- single image, multiple images, mask, empty model, and DALL-E 2 default response-format scenarios remain covered
