### PR TITLE
fix: Codex Remote Compaction V2 的响应在 AxonHub 中被当作 Empty Reponse 错误

### DIFF
--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -695,6 +695,13 @@ func (a *streamAggregator) buildResponse() *Response {
 					Result: item.Result,
 				})
 
+			case "compaction", "compaction_summary":
+				output = append(output, Item{
+					ID:               item.ID,
+					Type:             item.Type,
+					EncryptedContent: item.EncryptedContent,
+				})
+
 			default:
 				// Generic item
 				output = append(output, Item{

--- a/llm/transformer/openai/responses/inbound_stream.go
+++ b/llm/transformer/openai/responses/inbound_stream.go
@@ -273,6 +273,12 @@ func (s *responsesInboundStream) Next() bool {
 				return false
 			}
 		}
+		if choice.Delta != nil && len(choice.Delta.Content.MultipleContent) > 0 {
+			if err := s.handleCompactionContent(choice.Delta.Content.MultipleContent); err != nil {
+				s.err = err
+				return false
+			}
+		}
 
 		// Handle tool calls
 		if choice.Delta != nil && len(choice.Delta.ToolCalls) > 0 {
@@ -544,6 +550,37 @@ func (s *responsesInboundStream) handleTextContent(content *string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to enqueue output_text.delta event: %w", err)
+	}
+
+	return nil
+}
+
+func (s *responsesInboundStream) handleCompactionContent(parts []llm.MessageContentPart) error {
+	for _, part := range parts {
+		if (part.Type != "compaction" && part.Type != "compaction_summary") || part.Compact == nil {
+			continue
+		}
+
+		if err := s.closeCurrentOutputItem(); err != nil {
+			return err
+		}
+
+		item := compactionItemFromPart(part, part.Type)
+		if item.ID == "" {
+			item.ID = generateItemID()
+		}
+
+		for _, eventType := range []StreamEventType{StreamEventTypeOutputItemAdded, StreamEventTypeOutputItemDone} {
+			if err := s.enqueueEvent(&StreamEvent{
+				Type:        eventType,
+				OutputIndex: s.outputIndex,
+				Item:        &item,
+			}); err != nil {
+				return fmt.Errorf("failed to enqueue compaction %s event: %w", eventType, err)
+			}
+		}
+
+		s.outputIndex++
 	}
 
 	return nil

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -439,6 +439,13 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		if streamEvent.Item == nil {
 			return nil // Intentionally skip this event
 		}
+		if streamEvent.Item.Type == "compaction" || streamEvent.Item.Type == "compaction_summary" {
+			resp.Choices = []llm.Choice{{
+				Index: 0,
+				Delta: lo.ToPtr(convertOutputToMessage([]Item{*streamEvent.Item}, s.state.transformerMetadata)),
+			}}
+			break
+		}
 		if streamEvent.Item.Type == "web_search_call" {
 			appendResponseWebSearchCallMetadata(s.state.transformerMetadata, *streamEvent.Item)
 			return nil // Intentionally skip this event

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -2,9 +2,11 @@ package responses
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
@@ -170,6 +172,66 @@ func TestOutboundTransformer_TransformStream_UsesFinalEncryptedContentPerReasoni
 
 	require.Equal(t, []string{"gAAAA_done_1", "gAAAA_done_2"}, signatures)
 	require.Equal(t, []string{"rs_1", "rs_2"}, sourceIDs)
+}
+
+func TestResponsesTransformer_StreamRoundTrip_PreservesCompactionSummary(t *testing.T) {
+	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	upstreamEvents := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_compact_1","object":"response.compaction","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_1","type":"message","status":"completed","content":[{"type":"input_text","text":"Preserve this fact."}],"role":"user"}}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","output_index":1,"item":{"id":"cmp_1","type":"compaction_summary","encrypted_content":"encrypted-summary"}}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_compact_1","object":"response.compaction","created_at":1700000000,"model":"gpt-5","status":"completed","output":[{"id":"msg_1","type":"message","status":"completed","content":[{"type":"input_text","text":"Preserve this fact."}],"role":"user"},{"id":"cmp_1","type":"compaction_summary","encrypted_content":"encrypted-summary"}],"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}`)},
+	}
+
+	llmStream, err := outbound.TransformStream(t.Context(), nil, streams.SliceStream(upstreamEvents))
+	require.NoError(t, err)
+
+	llmResponses, err := streams.All(llmStream)
+	require.NoError(t, err)
+
+	var compactPart *llm.MessageContentPart
+	for _, resp := range llmResponses {
+		if resp == llm.DoneResponse || len(resp.Choices) == 0 || resp.Choices[0].Delta == nil {
+			continue
+		}
+		for i := range resp.Choices[0].Delta.Content.MultipleContent {
+			part := &resp.Choices[0].Delta.Content.MultipleContent[i]
+			if part.Type == "compaction_summary" {
+				compactPart = part
+			}
+		}
+	}
+	require.NotNil(t, compactPart)
+	require.NotNil(t, compactPart.Compact)
+	require.Equal(t, "cmp_1", compactPart.Compact.ID)
+	require.Equal(t, "encrypted-summary", compactPart.Compact.EncryptedContent)
+
+	inboundStream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream(llmResponses))
+	require.NoError(t, err)
+
+	var compactDone *Item
+	var completed *Response
+	for inboundStream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(inboundStream.Current().Data, &event))
+		if event.Type == StreamEventTypeOutputItemDone && event.Item != nil && event.Item.Type == "compaction_summary" {
+			compactDone = event.Item
+		}
+		if event.Type == StreamEventTypeResponseCompleted {
+			completed = event.Response
+		}
+	}
+	require.NoError(t, inboundStream.Err())
+	require.NotNil(t, compactDone)
+	require.Equal(t, "cmp_1", compactDone.ID)
+	require.Equal(t, "encrypted-summary", lo.FromPtr(compactDone.EncryptedContent))
+	require.NotNil(t, completed)
+	require.Equal(t, "resp_compact_1", completed.ID)
+	require.Len(t, completed.Output, 1)
+	require.Equal(t, "compaction_summary", completed.Output[0].Type)
+	require.Equal(t, "encrypted-summary", lo.FromPtr(completed.Output[0].EncryptedContent))
 }
 
 func TestOutboundTransformer_TransformStream_ResponseCancelledCompletes(t *testing.T) {


### PR DESCRIPTION
## 1. 问题

Codex 现在默认对官方（和 Azure）Provider 启用 Remote Compaction V2 压缩协议（见 <https://github.com/openai/codex/pull/27573>）。

与之前的 V1 的区别是，V1 使用单独的 API Endpoint `/responses/compact`，V2 则在普通 `/responses` 请求的消息列表末尾添加一个 `compaction_trigger` 类型的消息项（见 <https://github.com/openai/codex/pull/22809>）。服务器会响应一个消息列表，其中包含加密的 `compaction`（或 `compaction_summary`）类型的消息项（见 [官方文档介绍](https://developers.openai.com/api/docs/guides/compaction#server-side-compaction)）。

AxonHub 目前支持 V1 接口（即 `/responses/compact`）。但是**处理普通 `/responses` 响应的 path 直接丢弃了 `compaction` 项，导致 Remote Compaction V2 的有效响应被当作「没有返回任何消息项」，最终报错：`failed to stream request: empty response detected`。**

目前该 API 已在其他 Gateway 项目中适配，例如：<https://github.com/Wei-Shaw/sub2api/pull/3971>。

## 2. 更改

本 PR 在各个处理层级添加了对 Remote Compaction V2 响应的支持：

- `inbound_stream.go`：考虑了 `MultipleContent` 的情况，处理和发送 `compaction` 事件；
- `aggregator.go`：考虑了 `compaction` 类型；
- `outbound_stream.go`：补全了一些字段，并原样输出 Compresson Messages。

另外添加了一个测试项。

Fixes #1938.