### PR TITLE
fix(openai): normalize empty finish_reason to nil for providers that always emit it

### DIFF
--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -340,6 +340,17 @@ func (t *OutboundTransformer) TransformStreamChunk(
 		return nil, err
 	}
 
+	// Normalize empty finish_reason to nil. Some OpenAI-compatible providers
+	// (e.g. Sensenova) emit finish_reason:"" in every stream chunk. An empty
+	// string is semantically identical to "not finished" (null), so this
+	// normalization prevents downstream code from mistaking every chunk for
+	// a terminal event.
+	for i := range resp.Choices {
+		if resp.Choices[i].FinishReason != nil && *resp.Choices[i].FinishReason == "" {
+			resp.Choices[i].FinishReason = nil
+		}
+	}
+
 	// Skip non-standard events with explicit empty choices array and no usage
 	// (e.g. inference-cost, cost) that some providers emit alongside standard chat
 	// completion chunks. Keep the standard OpenAI include_usage terminal chunk,


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g. Sensenova) send `finish_reason:""` (empty string) in every SSE stream chunk instead of omitting the field or setting it to null. Go's `json.Unmarshal` creates a non-nil `*string` pointer pointing to an empty string, which downstream code treats as a legitimate finish_reason signal.

This causes the Anthropic inbound stream transformer to set `hasFinished=true` on the very first chunk, preventing the actual `finish_reason` (e.g. `"tool_calls"`) from being processed. The final response ends up with a missing `content_block_stop` for the tool_use block and an incorrect `stop_reason`.

**Fix:** after parsing each stream chunk, normalize empty `finish_reason` strings to nil so only semantically meaningful values trigger terminal processing.