### PR TITLE
fix: handle moderation responses in empty response detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ config.schema.json
 .omc/
 .playwright-mcp/
 .ace-tool/
+.omx/

--- a/llm/pipeline/empty_response.go
+++ b/llm/pipeline/empty_response.go
@@ -68,6 +68,10 @@ func hasResponseContent(resp *llm.Response) bool {
 		return false
 	}
 
+	if resp.Moderation != nil && len(resp.Moderation.Results) > 0 {
+		return true
+	}
+
 	if resp.Embedding != nil && len(resp.Embedding.Data) > 0 {
 		return true
 	}

--- a/llm/pipeline/empty_response_moderation_integration_test.go
+++ b/llm/pipeline/empty_response_moderation_integration_test.go
@@ -1,0 +1,95 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+func TestPipeline_ModerationEmptyResponseDetection(t *testing.T) {
+	inbound := openai.NewModerationInboundTransformer()
+	outbound, err := openai.NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	executorCalls := 0
+	executor := &mockExecutor{
+		doFunc: func(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+			executorCalls++
+			require.Equal(t, http.MethodPost, request.Method)
+			require.Equal(t, "https://api.openai.com/v1/moderations", request.URL)
+			require.Equal(t, string(llm.RequestTypeModeration), request.RequestType)
+			require.Equal(t, string(llm.APIFormatOpenAIModeration), request.APIFormat)
+			require.Nil(t, request.Auth)
+			require.Equal(t, "Bearer test-api-key", request.Headers.Get("Authorization"))
+
+			return &httpclient.Response{
+				StatusCode: http.StatusOK,
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Request: request,
+				Body: []byte(`{
+					"id":"modr-integration-test",
+					"model":"omni-moderation-latest",
+					"results":[{
+						"flagged":false,
+						"categories":{"hate":false,"sexual/minors":false},
+						"category_scores":{"hate":0.01,"sexual/minors":0.001},
+						"category_applied_input_types":{"hate":["text"],"sexual/minors":["text"]}
+					}]
+				}`),
+			}, nil
+		},
+	}
+
+	p := pipeline.NewFactory(executor).Pipeline(
+		inbound,
+		outbound,
+		pipeline.WithEmptyResponseDetection(),
+	)
+
+	result, err := p.Process(context.Background(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "/v1/moderations",
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: []byte(`{"input":"这里是需要进行内容安全检测的文本","model":"omni-moderation-latest"}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, executorCalls)
+	require.NotNil(t, result)
+	require.False(t, result.Stream)
+	require.NotNil(t, result.Response)
+	require.Equal(t, http.StatusOK, result.Response.StatusCode)
+	require.Equal(t, "application/json", result.Response.Headers.Get("Content-Type"))
+
+	var response struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Results []struct {
+			Flagged                   *bool               `json:"flagged"`
+			Categories                map[string]bool     `json:"categories"`
+			CategoryScores            map[string]float64  `json:"category_scores"`
+			CategoryAppliedInputTypes map[string][]string `json:"category_applied_input_types"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(result.Response.Body, &response))
+	require.Equal(t, "modr-integration-test", response.ID)
+	require.Equal(t, "omni-moderation-latest", response.Model)
+	require.Len(t, response.Results, 1)
+	require.NotNil(t, response.Results[0].Flagged)
+	require.False(t, *response.Results[0].Flagged)
+	require.Contains(t, response.Results[0].Categories, "sexual/minors")
+	require.False(t, response.Results[0].Categories["sexual/minors"])
+	require.Equal(t, 0.001, response.Results[0].CategoryScores["sexual/minors"])
+	require.Equal(t, []string{"text"}, response.Results[0].CategoryAppliedInputTypes["sexual/minors"])
+}

--- a/llm/pipeline/empty_response_test.go
+++ b/llm/pipeline/empty_response_test.go
@@ -103,6 +103,28 @@ func TestHasResponseContent(t *testing.T) {
 			},
 		}))
 	})
+
+	t.Run("moderation response with results", func(t *testing.T) {
+		require.True(t, hasResponseContent(&llm.Response{
+			Moderation: &llm.ModerationResponse{
+				Results: []llm.ModerationClassification{{
+					Flagged: false,
+					Categories: map[string]bool{
+						"hate": false,
+					},
+					CategoryScores: map[string]float64{
+						"hate": 0.01,
+					},
+				}},
+			},
+		}))
+	})
+
+	t.Run("empty moderation response", func(t *testing.T) {
+		require.False(t, hasResponseContent(&llm.Response{
+			Moderation: &llm.ModerationResponse{},
+		}))
+	})
 }
 
 func TestPipeline_Process_StreamEmptyResponseDetection(t *testing.T) {
@@ -445,6 +467,48 @@ func TestPipeline_Process_NonStreamEmptyResponseDetection(t *testing.T) {
 								Embedding: []float64{0.1, 0.2, 0.3},
 							},
 							Index: 0,
+						}},
+					},
+				}, nil
+			},
+		}
+
+		p := &pipeline{
+			Executor:               executor,
+			Inbound:                &mockInbound{},
+			Outbound:               outbound,
+			emptyResponseDetection: true,
+		}
+
+		res, err := p.Process(context.Background(), &httpclient.Request{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, 1, execCalls)
+	})
+
+	t.Run("accepts non-stream moderation response", func(t *testing.T) {
+		execCalls := 0
+		executor := &mockExecutor{
+			do: func(ctx context.Context, req *httpclient.Request) (*httpclient.Response, error) {
+				execCalls++
+				return &httpclient.Response{}, nil
+			},
+		}
+
+		outbound := &mockOutbound{
+			transformResponse: func(ctx context.Context, resp *httpclient.Response) (*llm.Response, error) {
+				return &llm.Response{
+					RequestType: llm.RequestTypeModeration,
+					APIFormat:   llm.APIFormatOpenAIModeration,
+					Moderation: &llm.ModerationResponse{
+						Results: []llm.ModerationClassification{{
+							Flagged: false,
+							Categories: map[string]bool{
+								"hate": false,
+							},
+							CategoryScores: map[string]float64{
+								"hate": 0.01,
+							},
 						}},
 					},
 				}, nil


### PR DESCRIPTION
## 问题说明

开启重试策略中的空响应检测（`empty_response_detection`）后，请求 OpenAI 兼容的 `POST /v1/moderations` 端点会返回 500：

```json
{
  "error": {
    "message": "empty response detected",
    "type": "internal_server_error"
  }
}
```

上游实际已经正常返回 moderation 结果，但 AxonHub 会先在同一渠道重试，随后切换 moderation 渠道继续重试，最终仍以 `empty response detected` 失败。这个现象在不同 OpenAI-compatible 渠道上都会出现，因此并非单一供应商返回了空响应。

## 原因分析

`/v1/moderations` 的上游响应经过 OpenAI outbound transformer 后，业务结果存放在：

```go
llm.Response.Moderation.Results
```

非流式 pipeline 会在 outbound 响应转换完成后、最终 inbound HTTP 响应生成前调用 `hasResponseContent`。原有实现能够识别 chat choices、embedding、rerank、image、audio、transcription 等响应内容，但没有识别 moderation 响应。

因此即使上游返回了合法的：

```json
{
  "results": [{ "flagged": false }]
}
```

`hasResponseContent` 仍会返回 `false`，pipeline 随即返回 `pipeline.ErrEmptyResponse`。该错误属于可重试错误，所以会触发日志中看到的同渠道重试和渠道切换，最终返回 500。

## 修复内容

- 在 `hasResponseContent` 中识别非空的 `resp.Moderation.Results`。
- 使用 `len(Results) > 0` 作为有效内容条件：
  - `flagged: false` 的正常审核结果会被正确接受；
  - `results: []` 仍会被视为无有效内容，保留空响应检测的保护能力。
- 增加 helper 单元测试，覆盖非空和空 moderation 响应。
- 增加非流式 pipeline 回归测试，确认开启空响应检测后 moderation 结果不会被误判。
- 增加完整 pipeline 集成测试，使用真实 OpenAI moderation inbound/outbound transformers，仅 fake 外部 HTTP executor，覆盖：
  - 原始 OpenAI moderation JSON 解析；
  - API format 分派；
  - empty-response detection；
  - 最终 HTTP 200 响应序列化；
  - `flagged: false`、`sexual/minors`、`category_scores` 和 `category_applied_input_types` 字段保留；
  - executor 只调用一次，不发生错误重试。
- 将 `.omx/` 加入 `.gitignore`。

## 回归验证

对集成测试做了 mutation 验证：临时移除 moderation 内容判定后，测试会准确失败并返回 `empty response detected`；恢复修复后测试通过。

在 `llm` 独立 Go module 下执行：

```bash
go test ./...
```

全部通过。

此外，`git diff --check` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of moderation responses so valid results are recognized as complete responses.
  - Prevented unnecessary empty-response handling and retries for successful moderation requests.
  - Preserved moderation response details, including classification results and scoring information.

- **Tests**
  - Added coverage for moderation response processing, including empty and non-empty response scenarios.
  - Verified successful moderation requests return the expected response format and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->