### PR TITLE
feat:增加每次请求新连接功能，使得类似resin之类的代理池能够轮换ip

### DIFF
--- a/frontend/src/features/channels/components/channels-proxy-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-proxy-dialog.tsx
@@ -10,9 +10,10 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import LongText from '@/components/long-text';
 import { useUpdateChannel, useTestChannel } from '../data/channels';
 import { Channel } from '../data/schema';
@@ -40,6 +41,7 @@ const proxyConfigSchema = z
     url: z.string().optional(),
     username: z.string().optional(),
     password: z.string().optional(),
+    disableConnectionReuse: z.boolean().optional(),
   })
   .refine(
     (data) => {
@@ -73,6 +75,7 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
       url: currentRow.settings?.proxy?.url || '',
       username: currentRow.settings?.proxy?.username || '',
       password: currentRow.settings?.proxy?.password || '',
+      disableConnectionReuse: currentRow.settings?.proxy?.disableConnectionReuse || false,
     },
   });
 
@@ -97,6 +100,7 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
           url: values.url,
           username: values.username || undefined,
           password: values.password || undefined,
+          disableConnectionReuse: values.disableConnectionReuse,
         }),
       };
 
@@ -142,6 +146,7 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
           url: values.url,
           username: values.username || undefined,
           password: values.password || undefined,
+          disableConnectionReuse: values.disableConnectionReuse,
         }),
       };
 
@@ -283,6 +288,22 @@ export function ChannelsProxyDialog({ open, onOpenChange, currentRow }: Props) {
                               <Input type='password' placeholder={t('channels.dialogs.proxy.fields.password.placeholder')} {...field} />
                             </FormControl>
                             <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name='disableConnectionReuse'
+                        render={({ field }) => (
+                          <FormItem className='flex flex-row items-center justify-between gap-4 rounded-md border p-3'>
+                            <div className='space-y-0.5'>
+                              <FormLabel>{t('channels.dialogs.proxy.fields.disableConnectionReuse.label')}</FormLabel>
+                              <FormDescription>{t('channels.dialogs.proxy.fields.disableConnectionReuse.description')}</FormDescription>
+                            </div>
+                            <FormControl>
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
+                            </FormControl>
                           </FormItem>
                         )}
                       />

--- a/frontend/src/features/channels/data/channel-config.test.mjs
+++ b/frontend/src/features/channels/data/channel-config.test.mjs
@@ -36,3 +36,57 @@ test('Cline has localized channel and provider labels', () => {
     assert.equal(messages['channels.providers.cline'], 'Cline');
   }
 });
+
+test('channel proxy connection reuse setting is submitted, echoed, and localized', () => {
+  const schema = read('features/channels/data/schema.ts');
+  const channelsData = read('features/channels/data/channels.ts');
+  const proxyDialog = read('features/channels/components/channels-proxy-dialog.tsx');
+
+  assert.match(
+    schema,
+    /proxyConfigSchema[\s\S]*disableConnectionReuse:\s*z\.boolean\(\)\.optional\(\)/,
+    'ProxyConfig schema should accept disableConnectionReuse'
+  );
+
+  const proxySelections = channelsData.match(/proxy\s*\{[\s\S]*?\}/g) ?? [];
+  assert.equal(proxySelections.length, 5, 'all five channel proxy selections should be covered by this assertion');
+  for (const selection of proxySelections) {
+    assert.match(selection, /disableConnectionReuse/, 'channel proxy queries should echo disableConnectionReuse');
+  }
+  assert.match(channelsData, /proxy\?:\s*ProxyConfig;/, 'channel test input should use the shared ProxyConfig type');
+
+  assert.match(proxyDialog, /name='disableConnectionReuse'/, 'proxy dialog should render the connection reuse switch');
+  const submitSection = proxyDialog.slice(proxyDialog.indexOf('const onSubmit'), proxyDialog.indexOf('const handleTest'));
+  const testSection = proxyDialog.slice(proxyDialog.indexOf('const handleTest'), proxyDialog.indexOf('return ('));
+  assert.match(
+    submitSection,
+    /const proxyConfig[\s\S]*disableConnectionReuse:\s*values\.disableConnectionReuse/,
+    'channel save payload should send disableConnectionReuse'
+  );
+  assert.match(
+    testSection,
+    /const proxyConfig[\s\S]*disableConnectionReuse:\s*values\.disableConnectionReuse/,
+    'channel test payload should send disableConnectionReuse'
+  );
+  const presetPayload = submitSection.match(/saveProxyPreset\.mutate\(\{[\s\S]*?\}\);/)?.[0] ?? '';
+  assert.doesNotMatch(presetPayload, /disableConnectionReuse/, 'proxy presets should remain address and credential only');
+  assert.match(
+    proxyDialog,
+    /channels\.dialogs\.proxy\.fields\.disableConnectionReuse\.description/,
+    'proxy dialog should render the explanatory text below the option'
+  );
+
+  const en = parseLocale('en');
+  assert.equal(en['channels.dialogs.proxy.fields.disableConnectionReuse.label'], 'Use a new proxy connection for every request');
+  assert.equal(
+    en['channels.dialogs.proxy.fields.disableConnectionReuse.description'],
+    'Enable this for proxy pools such as Resin that rotate nodes per connection. Each request will create a new proxy connection, increasing CONNECT and TLS handshake overhead.'
+  );
+
+  const zh = parseLocale('zh-CN');
+  assert.equal(zh['channels.dialogs.proxy.fields.disableConnectionReuse.label'], '每次请求使用新的代理连接');
+  assert.equal(
+    zh['channels.dialogs.proxy.fields.disableConnectionReuse.description'],
+    '适用于 Resin 等按连接切换节点的代理池。开启后每个请求都会重新建立代理连接，并增加 CONNECT 与 TLS 握手开销。'
+  );
+});

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -22,6 +22,7 @@ import {
   bulkUpdateChannelOrderingResultSchema,
   channelSummaryConnectionSchema,
   ChannelSettings,
+  ProxyConfig,
   ChannelPolicies,
   ChannelModelPrice,
   SaveChannelModelPriceInput,
@@ -98,6 +99,7 @@ const CREATE_CHANNEL_MUTATION = `
           url
           username
           password
+          disableConnectionReuse
         }
         transformOptions {
           forceArrayInstructions
@@ -171,6 +173,7 @@ const DUPLICATE_CHANNEL_MUTATION = `
           url
           username
           password
+          disableConnectionReuse
         }
         transformOptions {
           forceArrayInstructions
@@ -244,6 +247,7 @@ const BULK_CREATE_CHANNELS_MUTATION = `
           url
           username
           password
+          disableConnectionReuse
         }
         transformOptions {
           forceArrayInstructions
@@ -317,6 +321,7 @@ const UPDATE_CHANNEL_MUTATION = `
           url
           username
           password
+          disableConnectionReuse
         }
         transformOptions {
           forceArrayInstructions
@@ -855,6 +860,7 @@ const QUERY_CHANNELS_QUERY = `
               url
               username
               password
+              disableConnectionReuse
             }
             transformOptions {
               forceArrayInstructions
@@ -1400,7 +1406,7 @@ export function useTestChannel(options?: { silent?: boolean }) {
     }: {
       channelID: string;
       modelID?: string;
-      proxy?: { type: string; url?: string; username?: string; password?: string };
+      proxy?: ProxyConfig;
     }) => {
       try {
         const data = await graphqlRequest<{

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -173,6 +173,7 @@ export const proxyConfigSchema = z.object({
   url: z.string().optional(),
   username: z.string().optional(),
   password: z.string().optional(),
+  disableConnectionReuse: z.boolean().optional(),
 });
 export type ProxyConfig = z.infer<typeof proxyConfigSchema>;
 

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -510,6 +510,8 @@
   "channels.dialogs.proxy.fields.username.placeholder": "Enter proxy username",
   "channels.dialogs.proxy.fields.password.label": "Password (Optional)",
   "channels.dialogs.proxy.fields.password.placeholder": "Enter proxy password",
+  "channels.dialogs.proxy.fields.disableConnectionReuse.label": "Use a new proxy connection for every request",
+  "channels.dialogs.proxy.fields.disableConnectionReuse.description": "Enable this for proxy pools such as Resin that rotate nodes per connection. Each request will create a new proxy connection, increasing CONNECT and TLS handshake overhead.",
   "channels.dialogs.proxy.types.disabled": "Disabled - No proxy",
   "channels.dialogs.proxy.types.environment": "Environment - Use system proxy settings",
   "channels.dialogs.proxy.types.url": "Custom URL - Use specified proxy",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -507,6 +507,8 @@
   "channels.dialogs.proxy.fields.username.placeholder": "输入代理用户名",
   "channels.dialogs.proxy.fields.password.label": "密码（可选）",
   "channels.dialogs.proxy.fields.password.placeholder": "输入代理密码",
+  "channels.dialogs.proxy.fields.disableConnectionReuse.label": "每次请求使用新的代理连接",
+  "channels.dialogs.proxy.fields.disableConnectionReuse.description": "适用于 Resin 等按连接切换节点的代理池。开启后每个请求都会重新建立代理连接，并增加 CONNECT 与 TLS 握手开销。",
   "channels.dialogs.proxy.types.disabled": "禁用 - 不使用代理",
   "channels.dialogs.proxy.types.environment": "环境变量 - 使用系统代理设置",
   "channels.dialogs.proxy.types.url": "自定义 URL - 使用指定代理",

--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -298,6 +298,9 @@ func (svc *ChannelService) cleanupSwappedChannels(channels []*Channel) {
 			ch.stopTokenProvider()
 		}
 		stopChannelOutbounds(ch)
+		if ch != nil && ch.HTTPClient != nil && ch.HTTPClient != svc.httpClient {
+			ch.HTTPClient.CloseIdleConnections()
+		}
 	}
 }
 

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -2,6 +2,7 @@ package biz
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -220,6 +221,35 @@ func TestStopChannelOutboundsStopsEachOutboundOnce(t *testing.T) {
 
 	require.Equal(t, 1, primary.stops)
 	require.Equal(t, 1, secondary.stops)
+}
+
+type closeIdleTrackingTransport struct {
+	closeIdleCalls int
+}
+
+func (*closeIdleTrackingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (t *closeIdleTrackingTransport) CloseIdleConnections() {
+	t.closeIdleCalls++
+}
+
+func TestCleanupSwappedChannelsClosesOnlyOwnedHTTPClients(t *testing.T) {
+	sharedTransport := &closeIdleTrackingTransport{}
+	ownedTransport := &closeIdleTrackingTransport{}
+	sharedClient := httpclient.NewHttpClientWithClient(&http.Client{Transport: sharedTransport})
+	ownedClient := httpclient.NewHttpClientWithClient(&http.Client{Transport: ownedTransport})
+	svc := &ChannelService{httpClient: sharedClient}
+
+	svc.cleanupSwappedChannels([]*Channel{
+		{HTTPClient: sharedClient},
+		{HTTPClient: ownedClient},
+		{},
+	})
+
+	require.Zero(t, sharedTransport.closeIdleCalls)
+	require.Equal(t, 1, ownedTransport.closeIdleCalls)
 }
 
 func TestOnEnabledChannelsSwapDoesNotWaitForOldCleanup(t *testing.T) {

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -92,6 +92,7 @@ type ProxyConfig {
   url: String
   username: String
   password: String
+  disableConnectionReuse: Boolean
 }
 
 type ChannelEndpoint {
@@ -118,6 +119,7 @@ input ProxyConfigInput {
   url: String
   username: String
   password: String
+  disableConnectionReuse: Boolean
 }
 
 type RetryableErrorPattern {

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1264,10 +1264,11 @@ type ComplexityRoot struct {
 	}
 
 	ProxyConfig struct {
-		Password func(childComplexity int) int
-		Type     func(childComplexity int) int
-		URL      func(childComplexity int) int
-		Username func(childComplexity int) int
+		DisableConnectionReuse func(childComplexity int) int
+		Password               func(childComplexity int) int
+		Type                   func(childComplexity int) int
+		URL                    func(childComplexity int) int
+		Username               func(childComplexity int) int
 	}
 
 	ProxyPreset struct {
@@ -7633,6 +7634,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ProviderQuotaStatus.UpdatedAt(childComplexity), true
 
+	case "ProxyConfig.disableConnectionReuse":
+		if e.complexity.ProxyConfig.DisableConnectionReuse == nil {
+			break
+		}
+
+		return e.complexity.ProxyConfig.DisableConnectionReuse(childComplexity), true
 	case "ProxyConfig.password":
 		if e.complexity.ProxyConfig.Password == nil {
 			break
@@ -23870,6 +23877,8 @@ func (ec *executionContext) fieldContext_ChannelSettings_proxy(_ context.Context
 				return ec.fieldContext_ProxyConfig_username(ctx, field)
 			case "password":
 				return ec.fieldContext_ProxyConfig_password(ctx, field)
+			case "disableConnectionReuse":
+				return ec.fieldContext_ProxyConfig_disableConnectionReuse(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProxyConfig", field.Name)
 		},
@@ -41352,6 +41361,35 @@ func (ec *executionContext) fieldContext_ProxyConfig_password(_ context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProxyConfig_disableConnectionReuse(ctx context.Context, field graphql.CollectedField, obj *httpclient.ProxyConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProxyConfig_disableConnectionReuse,
+		func(ctx context.Context) (any, error) {
+			return obj.DisableConnectionReuse, nil
+		},
+		nil,
+		ec.marshalOBoolean2bool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProxyConfig_disableConnectionReuse(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProxyConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -59520,6 +59558,8 @@ func (ec *executionContext) fieldContext_WebhookTarget_proxy(_ context.Context, 
 				return ec.fieldContext_ProxyConfig_username(ctx, field)
 			case "password":
 				return ec.fieldContext_ProxyConfig_password(ctx, field)
+			case "disableConnectionReuse":
+				return ec.fieldContext_ProxyConfig_disableConnectionReuse(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProxyConfig", field.Name)
 		},
@@ -75069,7 +75109,7 @@ func (ec *executionContext) unmarshalInputProxyConfigInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "url", "username", "password"}
+	fieldsInOrder := [...]string{"type", "url", "username", "password", "disableConnectionReuse"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -75104,6 +75144,13 @@ func (ec *executionContext) unmarshalInputProxyConfigInput(ctx context.Context, 
 				return it, err
 			}
 			it.Password = data
+		case "disableConnectionReuse":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disableConnectionReuse"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DisableConnectionReuse = data
 		}
 	}
 
@@ -97268,6 +97315,8 @@ func (ec *executionContext) _ProxyConfig(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._ProxyConfig_username(ctx, field, obj)
 		case "password":
 			out.Values[i] = ec._ProxyConfig_password(ctx, field, obj)
+		case "disableConnectionReuse":
+			out.Values[i] = ec._ProxyConfig_disableConnectionReuse(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/llm/httpclient/client.go
+++ b/llm/httpclient/client.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/looplj/axonhub/llm/streams"
 )
+
 // MaxErrorBodySize is the maximum number of bytes read from an upstream error
 // response body. Error bodies beyond this size are truncated to prevent OOM
 // from pathological upstream responses that echo large request payloads in
 // validation error messages, producing response bodies of 1+ GB.
 const MaxErrorBodySize = 1 << 20 // 1 MB
-
 
 // HttpClient implements the HttpClient interface.
 type HttpClient struct {
@@ -51,14 +51,18 @@ func NewHttpClientWithProxy(proxyConfig *ProxyConfig, opts ...ClientOption) *Htt
 	for _, opt := range opts {
 		opt(&options)
 	}
+	disableConnectionReuse := proxyConfig != nil &&
+		proxyConfig.Type == ProxyTypeURL &&
+		proxyConfig.DisableConnectionReuse
 
 	transport := &http.Transport{
-		Proxy: getProxyFunc(proxyConfig),
+		Proxy:             getProxyFunc(proxyConfig),
+		DisableKeepAlives: disableConnectionReuse,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
+		ForceAttemptHTTP2:     !disableConnectionReuse,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
@@ -89,6 +93,11 @@ func (hc *HttpClient) WithProxy(proxyConfig *ProxyConfig) *HttpClient {
 // GetNativeClient returns the underlying *http.Client for advanced use cases.
 func (hc *HttpClient) GetNativeClient() *http.Client {
 	return hc.client
+}
+
+// CloseIdleConnections closes idle connections held by the underlying HTTP transport.
+func (hc *HttpClient) CloseIdleConnections() {
+	hc.client.CloseIdleConnections()
 }
 
 func (hc *HttpClient) ProxyFunc() func(*http.Request) (*url.URL, error) {

--- a/llm/httpclient/client_test.go
+++ b/llm/httpclient/client_test.go
@@ -1,13 +1,17 @@
 package httpclient
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -279,6 +283,97 @@ func TestNewHttpClient_WithInsecureSkipVerify_PreservesDefaultTransportSettings(
 	require.NotNil(t, tr.Proxy)
 	require.NotNil(t, tr.TLSClientConfig)
 	require.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+}
+
+type proxyConnectionIDContextKey struct{}
+
+func TestNewHttpClientWithProxy_ConnectionReuse(t *testing.T) {
+	tests := []struct {
+		name                    string
+		disableConnectionReuse  bool
+		wantDistinctConnections int
+	}{
+		{
+			name:                    "reuses proxy connection by default",
+			wantDistinctConnections: 1,
+		},
+		{
+			name:                    "uses a new proxy connection for every request when disabled",
+			disableConnectionReuse:  true,
+			wantDistinctConnections: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var nextConnectionID atomic.Int64
+			var connectionIDsMu sync.Mutex
+			connectionIDs := make([]int64, 0, 2)
+
+			proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				connectionID, ok := r.Context().Value(proxyConnectionIDContextKey{}).(int64)
+				require.True(t, ok)
+
+				connectionIDsMu.Lock()
+				connectionIDs = append(connectionIDs, connectionID)
+				connectionIDsMu.Unlock()
+
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(`{"ok":true}`))
+				require.NoError(t, err)
+			}))
+			proxy.Config.ConnContext = func(ctx context.Context, _ net.Conn) context.Context {
+				return context.WithValue(ctx, proxyConnectionIDContextKey{}, nextConnectionID.Add(1))
+			}
+			proxy.Start()
+			defer proxy.Close()
+
+			client := NewHttpClientWithProxy(&ProxyConfig{
+				Type:                   ProxyTypeURL,
+				URL:                    proxy.URL,
+				DisableConnectionReuse: tt.disableConnectionReuse,
+			})
+			defer client.GetNativeClient().CloseIdleConnections()
+			transport, ok := client.GetNativeClient().Transport.(*http.Transport)
+			require.True(t, ok)
+			require.Equal(t, tt.disableConnectionReuse, transport.DisableKeepAlives)
+			require.Equal(t, !tt.disableConnectionReuse, transport.ForceAttemptHTTP2)
+
+			for range 2 {
+				_, err := client.Do(t.Context(), &Request{
+					Method: http.MethodGet,
+					URL:    "http://upstream.example/test",
+				})
+				require.NoError(t, err)
+			}
+
+			connectionIDsMu.Lock()
+			defer connectionIDsMu.Unlock()
+
+			require.Len(t, connectionIDs, 2)
+			require.Len(t, map[int64]struct{}{
+				connectionIDs[0]: {},
+				connectionIDs[1]: {},
+			}, tt.wantDistinctConnections)
+		})
+	}
+}
+
+func TestNewHttpClientWithProxy_DisableConnectionReuseOnlyAppliesToURLProxy(t *testing.T) {
+	for _, proxyType := range []ProxyType{ProxyTypeDisabled, ProxyTypeEnvironment} {
+		t.Run(string(proxyType), func(t *testing.T) {
+			client := NewHttpClientWithProxy(&ProxyConfig{
+				Type:                   proxyType,
+				DisableConnectionReuse: true,
+			})
+			defer client.CloseIdleConnections()
+
+			transport, ok := client.GetNativeClient().Transport.(*http.Transport)
+			require.True(t, ok)
+			require.False(t, transport.DisableKeepAlives)
+			require.True(t, transport.ForceAttemptHTTP2)
+		})
+	}
 }
 
 func TestHttpClientImpl_buildHttpRequest(t *testing.T) {

--- a/llm/httpclient/proxy.go
+++ b/llm/httpclient/proxy.go
@@ -9,8 +9,9 @@ const (
 )
 
 type ProxyConfig struct {
-	Type     ProxyType `json:"type"`
-	URL      string    `json:"url,omitempty"`
-	Username string    `json:"username,omitempty"`
-	Password string    `json:"password,omitempty"`
+	Type                   ProxyType `json:"type"`
+	URL                    string    `json:"url,omitempty"`
+	Username               string    `json:"username,omitempty"`
+	Password               string    `json:"password,omitempty"`
+	DisableConnectionReuse bool      `json:"disableConnectionReuse,omitempty"`
 }


### PR DESCRIPTION
在渠道代理配置中新增 disableConnectionReuse 开关，默认关闭，仅对自定义 URL 代理生效。
开启后禁用 HTTP Keep-Alive 和 HTTP/2 连接复用，使每次请求建立新的代理连接，适配 Resin 等按连接轮换节点的代理池。
渠道缓存替换时关闭频道独占 HTTP 客户端的空闲连接，不影响共享默认客户端。
在渠道“代理配置”弹窗的自定义 URL 区域增加开关及中英文说明，并同步保存、测试和 GraphQL 回显链路。