### PR TITLE
fix(responses): expand namespace function tools

### DIFF
--- a/llm/provider_extensions.go
+++ b/llm/provider_extensions.go
@@ -21,11 +21,13 @@ type OpenAIResponsesRequestExtensions struct {
 }
 
 type OpenAIResponsesRawFragment struct {
-	Type          string          `json:"-"`
-	Name          string          `json:"-"`
-	CallID        string          `json:"-"`
-	OriginalIndex int             `json:"-"`
-	Raw           json.RawMessage `json:"-"`
+	Type          string `json:"-"`
+	Name          string `json:"-"`
+	CallID        string `json:"-"`
+	OriginalIndex int    `json:"-"`
+	// RepresentedToolCount is the number of structured tools replaced when Raw is replayed.
+	RepresentedToolCount int             `json:"-"`
+	Raw                  json.RawMessage `json:"-"`
 }
 
 func EnsureOpenAIResponsesProviderExtensions(req *Request) *OpenAIResponsesProviderExtensions {

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -784,6 +784,28 @@ func convertToolsToLLM(tools []Tool) ([]llm.Tool, error) {
 				ResponseCustomTool: customTool,
 			})
 
+		case "namespace":
+			for _, subTool := range tool.Tools {
+				if subTool.Type != "function" {
+					continue
+				}
+
+				params, err := json.Marshal(subTool.Parameters)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal namespace tool parameters: %w", err)
+				}
+
+				result = append(result, llm.Tool{
+					Type: "function",
+					Function: llm.Function{
+						Name:        namespaceFunctionName(tool.Name, subTool.Name),
+						Description: subTool.Description,
+						Parameters:  params,
+						Strict:      subTool.Strict,
+					},
+				})
+			}
+
 		default:
 			// Skip unsupported tool types
 			continue
@@ -791,6 +813,10 @@ func convertToolsToLLM(tools []Tool) ([]llm.Tool, error) {
 	}
 
 	return result, nil
+}
+
+func namespaceFunctionName(namespaceName, functionName string) string {
+	return namespaceName + "__" + functionName
 }
 
 func getResponseWebSearchCallsFromMetadata(metadata map[string]any) []Item {

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -154,6 +154,67 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "request with namespace tools",
+			httpReq: &httpclient.Request{
+				Body: []byte(`{
+					"model": "gpt-4o",
+					"input": "List the projects.",
+					"tools": [
+						{
+							"type": "namespace",
+							"name": "mcp__codebase_memory_mcp",
+							"tools": [
+								{
+									"type": "function",
+									"name": "list_projects",
+									"description": "List stored projects",
+									"parameters": {
+										"type": "object",
+										"properties": {}
+									},
+									"strict": true
+								},
+								{
+									"type": "function",
+									"name": "get_project",
+									"description": "Get a stored project",
+									"parameters": {
+										"type": "object",
+										"properties": {"id": {"type": "string"}},
+										"required": ["id"]
+									}
+								},
+								{
+									"type": "web_search",
+									"name": "unsupported_nested_tool"
+								}
+							]
+						},
+						{
+							"type": "function",
+							"name": "get_weather",
+							"parameters": {"type": "object", "properties": {}}
+						}
+					]
+				}`),
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *llm.Request) {
+				require.Len(t, result.Tools, 3)
+
+				namespaceTool := result.Tools[0]
+				require.Equal(t, "function", namespaceTool.Type)
+				require.Equal(t, "mcp__codebase_memory_mcp__list_projects", namespaceTool.Function.Name)
+				require.Equal(t, "List stored projects", namespaceTool.Function.Description)
+				require.JSONEq(t, `{"type":"object","properties":{}}`, string(namespaceTool.Function.Parameters))
+				require.NotNil(t, namespaceTool.Function.Strict)
+				require.True(t, *namespaceTool.Function.Strict)
+
+				require.Equal(t, "mcp__codebase_memory_mcp__get_project", result.Tools[1].Function.Name)
+				require.Equal(t, "get_weather", result.Tools[2].Function.Name)
+			},
+		},
+		{
 			name: "captures responses provider raw tools and tool choice",
 			httpReq: &httpclient.Request{
 				Body: []byte(`{

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -23,7 +23,7 @@ type ImageGeneration struct {
 }
 
 type Tool struct {
-	// Any of "function", "image_generation", "custom", "web_search".
+	// Any of "function", "image_generation", "custom", "web_search", "namespace".
 	Type        string `json:"type,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -32,6 +32,9 @@ type Tool struct {
 	Parameters map[string]any `json:"parameters,omitempty"`
 	// This field is from variant [FunctionTool].
 	Strict *bool `json:"strict,omitempty"`
+
+	// Tools holds sub-tools when Type is "namespace".
+	Tools []Tool `json:"tools,omitempty"`
 
 	// This field is for custom tool format definition.
 	Format *CustomToolFormat `json:"format,omitempty"`

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -280,6 +280,54 @@ func TestOutboundTransformer_TransformRequest_ReplaysProviderRawToolsAndToolChoi
 	require.Len(t, toolChoice["tools"], 1)
 }
 
+func TestOutboundTransformer_TransformRequest_ReplaysNamespaceTool(t *testing.T) {
+	inbound := NewInboundTransformer()
+	inboundReq := &httpclient.Request{
+		Body: []byte(`{
+			"model": "gpt-4o",
+			"input": "List the projects.",
+			"tools": [
+				{
+					"type": "namespace",
+					"name": "mcp__codebase_memory_mcp",
+					"tools": [
+						{"type": "function", "name": "list_projects", "parameters": {"type": "object"}},
+						{"type": "function", "name": "get_project", "parameters": {"type": "object"}}
+					]
+				},
+				{"type": "function", "name": "get_weather", "parameters": {"type": "object"}}
+			]
+		}`),
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), inboundReq)
+	require.NoError(t, err)
+	require.Len(t, llmReq.Tools, 3)
+
+	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	httpReq, err := outbound.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+
+	tools, ok := payload["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 2)
+	namespaceTool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "namespace", namespaceTool["type"])
+	require.Equal(t, "mcp__codebase_memory_mcp", namespaceTool["name"])
+	require.Len(t, namespaceTool["tools"], 2)
+
+	functionTool, ok := tools[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "get_weather", functionTool["name"])
+}
+
 func TestOutboundTransformer_TransformRequest_ReplaysProviderRawInputItems(t *testing.T) {
 	inbound := NewInboundTransformer()
 	inboundReq := &httpclient.Request{

--- a/llm/transformer/openai/responses/request_extensions.go
+++ b/llm/transformer/openai/responses/request_extensions.go
@@ -74,6 +74,17 @@ func buildRepresentedToolSignatures(tools []Tool) []string {
 
 	signatures := make([]string, 0, len(tools))
 	for _, tool := range tools {
+		if tool.Type == "namespace" {
+			for _, subTool := range tool.Tools {
+				if subTool.Type == "function" {
+					signatures = append(signatures, responseToolSignature(Tool{
+						Type: "function",
+						Name: namespaceFunctionName(tool.Name, subTool.Name),
+					}))
+				}
+			}
+			continue
+		}
 		if !isStructurallyRepresentedToolType(tool.Type) {
 			continue
 		}
@@ -95,14 +106,30 @@ func buildRawOnlyToolFragments(tools []Tool, rawTools []json.RawMessage) []llm.O
 		}
 
 		fragments = append(fragments, llm.OpenAIResponsesRawFragment{
-			Type:          tools[i].Type,
-			Name:          tools[i].Name,
-			OriginalIndex: i,
-			Raw:           cloneRaw(rawTools[i]),
+			Type:                 tools[i].Type,
+			Name:                 tools[i].Name,
+			OriginalIndex:        i,
+			RepresentedToolCount: representedNamespaceToolCount(tools[i]),
+			Raw:                  cloneRaw(rawTools[i]),
 		})
 	}
 
 	return fragments
+}
+
+func representedNamespaceToolCount(tool Tool) int {
+	if tool.Type != "namespace" {
+		return 0
+	}
+
+	count := 0
+	for _, subTool := range tool.Tools {
+		if subTool.Type == "function" {
+			count++
+		}
+	}
+
+	return count
 }
 
 func isStructurallyRepresentedToolType(toolType string) bool {
@@ -274,20 +301,35 @@ func mergeRawOnlyTools(structuredRaw json.RawMessage, requestExt *llm.OpenAIResp
 		return nil, false
 	}
 
-	total := len(structuredTools) + len(requestExt.RawTools)
+	representedCount := 0
+	for _, fragment := range requestExt.RawTools {
+		if fragment.RepresentedToolCount < 0 {
+			return nil, false
+		}
+		representedCount += fragment.RepresentedToolCount
+	}
+	if representedCount > len(structuredTools) {
+		return nil, false
+	}
+
+	total := len(structuredTools) - representedCount + len(requestExt.RawTools)
 	tools := make([]json.RawMessage, 0, total)
 	structuredIndex := 0
-	rawByIndex := make(map[int]json.RawMessage, len(requestExt.RawTools))
+	rawByIndex := make(map[int]llm.OpenAIResponsesRawFragment, len(requestExt.RawTools))
 	for _, fragment := range requestExt.RawTools {
 		if len(fragment.Raw) == 0 || fragment.OriginalIndex < 0 {
 			return nil, false
 		}
-		rawByIndex[fragment.OriginalIndex] = cloneRaw(fragment.Raw)
+		rawByIndex[fragment.OriginalIndex] = fragment
 	}
 
 	for i := 0; i < total; i++ {
-		if raw, ok := rawByIndex[i]; ok {
-			tools = append(tools, raw)
+		if fragment, ok := rawByIndex[i]; ok {
+			tools = append(tools, cloneRaw(fragment.Raw))
+			structuredIndex += fragment.RepresentedToolCount
+			if structuredIndex > len(structuredTools) {
+				return nil, false
+			}
 			continue
 		}
 		if structuredIndex >= len(structuredTools) {


### PR DESCRIPTION
## Summary

- parse Responses API `namespace` tools and expand nested function tools as `<namespace>__<function>`
- preserve nested function descriptions, parameters, and strict settings while skipping unsupported nested tool types
- replay original namespace tools for unchanged Responses-to-Responses forwarding
- add inbound transformation and round-trip regression coverage

## Tests

- `go test ./transformer/... -count=1` from the `llm` module using Go 1.26.0

Fixes #1873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for namespace tools in OpenAI Responses requests.
  - Nested function tools are automatically expanded and made available with namespace-qualified names.
  - Namespace tools and their nested functions are preserved when requests are transformed and sent.
  - Tool definitions now support nested sub-tools and maintain settings such as strict mode.
- **Bug Fixes**
  - Improved handling of raw tool fragments so namespace tools merge correctly with structured tool definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->