### PR TITLE
feat: response with trace headers, close #2100

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -224,6 +224,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.trace.thread_header", "AH-Thread-Id")
 	v.SetDefault("server.trace.trace_header", "AH-Trace-Id")
 	v.SetDefault("server.trace.extra_trace_headers", []string{})
+	v.SetDefault("server.trace.response_trace_headers", []string{})
 	v.SetDefault("server.trace.extra_trace_body_fields", []string{})
 	v.SetDefault("server.trace.claude_code_trace_enabled", false)
 	v.SetDefault("server.trace.codex_trace_enabled", false)

--- a/config.example.yml
+++ b/config.example.yml
@@ -15,6 +15,7 @@ server:
     thread_header: "AH-Thread-Id" # Thread ID header name (env: AXONHUB_SERVER_TRACE_THREAD_HEADER)
     trace_header: "AH-Trace-Id" # Trace ID header name (env: AXONHUB_SERVER_TRACE_TRACE_HEADER)
     extra_trace_headers: [] # Extra trace headers (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS)
+    response_trace_headers: [] # Response headers for the resolved trace ID (env: AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS)
     extra_trace_body_fields: [] # Extra trace body fields (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_BODY_FIELDS)
     claude_code_trace_enabled: false # Enable extracting trace IDs from Claude Code request metadata (env: AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED)
     codex_trace_enabled: false # Enable extracting trace IDs from Codex Session_id header (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -66,6 +66,7 @@ server:
     thread_header: "AH-Thread-Id" # Thread ID header name
     trace_header: "AH-Trace-Id" # Trace ID header name
     extra_trace_headers: []     # Extra trace headers
+    response_trace_headers: []  # Response headers that receive the resolved trace ID; empty disables it
     claude_code_trace_enabled: false # Enable Claude Code trace extraction
     codex_trace_enabled: false # Enable Codex trace extraction
   debug: false                  # Enable debug mode
@@ -81,6 +82,7 @@ server:
 - `AXONHUB_SERVER_TRACE_THREAD_HEADER`
 - `AXONHUB_SERVER_TRACE_TRACE_HEADER`
 - `AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS`
+- `AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS`
 - `AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`

--- a/docs/en/guides/tracing.md
+++ b/docs/en/guides/tracing.md
@@ -53,10 +53,15 @@ server:
     trace_header: "AH-Trace-Id"
     extra_trace_headers:
       - "Sentry-Trace"
+    response_trace_headers:
+      - "AH-Trace-Id"
+      - "X-Oneapi-Request-Id"
 ```
 
 - Set `extra_trace_headers` to reuse existing instrumentation headers.
-- Leave headers empty to fall back to the defaults shown above.
+- `response_trace_headers` writes the final resolved trace ID before the response starts; an empty list disables it. It is independent from inbound extraction and can include multiple gateway-compatible headers.
+- Browser clients must also include these names in `server.cors.exposed_headers` to read them.
+- Leave `thread_header` or `trace_header` empty to use the default header names above.
 
 ### Using Tracing with OpenAI-Compatible Clients
 ```bash

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -66,6 +66,7 @@ server:
     thread_header: "AH-Thread-Id" # 线程 ID 请求头名称
     trace_header: "AH-Trace-Id" # 追踪 ID 请求头名称
     extra_trace_headers: []     # 额外的追踪请求头
+    response_trace_headers: []  # 回写最终追踪 ID 的响应头列表，空列表时关闭
     claude_code_trace_enabled: false # 启用 Claude Code 追踪提取
     codex_trace_enabled: false # 启用 Codex 追踪提取
   debug: false                  # 启用调试模式
@@ -81,6 +82,7 @@ server:
 - `AXONHUB_SERVER_TRACE_THREAD_HEADER`
 - `AXONHUB_SERVER_TRACE_TRACE_HEADER`
 - `AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS`
+- `AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS`
 - `AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`

--- a/docs/zh/guides/tracing.md
+++ b/docs/zh/guides/tracing.md
@@ -53,10 +53,15 @@ server:
     trace_header: "AH-Trace-Id"
     extra_trace_headers:
       - "Sentry-Trace"
+    response_trace_headers:
+      - "AH-Trace-Id"
+      - "X-Oneapi-Request-Id"
 ```
 
 - 通过 `extra_trace_headers` 复用已有的埋点请求头。
-- 如不配置，将采用上述默认值。
+- `response_trace_headers` 会在响应开始前回写本次最终采用的 Trace ID；为空时不回写。它与入站解析配置独立，可为上游网关配置多个兼容头。
+- 浏览器客户端如需读取这些头，还应将相应名称加入 `server.cors.exposed_headers`。
+- 未配置 `thread_header` 或 `trace_header` 时，将采用上面的默认头名。
 
 ### 在 OpenAI 兼容客户端中使用追踪
 ```bash

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -107,8 +107,23 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 		}
 
 		if traceID == "" {
-			c.Next()
-			return
+			// WithLoggingTracing creates a trace ID for every request. Reuse it so
+			// requests without an inbound trace header still have a persisted trace.
+			if existingTraceID, ok := tracing.GetTraceID(c.Request.Context()); ok {
+				traceID = existingTraceID
+			} else {
+				traceID = tracing.GenerateTraceID()
+			}
+		}
+
+		// The trace middleware can resolve a more specific ID from fallback headers
+		// or request bodies. Keep the request context in sync with that final value.
+		c.Request = c.Request.WithContext(tracing.WithTraceID(c.Request.Context(), traceID))
+
+		for _, header := range config.ResponseTraceHeaders {
+			if header = strings.TrimSpace(header); header != "" {
+				c.Header(header, traceID)
+			}
 		}
 
 		// Get project ID from context

--- a/internal/server/middleware/trace_test.go
+++ b/internal/server/middleware/trace_test.go
@@ -356,11 +356,12 @@ func TestWithTrace_OpenCodeDisabled(t *testing.T) {
 	})
 	router.Use(WithTrace(config, traceService))
 
-	var hasTrace bool
+	var traceID string
 
 	router.POST("/v1/chat/completions", func(c *gin.Context) {
-		_, ok := contexts.GetTrace(c.Request.Context())
-		hasTrace = ok
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+		traceID = trace.TraceID
 
 		c.Status(http.StatusOK)
 	})
@@ -373,7 +374,8 @@ func TestWithTrace_OpenCodeDisabled(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.False(t, hasTrace)
+	require.Regexp(t, `^at-`, traceID)
+	require.NotEqual(t, "opencode-session-123", traceID)
 }
 
 func TestWithTrace_OpenCodeHeaderSetsTrace(t *testing.T) {
@@ -515,11 +517,12 @@ func TestWithTrace_CodexDisabled(t *testing.T) {
 	})
 	router.Use(WithTrace(config, traceService))
 
-	var hasTrace bool
+	var traceID string
 
 	router.POST("/v1/chat/completions", func(c *gin.Context) {
-		_, ok := contexts.GetTrace(c.Request.Context())
-		hasTrace = ok
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+		traceID = trace.TraceID
 
 		c.Status(http.StatusOK)
 	})
@@ -532,7 +535,8 @@ func TestWithTrace_CodexDisabled(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.False(t, hasTrace)
+	require.Regexp(t, `^at-`, traceID)
+	require.NotEqual(t, "codex-session-123", traceID)
 }
 
 func TestWithTrace_CodexHeaderSetsTrace(t *testing.T) {
@@ -714,7 +718,7 @@ func TestWithTrace_CodexHeaderHasPriorityOverTurnMetadata(t *testing.T) {
 	require.Equal(t, "codex-session-123", capturedSessionID)
 }
 
-func TestWithTrace_CodexTurnMetadataInvalidOrMissingSessionDoesNotSetTrace(t *testing.T) {
+func TestWithTrace_CodexTurnMetadataInvalidOrMissingSessionUsesGeneratedTrace(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	config := tracing.Config{
@@ -766,11 +770,17 @@ func TestWithTrace_CodexTurnMetadataInvalidOrMissingSessionDoesNotSetTrace(t *te
 			var (
 				hasTrace   bool
 				hasSession bool
+				sessionID  string
+				traceID    string
 			)
 
 			router.POST("/v1/chat/completions", func(c *gin.Context) {
-				_, hasTrace = contexts.GetTrace(c.Request.Context())
-				_, hasSession = shared.GetSessionID(c.Request.Context())
+				trace, ok := contexts.GetTrace(c.Request.Context())
+				hasTrace = ok
+				if trace != nil {
+					traceID = trace.TraceID
+				}
+				sessionID, hasSession = shared.GetSessionID(c.Request.Context())
 				c.Status(http.StatusOK)
 			})
 
@@ -782,13 +792,15 @@ func TestWithTrace_CodexTurnMetadataInvalidOrMissingSessionDoesNotSetTrace(t *te
 			router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusOK, w.Code)
-			require.False(t, hasTrace)
-			require.False(t, hasSession)
+			require.True(t, hasTrace)
+			require.Regexp(t, `^at-`, traceID)
+			require.True(t, hasSession)
+			require.Equal(t, traceID, sessionID)
 		})
 	}
 }
 
-func TestWithTrace_CodexSessionMissingDoesNotSetTrace(t *testing.T) {
+func TestWithTrace_CodexSessionMissingUsesGeneratedTrace(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	config := tracing.Config{
@@ -817,12 +829,20 @@ func TestWithTrace_CodexSessionMissingDoesNotSetTrace(t *testing.T) {
 	})
 	router.Use(WithTrace(config, traceService))
 
-	var hasTrace bool
+	var (
+		hasTrace bool
+		traceID  string
+	)
 	var hasSession bool
+	var sessionID string
 
 	router.POST("/v1/chat/completions", func(c *gin.Context) {
-		_, hasTrace = contexts.GetTrace(c.Request.Context())
-		_, hasSession = shared.GetSessionID(c.Request.Context())
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		hasTrace = ok
+		if trace != nil {
+			traceID = trace.TraceID
+		}
+		sessionID, hasSession = shared.GetSessionID(c.Request.Context())
 
 		c.Status(http.StatusOK)
 	})
@@ -833,8 +853,10 @@ func TestWithTrace_CodexSessionMissingDoesNotSetTrace(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.False(t, hasTrace)
-	require.False(t, hasSession)
+	require.True(t, hasTrace)
+	require.Regexp(t, `^at-`, traceID)
+	require.True(t, hasSession)
+	require.Equal(t, traceID, sessionID)
 }
 
 func TestWithTraceID_Success(t *testing.T) {
@@ -1274,4 +1296,161 @@ func TestWithTrace_ExtraTraceBodyFields_InvalidJSON(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestWithTrace_GeneratesTraceAndWritesResponseAliases(t *testing.T) {
+	config := tracing.Config{
+		ResponseTraceHeaders: []string{"AH-Trace-Id", "X-Oneapi-Request-Id", "  "},
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(WithLoggingTracing(config))
+	router.Use(func(c *gin.Context) {
+		requestCtx := authz.WithTestBypass(c.Request.Context())
+		requestCtx = ent.NewContext(requestCtx, client)
+		requestCtx = contexts.WithProjectID(requestCtx, testProject.ID)
+		c.Request = c.Request.WithContext(requestCtx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	var traceID string
+	router.GET("/stream", func(c *gin.Context) {
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+		traceID = trace.TraceID
+
+		contextTraceID, ok := tracing.GetTraceID(c.Request.Context())
+		require.True(t, ok)
+		require.Equal(t, traceID, contextTraceID)
+
+		// Response headers must be available before the streaming response starts.
+		require.Equal(t, traceID, c.Writer.Header().Get("Ah-Trace-Id"))
+		c.Header("Content-Type", "text/event-stream")
+		_, err := c.Writer.WriteString("data: complete\n\n")
+		require.NoError(t, err)
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/stream", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Regexp(t, `^at-`, traceID)
+	require.Equal(t, traceID, w.Header().Get("Ah-Trace-Id"))
+	require.Equal(t, traceID, w.Header().Get("X-Oneapi-Request-Id"))
+
+	storedTrace, err := client.Trace.Query().Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, traceID, storedTrace.TraceID)
+}
+
+func TestWithTrace_UsesExtraHeaderForResponseAlias(t *testing.T) {
+	config := tracing.Config{
+		TraceHeader:          "AH-Trace-Id",
+		ExtraTraceHeaders:    []string{"X-Oneapi-Request-Id"},
+		ResponseTraceHeaders: []string{"AH-Trace-Id", "X-Oneapi-Request-Id"},
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(WithLoggingTracing(config))
+	router.Use(func(c *gin.Context) {
+		requestCtx := authz.WithTestBypass(c.Request.Context())
+		requestCtx = ent.NewContext(requestCtx, client)
+		requestCtx = contexts.WithProjectID(requestCtx, testProject.ID)
+		c.Request = c.Request.WithContext(requestCtx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	router.GET("/test", func(c *gin.Context) {
+		traceID, ok := tracing.GetTraceID(c.Request.Context())
+		require.True(t, ok)
+		require.Equal(t, "new-api-trace-123", traceID)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Oneapi-Request-Id", "new-api-trace-123")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "new-api-trace-123", w.Header().Get("Ah-Trace-Id"))
+	require.Equal(t, "new-api-trace-123", w.Header().Get("X-Oneapi-Request-Id"))
+
+	storedTrace, err := client.Trace.Query().Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new-api-trace-123", storedTrace.TraceID)
+}
+
+func TestWithTrace_WritesResponseAliasesWithoutProject(t *testing.T) {
+	config := tracing.Config{
+		ResponseTraceHeaders: []string{"AH-Trace-Id", "X-Oneapi-Request-Id"},
+	}
+
+	router := gin.New()
+	router.Use(WithTrace(config, nil))
+	router.GET("/test", func(c *gin.Context) {
+		traceID, ok := tracing.GetTraceID(c.Request.Context())
+		require.True(t, ok)
+		require.Regexp(t, `^at-`, traceID)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	traceID := w.Header().Get("Ah-Trace-Id")
+	require.Regexp(t, `^at-`, traceID)
+	require.Equal(t, traceID, w.Header().Get("X-Oneapi-Request-Id"))
+}
+
+func TestWithTrace_WritesResponseAliasesWhenTracePersistenceFails(t *testing.T) {
+	config := tracing.Config{
+		TraceHeader:          "AH-Trace-Id",
+		ResponseTraceHeaders: []string{"AH-Trace-Id", "X-Oneapi-Request-Id"},
+	}
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(contexts.WithProjectID(c.Request.Context(), 1))
+		c.Next()
+	})
+	router.Use(WithTrace(config, biz.NewTraceService(biz.TraceServiceParams{})))
+	router.GET("/test", func(c *gin.Context) {
+		traceID, ok := tracing.GetTraceID(c.Request.Context())
+		require.True(t, ok)
+		require.Equal(t, "client-trace-123", traceID)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Ah-Trace-Id", "client-trace-123")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "client-trace-123", w.Header().Get("Ah-Trace-Id"))
+	require.Equal(t, "client-trace-123", w.Header().Get("X-Oneapi-Request-Id"))
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -28,6 +28,11 @@ type Config struct {
 	// Default to nil.
 	ExtraTraceHeaders []string `conf:"extra_trace_headers" yaml:"extra_trace_headers" json:"extra_trace_headers"`
 
+	// ResponseTraceHeaders is the response header names to write the resolved trace ID to.
+	// An empty list disables trace ID response headers.
+	// Default to nil.
+	ResponseTraceHeaders []string `conf:"response_trace_headers" yaml:"response_trace_headers" json:"response_trace_headers"`
+
 	// ExtraTraceBodyFields is the extra body fields names for trace ID.
 	// It will use if primary trace header is not found in request body.
 	// Default to nil.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `server.trace.response_trace_headers` to return the resolved trace ID in configurable response headers (supports multiple header names); an empty list disables it.
  * When no inbound trace ID is available, a trace ID is ensured (reuses any existing request trace context when present or generates a new one), and response header values are set before the response starts.

* **Documentation**
  * Updated English and Chinese configuration docs, examples, and tracing guides to describe the new option, its defaults, and CORS `exposed_headers` requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->