### PR TITLE
fix(permissions): align system settings scope

### DIFF
--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -88,7 +88,7 @@ export function AppHeader() {
           {/* Desktop-only controls - hidden on mobile */}
           {!isMobile && (
             <>
-              <PermissionGuard requiredSystemScope='read_system'>
+              <PermissionGuard requiredSystemScope='read_settings'>
                 <Link to='/system'>
                   <Button variant='ghost' size='icon' className='size-8'>
                     <IconSettings className='h-4 w-4' />

--- a/frontend/src/config/route-permission.ts
+++ b/frontend/src/config/route-permission.ts
@@ -69,7 +69,7 @@ export const routeConfigs: RouteGroup[] = [
       },
       {
         path: '/system',
-        requiredScopes: ['read_system'],
+        requiredScopes: ['read_settings'],
         mode: 'hidden',
       },
       {

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -25,6 +25,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { SelectDropdown } from '@/components/select-dropdown';
 import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/system';
+import { usePermissions } from '@/hooks/usePermissions';
 import { antigravityOAuthExchange, antigravityOAuthStart } from '../data/antigravity';
 import {
   useCreateChannel,
@@ -332,6 +333,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const { data: allTags = [], isLoading: isLoadingTags } = useAllChannelTags();
   const { data: proxyPresets = [] } = useProxyPresets();
   const saveProxyPreset = useSaveProxyPreset();
+  const { hasSystemScope } = usePermissions();
   const [supportedModels, setSupportedModels] = useState<string[]>(() => initialRow?.supportedModels || []);
   const [manualModels, setManualModels] = useState<string[]>(() => initialRow?.manualModels || []);
   const [newModel, setNewModel] = useState('');
@@ -1281,7 +1283,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }
 
         // Auto-save proxy preset (preserve existing name if available)
-        if (proxyType === ProxyType.URL && proxyUrl) {
+        if (hasSystemScope('write_settings') && proxyType === ProxyType.URL && proxyUrl) {
           const existingPreset = proxyPresets.find((p) => p.url === proxyUrl);
           saveProxyPreset.mutate({
             name: existingPreset?.name,

--- a/frontend/src/features/channels/components/channels-primary-buttons.tsx
+++ b/frontend/src/features/channels/components/channels-primary-buttons.tsx
@@ -12,7 +12,7 @@ export function ChannelsPrimaryButtons() {
 
   return (
     <div className='flex gap-2 overflow-x-auto md:overflow-x-visible'>
-      <PermissionGuard requiredScope='read_system'>
+      <PermissionGuard requiredSystemScope='read_settings'>
         {/* Load Balancing Strategy - navigate to system retry configuration */}
         <Button
           variant='outline'

--- a/frontend/src/features/channels/components/channels-proxy-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-proxy-dialog.tsx
@@ -19,6 +19,7 @@ import { Channel } from '../data/schema';
 import { mergeChannelSettingsForUpdate } from '../utils/merge';
 import { ErrorDisplay } from '../utils/error-formatter';
 import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/system';
+import { usePermissions } from '@/hooks/usePermissions';
 
 interface Props {
   open: boolean;
@@ -64,6 +65,7 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
   const [isTesting, setIsTesting] = useState(false);
   const { data: proxyPresets = [] } = useProxyPresets();
   const saveProxyPreset = useSaveProxyPreset();
+  const { hasSystemScope } = usePermissions();
   const [testResult, setTestResult] = useState<{ success: boolean; message?: string | null; latency?: number } | null>(null);
 
   const form = useForm<ProxyConfig>({
@@ -112,7 +114,7 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
       });
       toast.success(t('channels.messages.updateSuccess'));
       // Auto-save to proxy presets (preserve existing name if available)
-      if (values.type === ProxyType.URL && values.url) {
+      if (hasSystemScope('write_settings') && values.type === ProxyType.URL && values.url) {
         const existingPreset = proxyPresets.find((p) => p.url === values.url);
         saveProxyPreset.mutate({
           name: existingPreset?.name,

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -30,13 +30,13 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'zh' ? zhCN : enUS;
   const permissions = useRequestPermissions();
-  const { hasScope } = usePermissions();
+  const { hasSystemScope } = usePermissions();
   const { data: settings } = useGeneralSettings();
   const { data: securitySettings } = useSecuritySettings();
   const updateSecuritySettings = useUpdateSecuritySettings();
   const { navigateWithSearch } = usePaginationSearch({ defaultPageSize: 20 });
   const [displayMode, setDisplayMode] = useDisplayMode();
-  const canManageSecuritySettings = hasScope('write_settings');
+  const canManageSecuritySettings = hasSystemScope('write_settings');
 
   const blockedIPs = securitySettings?.blockedIPs ?? [];
   const showIPBanIcon = securitySettings?.showRequestLogIPBanIcon === true;

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { getTokenFromStorage } from '@/stores/authStore';
 import i18n from '@/lib/i18n';
 import { useErrorHandler } from '@/hooks/use-error-handler';
+import { usePermissions } from '@/hooks/usePermissions';
 import type { ProxyConfig } from '@/features/channels/data/schema';
 import type { ModelAssociation } from '@/features/models/data/schema';
 
@@ -449,10 +450,11 @@ export interface ClearCachePayload {
 // Hooks
 export function useBrandSettings(options?: { enabled?: boolean }) {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['brandSettings'],
-    enabled: options?.enabled,
+    enabled: options?.enabled !== false && hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ brandSettings: BrandSettings }>(BRAND_SETTINGS_QUERY);
@@ -467,9 +469,11 @@ export function useBrandSettings(options?: { enabled?: boolean }) {
 
 export function useStoragePolicy() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['storagePolicy'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ storagePolicy: StoragePolicy }>(STORAGE_POLICY_QUERY);
@@ -614,9 +618,11 @@ export function useUpdateWebhookNotifierConfig() {
 
 export function useDefaultDataStorageID() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['defaultDataStorageID'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ defaultDataStorageID: string | null }>(DEFAULT_DATA_STORAGE_QUERY);
@@ -973,9 +979,11 @@ export interface DeveloperModelSettings {
 
 export function useModelSettings() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['modelSettings'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ systemModelSettings: ModelSettings }>(MODEL_SETTINGS_QUERY);
@@ -1045,10 +1053,11 @@ export interface UpdateSystemChannelSettingsInput {
 
 export function useChannelSetting(options?: { enabled?: boolean }) {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['channelSetting'],
-    enabled: options?.enabled,
+    enabled: options?.enabled !== false && hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ systemChannelSettings: ChannelSetting }>(CHANNEL_SETTINGS_QUERY);
@@ -1082,9 +1091,11 @@ export function useUpdateChannelSetting() {
 
 export function useGeneralSettings() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['generalSettings'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ systemGeneralSettings: SystemGeneralSettings }>(SYSTEM_GENERAL_SETTINGS_QUERY);
@@ -1157,9 +1168,11 @@ export function useUpdateVideoStorageSettings() {
 
 export function useSecuritySettings() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['securitySettings'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ securitySettings: SecuritySettings }>(SECURITY_SETTINGS_QUERY);
@@ -1479,9 +1492,11 @@ export interface SaveProxyPresetInput {
 
 export function useProxyPresets() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['proxyPresets'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ proxyPresets: ProxyPreset[] }>(PROXY_PRESETS_QUERY);
@@ -1675,9 +1690,11 @@ export interface UpdateQuotaEnforcementSettingsInput {
 
 export function useQuotaEnforcementSettings() {
   const { handleError } = useErrorHandler();
+  const { hasSystemScope } = usePermissions();
 
   return useQuery({
     queryKey: ['quotaEnforcementSettings'],
+    enabled: hasSystemScope('read_settings'),
     queryFn: async () => {
       try {
         const data = await graphqlRequest<{ quotaEnforcementSettings: QuotaEnforcementSettings }>(QUOTA_ENFORCEMENT_SETTINGS_QUERY);

--- a/frontend/src/routes/_authenticated/system/index.tsx
+++ b/frontend/src/routes/_authenticated/system/index.tsx
@@ -8,7 +8,7 @@ function ProtectedSystem() {
   const search = Route.useSearch();
 
   return (
-    <RouteGuard requiredScopes={['read_system']} scopeLevel="system">
+    <RouteGuard requiredScopes={['read_settings']} scopeLevel="system">
       <SystemManagement initialTab={search.tab as SystemTabKey | undefined} />
     </RouteGuard>
   );


### PR DESCRIPTION
## Summary

- Align system route and navigation guards with the backend `read_settings` scope.
- Require a system-level settings scope for the channel load-balancing shortcut.
- Prevent users with obsolete `read_system` data from reaching system settings and triggering denied GraphQL queries.

## Verification

- `git diff --check origin/unstable...HEAD`