### PR TITLE
fix(responses): scope fallback prompt_cache_key per conversation

### DIFF
--- a/llm/transformer/openai/responses/cache_anchor.go
+++ b/llm/transformer/openai/responses/cache_anchor.go
@@ -3,12 +3,16 @@ package responses
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
 
 	"github.com/looplj/axonhub/llm"
 )
 
-// anchorMaxBytes bounds how much of the conversation head is hashed.
-const anchorMaxBytes = 8192
+// anchorMaxBytesPerUnit bounds how much each content unit (a message's plain
+// string content, or a single field of a content part) contributes to the
+// hash. The budget is per unit rather than global so that a large instruction
+// prefix can never starve the first user message out of the fingerprint.
+const anchorMaxBytesPerUnit = 4096
 
 // conversationAnchor derives a stable fingerprint for the conversation a
 // request belongs to: the contiguous leading system/developer messages plus
@@ -19,19 +23,19 @@ const anchorMaxBytes = 8192
 // per-conversation prompt_cache_key instead of a per-session one.
 func conversationAnchor(messages []llm.Message) string {
 	h := sha256.New()
-	written := 0
 
-	write := func(s string) {
-		if written >= anchorMaxBytes {
-			return
-		}
+	// Each unit is hashed as <len>:<capped bytes>. The length prefix keeps
+	// concatenated units unambiguous and still distinguishes oversized units
+	// (e.g. two base64 images sharing their first 4 KiB) by their size.
+	writeUnit := func(s string) {
+		h.Write([]byte(strconv.Itoa(len(s))))
+		h.Write([]byte{':'})
 
-		if remaining := anchorMaxBytes - written; len(s) > remaining {
-			s = s[:remaining]
+		if len(s) > anchorMaxBytesPerUnit {
+			s = s[:anchorMaxBytesPerUnit]
 		}
 
 		h.Write([]byte(s))
-		written += len(s)
 	}
 
 	hashed := false
@@ -41,25 +45,44 @@ func conversationAnchor(messages []llm.Message) string {
 			break
 		}
 
-		write(msg.Role)
-		write("\x00")
+		h.Write([]byte(msg.Role))
+		h.Write([]byte{0x00})
 
 		if msg.Content.Content != nil {
-			write(*msg.Content.Content)
+			writeUnit(*msg.Content.Content)
 		}
 
 		for _, part := range msg.Content.MultipleContent {
-			if part.Text != nil {
-				write(*part.Text)
+			h.Write([]byte(part.Type))
+			h.Write([]byte{0x1f})
+
+			switch {
+			case part.Text != nil:
+				writeUnit(*part.Text)
+			case part.ImageURL != nil:
+				writeUnit(part.ImageURL.URL)
+			case part.VideoURL != nil:
+				writeUnit(part.VideoURL.URL)
+			case part.Document != nil:
+				writeUnit(part.Document.MIMEType)
+				writeUnit(part.Document.URL)
+			case part.InputAudio != nil:
+				writeUnit(part.InputAudio.Format)
+				writeUnit(part.InputAudio.Data)
+			case part.Compact != nil:
+				writeUnit(part.Compact.ID)
+				writeUnit(part.Compact.EncryptedContent)
 			}
+
+			h.Write([]byte{0x1f})
 		}
 
-		write("\x1e")
+		h.Write([]byte{0x1e})
 
 		hashed = true
 
 		// The first user message ends the stable conversation head.
-		if msg.Role == "user" || written >= anchorMaxBytes {
+		if msg.Role == "user" {
 			break
 		}
 	}

--- a/llm/transformer/openai/responses/cache_anchor.go
+++ b/llm/transformer/openai/responses/cache_anchor.go
@@ -1,0 +1,72 @@
+package responses
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+// anchorMaxBytes bounds how much of the conversation head is hashed.
+const anchorMaxBytes = 8192
+
+// conversationAnchor derives a stable fingerprint for the conversation a
+// request belongs to: the contiguous leading system/developer messages plus
+// the first user message. Later turns of the same conversation keep this head
+// unchanged, while sibling conversations multiplexed over one client session
+// (e.g. Claude Code subagents sharing a session_id) diverge in their first
+// user message. Combining this anchor with the session ID therefore yields a
+// per-conversation prompt_cache_key instead of a per-session one.
+func conversationAnchor(messages []llm.Message) string {
+	h := sha256.New()
+	written := 0
+
+	write := func(s string) {
+		if written >= anchorMaxBytes {
+			return
+		}
+
+		if remaining := anchorMaxBytes - written; len(s) > remaining {
+			s = s[:remaining]
+		}
+
+		h.Write([]byte(s))
+		written += len(s)
+	}
+
+	hashed := false
+
+	for _, msg := range messages {
+		if msg.Role != "system" && msg.Role != "developer" && msg.Role != "user" {
+			break
+		}
+
+		write(msg.Role)
+		write("\x00")
+
+		if msg.Content.Content != nil {
+			write(*msg.Content.Content)
+		}
+
+		for _, part := range msg.Content.MultipleContent {
+			if part.Text != nil {
+				write(*part.Text)
+			}
+		}
+
+		write("\x1e")
+
+		hashed = true
+
+		// The first user message ends the stable conversation head.
+		if msg.Role == "user" || written >= anchorMaxBytes {
+			break
+		}
+	}
+
+	if !hashed {
+		return ""
+	}
+
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -274,6 +274,13 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	if lo.FromPtr(payload.PromptCacheKey) == "" {
 		if sessionID, ok := shared.GetSessionID(ctx); ok {
+			// A session may multiplex several concurrent conversations
+			// (e.g. Claude Code subagents); scope the cache key to the
+			// conversation so they do not evict each other upstream.
+			if anchor := conversationAnchor(llmReq.Messages); anchor != "" {
+				sessionID = sessionID + "-" + anchor
+			}
+
 			payload.PromptCacheKey = lo.ToPtr(sessionID)
 		}
 	}

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -1050,7 +1050,52 @@ func TestOutboundTransformer_TransformRequest_UsesSharedSessionIDAsPromptCacheKe
 	err = json.Unmarshal(httpReq.Body, &payload)
 	require.NoError(t, err)
 	require.NotNil(t, payload.PromptCacheKey)
-	require.Equal(t, "shared-session-123", *payload.PromptCacheKey)
+	require.Equal(t, "shared-session-123-"+conversationAnchor(req.Messages), *payload.PromptCacheKey)
+}
+
+func TestOutboundTransformer_TransformRequest_PromptCacheKeyScopedPerConversation(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	ctx := shared.WithSessionID(context.Background(), "shared-session-123")
+
+	newReq := func(firstUser string, extraTurns ...llm.Message) *llm.Request {
+		messages := []llm.Message{
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("You are an agent.")}},
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr(firstUser)}},
+		}
+		messages = append(messages, extraTurns...)
+
+		return &llm.Request{Model: "gpt-5.4", Messages: messages}
+	}
+
+	cacheKey := func(req *llm.Request) string {
+		httpReq, err := transformer.TransformRequest(ctx, req)
+		require.NoError(t, err)
+
+		var payload Request
+
+		require.NoError(t, json.Unmarshal(httpReq.Body, &payload))
+		require.NotNil(t, payload.PromptCacheKey)
+
+		return *payload.PromptCacheKey
+	}
+
+	// Later turns of the same conversation keep the same cache key.
+	turn1 := cacheKey(newReq("task A"))
+	turn2 := cacheKey(newReq("task A",
+		llm.Message{Role: "assistant", Content: llm.MessageContent{Content: lo.ToPtr("working")}},
+		llm.Message{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("continue")}},
+	))
+	require.Equal(t, turn1, turn2)
+
+	// Sibling conversations in the same session get distinct cache keys.
+	require.NotEqual(t, turn1, cacheKey(newReq("task B")))
+
+	// Client-provided keys are preserved untouched.
+	explicit := newReq("task A")
+	explicit.PromptCacheKey = lo.ToPtr("client-key")
+	require.Equal(t, "client-key", cacheKey(explicit))
 }
 
 func TestOutboundTransformer_TransformResponse(t *testing.T) {

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -1096,6 +1096,41 @@ func TestOutboundTransformer_TransformRequest_PromptCacheKeyScopedPerConversatio
 	explicit := newReq("task A")
 	explicit.PromptCacheKey = lo.ToPtr("client-key")
 	require.Equal(t, "client-key", cacheKey(explicit))
+
+	// A large shared instruction prefix must not starve the first user
+	// message out of the fingerprint: sibling conversations still get
+	// distinct keys.
+	largeSystem := strings.Repeat("shared instructions. ", 2048)
+	largeReq := func(firstUser string) *llm.Request {
+		return &llm.Request{
+			Model: "gpt-5.4",
+			Messages: []llm.Message{
+				{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr(largeSystem)}},
+				{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr(firstUser)}},
+			},
+		}
+	}
+	require.NotEqual(t, cacheKey(largeReq("task A")), cacheKey(largeReq("task B")))
+
+	// Non-text content contributes to the fingerprint: first user messages
+	// that differ only by an image part get distinct keys.
+	imageReq := func(imageURL string) *llm.Request {
+		return &llm.Request{
+			Model: "gpt-5.4",
+			Messages: []llm.Message{
+				{Role: "user", Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{Type: "text", Text: lo.ToPtr("describe this image")},
+						{Type: "image_url", ImageURL: &llm.ImageURL{URL: imageURL}},
+					},
+				}},
+			},
+		}
+	}
+	require.NotEqual(t,
+		cacheKey(imageReq("https://example.com/a.png")),
+		cacheKey(imageReq("https://example.com/b.png")),
+	)
 }
 
 func TestOutboundTransformer_TransformResponse(t *testing.T) {


### PR DESCRIPTION
## Problem

The session-ID fallback introduced in #1350 (fixes #1348) works well when one session maps to one conversation. But Claude Code multiplexes many **concurrent conversations over a single `session_id`**: every subagent (Task/Explore agent) runs its own conversation, while `metadata.user_id` carries the same session ID for all of them.

All these conversations therefore go upstream with the **same `prompt_cache_key` and the same prompt head**, so the provider routes them to the same cache shard, where their 100k+-token prefixes keep evicting each other.

## Measured impact

Same gateway, same upstream channel (OpenAI Responses relay), same model, 3-day window:

| client | inbound format | prompt_cache_key | requests | cache hit rate |
|---|---|---|---|---|
| Codex | openai/responses | per-thread UUID (client-provided) | 20,502 | **96.8%** |
| Claude Code | anthropic/messages | one per session (fallback) | 3,744 | **32.5%** |

During a Claude Code subagent fan-out (~20 concurrent conversations), nearly every request hit exactly 4,608 or 5,632 cached tokens regardless of prompt size (11k–142k): only the static system+tools prefix survives, and every conversation tail misses on every turn.

With this patch deployed on the same setup (3 parallel subagents): 81% for the whole session including unavoidable cold starts, with steady-state turns at 95–99% (e.g. 152,064 cached / 152,686 prompt). Distinct per-conversation keys were confirmed in the stored outbound bodies.

## Change

When the fallback applies (client provided no `prompt_cache_key`), append a deterministic conversation anchor to the session ID:

```
prompt_cache_key = <sessionID>-<hex(sha256(leading system/developer messages + first user message))[:16]>
```

- Later turns of one conversation keep the same key — the anchored head never changes mid-conversation.
- Sibling conversations in the same session diverge in their first user message → distinct keys → distinct shards.
- Client-provided keys are preserved untouched, so Codex and other Responses clients are unaffected.
- No key is emitted where none was emitted before — this only strengthens the existing fallback, so the third-party-backend regression concerns discussed in #1429 do not apply.

## Why this cannot be fixed client-side

Unlike OpenCode (tracing plugin) or Hermes (client-side patch), Claude Code has no mechanism to attach per-conversation identity: `metadata.user_id` is session-scoped and shared by all subagents, and custom headers are static per process. The protocol translation layer is the only place that holds both the conversation content and the outbound field.

## Tests

- Updated `TestOutboundTransformer_TransformRequest_UsesSharedSessionIDAsPromptCacheKeyFallback` for the new key shape.
- Added `TestOutboundTransformer_TransformRequest_PromptCacheKeyScopedPerConversation`: same conversation across turns → same key; sibling conversations → distinct keys; client-provided key untouched.
- `cd llm && go build ./... && go test ./transformer/openai/responses/ && go vet ./transformer/openai/responses/` all pass.

---

### 中文摘要

Claude Code 的 subagent 会在同一个 session 里并发跑多个会话。#1350 的兜底让它们共用同一个 `prompt_cache_key`，上游把所有会话路由到同一个缓存分片，互相驱逐——实测同一上游同一模型：Codex（线程级 key）96.8% vs Claude Code（session 级 key）32.5%，subagent 并发期间每请求不论 prompt 多大都恒定只命中 ~5k token 的静态前缀。

本 PR 在兜底 key 上追加"会话锚点"（开头 system/developer 消息 + 首条 user 消息的 SHA-256 前 16 位十六进制）：同会话逐轮 key 稳定，不同会话自然分流。客户端显式传 key 时不受影响，也不会给原本收不到该字段的后端新增字段（#1429 中讨论的第三方后端回归风险不适用）。补丁部署后同场景实测：整体 81%（含冷启动），稳态轮次 95–99%。

与 OpenCode/Hermes 不同，Claude Code 没有任何客户端机制能按会话（subagent）注入标识——`metadata.user_id` 是 session 级的、自定义头是进程级静态的——因此只能在协议转换层修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
