### PR TITLE
fix(gemini): preserve file data MIME type for Vertex

### DIFF
--- a/llm/model.go
+++ b/llm/model.go
@@ -555,6 +555,9 @@ type ImageURL struct {
 	// URL is the URL of the image.
 	URL string `json:"url"`
 
+	// MIMEType is the MIME type of the image when provided by the source protocol.
+	MIMEType string `json:"mime_type,omitempty"`
+
 	// Specifies the detail level of the image. Learn more in the
 	// [Vision guide](https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding).
 	//

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -136,8 +136,12 @@ func convertLLMFinishReasonToGemini(reason *string) string {
 	}
 }
 
-func convertImageURLToGeminiPart(url string) *Part {
-	if parsed := xurl.ParseDataURL(url); parsed != nil {
+func convertImageURLToGeminiPart(image *llm.ImageURL) *Part {
+	if image == nil || image.URL == "" {
+		return nil
+	}
+
+	if parsed := xurl.ParseDataURL(image.URL); parsed != nil {
 		return &Part{
 			InlineData: &Blob{
 				MIMEType: parsed.MediaType,
@@ -146,14 +150,12 @@ func convertImageURLToGeminiPart(url string) *Part {
 		}
 	}
 
-	// Regular URL - use FileData with MIME type detection
-	part := &Part{
+	return &Part{
 		FileData: &FileData{
-			FileURI: url,
+			FileURI:  image.URL,
+			MIMEType: image.MIMEType,
 		},
 	}
-
-	return part
 }
 
 func convertVideoURLToGeminiPart(video *llm.VideoURL) *Part {

--- a/llm/transformer/gemini/filedata_mimetype_test.go
+++ b/llm/transformer/gemini/filedata_mimetype_test.go
@@ -1,0 +1,50 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
+	// Given
+	inbound := NewInboundTransformer()
+	outbound, err := NewOutboundTransformerWithConfig(Config{
+		BaseURL:      "https://us-central1-aiplatform.googleapis.com",
+		PlatformType: PlatformVertex,
+	})
+	require.NoError(t, err)
+
+	inboundRequest := &httpclient.Request{
+		Path: "/v1beta/models/gemini-2.5-flash:generateContent",
+		Body: []byte(`{
+			"contents": [{
+				"role": "user",
+				"parts": [{
+					"fileData": {
+						"mimeType": "image/png",
+						"fileUri": "gs://example-bucket/image.png"
+					}
+				}]
+			}]
+		}`),
+	}
+
+	// When
+	llmRequest, err := inbound.TransformRequest(t.Context(), inboundRequest)
+	require.NoError(t, err)
+	vertexRequest, err := outbound.TransformRequest(t.Context(), llmRequest)
+	require.NoError(t, err)
+
+	var got GenerateContentRequest
+	require.NoError(t, json.Unmarshal(vertexRequest.Body, &got))
+
+	// Then
+	require.Len(t, got.Contents, 1)
+	require.Len(t, got.Contents[0].Parts, 1)
+	require.NotNil(t, got.Contents[0].Parts[0].FileData)
+	require.Equal(t, "image/png", got.Contents[0].Parts[0].FileData.MIMEType)
+}

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -351,7 +351,8 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "image_url",
 					ImageURL: &llm.ImageURL{
-						URL: dataURL,
+						URL:      dataURL,
+						MIMEType: part.InlineData.MIMEType,
 					},
 				})
 			}
@@ -387,7 +388,8 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "image_url",
 					ImageURL: &llm.ImageURL{
-						URL: part.FileData.FileURI,
+						URL:      part.FileData.FileURI,
+						MIMEType: mimeType,
 					},
 				})
 			}
@@ -573,7 +575,7 @@ func convertLLMChoiceToGeminiCandidate(choice *llm.Choice, isStream bool) *Candi
 				case "image_url":
 					// Handle image_url type
 					if part.ImageURL != nil && part.ImageURL.URL != "" {
-						geminiPart := convertImageURLToGeminiPart(part.ImageURL.URL)
+						geminiPart := convertImageURLToGeminiPart(part.ImageURL)
 						if geminiPart != nil {
 							parts = append(parts, geminiPart)
 							lastPart = geminiPart

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -356,7 +356,7 @@ func convertLLMMessageToGeminiContent(msg *llm.Message) *Content {
 			case "image_url":
 				// Handle image_url type
 				if part.ImageURL != nil && part.ImageURL.URL != "" {
-					geminiPart := convertImageURLToGeminiPart(part.ImageURL.URL)
+					geminiPart := convertImageURLToGeminiPart(part.ImageURL)
 					if geminiPart != nil {
 						parts = append(parts, geminiPart)
 						lastPart = geminiPart

--- a/llm/transformer/gemini/outbound_convert_test.go
+++ b/llm/transformer/gemini/outbound_convert_test.go
@@ -2642,7 +2642,7 @@ func TestConvertImageURLToGeminiPart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertImageURLToGeminiPart(tt.url)
+			result := convertImageURLToGeminiPart(&llm.ImageURL{URL: tt.url})
 			tt.validate(t, result)
 		})
 	}


### PR DESCRIPTION
## Summary

- preserve image MIME metadata while normalizing Gemini `fileData` and `inlineData` into the shared LLM request model
- restore the MIME type when constructing Gemini/Vertex `fileData` payloads
- add an end-to-end Gemini inbound to Vertex outbound regression test

## Root cause

The Gemini request model correctly decoded the external camelCase `mimeType` field. The value was then dropped when the part was normalized into `llm.ImageURL`, which previously stored only the URI. When the Vertex request was rebuilt, `fileData.mimeType` was therefore empty and omitted by JSON serialization, violating Vertex AI's required `FileData.mimeType` contract.

The shared model continues to use its internal snake_case JSON convention (`mime_type`); the transformer explicitly maps that value back to Gemini's `mimeType` field.

## Verification

- reproduced the regression before the fix: expected `image/png`, got an empty MIME type
- `go test -race -shuffle=on -count=1 ./transformer/gemini`
- manually exercised the public inbound and Vertex outbound transformer surfaces and observed:

```json
{"fileData":{"mimeType":"image/png","fileUri":"gs://example-bucket/image.png"}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image metadata now supports optional MIME types.
  * Image MIME types are preserved when converting images between supported Gemini formats.
  * External image references now include their MIME type when available.

* **Bug Fixes**
  * Improved image conversion reliability for inline and file-based image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->