### PR TITLE
fix(orchestrator): detect stream completion from JSON data type and finish_reason

### DIFF
--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/looplj/axonhub/internal/dumper"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/log"
@@ -78,11 +80,15 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	return event
 }
 
-// isTerminalStreamEvent checks if the event represents the end of a successfully completed stream.
-// For Chat Completions API this is the raw [DONE] event; for Responses API this is response.completed.
+// isTerminalStreamEvent checks both SSE metadata and JSON data for a successful
+// protocol-level or semantic completion marker.
 func isTerminalStreamEvent(event *httpclient.StreamEvent) bool {
+	if event == nil {
+		return false
+	}
+
 	// For chat completions, check for [DONE] event
-	return bytes.Equal(event.Data, llm.DoneStreamEvent.Data) ||
+	if bytes.Equal(event.Data, llm.DoneStreamEvent.Data) ||
 		// For Responses API, check for response.completed event
 		event.Type == "response.completed" ||
 		// For Anthropic Messages API, check for message_stop event
@@ -91,7 +97,35 @@ func isTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 		// rely on the terminal *.done event surfaced as StreamEvent.Type.
 		event.Type == "speech.audio.done" ||
 		event.Type == "transcript.text.done" ||
-		event.Type == httpclient.BinaryStreamDoneEventType
+		event.Type == httpclient.BinaryStreamDoneEventType {
+		return true
+	}
+
+	// Compatible SSE providers do not always populate the SSE `event` field and
+	// instead carry the event type only in the JSON data. Also recognize a chat
+	// completion's finish_reason as semantic completion: clients commonly close
+	// the connection immediately after consuming that final useful chunk, before
+	// the trailing [DONE] marker is read by the server.
+	eventType := gjson.GetBytes(event.Data, "type").String()
+	switch eventType {
+	case "response.completed", "message_stop", "speech.audio.done", "transcript.text.done":
+		return true
+	}
+
+	choices := gjson.GetBytes(event.Data, "choices")
+	if !choices.IsArray() {
+		return false
+	}
+
+	completed := false
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		finishReason := choice.Get("finish_reason")
+		completed = finishReason.Type == gjson.String && finishReason.String() != ""
+
+		return !completed
+	})
+
+	return completed
 }
 
 func (ts *InboundPersistentStream) Err() error {

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -138,8 +138,8 @@ func newInboundPersistentStreamHelper(
 	return stream, client, ctx, state
 }
 
-// TestInboundPersistentStream_Close_WithCompleteResponse tests the NEW behavior:
-// complete response without terminal event (e.g., Codex executor that aggregates internally)
+// TestInboundPersistentStream_Close_WithCompleteResponse verifies that a complete
+// response carrying finish_reason is recognized before Close persists it.
 func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
 	completeResponseChunk := &httpclient.StreamEvent{
 		Type: "chunk",
@@ -170,7 +170,7 @@ func TestInboundPersistentStream_Close_WithCompleteResponse(t *testing.T) {
 	event := stream.Current()
 	require.NotNil(t, event, "Expected current event to not be nil")
 
-	assert.False(t, state.StreamCompleted, "StreamCompleted should be false before Close()")
+	assert.True(t, state.StreamCompleted, "StreamCompleted should be true after consuming finish_reason")
 
 	err := stream.Close()
 	require.NoError(t, err, "Close() should not return an error")
@@ -271,4 +271,48 @@ func TestIsTerminalStreamEvent_AudioDoneEvents(t *testing.T) {
 	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.delta"}))
 	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.delta"}))
 	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "audio/mpeg"}))
+}
+
+func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *httpclient.StreamEvent
+		want  bool
+	}{
+		{
+			name:  "responses completion without SSE event field",
+			event: &httpclient.StreamEvent{Data: []byte(`{"type":"response.completed","response":{"status":"completed"}}`)},
+			want:  true,
+		},
+		{
+			name:  "anthropic message stop without SSE event field",
+			event: &httpclient.StreamEvent{Data: []byte(`{"type":"message_stop"}`)},
+			want:  true,
+		},
+		{
+			name:  "chat completion finish reason",
+			event: &httpclient.StreamEvent{Data: []byte(`{"choices":[{"index":0,"finish_reason":"stop"}]}`)},
+			want:  true,
+		},
+		{
+			name:  "chat completion without finish reason",
+			event: &httpclient.StreamEvent{Data: []byte(`{"choices":[{"index":0,"finish_reason":null}]}`)},
+			want:  false,
+		},
+		{
+			name:  "non-terminal responses event",
+			event: &httpclient.StreamEvent{Data: []byte(`{"type":"response.output_text.delta","delta":"done"}`)},
+			want:  false,
+		},
+		{
+			name: "nil event",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isTerminalStreamEvent(tt.event))
+		})
+	}
 }

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -804,6 +804,66 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 		require.Equal(t, "resp_codex_like", dbExec.ExternalID)
 		require.True(t, state.StreamCompleted)
 	})
+
+	t.Run("canceled client after finish reason is still completed without done or usage", func(t *testing.T) {
+		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+		defer client.Close()
+
+		baseCtx := ent.NewContext(ctx, client)
+		project := createTestProject(t, baseCtx, client)
+		ch := createTestChannel(t, baseCtx, client)
+		_, requestService, _, usageLogService := setupTestServices(t, client)
+
+		req, err := client.Request.Create().
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetStatus(request.StatusPending).
+			SetRequestBody([]byte(`{"stream":true}`)).
+			Save(baseCtx)
+		require.NoError(t, err)
+
+		exec, err := client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetRequestBody([]byte(`{"stream":true}`)).
+			SetFormat("openai/chat_completions").
+			SetStatus(requestexecution.StatusPending).
+			SetStream(true).
+			Save(baseCtx)
+		require.NoError(t, err)
+
+		finalChunk := &httpclient.StreamEvent{
+			Data: []byte(`{"id":"chatcmpl_complete","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`),
+		}
+		stream := &sliceEventStream{events: []*httpclient.StreamEvent{finalChunk}}
+		aggregated := []byte(`{"id":"chatcmpl_complete","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]}`)
+		transformer := &mockTransformer{
+			apiFormat:          llm.APIFormatOpenAIChatCompletion,
+			aggregatedResponse: aggregated,
+			aggregatedMeta:     llm.ResponseMeta{ID: "chatcmpl_complete"},
+		}
+		state := &PersistenceState{}
+
+		requestCtx, cancel := context.WithCancel(baseCtx)
+		persistentStream := NewOutboundPersistentStream(requestCtx, stream, req, exec, requestService, usageLogService, transformer, nil, state)
+		require.True(t, persistentStream.Next())
+		require.Equal(t, finalChunk, persistentStream.Current())
+		require.True(t, state.StreamCompleted)
+
+		// Simulate the agent closing its SSE request immediately after consuming
+		// the final semantic response, before a trailing [DONE] can be consumed.
+		cancel()
+		require.NoError(t, persistentStream.Close())
+
+		dbExec, err := client.RequestExecution.Get(baseCtx, exec.ID)
+		require.NoError(t, err)
+		require.Equal(t, requestexecution.StatusCompleted, dbExec.Status)
+		require.Empty(t, dbExec.ErrorMessage)
+		require.JSONEq(t, string(aggregated), string(dbExec.ResponseBody))
+	})
 }
 
 func TestPersistentOutboundTransformer_TransformRequest_WithPrepopulatedState(t *testing.T) {


### PR DESCRIPTION
Some SSE-compatible providers do not populate the SSE `event` field and instead carry the event type only in the JSON data payload. This also recognizes a chat completion's `finish_reason` as a semantic stream completion marker, since clients commonly close the connection immediately after consuming that final useful chunk, before the trailing `[DONE]` marker is read by the server.

## Motivation: real-world issue with pi (coding agent)

When using [pi](https://github.com/earendil-works/pi) (an AI coding agent) through AxonHub, streaming chat completion requests were incorrectly marked as `context canceled` errors even though the response was complete:

1. Pi uses the OpenAI SDK to stream chat completions through AxonHub.
2. The upstream provider returns a chunk with `finish_reason: "stop"` in the JSON data, but does **not** set the SSE `event` field and does not follow up with a `[DONE]` marker (or `[DONE]` arrives after pi has already processed `finish_reason`).
3. Pi's OpenAI SDK sees `finish_reason`, the `for-await` loop ends naturally, pi emits a `done` event, and **closes the SSE connection** to AxonHub.
4. At this point, AxonHub (the proxy) sees the client disconnect. Before this fix, `isTerminalStreamEvent` only checked the SSE `event` field and `[DONE]` byte comparison — it could not recognize `finish_reason` as a stream completion marker.
5. With `StreamCompleted = false` and `ctx.Done()`, AxonHub persisted the execution as failed/canceled.

After this fix, `isTerminalStreamEvent` recognizes `finish_reason` in the JSON data as a semantic completion, so `StreamCompleted` is set to `true` during `Next()`. When pi closes the connection, `Close()` sees `StreamCompleted = true` and correctly persists the execution as completed.

## Changes

- **inbound.go**: Parse JSON data for event types (`response.completed`, `message_stop`, `speech.audio.done`, `transcript.text.done`) and treat non-empty `finish_reason` in `choices` as stream completion. Add nil guard.
- **inbound_test.go**: Update existing test expectations and add `TestIsTerminalStreamEvent_SemanticCompletionInData` covering JSON-data-based detection.
- **outbound_test.go**: Add integration test (`canceled client after finish reason is still completed without done or usage`) verifying that a canceled context after `finish_reason` still completes the execution successfully.