### PR TITLE
feat(models): add Tencent developer with Hunyuan models

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -1,6 +1,7 @@
 export const DEVELOPER_IDS = [
   'deepseek',
   'alibaba',
+  'tencent',
   'zai',
   'openai',
   'moonshot',
@@ -30,6 +31,7 @@ export const DEVELOPER_ICONS: Record<string, string> = {
   minimax: 'Minimax',
   kwaipilot: 'KwaiKAT',
   alibaba: 'Qwen',
+  tencent: 'Hunyuan',
   xiaomi: 'XiaomiMiMo',
   longcat: 'LongCat',
   mistral: 'Mistral',

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -361,6 +361,47 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
+	// Merge Tencent plan providers into the Tencent developer
+	if (allowedIds.includes("tencent")) {
+		const tencentProviderKeys = [
+			"tencent-token-plan",
+			"tencent-tokenhub",
+			"tencent-coding-plan",
+		];
+		const mergedModels = new Map();
+
+		for (const key of tencentProviderKeys) {
+			const provider = data.providers[key];
+			if (!provider) continue;
+
+			for (const model of provider.models || []) {
+				const id = model.id?.toLowerCase() || "";
+				const normalizedId = id.startsWith("tencent/")
+					? id.slice("tencent/".length)
+					: id;
+				const isTencentModel =
+					normalizedId === "hy3" ||
+					normalizedId.startsWith("hy3-") ||
+					normalizedId.startsWith("hunyuan-");
+
+				if (!isTencentModel || mergedModels.has(id)) continue;
+				mergedModels.set(id, deepClone(model));
+			}
+		}
+
+		if (mergedModels.size > 0) {
+			filtered.tencent = {
+				id: "tencent",
+				name: "Tencent",
+				display_name: "Tencent",
+				models: Array.from(mergedModels.values()),
+			};
+			console.log(
+				`Merged ${mergedModels.size} Hy3/Hunyuan models into Tencent developer`,
+			);
+		}
+	}
+
 	// Merge xiaomi-token-plan-* providers into xiaomi developer
 	if (allowedIds.includes("xiaomi")) {
 		const xiaomiTokenPlanKeys = [

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -369,6 +369,20 @@ function filterProviders(data, allowedIds) {
 			"tencent-coding-plan",
 		];
 		const mergedModels = new Map();
+		const baseProvider = filtered.tencent || data.providers.tencent || null;
+
+		// Process the base provider first so its metadata takes precedence
+		if (baseProvider) {
+			for (const model of baseProvider.models || []) {
+				const id = model.id?.toLowerCase() || "";
+				const normalizedId = id.startsWith("tencent/")
+					? id.slice("tencent/".length)
+					: id;
+				if (normalizedId && !mergedModels.has(normalizedId)) {
+					mergedModels.set(normalizedId, deepClone(model));
+				}
+			}
+		}
 
 		for (const key of tencentProviderKeys) {
 			const provider = data.providers[key];
@@ -384,13 +398,14 @@ function filterProviders(data, allowedIds) {
 					normalizedId.startsWith("hy3-") ||
 					normalizedId.startsWith("hunyuan-");
 
-				if (!isTencentModel || mergedModels.has(id)) continue;
-				mergedModels.set(id, deepClone(model));
+				if (!isTencentModel || mergedModels.has(normalizedId)) continue;
+				mergedModels.set(normalizedId, deepClone(model));
 			}
 		}
 
 		if (mergedModels.size > 0) {
 			filtered.tencent = {
+				...(baseProvider || {}),
 				id: "tencent",
 				name: "Tencent",
 				display_name: "Tencent",


### PR DESCRIPTION
## Summary

- add Tencent to the supported model developers
- aggregate Hy3 and Hunyuan models from the existing Tencent provider data
- exclude non-Tencent models bundled with Tencent Coding Plan

Closes #2009

## Scope

This only updates the model developer sync pipeline. It does not add a new channel type or change routing behavior.

## Validation

- verified the sync output contains six Tencent models: Hy3, Hy3 Preview, Hunyuan 2.0 Instruct, Hunyuan 2.0 Thinking, Hunyuan T1, and Hunyuan TurboS
- verified MiniMax, Kimi, GLM, and tc-code-latest are excluded
- verified there are no duplicate logical model IDs, including optional `tencent/` aliases
- verified existing Tencent provider metadata and models are preserved during aggregation
- verified `Hunyuan` is exported by the resolved `@lobehub/icons` package version
- `node --check scripts/sync/sync-model-developers.js`
- `git diff --check`

## Implementation Notes

Tencent data is sourced from the existing PublicProviderConf provider keys. Missing provider entries are skipped, and any existing Tencent provider metadata and models are preserved before plan models are merged.