### PR TITLE
feat(models): add poolside as model developer

### DIFF
--- a/frontend/src/features/models/data/constants.ts
+++ b/frontend/src/features/models/data/constants.ts
@@ -18,6 +18,7 @@ export const DEVELOPER_IDS = [
   'stepfun',
   'meta',
   'ibm',
+  'poolside',
 ];
 
 export const DEVELOPER_ICONS: Record<string, string> = {

--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -18661,6 +18661,153 @@
           "family": "kat-coder"
         }
       ]
+    },
+    "poolside": {
+      "id": "poolside",
+      "api": "https://inference.poolside.ai/v1",
+      "name": "Poolside",
+      "doc": "https://docs.poolside.ai",
+      "display_name": "Poolside",
+      "models": [
+        {
+          "id": "poolside/laguna-s-2.1",
+          "name": "Laguna S 2.1",
+          "description": "Poolside's 118B MoE model with 1M context window, supporting reasoning on/off toggle",
+          "family": "laguna-s",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "toggle"
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2025-07-22",
+          "last_updated": "2025-07-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 1000000,
+            "output": 16384
+          },
+          "cost": {
+            "input": 0.29,
+            "output": 0.59,
+            "cache_read": 0.029
+          },
+          "display_name": "Laguna S 2.1",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          }
+        },
+        {
+          "id": "poolside/laguna-xs-2.1",
+          "name": "Laguna XS 2.1",
+          "description": "Poolside's 33B MoE model with 256K context window, supporting reasoning on/off toggle",
+          "family": "laguna-xs",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "toggle"
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2025-07-22",
+          "last_updated": "2025-07-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 262144,
+            "output": 8192
+          },
+          "cost": {
+            "input": 0.085,
+            "output": 0.17,
+            "cache_read": 0.0085
+          },
+          "display_name": "Laguna XS 2.1",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          }
+        },
+        {
+          "id": "poolside/laguna-m.1",
+          "name": "Laguna M.1",
+          "description": "Poolside's 225B MoE model with 256K context window, supporting reasoning on/off toggle",
+          "family": "laguna-m",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "toggle"
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2025-07-22",
+          "last_updated": "2025-07-22",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 262144,
+            "output": 16384
+          },
+          "cost": {
+            "input": 0.59,
+            "output": 1.18,
+            "cache_read": 0.059
+          },
+          "display_name": "Laguna M.1",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/frontend/src/locales/en/models.json
+++ b/frontend/src/locales/en/models.json
@@ -250,6 +250,7 @@
   "models.developers.xai": "xAI",
   "models.developers.xiaomi": "Xiaomi",
   "models.developers.zai": "Z.ai",
+  "models.developers.poolside": "Poolside",
   "models.groupedView.expandAll": "Expand All",
   "models.groupedView.collapseAll": "Collapse All",
   "models.groupedView.summary": "{{groups}} developers · {{models}} models",

--- a/frontend/src/locales/zh-CN/models.json
+++ b/frontend/src/locales/zh-CN/models.json
@@ -250,6 +250,7 @@
   "models.developers.xai": "xAI",
   "models.developers.xiaomi": "小米",
   "models.developers.zai": "智谱",
+  "models.developers.poolside": "Poolside",
   "models.groupedView.expandAll": "展开全部",
   "models.groupedView.collapseAll": "折叠全部",
   "models.groupedView.summary": "{{groups}} 个开发者 · {{models}} 个模型",


### PR DESCRIPTION
## Description

Add Poolside as a developer in the models listing UI so that Poolside's Laguna models are visible and selectable when creating models.

This is a frontend-only change that adds Poolside's provider data to `providers.json`, registers it in `DEVELOPER_IDS`, and adds the locale label. No backend channel type or API changes are included.

### Changes

- **`frontend/src/features/models/data/providers.json`** — Add `poolside` provider entry with OpenAI-compatible API endpoint (`https://inference.poolside.ai/v1`) and three Laguna model definitions:
  - `poolside/laguna-s-2.1` — Laguna S 2.1 (118B params, 1M context, MoE, reasoning on/off)
  - `poolside/laguna-xs-2.1` — Laguna XS 2.1 (33B params, 256K context, MoE, reasoning on/off)
  - `poolside/laguna-m.1` — Laguna M.1 (225B params, 256K context, MoE, reasoning on/off)
- **`frontend/src/features/models/data/constants.ts`** — Register `'poolside'` in the `DEVELOPER_IDS` array.
- **`frontend/src/locales/en/models.json`** — Add `models.developers.poolside` locale key with value `"Poolside"`.
- **`frontend/src/locales/zh-CN/models.json`** — Add `models.developers.poolside` locale key with value `"Poolside"`.

### Verification

- Frontend build: `cd frontend && npm run build` — confirms the JSON schema, constants, and locale changes compile.
- Models listing: "Poolside" appears as a developer group in the table with Laguna S 2.1, Laguna XS 2.1, and Laguna M.1 listed under it.
- Model creation: "poolside" appears in the developer selector, and the three Laguna model IDs are available in the model ID autocomplete.

### Notes

- Poolside's API is OpenAI-compatible (base URL `https://inference.poolside.ai/v1`, Bearer auth, `/v1/models` endpoint).
- No Poolside icon exists in `@lobehub/icons`; the developer name string is used as a fallback, which renders as `-` in the icon column. The developer is still visible in the grouped table header with its translated label.
- The local `providers.json` serves as a fallback when the remote `DEVELOPERS_URL` fetch fails.

## Checklist

- [x] Frontend build passes
- [x] No backend changes
- [x] Locale keys added for en and zh-CN
- [x] Provider data matches `providerSchema`