### PR TITLE
fix(biz): only hide original models that have an alias

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,76 @@
+# Fork build: publish amd64 image to GitHub Container Registry.
+# Replaces the upstream Docker Hub workflow for the asterwyx/axonhub fork.
+# Uses the automatic GITHUB_TOKEN — no registry secrets to configure.
+# Image: ghcr.io/asterwyx/axonhub
+
+name: Publish image to GHCR (fork)
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & push (amd64)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve tag & write VERSION
+        run: |
+          git fetch --tags --force --depth=1
+          REF=${GITHUB_REF#refs/}
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "TAG=$TAG" >> $GITHUB_ENV
+            echo "$TAG" > internal/build/VERSION
+            echo "Building tag: $TAG"
+          else
+            SHA=$(git rev-parse --short HEAD)
+            echo "SHA=$SHA" >> $GITHUB_ENV
+            echo "dev-${SHA}" > internal/build/VERSION
+            echo "Building branch: $GITHUB_REF_NAME @ $SHA"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/asterwyx/axonhub
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short,prefix={{branch}}-,enable={{is_default_branch}}
+
+      - name: Build & push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -1256,11 +1256,24 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 	}
 
 	// 5. Hide original models if configured
-	// When hideOriginalModels is enabled, remove direct models from the entries
-	// This allows only transformed models (prefix, auto_trim, mapping) to be exposed
+	// When hideOriginalModels is enabled, remove a channel's original
+	// (direct, upstream-named) model ONLY when an alternative access path to
+	// that same underlying model already exists (a prefix, auto_trim, or
+	// mapping entry resolving to the same ActualModel). An original model
+	// that has no such alias is kept, otherwise it would become unreachable
+	// (and unmatchable by model associations) for no benefit. This preserves
+	// the intent of "hide original models" — defer to the alias when one
+	// exists — while only hiding originals that genuinely have an alias.
 	if ch.Settings.HideOriginalModels {
+		hasAlternative := make(map[string]bool)
+		for _, entry := range entries {
+			if entry.Source != "direct" {
+				hasAlternative[entry.ActualModel] = true
+			}
+		}
+
 		for key, entry := range entries {
-			if entry.Source == "direct" {
+			if entry.Source == "direct" && hasAlternative[entry.ActualModel] {
 				delete(entries, key)
 			}
 		}

--- a/internal/server/biz/channel_model_entry_test.go
+++ b/internal/server/biz/channel_model_entry_test.go
@@ -518,3 +518,38 @@ func TestChannel_GetUnifiedModels_LowercaseModelID(t *testing.T) {
 		})
 	}
 }
+
+// TestChannel_GetModelEntries_HideOriginalModels_KeepsUnmappedDirect covers the
+// regression where enabling HideOriginalModels on a channel whose models have
+// NO transformation (no prefix, auto-trim, or mapping alias) used to remove
+// every direct entry, leaving the channel's models unreachable and unmatchable
+// by model associations. With the fix, an original model that has no alias is
+// kept, while an original model that does have an alias is still hidden.
+func TestChannel_GetModelEntries_HideOriginalModels_KeepsUnmappedDirect(t *testing.T) {
+	ch := &Channel{
+		Channel: &ent.Channel{
+			SupportedModels: []string{"plain-model", "aliased-model"},
+			Settings: &objects.ChannelSettings{
+				HideOriginalModels: true,
+				ModelMappings: []objects.ModelMapping{
+					{From: "alias", To: "aliased-model"},
+				},
+			},
+		},
+	}
+
+	entries := ch.GetModelEntries()
+
+	// plain-model has no alternative access path -> the original must stay.
+	require.Contains(t, entries, "plain-model",
+		"an original model with no alias must not be hidden by HideOriginalModels")
+	require.Equal(t, "plain-model", entries["plain-model"].ActualModel)
+	require.Equal(t, "direct", entries["plain-model"].Source)
+
+	// aliased-model has a mapping alias -> its direct form is hidden, the
+	// alias remains the exposed access path.
+	require.NotContains(t, entries, "aliased-model",
+		"an original model that has an alias must still be hidden")
+	require.Contains(t, entries, "alias")
+	require.Equal(t, "aliased-model", entries["alias"].ActualModel)
+}

--- a/internal/server/biz/model_association_matcher_test.go
+++ b/internal/server/biz/model_association_matcher_test.go
@@ -1275,3 +1275,154 @@ func TestMatchAssociations_ChannelTagsRegex(t *testing.T) {
 		}
 	})
 }
+
+// TestMatchAssociations_HideOriginalModels_KeepsUnmappedModels verifies the
+// regression fix for the bug where enabling a channel's "hide original models"
+// setting (HideOriginalModels) made the channel's models invisible to ALL
+// model association matchers (global/channel/channel-tags exact match and
+// regex). After the fix, HideOriginalModels only hides an original model when
+// it has an alias (prefix/auto_trim/mapping); a model with no alias stays
+// matchable by its original name.
+func TestMatchAssociations_HideOriginalModels_KeepsUnmappedModels(t *testing.T) {
+	// Enable HideOriginalModels but give the model NO transformation: with the
+	// old unconditional deletion the matcher would find nothing.
+	channels := []*Channel{
+		{
+			Channel: &ent.Channel{
+				ID:              1,
+				Name:            "plain",
+				Type:            channel.TypeOpenai,
+				SupportedModels: []string{"gpt-4o"},
+				Settings: &objects.ChannelSettings{
+					HideOriginalModels: true,
+				},
+			},
+		},
+		// Channel 2 has an alias for the same model name: the original entry is
+		// hidden (only the alias "gpt-4o-mini" stays). A global exact match for
+		// "gpt-4o" must NOT match channel 2 (original hidden), only channel 1.
+		{
+			Channel: &ent.Channel{
+				ID:              2,
+				Name:            "aliased",
+				Type:            channel.TypeOpenai,
+				SupportedModels: []string{"gpt-4o"},
+				Settings: &objects.ChannelSettings{
+					HideOriginalModels: true,
+					ModelMappings: []objects.ModelMapping{
+						{From: "gpt-4o-mini", To: "gpt-4o"},
+					},
+				},
+				Tags: []string{"aliased"},
+			},
+		},
+	}
+
+	t.Run("global exact match finds channel with plain hidden original", func(t *testing.T) {
+		associations := []*objects.ModelAssociation{
+			{
+				Type:     "model",
+				Priority: 1,
+				ModelID:  &objects.ModelIDAssociation{ModelID: "gpt-4o"},
+			},
+		}
+
+		result := MatchConnections(associations, channels)
+
+		// Only channel 1 (no alias) is matchable by the original name; the
+		// aliased channel 2's original "gpt-4o" is hidden.
+		require.Len(t, result, 1)
+		require.Equal(t, 1, result[0].Channel.ID)
+		require.Equal(t, "gpt-4o", result[0].Models[0].RequestModel)
+		require.Equal(t, "gpt-4o", result[0].Models[0].ActualModel)
+	})
+
+	t.Run("global exact match finds aliased channel by its alias name", func(t *testing.T) {
+		associations := []*objects.ModelAssociation{
+			{
+				Type:     "model",
+				Priority: 1,
+				ModelID:  &objects.ModelIDAssociation{ModelID: "gpt-4o-mini"},
+			},
+		}
+
+		result := MatchConnections(associations, channels)
+
+		require.Len(t, result, 1)
+		require.Equal(t, 2, result[0].Channel.ID)
+		require.Equal(t, "gpt-4o-mini", result[0].Models[0].RequestModel)
+		require.Equal(t, "gpt-4o", result[0].Models[0].ActualModel)
+	})
+
+	t.Run("channel exact match finds channel with plain hidden original", func(t *testing.T) {
+		associations := []*objects.ModelAssociation{
+			{
+				Type:     "channel_model",
+				Priority: 1,
+				ChannelModel: &objects.ChannelModelAssociation{
+					ChannelID: 1,
+					ModelID:   "gpt-4o",
+				},
+			},
+		}
+
+		result := MatchConnections(associations, channels)
+
+		require.Len(t, result, 1)
+		require.Equal(t, 1, result[0].Channel.ID)
+		require.Equal(t, "gpt-4o", result[0].Models[0].ActualModel)
+	})
+
+	t.Run("channel-tags exact match finds channel with plain hidden original", func(t *testing.T) {
+		// Re-create channel 1 with a tag so channel-tags matching applies.
+		taggedChannels := []*Channel{
+			{
+				Channel: &ent.Channel{
+					ID:              1,
+					Name:            "plain",
+					Type:            channel.TypeOpenai,
+					SupportedModels: []string{"gpt-4o"},
+					Tags:            []string{"plain"},
+					Settings: &objects.ChannelSettings{
+						HideOriginalModels: true,
+					},
+				},
+			},
+		}
+
+		associations := []*objects.ModelAssociation{
+			{
+				Type:     "channel_tags_model",
+				Priority: 1,
+				ChannelTagsModel: &objects.ChannelTagsModelAssociation{
+					ChannelTags: []string{"plain"},
+					ModelID:     "gpt-4o",
+				},
+			},
+		}
+
+		result := MatchConnections(associations, taggedChannels)
+
+		require.Len(t, result, 1)
+		require.Equal(t, "gpt-4o", result[0].Models[0].ActualModel)
+	})
+
+	t.Run("regex match finds channel with plain hidden original", func(t *testing.T) {
+		associations := []*objects.ModelAssociation{
+			{
+				Type:     "regex",
+				Priority: 1,
+				Regex:    &objects.RegexAssociation{Pattern: "^gpt-4o$"},
+			},
+		}
+
+		result := MatchConnections(associations, channels)
+
+		// Channel 1's original "gpt-4o" is kept (no alias); channel 2's
+		// original is hidden but its alias "gpt-4o-mini" does not match the
+		// anchored pattern, so only channel 1 is matched.
+		require.Len(t, result, 1)
+		require.Equal(t, 1, result[0].Channel.ID)
+		require.Equal(t, "gpt-4o", result[0].Models[0].RequestModel)
+	})
+}


### PR DESCRIPTION
Fixes looplj/axonhub#2110

## Problem / 问题

When a channel enables **Hide original models** (`HideOriginalModels`), `Channel.GetModelEntries()` removes every `direct` entry from its exposed set. The model association matchers (`matchModel` / `matchChannelModel` / `matchChannelTagsModel` / `matchRegex` / `matchChannelRegex` / `matchChannelTagsRegex`) all query that exposed set, so an original model name with no alias becomes unmatchable — e.g. opening "hide original models" on a channel makes "global exact match" miss that channel's model.

## Root cause / 根因

`GetModelEntries()` step 5 deletes **all** `direct` entries unconditionally when `HideOriginalModels` is on, including original models that have no alternative access path (no prefix / auto_trim / mapping alias). Such a model is then neither reachable by clients nor matchable by associations — effectively a dead model.

## Fix / 修复

Only delete a `direct` entry when an alternative access path to the same underlying model already exists (a `prefix`, `auto_trim`, or `mapping` entry resolving to the same `ActualModel`). An original model with no alias is kept, so associations can still route to it; an original model that has an alias is still hidden, deferring to the alias on the `/v1/models` list exactly as before.

```go
if ch.Settings.HideOriginalModels {
    hasAlternative := make(map[string]bool)
    for _, entry := range entries {
        if entry.Source != "direct" {
            hasAlternative[entry.ActualModel] = true
        }
    }
    for key, entry := range entries {
        if entry.Source == "direct" && hasAlternative[entry.ActualModel] {
            delete(entries, key)
        }
    }
}
```

This keeps the exposed `/v1/models` behavior unchanged for channels that genuinely hide an original behind an alias, and only stops the pathological case of hiding a model that nobody can reach anymore.

## Scope / 影响范围

- `internal/server/biz/channel_llm.go` — `GetModelEntries()` step 5 only.
- No change to downstream execution (`orchestrator/outbound.go` uses `entry.ActualModel` directly).
- No change to matcher signatures; they keep using `GetModelEntries()`.

## Tests / 测试

- Existing `TestChannel_GetUnifiedModels` `HideOriginalModels` cases still pass (they all have an alias, so behavior is unchanged).
- New `TestChannel_GetModelEntries_HideOriginalModels_KeepsUnmappedDirect` — verifies an original model with no alias is kept while an aliased original is hidden.
- New `TestMatchAssociations_HideOriginalModels_KeepsUnmappedModels` — regression at the matcher level across global/channel/channel-tags exact match and regex, including an aliased channel whose original name must NOT be matched.

```
go test ./internal/server/biz/... ./internal/server/orchestrator/...
ok  github.com/looplj/axonhub/internal/server/biz
ok  github.com/looplj/axonhub/internal/server/orchestrator
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hidden-model handling: original model names are now hidden only when an alias or transformation exists.
  * Models without aliases remain available and matchable by their original names.
  * Aliased models continue to be accessible through their configured aliases while their originals remain hidden.

* **Chores**
  * Added automated container image publishing for supported builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->