### PR TITLE
feat: add cache write for response api

### DIFF
--- a/llm/transformer/openai/responses/usage.go
+++ b/llm/transformer/openai/responses/usage.go
@@ -7,6 +7,9 @@ import (
 type Usage struct {
 	InputTokens       int64 `json:"input_tokens"`
 	InputTokenDetails struct {
+		// CacheWriteTokens is the number of input tokens written to the prompt cache.
+		CacheWriteTokens int64 `json:"cache_write_tokens"`
+		// CachedTokens is the number of input tokens retrieved from the prompt cache.
 		CachedTokens int64 `json:"cached_tokens"`
 	} `json:"input_tokens_details"`
 	OutputTokens       int64 `json:"output_tokens"`
@@ -22,7 +25,8 @@ func (u *Usage) ToUsage() *llm.Usage {
 		CompletionTokens: u.OutputTokens,
 		TotalTokens:      u.TotalTokens,
 		PromptTokensDetails: &llm.PromptTokensDetails{
-			CachedTokens: u.InputTokenDetails.CachedTokens,
+			CachedTokens:      u.InputTokenDetails.CachedTokens,
+			WriteCachedTokens: u.InputTokenDetails.CacheWriteTokens,
 		},
 		CompletionTokensDetails: &llm.CompletionTokensDetails{
 			ReasoningTokens: u.OutputTokenDetails.ReasoningTokens,
@@ -44,6 +48,7 @@ func ConvertLLMUsageToResponsesUsage(usage *llm.Usage) *Usage {
 
 	if usage.PromptTokensDetails != nil {
 		result.InputTokenDetails.CachedTokens = usage.PromptTokensDetails.CachedTokens
+		result.InputTokenDetails.CacheWriteTokens = usage.PromptTokensDetails.WriteCachedTokens
 	}
 
 	if usage.CompletionTokensDetails != nil {

--- a/llm/transformer/openai/responses/usage_test.go
+++ b/llm/transformer/openai/responses/usage_test.go
@@ -1,0 +1,64 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestUsageCacheWriteTokensRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("responses usage to unified usage", func(t *testing.T) {
+		t.Parallel()
+
+		responsesUsage := &Usage{
+			InputTokens:  100,
+			OutputTokens: 20,
+			TotalTokens:  120,
+		}
+		responsesUsage.InputTokenDetails.CacheWriteTokens = 80
+		responsesUsage.InputTokenDetails.CachedTokens = 10
+
+		usage := responsesUsage.ToUsage()
+
+		require.NotNil(t, usage.PromptTokensDetails)
+		require.Equal(t, int64(80), usage.PromptTokensDetails.WriteCachedTokens)
+		require.Equal(t, int64(10), usage.PromptTokensDetails.CachedTokens)
+	})
+
+	t.Run("unified usage to responses usage", func(t *testing.T) {
+		t.Parallel()
+
+		responsesUsage := ConvertLLMUsageToResponsesUsage(&llm.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			PromptTokensDetails: &llm.PromptTokensDetails{
+				WriteCachedTokens: 80,
+				CachedTokens:      10,
+			},
+		})
+
+		require.Equal(t, int64(80), responsesUsage.InputTokenDetails.CacheWriteTokens)
+		require.Equal(t, int64(10), responsesUsage.InputTokenDetails.CachedTokens)
+
+		body, err := json.Marshal(responsesUsage)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"input_tokens": 100,
+			"input_tokens_details": {
+				"cache_write_tokens": 80,
+				"cached_tokens": 10
+			},
+			"output_tokens": 20,
+			"output_tokens_details": {
+				"reasoning_tokens": 0
+			},
+			"total_tokens": 120
+		}`, string(body))
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of cached prompt token usage details when converting usage data between supported formats.
  * Added support for tracking tokens written to the prompt cache.

* **Tests**
  * Added validation for cached token metadata conversion and serialized usage responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->