### PR TITLE
fix(frontend): keep detail page header visible when scrolling

### DIFF
--- a/frontend/src/features/requests/components/request-detail-global-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-global-page.tsx
@@ -17,7 +17,7 @@ export default function RequestDetailGlobalPage() {
   const { data: request } = useRequest(requestId, { projectId: null });
 
   return (
-    <div className='flex h-screen flex-col'>
+    <div className='flex h-full flex-col'>
       <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur'>
         <div className='flex items-center space-x-4'>
           <Button variant='ghost' size='sm' onClick={() => router.history.back()} className='hover:bg-accent'>

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -347,7 +347,7 @@ export default function RequestDetailPage() {
   };
 
   return (
-    <div className='flex h-screen flex-col'>
+    <div className='flex h-full flex-col'>
       <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur'>
         <div className='flex items-center space-x-4'>
           <Button variant='ghost' size='sm' onClick={handleBack} className='hover:bg-accent'>

--- a/frontend/src/features/threads/components/thread-detail-page.tsx
+++ b/frontend/src/features/threads/components/thread-detail-page.tsx
@@ -117,7 +117,7 @@ export default function ThreadDetailPage() {
 
   if (isLoading) {
     return (
-      <div className='flex h-screen flex-col'>
+      <div className='flex h-full flex-col'>
         <Header className='border-b'></Header>
         <Main className='flex-1'>
           <div className='flex h-full items-center justify-center'>
@@ -133,7 +133,7 @@ export default function ThreadDetailPage() {
 
   if (!thread) {
     return (
-      <div className='flex h-screen flex-col'>
+      <div className='flex h-full flex-col'>
         <Header className='border-b'></Header>
         <Main className='flex-1'>
           <div className='flex h-full items-center justify-center'>
@@ -156,7 +156,7 @@ export default function ThreadDetailPage() {
   const createdAtLabel = format(thread.createdAt, 'yyyy-MM-dd HH:mm:ss', { locale });
 
   return (
-    <div className='flex h-screen flex-col'>
+    <div className='flex h-full flex-col'>
       <Header className='bg-background/95 supports-[backdrop-filter]:bg-background/60 w-full border-b backdrop-blur'>
         <div className='flex w-full items-center justify-between gap-2'>
           <div className='flex items-center gap-2 sm:gap-4 min-w-0 flex-1'>

--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -127,7 +127,7 @@ export default function TraceDetailPage() {
 
   if (isLoading) {
     return (
-      <div className='flex h-screen flex-col'>
+      <div className='flex h-full flex-col'>
         <Header className='border-b'></Header>
         <Main className='flex-1'>
           <div className='flex h-full items-center justify-center'>
@@ -143,7 +143,7 @@ export default function TraceDetailPage() {
 
   if (!trace) {
     return (
-      <div className='flex h-screen flex-col'>
+      <div className='flex h-full flex-col'>
         <Header className='border-b'></Header>
         <Main className='flex-1'>
           <div className='flex h-full items-center justify-center'>
@@ -164,7 +164,7 @@ export default function TraceDetailPage() {
   }
 
   return (
-    <div className='flex h-screen flex-col'>
+    <div className='flex h-full flex-col'>
       {/* Normal Header - hidden in fullscreen */}
       {!isFullscreen && (
         <>


### PR DESCRIPTION
## Summary

Detail pages used `h-screen` inside the authenticated layout, making them taller than the available content area. After the inner content reached the bottom, continued scrolling moved the outer page and hid the detail header.

Use `h-full` so Request, Trace, and Thread detail pages fit the available height and keep scrolling within their content area.

## Before

<img width="2560" height="1528" alt="Detail page before fix" src="https://github.com/user-attachments/assets/0f196f0b-32f7-4d59-8a62-8dd54e0aa459" />

## After

<img width="2560" height="1528" alt="Detail page after fix" src="https://github.com/user-attachments/assets/17534696-0654-4f06-9b3b-899b87036c4a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the height behavior of request, thread, and trace detail pages.
  * Updated loading, empty, and primary content views to fit their available layout space more consistently.
  * Reduced potential viewport-height layout issues within nested page containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->