### PR TITLE
fix(openai): transform Responses image results

### DIFF
--- a/llm/transformer/openai/responses/image_roundtrip_test.go
+++ b/llm/transformer/openai/responses/image_roundtrip_test.go
@@ -1,0 +1,72 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+func TestImageEditRoundTripReturnsImagesResponse(t *testing.T) {
+	outbound, err := responses.NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	providerReq, err := outbound.TransformRequest(t.Context(), &llm.Request{
+		Model:       "gpt-image-1",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt:       "edit this image",
+			Images:       [][]byte{[]byte("source-image")},
+			OutputFormat: "webp",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, llm.RequestTypeImage.String(), providerReq.RequestType)
+	require.Equal(t, llm.APIFormatOpenAIResponse.String(), providerReq.APIFormat)
+
+	llmResp, err := outbound.TransformResponse(t.Context(), &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Request:    providerReq,
+		Body: []byte(`{
+			"id": "resp_image_123",
+			"object": "response",
+			"created_at": 1759161016,
+			"status": "completed",
+			"model": "gpt-image-1",
+			"output": [{
+				"id": "img_123",
+				"type": "image_generation_call",
+				"status": "completed",
+				"result": "data:image/webp;base64,aW1hZ2UtZGF0YQ=="
+			}]
+		}`),
+	})
+	require.NoError(t, err)
+
+	clientResp, err := openai.NewImageEditInboundTransformer().TransformResponse(t.Context(), llmResp)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, clientResp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(clientResp.Body, &body))
+	require.Contains(t, body, "created")
+	require.Contains(t, body, "data")
+	require.NotContains(t, body, "id")
+	require.NotContains(t, body, "object")
+	require.NotContains(t, body, "output")
+	require.NotContains(t, body, "tools")
+
+	data, ok := body["data"].([]any)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+	image, ok := data[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "aW1hZ2UtZGF0YQ==", image["b64_json"])
+}

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -194,6 +194,9 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, fmt.Errorf("chat request is nil")
 	}
 
+	originalRequestType := llmReq.RequestType
+	isImageRequest := originalRequestType == llm.RequestTypeImage
+
 	//nolint:exhaustive // Checked.
 	switch llmReq.RequestType {
 	case llm.RequestTypeCompact:
@@ -305,7 +308,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, err
 	}
 
-	return &httpclient.Request{
+	httpReq := &httpclient.Request{
 		Method:  http.MethodPost,
 		URL:     fullURL,
 		Headers: headers,
@@ -318,7 +321,13 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		TransformerMetadata:   llmReq.TransformerMetadata,
 		SkipInboundQueryMerge: true,
 		Metadata:              nil,
-	}, nil
+	}
+
+	if isImageRequest {
+		httpReq.RequestType = originalRequestType.String()
+	}
+
+	return httpReq, nil
 }
 
 // buildFullRequestURL constructs the appropriate URL based on the platform.
@@ -350,7 +359,29 @@ func (t *OutboundTransformer) TransformResponse(
 		return t.transformCompactResponse(ctx, httpResp)
 	}
 
+	if httpResp.Request != nil && httpResp.Request.RequestType == llm.RequestTypeImage.String() {
+		return t.transformImageResponse(httpResp)
+	}
+
 	return t.transformStandardResponse(ctx, httpResp)
+}
+
+func (t *OutboundTransformer) transformImageResponse(httpResp *httpclient.Response) (*llm.Response, error) {
+	if httpResp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("HTTP error %d: %s", httpResp.StatusCode, strings.TrimSpace(string(httpResp.Body)))
+	}
+
+	var upstream Response
+	if err := json.Unmarshal(httpResp.Body, &upstream); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal responses api image response: %w", err)
+	}
+
+	metadata := map[string]any{}
+	if httpResp.Request.TransformerMetadata != nil {
+		metadata = httpResp.Request.TransformerMetadata
+	}
+
+	return BuildImageResponse(&upstream, metadata)
 }
 
 func (t *OutboundTransformer) transformStandardResponse(

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -1251,6 +1251,57 @@ func TestOutboundTransformer_TransformResponse(t *testing.T) {
 	}
 }
 
+func TestOutboundTransformer_TransformImageEditResponse(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	httpReq, err := transformer.TransformRequest(t.Context(), &llm.Request{
+		Model:       "gpt-image-1",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt:       "edit this image",
+			Images:       [][]byte{[]byte("source-image")},
+			OutputFormat: "webp",
+			Quality:      "high",
+			Size:         "1024x1024",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, llm.RequestTypeImage.String(), httpReq.RequestType)
+	require.Equal(t, llm.APIFormatOpenAIResponse.String(), httpReq.APIFormat)
+
+	result, err := transformer.TransformResponse(t.Context(), &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Request:    httpReq,
+		Body: []byte(`{
+			"id": "resp_image_123",
+			"object": "response",
+			"created_at": 1759161016,
+			"status": "completed",
+			"model": "gpt-image-1",
+			"output": [
+				{
+					"id": "img_123",
+					"type": "image_generation_call",
+					"status": "completed",
+					"result": "data:image/webp;base64,aW1hZ2UtZGF0YQ=="
+				}
+			]
+		}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "image.generation", result.Object)
+	require.Equal(t, llm.RequestTypeImage, result.RequestType)
+	require.Equal(t, "gpt-image-1", result.Model)
+	require.NotNil(t, result.Image)
+	require.Equal(t, "webp", result.Image.OutputFormat)
+	require.Equal(t, "high", result.Image.Quality)
+	require.Equal(t, "1024x1024", result.Image.Size)
+	require.Len(t, result.Image.Data, 1)
+	require.Equal(t, "aW1hZ2UtZGF0YQ==", result.Image.Data[0].B64JSON)
+}
+
 func TestOutboundTransformer_TransformRequest_WithTestData(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- preserve the original image request type when OpenAI image requests are converted to Responses API requests
- route non-streaming `image_generation_call` results through `BuildImageResponse`
- keep the emitted provider API format as `openai/responses` so response pass-through does not replace the converted Images API response with raw Responses JSON
- add transformer and end-to-end image edit response coverage

## Tests

- `go test ./transformer/openai/responses` from the `llm` module
- `go test ./internal/server/orchestrator -run TestApplyPassThroughResponse_MismatchedAPIFormat -count=1`

Fixes #2069