### PR TITLE
feat: add archive/retain buttons to trace and thread detail pages

### DIFF
--- a/frontend/src/features/threads/components/thread-detail-page.tsx
+++ b/frontend/src/features/threads/components/thread-detail-page.tsx
@@ -3,19 +3,30 @@ import { format } from 'date-fns';
 import { useParams, useNavigate } from '@tanstack/react-router';
 import { zhCN, enUS } from 'date-fns/locale';
 import { ArrowLeft, Activity, RefreshCw, FileText, Eye, EyeOff } from 'lucide-react';
+import { IconArchive, IconPin, IconRotate } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { extractNumberID } from '@/lib/utils';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
 import { ServerSidePagination } from '@/components/server-side-pagination';
 import { Badge } from '@/components/ui/badge';
 import type { Trace } from '@/features/traces/data/schema';
 import { useGeneralSettings } from '@/features/system/data/system';
-import { useThreadDetail } from '../data/threads';
+import { useThreadDetail, useArchiveThread, useUnarchiveThread, useRetainThread, useUnretainThread } from '../data/threads';
 import { TraceCard } from './trace-card';
 import { TraceDrawer } from './trace-drawer';
 
@@ -42,6 +53,12 @@ export default function ThreadDetailPage() {
   }>({ open: false, traceId: null });
 
   const [showArchivedTraces, setShowArchivedTraces] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+
+  const archiveMutation = useArchiveThread();
+  const unarchiveMutation = useUnarchiveThread();
+  const retainMutation = useRetainThread();
+  const unretainMutation = useUnretainThread();
 
   const { data: settings } = useGeneralSettings();
 
@@ -169,9 +186,58 @@ export default function ThreadDetailPage() {
               <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
               <span className='hidden sm:inline ml-2'>{t('common.refresh')}</span>
             </Button>
+            {(() => {
+              const status = thread.status ?? 'active';
+              if (status === 'active') {
+                return (
+                  <>
+                    <Button variant='outline' size='sm' onClick={() => setShowArchiveDialog(true)} className='px-2 sm:px-3'>
+                      <IconArchive className='h-4 w-4' />
+                      <span className='hidden sm:inline ml-2'>{t('common.actions.archive')}</span>
+                    </Button>
+                    <Button variant='outline' size='sm' onClick={() => retainMutation.mutate(thread.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                      <IconPin className='h-4 w-4' />
+                      <span className='hidden sm:inline ml-2'>{t('common.actions.retain')}</span>
+                    </Button>
+                  </>
+                );
+              }
+              if (status === 'archived') {
+                return (
+                  <Button variant='outline' size='sm' onClick={() => unarchiveMutation.mutate(thread.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                    <IconRotate className='h-4 w-4' />
+                    <span className='hidden sm:inline ml-2'>{t('common.actions.unarchive')}</span>
+                  </Button>
+                );
+              }
+              if (status === 'retained') {
+                return (
+                  <Button variant='outline' size='sm' onClick={() => unretainMutation.mutate(thread.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                    <IconRotate className='h-4 w-4' />
+                    <span className='hidden sm:inline ml-2'>{t('common.actions.unretain')}</span>
+                  </Button>
+                );
+              }
+              return null;
+            })()}
           </div>
         </div>
       </Header>
+
+      <AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('threads.dialogs.archiveTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('threads.dialogs.archiveDescription')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.actions.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={() => { archiveMutation.mutate(thread.id, { onSuccess: () => refetch() }); setShowArchiveDialog(false); }}>
+              {t('common.actions.archive')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <Main className='flex-1 overflow-hidden flex flex-col p-0'>
         {/* Top: Usage Metadata */}

--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { useParams, useNavigate } from '@tanstack/react-router';
 import { zhCN, enUS } from 'date-fns/locale';
 import { ArrowLeft, FileText, Activity, RefreshCw, List, GitBranch, Waypoints, Maximize2, X, Wrench, MessageSquare, ChevronDown } from 'lucide-react';
+import { IconArchive, IconPin, IconRotate } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { cn, extractNumberID } from '@/lib/utils';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
@@ -13,10 +14,20 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
 import { useGeneralSettings } from '@/features/system/data/system';
-import { useTraceWithSegments } from '../data';
+import { useTraceWithSegments, useArchiveTrace, useUnarchiveTrace, useRetainTrace, useUnretainTrace } from '../data';
 import { Segment, Span, parseRawRootSegment } from '../data/schema';
 import { SpanSection } from './span-section';
 import { TraceFlatTimeline } from './trace-flat-timeline';
@@ -34,7 +45,13 @@ export default function TraceDetailPage() {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [viewMode, setViewMode] = useState<'flat' | 'flow' | 'tree'>('flat');
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const { getSearchParams } = usePaginationSearch({ defaultPageSize: 20 });
+
+  const archiveMutation = useArchiveTrace();
+  const unarchiveMutation = useUnarchiveTrace();
+  const retainMutation = useRetainTrace();
+  const unretainMutation = useUnretainTrace();
 
   const { data: trace, isLoading, refetch } = useTraceWithSegments(traceId);
   const { data: settings } = useGeneralSettings();
@@ -150,6 +167,7 @@ export default function TraceDetailPage() {
     <div className='flex h-screen flex-col'>
       {/* Normal Header - hidden in fullscreen */}
       {!isFullscreen && (
+        <>
         <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 w-full border-b backdrop-blur'>
           <div className='flex w-full items-center justify-between gap-2'>
             <div className='flex items-center gap-2 sm:gap-4 min-w-0 flex-1'>
@@ -185,9 +203,58 @@ export default function TraceDetailPage() {
                 <RefreshCw className={`h-4 w-4 ${isLoading || autoRefresh ? 'animate-spin' : ''}`} />
                 <span className='hidden sm:inline ml-2'>{t('common.refresh')}</span>
               </Button>
+              {(() => {
+                const status = trace.status ?? 'active';
+                if (status === 'active') {
+                  return (
+                    <>
+                      <Button variant='outline' size='sm' onClick={() => setShowArchiveDialog(true)} className='px-2 sm:px-3'>
+                        <IconArchive className='h-4 w-4' />
+                        <span className='hidden sm:inline ml-2'>{t('common.actions.archive')}</span>
+                      </Button>
+                      <Button variant='outline' size='sm' onClick={() => retainMutation.mutate(trace.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                        <IconPin className='h-4 w-4' />
+                        <span className='hidden sm:inline ml-2'>{t('common.actions.retain')}</span>
+                      </Button>
+                    </>
+                  );
+                }
+                if (status === 'archived') {
+                  return (
+                    <Button variant='outline' size='sm' onClick={() => unarchiveMutation.mutate(trace.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                      <IconRotate className='h-4 w-4' />
+                      <span className='hidden sm:inline ml-2'>{t('common.actions.unarchive')}</span>
+                    </Button>
+                  );
+                }
+                if (status === 'retained') {
+                  return (
+                    <Button variant='outline' size='sm' onClick={() => unretainMutation.mutate(trace.id, { onSuccess: () => refetch() })} className='px-2 sm:px-3'>
+                      <IconRotate className='h-4 w-4' />
+                      <span className='hidden sm:inline ml-2'>{t('common.actions.unretain')}</span>
+                    </Button>
+                  );
+                }
+                return null;
+              })()}
             </div>
           </div>
         </Header>
+        <AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('traces.dialogs.archiveTitle')}</AlertDialogTitle>
+              <AlertDialogDescription>{t('traces.dialogs.archiveDescription')}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('common.actions.cancel')}</AlertDialogCancel>
+              <AlertDialogAction onClick={() => { archiveMutation.mutate(trace.id, { onSuccess: () => refetch() }); setShowArchiveDialog(false); }}>
+                {t('common.actions.archive')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+        </>
       )}
 
       <Main className={cn('flex-1 overflow-hidden flex flex-col p-0', isFullscreen && 'fixed inset-0 z-50 bg-background')}>


### PR DESCRIPTION
## Summary

在 Trace 和 Thread 详情页的刷新按钮旁新增归档/保留操作按钮，支持直接在详情页进行状态管理。

## Changes

- **Trace 详情页**: 刷新按钮右侧新增归档、保留按钮；已归档显示恢复按钮；已保留显示取消保留按钮
- **Thread 详情页**: 同上，归档操作级联到关联 traces
- 归档操作需 AlertDialog 确认，其他操作直接执行
- mutation 成功后自动 refetch 详情数据，状态即时更新
- 按钮风格与刷新按钮一致（`outline` + `sm`），响应式设计
