### PR TITLE
[codex] Forward verified reasoning accounting response header

### DIFF
--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -81,6 +81,8 @@ func (handlers *ChatCompletionHandlers) ChatCompletionWithRequest(c *gin.Context
 		return
 	}
 
+	writeForwardResponseHeaders(c, result.ResponseHeaders)
+
 	if result.ChatCompletion != nil {
 		resp := result.ChatCompletion
 
@@ -112,6 +114,12 @@ func (handlers *ChatCompletionHandlers) ChatCompletionWithRequest(c *gin.Context
 		}
 
 		streamWriter(c, newUpstreamErrorStream(ctx, result.ChatCompletionStream, handlers.ChatCompletionOrchestrator.SystemService))
+	}
+}
+
+func writeForwardResponseHeaders(c *gin.Context, headers http.Header) {
+	for name, values := range httpclient.ForwardResponseHeaders(headers) {
+		c.Writer.Header()[name] = append([]string(nil), values...)
 	}
 }
 

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -135,6 +135,46 @@ func TestWriteSSEStream_Success(t *testing.T) {
 	assert.Contains(t, body, `[DONE]`)
 }
 
+func TestWriteForwardResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    http.Header
+		wantHeader string
+	}{
+		{
+			name: "writes allowlisted header",
+			headers: http.Header{
+				httpclient.ReasoningIncludedHeader: []string{"true"},
+			},
+			wantHeader: "true",
+		},
+		{
+			name: "does not write false value",
+			headers: http.Header{
+				httpclient.ReasoningIncludedHeader: []string{"false"},
+			},
+		},
+		{
+			name: "does not write unrelated upstream header",
+			headers: http.Header{
+				"Set-Cookie": []string{"secret=1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			writeForwardResponseHeaders(c, tt.headers)
+
+			require.Equal(t, tt.wantHeader, w.Header().Get(httpclient.ReasoningIncludedHeader))
+			require.Empty(t, w.Header().Get("Set-Cookie"))
+		})
+	}
+}
+
 func TestWriteSSEStream_ErrorFormatsAsJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/internal/server/orchestrator/channel_help_test.go
+++ b/internal/server/orchestrator/channel_help_test.go
@@ -182,6 +182,7 @@ func getCandidateNameByID(result []*ChannelModelsCandidate, channelID int) strin
 type mockExecutor struct {
 	response      *httpclient.Response
 	streamEvents  []*httpclient.StreamEvent
+	streamHeaders http.Header
 	err           error
 	requestCalled bool
 	requestCalls  atomic.Int64
@@ -209,7 +210,24 @@ func (m *mockExecutor) DoStream(ctx context.Context, request *httpclient.Request
 		return nil, m.err
 	}
 
-	return streams.SliceStream(m.streamEvents), nil
+	stream := streams.SliceStream(m.streamEvents)
+	if m.streamHeaders != nil {
+		return &mockStreamWithResponseHeaders{
+			Stream:  stream,
+			headers: m.streamHeaders,
+		}, nil
+	}
+
+	return stream, nil
+}
+
+type mockStreamWithResponseHeaders struct {
+	streams.Stream[*httpclient.StreamEvent]
+	headers http.Header
+}
+
+func (s *mockStreamWithResponseHeaders) UpstreamResponseHeaders() http.Header {
+	return s.headers
 }
 
 // setupTestServices creates all necessary services for integration testing.

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/looplj/axonhub/internal/authz"
@@ -166,6 +167,7 @@ func (processor *ChatCompletionOrchestrator) WithProxy(proxy *httpclient.ProxyCo
 type ChatCompletionResult struct {
 	ChatCompletion       *httpclient.Response
 	ChatCompletionStream streams.Stream[*httpclient.StreamEvent]
+	ResponseHeaders      http.Header
 }
 
 func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, request *httpclient.Request) (ChatCompletionResult, error) {
@@ -343,11 +345,13 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		return ChatCompletionResult{
 			ChatCompletion:       nil,
 			ChatCompletionStream: result.EventStream,
+			ResponseHeaders:      result.ResponseHeaders,
 		}, nil
 	}
 
 	return ChatCompletionResult{
 		ChatCompletion:       result.Response,
 		ChatCompletionStream: nil,
+		ResponseHeaders:      result.ResponseHeaders,
 	}, nil
 }

--- a/internal/server/orchestrator/orchestrator_basic_test.go
+++ b/internal/server/orchestrator/orchestrator_basic_test.go
@@ -293,7 +293,11 @@ func TestChatCompletionOrchestrator_Process_NonStreaming(t *testing.T) {
 		response: &httpclient.Response{
 			StatusCode: 200,
 			Body:       mockResp,
-			Headers:    http.Header{"Content-Type": []string{"application/json"}},
+			Headers: http.Header{
+				"Content-Type":                     []string{"application/json"},
+				httpclient.ReasoningIncludedHeader: []string{"true"},
+				"Set-Cookie":                       []string{"secret=1"},
+			},
 		},
 	}
 
@@ -338,6 +342,8 @@ func TestChatCompletionOrchestrator_Process_NonStreaming(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result.ChatCompletion)
 	assert.Nil(t, result.ChatCompletionStream)
+	assert.Equal(t, "true", result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+	assert.Empty(t, result.ResponseHeaders.Get("Set-Cookie"))
 
 	// Verify executor was called
 	assert.True(t, executor.requestCalled)

--- a/internal/server/orchestrator/orchestrator_streaming_test.go
+++ b/internal/server/orchestrator/orchestrator_streaming_test.go
@@ -426,6 +426,10 @@ func TestChatCompletionOrchestrator_Process_Streaming(t *testing.T) {
 
 	executor := &mockExecutor{
 		streamEvents: streamEvents,
+		streamHeaders: http.Header{
+			httpclient.ReasoningIncludedHeader: []string{"true"},
+			"Set-Cookie":                       []string{"secret=1"},
+		},
 	}
 
 	// Create outbound transformer
@@ -469,6 +473,8 @@ func TestChatCompletionOrchestrator_Process_Streaming(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, result.ChatCompletion)
 	assert.NotNil(t, result.ChatCompletionStream)
+	assert.Equal(t, "true", result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+	assert.Empty(t, result.ResponseHeaders.Get("Set-Cookie"))
 
 	// Consume the stream
 	var chunks []*httpclient.StreamEvent

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -17,18 +17,29 @@ import (
 
 	"github.com/looplj/axonhub/llm/streams"
 )
+
 // MaxErrorBodySize is the maximum number of bytes read from an upstream error
 // response body. Error bodies beyond this size are truncated to prevent OOM
 // from pathological upstream responses that echo large request payloads in
 // validation error messages, producing response bodies of 1+ GB.
 const MaxErrorBodySize = 1 << 20 // 1 MB
 
-
 // HttpClient implements the HttpClient interface.
 type HttpClient struct {
 	client      *http.Client
 	proxyConfig *ProxyConfig
 	opts        []ClientOption
+}
+
+// responseHeadersStream keeps the HTTP handshake headers available to the
+// pipeline without widening the generic streams.Stream interface.
+type responseHeadersStream struct {
+	streams.Stream[*StreamEvent]
+	headers http.Header
+}
+
+func (s *responseHeadersStream) UpstreamResponseHeaders() http.Header {
+	return s.headers.Clone()
 }
 
 // ClientOption configures an HttpClient.
@@ -362,7 +373,10 @@ func (hc *HttpClient) DoStream(ctx context.Context, request *Request) (streams.S
 
 	stream := decoderFactory(ctx, rawResp.Body)
 
-	return stream, nil
+	return &responseHeadersStream{
+		Stream:  stream,
+		headers: rawResp.Header.Clone(),
+	}, nil
 }
 
 // BuildHttpRequest builds an HTTP request from Request.

--- a/llm/httpclient/client_test.go
+++ b/llm/httpclient/client_test.go
@@ -271,6 +271,27 @@ func TestHttpClientImpl_DoStream(t *testing.T) {
 	}
 }
 
+func TestHttpClientImpl_DoStream_ExposesResponseHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("X-Reasoning-Included", "true")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	client := NewHttpClient()
+	stream, err := client.DoStream(t.Context(), &Request{
+		Method: http.MethodPost,
+		URL:    server.URL,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	defer stream.Close()
+
+	headers := GetUpstreamResponseHeaders(stream)
+	require.Equal(t, "true", headers.Get("X-Reasoning-Included"))
+}
+
 func TestNewHttpClient_WithInsecureSkipVerify_PreservesDefaultTransportSettings(t *testing.T) {
 	hc := NewHttpClient(WithInsecureSkipVerify(true))
 

--- a/llm/httpclient/response_headers.go
+++ b/llm/httpclient/response_headers.go
@@ -1,0 +1,63 @@
+package httpclient
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+// ReasoningIncludedHeader tells a compatible client that usage already
+// includes previously generated reasoning tokens.
+const ReasoningIncludedHeader = "X-Reasoning-Included"
+
+type upstreamResponseHeadersProvider interface {
+	UpstreamResponseHeaders() http.Header
+}
+
+// GetUpstreamResponseHeaders returns a copy of optional HTTP handshake headers
+// carried by a streaming transport. A plain streams.Stream has no metadata,
+// so callers must handle nil.
+func GetUpstreamResponseHeaders(stream streams.Stream[*StreamEvent]) http.Header {
+	if stream == nil {
+		return nil
+	}
+
+	provider, ok := stream.(upstreamResponseHeadersProvider)
+	if !ok {
+		return nil
+	}
+
+	return provider.UpstreamResponseHeaders().Clone()
+}
+
+// ForwardResponseHeaders returns the small, explicit set of upstream response
+// headers that are safe and meaningful at AxonHub's client boundary.
+//
+// Do not replace this with a full header copy: upstream responses can contain
+// hop-by-hop, credential-related, or provider-private headers.
+func ForwardResponseHeaders(headers http.Header) http.Header {
+	if !hasOnlyTrueHeaderValues(headers, ReasoningIncludedHeader) {
+		return nil
+	}
+
+	return http.Header{ReasoningIncludedHeader: []string{"true"}}
+}
+
+func hasOnlyTrueHeaderValues(headers http.Header, name string) bool {
+	found := false
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+
+		for _, value := range values {
+			found = true
+			if !strings.EqualFold(strings.TrimSpace(value), "true") {
+				return false
+			}
+		}
+	}
+
+	return found
+}

--- a/llm/httpclient/response_headers_test.go
+++ b/llm/httpclient/response_headers_test.go
@@ -1,0 +1,52 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      http.Header
+		wantHeader string
+	}{
+		{
+			name:       "forwards verified true value",
+			input:      http.Header{"x-reasoning-included": []string{" TRUE "}},
+			wantHeader: "true",
+		},
+		{
+			name: "does not synthesize false value",
+			input: http.Header{
+				ReasoningIncludedHeader: []string{"false"},
+			},
+		},
+		{
+			name: "does not forward unrelated headers",
+			input: http.Header{
+				ReasoningIncludedHeader: []string{"true"},
+				"Set-Cookie":            []string{"secret=1"},
+			},
+			wantHeader: "true",
+		},
+		{
+			name: "does not forward conflicting duplicate names",
+			input: http.Header{
+				ReasoningIncludedHeader: []string{"true"},
+				"x-reasoning-included":  []string{"false"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ForwardResponseHeaders(tt.input)
+
+			require.Equal(t, tt.wantHeader, got.Get(ReasoningIncludedHeader))
+			require.Empty(t, got.Get("Set-Cookie"))
+		})
+	}
+}

--- a/llm/pipeline/non_streaming.go
+++ b/llm/pipeline/non_streaming.go
@@ -16,17 +16,17 @@ func (p *pipeline) notStream(
 	ctx context.Context,
 	executor Executor,
 	request *httpclient.Request,
-) (*httpclient.Response, error) {
+) (*httpclient.Response, http.Header, error) {
 	httpResp, err := executor.Do(ctx, request)
 	if err != nil {
 		// Apply error response middlewares
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
 		if httpErr, ok := errors.AsType[*httpclient.Error](err); ok {
-			return nil, WrapUpstreamError(p.Outbound.TransformError(ctx, httpErr))
+			return nil, nil, WrapUpstreamError(p.Outbound.TransformError(ctx, httpErr))
 		}
 
-		return nil, WrapUpstreamError(fmt.Errorf("failed to do request: %w", err))
+		return nil, nil, WrapUpstreamError(fmt.Errorf("failed to do request: %w", err))
 	}
 
 	// Apply raw response middlewares
@@ -34,14 +34,15 @@ func (p *pipeline) notStream(
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, fmt.Errorf("failed to apply raw response middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply raw response middlewares: %w", err)
 	}
+	responseHeaders := httpclient.ForwardResponseHeaders(httpResp.Headers)
 
 	llmResp, err := p.Outbound.TransformResponse(ctx, httpResp)
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, WrapUpstreamError(fmt.Errorf("failed to transform response: %w", err))
+		return nil, nil, WrapUpstreamError(fmt.Errorf("failed to transform response: %w", err))
 	}
 
 	// Apply LLM response middlewares
@@ -49,13 +50,13 @@ func (p *pipeline) notStream(
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, fmt.Errorf("failed to apply llm response middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply llm response middlewares: %w", err)
 	}
 
 	if p.emptyResponseDetection && !hasResponseContent(llmResp) {
 		p.applyRawErrorResponseMiddlewares(ctx, ErrEmptyResponse)
 
-		return nil, ErrEmptyResponse
+		return nil, nil, ErrEmptyResponse
 	}
 
 	slog.DebugContext(ctx, "LLM response", slog.Any("response", llmResp))
@@ -64,7 +65,7 @@ func (p *pipeline) notStream(
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, fmt.Errorf("failed to transform final response: %w", err)
+		return nil, nil, fmt.Errorf("failed to transform final response: %w", err)
 	}
 
 	// Apply inbound raw response middlewares after final response transformation
@@ -72,20 +73,20 @@ func (p *pipeline) notStream(
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, fmt.Errorf("failed to apply inbound raw response middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply inbound raw response middlewares: %w", err)
 	}
 
-	return finalResp, nil
+	return finalResp, responseHeaders, nil
 }
 
 func (p *pipeline) autoAggregateStream(
 	ctx context.Context,
 	executor Executor,
 	request *httpclient.Request,
-) (*httpclient.Response, error) {
-	inboundStream, err := p.stream(ctx, executor, request, 0)
+) (*httpclient.Response, http.Header, error) {
+	inboundStream, responseHeaders, err := p.stream(ctx, executor, request, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer inboundStream.Close()
 
@@ -99,23 +100,23 @@ func (p *pipeline) autoAggregateStream(
 
 	if err := inboundStream.Err(); err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(chunks) == 0 {
 		p.applyRawErrorResponseMiddlewares(ctx, ErrEmptyStreamChunks)
-		return nil, ErrEmptyStreamChunks
+		return nil, nil, ErrEmptyStreamChunks
 	}
 
 	body, _, err := p.Inbound.AggregateStreamChunks(ctx, chunks)
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(body) == 0 {
 		p.applyRawErrorResponseMiddlewares(ctx, ErrEmptyAggregatedBody)
-		return nil, ErrEmptyAggregatedBody
+		return nil, nil, ErrEmptyAggregatedBody
 	}
 
 	resp := &httpclient.Response{
@@ -130,8 +131,8 @@ func (p *pipeline) autoAggregateStream(
 	resp, err = p.applyInboundRawResponseMiddlewares(ctx, resp)
 	if err != nil {
 		p.applyRawErrorResponseMiddlewares(ctx, err)
-		return nil, fmt.Errorf("failed to apply inbound raw response middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply inbound raw response middlewares: %w", err)
 	}
 
-	return resp, nil
+	return resp, responseHeaders, nil
 }

--- a/llm/pipeline/pipeline.go
+++ b/llm/pipeline/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/looplj/axonhub/llm"
@@ -130,6 +131,10 @@ type pipeline struct {
 type Result struct {
 	// Stream indicates whether the response is a stream
 	Stream bool
+
+	// ResponseHeaders contains the explicitly allowlisted headers from the
+	// successful upstream response.
+	ResponseHeaders http.Header
 
 	// Response is the final HTTP response, if Stream is false
 	Response *httpclient.Response
@@ -392,19 +397,20 @@ func (p *pipeline) processRequest(ctx context.Context, request *llm.Request) (*R
 			Stream: true,
 		}
 
-		stream, err := p.stream(ctx, executor, httpReq, p.streamFirstEventTimeout)
+		stream, responseHeaders, err := p.stream(ctx, executor, httpReq, p.streamFirstEventTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stream request: %w", err)
 		}
 
 		result.EventStream = stream
+		result.ResponseHeaders = responseHeaders
 	case effectiveWantStream:
 		result = &Result{
 			Stream: false,
 		}
 
 		timeoutCtx, cancel := p.withNonStreamTimeout(ctx)
-		response, err := p.autoAggregateStream(timeoutCtx, executor, httpReq)
+		response, responseHeaders, err := p.autoAggregateStream(timeoutCtx, executor, httpReq)
 		cancel()
 		if err != nil {
 			if p.isNonStreamTimeout(timeoutCtx) {
@@ -415,13 +421,14 @@ func (p *pipeline) processRequest(ctx context.Context, request *llm.Request) (*R
 		}
 
 		result.Response = response
+		result.ResponseHeaders = responseHeaders
 	default:
 		result = &Result{
 			Stream: false,
 		}
 
 		timeoutCtx, cancel := p.withNonStreamTimeout(ctx)
-		response, err := p.notStream(timeoutCtx, executor, httpReq)
+		response, responseHeaders, err := p.notStream(timeoutCtx, executor, httpReq)
 		cancel()
 		if err != nil {
 			if p.isNonStreamTimeout(timeoutCtx) {
@@ -432,6 +439,7 @@ func (p *pipeline) processRequest(ctx context.Context, request *llm.Request) (*R
 		}
 
 		result.Response = response
+		result.ResponseHeaders = responseHeaders
 	}
 
 	return result, nil

--- a/llm/pipeline/response_headers.go
+++ b/llm/pipeline/response_headers.go
@@ -1,0 +1,12 @@
+package pipeline
+
+import (
+	"net/http"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+func forwardStreamResponseHeaders(stream streams.Stream[*httpclient.StreamEvent]) http.Header {
+	return httpclient.ForwardResponseHeaders(httpclient.GetUpstreamResponseHeaders(stream))
+}

--- a/llm/pipeline/response_headers_test.go
+++ b/llm/pipeline/response_headers_test.go
@@ -1,0 +1,185 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+type streamWithResponseHeaders struct {
+	streams.Stream[*httpclient.StreamEvent]
+	headers http.Header
+}
+
+func (s *streamWithResponseHeaders) UpstreamResponseHeaders() http.Header {
+	return s.headers
+}
+
+type errorStreamWithResponseHeaders struct {
+	err     error
+	headers http.Header
+}
+
+func (s *errorStreamWithResponseHeaders) Next() bool                       { return false }
+func (s *errorStreamWithResponseHeaders) Current() *httpclient.StreamEvent { return nil }
+func (s *errorStreamWithResponseHeaders) Err() error                       { return s.err }
+func (s *errorStreamWithResponseHeaders) Close() error                     { return nil }
+func (s *errorStreamWithResponseHeaders) UpstreamResponseHeaders() http.Header {
+	return s.headers
+}
+
+func TestPipelineProcess_ForwardsAllowedNonStreamingResponseHeaders(t *testing.T) {
+	p := &pipeline{
+		Executor: &mockExecutor{
+			do: func(context.Context, *httpclient.Request) (*httpclient.Response, error) {
+				return &httpclient.Response{
+					Headers: http.Header{
+						httpclient.ReasoningIncludedHeader: []string{"true"},
+						"Set-Cookie":                       []string{"secret=1"},
+					},
+				}, nil
+			},
+		},
+		Inbound:  &mockInbound{},
+		Outbound: &mockOutbound{},
+	}
+
+	result, err := p.Process(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+	require.Equal(t, "true", result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+	require.Empty(t, result.ResponseHeaders.Get("Set-Cookie"))
+}
+
+func TestPipelineProcess_ForwardsAllowedStreamingResponseHeaders(t *testing.T) {
+	content := "ok"
+	p := &pipeline{
+		Executor: &mockExecutor{
+			doStream: func(context.Context, *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+				return &streamWithResponseHeaders{
+					Stream: streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("chunk")}}),
+					headers: http.Header{
+						httpclient.ReasoningIncludedHeader: []string{"true"},
+						"Set-Cookie":                       []string{"secret=1"},
+					},
+				}, nil
+			},
+		},
+		Inbound: &mockInbound{
+			transformRequest: func(context.Context, *httpclient.Request) (*llm.Request, error) {
+				stream := true
+				return &llm.Request{Stream: &stream}, nil
+			},
+		},
+		Outbound: &mockOutbound{
+			transformStream: func(_ context.Context, _ *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+				return streams.Map(stream, func(*httpclient.StreamEvent) *llm.Response {
+					return &llm.Response{Choices: []llm.Choice{{
+						Delta: &llm.Message{Content: llm.MessageContent{Content: &content}},
+					}}}
+				}), nil
+			},
+		},
+	}
+
+	result, err := p.Process(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+	require.Equal(t, "true", result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+	require.Empty(t, result.ResponseHeaders.Get("Set-Cookie"))
+	require.NoError(t, result.EventStream.Close())
+}
+
+func TestPipelineProcess_ForwardsAllowedHeadersWhenAggregatingUpgradedStream(t *testing.T) {
+	content := "ok"
+	p := &pipeline{
+		Executor: &mockExecutor{
+			doStream: func(context.Context, *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+				return &streamWithResponseHeaders{
+					Stream: streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("chunk")}}),
+					headers: http.Header{
+						httpclient.ReasoningIncludedHeader: []string{"true"},
+					},
+				}, nil
+			},
+		},
+		Inbound: &mockInbound{},
+		Outbound: &mockOutbound{
+			transformRequest: func(_ context.Context, request *llm.Request) (*httpclient.Request, error) {
+				stream := true
+				request.Stream = &stream
+
+				return &httpclient.Request{}, nil
+			},
+			transformStream: func(_ context.Context, _ *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+				return streams.Map(stream, func(*httpclient.StreamEvent) *llm.Response {
+					return &llm.Response{Choices: []llm.Choice{{
+						Delta: &llm.Message{Content: llm.MessageContent{Content: &content}},
+					}}}
+				}), nil
+			},
+		},
+	}
+
+	result, err := p.Process(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+	require.False(t, result.Stream)
+	require.NotNil(t, result.Response)
+	require.Equal(t, "true", result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+}
+
+func TestPipelineProcess_UsesOnlyFinalSuccessfulAttemptResponseHeaders(t *testing.T) {
+	content := "ok"
+	attempts := 0
+	p := &pipeline{
+		Executor: &mockExecutor{
+			doStream: func(context.Context, *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+				attempts++
+				if attempts == 1 {
+					return &errorStreamWithResponseHeaders{
+						err: errors.New("first channel failed before content"),
+						headers: http.Header{
+							httpclient.ReasoningIncludedHeader: []string{"true"},
+						},
+					}, nil
+				}
+
+				return &streamWithResponseHeaders{
+					Stream: streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("chunk")}}),
+					headers: http.Header{
+						httpclient.ReasoningIncludedHeader: []string{"false"},
+					},
+				}, nil
+			},
+		},
+		Inbound: &mockInbound{
+			transformRequest: func(context.Context, *httpclient.Request) (*llm.Request, error) {
+				stream := true
+				return &llm.Request{Stream: &stream}, nil
+			},
+		},
+		Outbound: &mockOutbound{
+			transformStream: func(_ context.Context, _ *httpclient.Request, stream streams.Stream[*httpclient.StreamEvent]) (streams.Stream[*llm.Response], error) {
+				return streams.Map(stream, func(*httpclient.StreamEvent) *llm.Response {
+					return &llm.Response{Choices: []llm.Choice{{
+						Delta: &llm.Message{Content: llm.MessageContent{Content: &content}},
+					}}}
+				}), nil
+			},
+			hasMoreChannels: func() bool { return true },
+			nextChannel:     func(context.Context) error { return nil },
+		},
+		maxChannelRetries: 1,
+	}
+
+	result, err := p.Process(t.Context(), &httpclient.Request{})
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+	require.Empty(t, result.ResponseHeaders.Get(httpclient.ReasoningIncludedHeader))
+	require.NoError(t, result.EventStream.Close())
+}

--- a/llm/pipeline/stream.go
+++ b/llm/pipeline/stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -291,7 +292,7 @@ func (p *pipeline) stream(
 	executor Executor,
 	request *httpclient.Request,
 	firstEventTimeout time.Duration,
-) (streams.Stream[*httpclient.StreamEvent], error) {
+) (streams.Stream[*httpclient.StreamEvent], http.Header, error) {
 	streamCtx, firstEventGuard := newFirstEventTimeoutGuard(ctx, firstEventTimeout)
 
 	outboundStream, err := executor.DoStream(streamCtx, request)
@@ -303,7 +304,7 @@ func (p *pipeline) stream(
 		timeoutErr := firstEventGuard.finishBeforeFirstEvent(ErrStreamFirstEventTimeout)
 		p.applyRawErrorResponseMiddlewares(ctx, timeoutErr)
 
-		return nil, timeoutErr
+		return nil, nil, timeoutErr
 	}
 	if err != nil {
 		err = firstEventGuard.finishBeforeFirstEvent(err)
@@ -312,15 +313,16 @@ func (p *pipeline) stream(
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
 		if errors.Is(err, ErrStreamFirstEventTimeout) {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if httpErr, ok := errors.AsType[*httpclient.Error](err); ok {
-			return nil, WrapUpstreamError(p.Outbound.TransformError(ctx, httpErr))
+			return nil, nil, WrapUpstreamError(p.Outbound.TransformError(ctx, httpErr))
 		}
 
-		return nil, WrapUpstreamError(err)
+		return nil, nil, WrapUpstreamError(err)
 	}
+	responseHeaders := forwardStreamResponseHeaders(outboundStream)
 
 	// Apply raw stream middlewares
 	rawStream := outboundStream
@@ -332,10 +334,10 @@ func (p *pipeline) stream(
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
 		if errors.Is(err, ErrStreamFirstEventTimeout) {
-			return nil, err
+			return nil, nil, err
 		}
 
-		return nil, fmt.Errorf("failed to apply raw stream middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply raw stream middlewares: %w", err)
 	}
 
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
@@ -356,10 +358,10 @@ func (p *pipeline) stream(
 		slog.ErrorContext(ctx, "Failed to transform streaming request", slog.Any("error", err))
 
 		if errors.Is(err, ErrStreamFirstEventTimeout) {
-			return nil, err
+			return nil, nil, err
 		}
 
-		return nil, WrapUpstreamError(err)
+		return nil, nil, WrapUpstreamError(err)
 	}
 
 	rawLlmStream := llmStream
@@ -372,10 +374,10 @@ func (p *pipeline) stream(
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
 		if errors.Is(err, ErrStreamFirstEventTimeout) {
-			return nil, err
+			return nil, nil, err
 		}
 
-		return nil, fmt.Errorf("failed to apply llm stream middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply llm stream middlewares: %w", err)
 	}
 
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
@@ -397,10 +399,10 @@ func (p *pipeline) stream(
 			p.applyRawErrorResponseMiddlewares(ctx, err)
 
 			if !shouldWrapPreReadStreamError(err) {
-				return nil, err
+				return nil, nil, err
 			}
 
-			return nil, WrapUpstreamError(err)
+			return nil, nil, WrapUpstreamError(err)
 		}
 	} else if firstEventGuard != nil {
 		firstEventGuard.stop()
@@ -414,7 +416,7 @@ func (p *pipeline) stream(
 
 		slog.ErrorContext(ctx, "Failed to transform streaming request", slog.Any("error", err))
 
-		return nil, err
+		return nil, nil, err
 	}
 
 	rawInboundStream := inboundStream
@@ -425,7 +427,7 @@ func (p *pipeline) stream(
 		firstEventGuard.cancelStream()
 		p.applyRawErrorResponseMiddlewares(ctx, err)
 
-		return nil, fmt.Errorf("failed to apply inbound raw stream middlewares: %w", err)
+		return nil, nil, fmt.Errorf("failed to apply inbound raw stream middlewares: %w", err)
 	}
 
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
@@ -445,5 +447,5 @@ func (p *pipeline) stream(
 		}
 	}
 
-	return inboundStream, nil
+	return inboundStream, responseHeaders, nil
 }

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -374,13 +374,20 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 		return nil, err
 	}
 
+	// This adapter turns an upstream stream into a non-stream response. Preserve
+	// only the response metadata approved for AxonHub clients while replacing
+	// the stream content type with the aggregated JSON content type.
+	responseHeaders := httpclient.ForwardResponseHeaders(httpclient.GetUpstreamResponseHeaders(stream))
+	if responseHeaders == nil {
+		responseHeaders = make(http.Header)
+	}
+	responseHeaders.Set("Content-Type", "application/json")
+
 	return &httpclient.Response{
 		StatusCode: http.StatusOK,
-		Headers: http.Header{
-			"Content-Type": []string{"application/json"},
-		},
-		Body:    body,
-		Request: request,
+		Headers:    responseHeaders,
+		Body:       body,
+		Request:    request,
 	}, nil
 }
 

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -321,12 +321,18 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 			{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"msg_test_456","type":"message","status":"completed","role":"assistant"}}`)},
 			{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_test_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"completed","output":[]}}`)},
 		},
+		streamHeaders: http.Header{
+			httpclient.ReasoningIncludedHeader: []string{"true"},
+			"Set-Cookie":                       []string{"secret=1"},
+		},
 	})
 
 	response, err := executor.Do(ctx, request)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode)
 	require.Equal(t, "application/json", response.Headers.Get("Content-Type"))
+	require.Equal(t, "true", response.Headers.Get(httpclient.ReasoningIncludedHeader))
+	require.Empty(t, response.Headers.Get("Set-Cookie"))
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(response.Body, &body))
@@ -365,7 +371,8 @@ func TestCodexOutbound_DoReturnsWebSocketErrorEvents(t *testing.T) {
 var _ pipeline.ChannelCustomizedExecutor = (*OutboundTransformer)(nil)
 
 type mockCodexExecutor struct {
-	streamEvents []*httpclient.StreamEvent
+	streamEvents  []*httpclient.StreamEvent
+	streamHeaders http.Header
 }
 
 func (m *mockCodexExecutor) Do(_ context.Context, _ *httpclient.Request) (*httpclient.Response, error) {
@@ -373,7 +380,24 @@ func (m *mockCodexExecutor) Do(_ context.Context, _ *httpclient.Request) (*httpc
 }
 
 func (m *mockCodexExecutor) DoStream(_ context.Context, _ *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
-	return streams.SliceStream(m.streamEvents), nil
+	stream := streams.SliceStream(m.streamEvents)
+	if m.streamHeaders == nil {
+		return stream, nil
+	}
+
+	return &mockCodexStreamWithResponseHeaders{
+		Stream:  stream,
+		headers: m.streamHeaders,
+	}, nil
+}
+
+type mockCodexStreamWithResponseHeaders struct {
+	streams.Stream[*httpclient.StreamEvent]
+	headers http.Header
+}
+
+func (s *mockCodexStreamWithResponseHeaders) UpstreamResponseHeaders() http.Header {
+	return s.headers
 }
 
 func TestCodexOutbound_DoesNotInjectCLIInstructions(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preserve upstream streaming handshake metadata through the HTTP client and pipeline.
- Forward `X-Reasoning-Included: true` to downstream clients for streaming, non-streaming, auto-aggregated, and Codex stream-to-JSON responses.
- Keep the boundary allowlisted: false/missing values and unrelated upstream headers are not forwarded.
- Ensure retries use only metadata from the final successful channel.

## Root cause

AxonHub terminates the upstream HTTP response, transforms the payload, and constructs a new downstream response. The streaming executor returned only `StreamEvent` values, so upstream response headers had no carrier. The API layer also rebuilt response headers rather than copying this protocol-significant header. The Codex non-stream adapter had a second stream-to-JSON aggregation boundary with the same loss.

This is not a full raw-header proxy by design: blindly copying hop-by-hop, credential-related, or provider-private headers would be unsafe. The fix adds a transport-level metadata carrier and an explicit safe forwarding rule.

## Validation

- `cd llm && go test ./httpclient ./pipeline ./transformer/openai/codex -count=1`
- `go test ./internal/server/orchestrator ./internal/server/api -count=1`
- `git diff --check`

The regression tests cover direct streaming, non-streaming, auto-aggregation, Codex aggregation, false/missing values, unrelated headers, and retry isolation.
