### PR TITLE
fix(transformer): 合并连续 function_call/custom_tool_call 为单条 assistant 消息

### DIFF
--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -325,7 +325,7 @@ func convertToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
 }
 
 // convertInputToMessages converts Responses API input to llm.Message slice.
-// It handles merging reasoning items with subsequent function_call items into a single assistant message.
+// It handles merging consecutive tool calls that belong to the same assistant turn.
 func convertInputToMessages(input *Input) ([]llm.Message, error) {
 	if input == nil {
 		return nil, nil
@@ -362,6 +362,30 @@ func convertInputToMessages(input *Input) ([]llm.Message, error) {
 			}
 
 			i += consumed
+
+			continue
+		}
+
+		if item.Type == "function_call" || item.Type == "custom_tool_call" {
+			msg := llm.Message{Role: "assistant"}
+
+			for i < len(input.Items) {
+				callItem := &input.Items[i]
+				if callItem.Type != "function_call" && callItem.Type != "custom_tool_call" {
+					break
+				}
+
+				callMsg, err := convertItemToMessage(callItem)
+				if err != nil {
+					return nil, err
+				}
+				if callMsg != nil {
+					msg.ToolCalls = append(msg.ToolCalls, callMsg.ToolCalls...)
+				}
+				i++
+			}
+
+			messages = append(messages, msg)
 
 			continue
 		}

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -720,6 +720,35 @@ func TestInboundTransformer_TransformStream_AttachesAnnotationsFromChoiceMessage
 	require.Equal(t, "https://example.com/message-stream", itemDone.Item.Content.Items[0].Annotations[0].URLCitation.URL)
 }
 
+func TestInboundTransformer_TransformRequest_GroupsConsecutiveFunctionCalls(t *testing.T) {
+	trans := NewInboundTransformer()
+
+	result, err := trans.TransformRequest(context.Background(), &httpclient.Request{
+		Body: []byte(`{
+			"model": "gpt-4o",
+			"input": [
+				{"role": "user", "content": "Run both tools."},
+				{"type": "function_call", "call_id": "call_a", "name": "first_tool", "arguments": "{}"},
+				{"type": "function_call", "call_id": "call_b", "name": "second_tool", "arguments": "{}"},
+				{"type": "function_call_output", "call_id": "call_a", "output": "first result"},
+				{"type": "function_call_output", "call_id": "call_b", "output": "second result"}
+			]
+		}`),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 4)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Equal(t, "assistant", result.Messages[1].Role)
+	require.Len(t, result.Messages[1].ToolCalls, 2)
+	require.Equal(t, "call_a", result.Messages[1].ToolCalls[0].ID)
+	require.Equal(t, "call_b", result.Messages[1].ToolCalls[1].ID)
+	require.Equal(t, "tool", result.Messages[2].Role)
+	require.Equal(t, "call_a", lo.FromPtr(result.Messages[2].ToolCallID))
+	require.Equal(t, "tool", result.Messages[3].Role)
+	require.Equal(t, "call_b", lo.FromPtr(result.Messages[3].ToolCallID))
+}
+
 func TestInboundTransformer_TransformResponse(t *testing.T) {
 	trans := NewInboundTransformer()
 
@@ -1566,6 +1595,122 @@ func TestConvertItemToMessage_Reasoning(t *testing.T) {
 	result, err := convertItemToMessage(item)
 	require.NoError(t, err)
 	require.Nil(t, result, "reasoning items should return nil from convertItemToMessage")
+}
+
+func TestConvertInputToMessages_GroupsConsecutiveToolCalls(t *testing.T) {
+	input := &Input{Items: []Item{
+		{Role: "user", Content: &Input{Text: lo.ToPtr("Run both tools.")}},
+		{Type: "function_call", CallID: "call_a", Name: "first_tool", Arguments: `{}`},
+		{Type: "function_call", CallID: "call_b", Name: "second_tool", Arguments: `{"value":2}`},
+		{Type: "function_call_output", CallID: "call_a", Output: &Input{Text: lo.ToPtr("first result")}},
+		{Type: "function_call_output", CallID: "call_b", Output: &Input{Text: lo.ToPtr("second result")}},
+		{Role: "user", Content: &Input{Text: lo.ToPtr("Continue.")}},
+	}}
+
+	messages, err := convertInputToMessages(input)
+	require.NoError(t, err)
+	require.Len(t, messages, 5)
+
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, "Run both tools.", lo.FromPtr(messages[0].Content.Content))
+
+	require.Equal(t, "assistant", messages[1].Role)
+	require.Len(t, messages[1].ToolCalls, 2)
+	require.Equal(t, "call_a", messages[1].ToolCalls[0].ID)
+	require.Equal(t, "first_tool", messages[1].ToolCalls[0].Function.Name)
+	require.Equal(t, `{}`, messages[1].ToolCalls[0].Function.Arguments)
+	require.Equal(t, "call_b", messages[1].ToolCalls[1].ID)
+	require.Equal(t, "second_tool", messages[1].ToolCalls[1].Function.Name)
+	require.Equal(t, `{"value":2}`, messages[1].ToolCalls[1].Function.Arguments)
+
+	require.Equal(t, "tool", messages[2].Role)
+	require.Equal(t, "call_a", lo.FromPtr(messages[2].ToolCallID))
+	require.Equal(t, "first result", lo.FromPtr(messages[2].Content.Content))
+	require.Equal(t, "tool", messages[3].Role)
+	require.Equal(t, "call_b", lo.FromPtr(messages[3].ToolCallID))
+	require.Equal(t, "second result", lo.FromPtr(messages[3].Content.Content))
+
+	require.Equal(t, "user", messages[4].Role)
+	require.Equal(t, "Continue.", lo.FromPtr(messages[4].Content.Content))
+}
+
+func TestConvertInputToMessages_GroupsMixedToolCallTypes(t *testing.T) {
+	input := &Input{Items: []Item{
+		{
+			Type:      "function_call",
+			CallID:    "call_function",
+			Name:      "function_tool",
+			Namespace: "namespace",
+			Arguments: `{"query":"value"}`,
+		},
+		{
+			Type:   "custom_tool_call",
+			CallID: "call_custom",
+			Name:   "custom_tool",
+			Input:  lo.ToPtr("freeform input"),
+		},
+	}}
+
+	messages, err := convertInputToMessages(input)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "assistant", messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 2)
+
+	functionCall := messages[0].ToolCalls[0]
+	require.Equal(t, "call_function", functionCall.ID)
+	require.Equal(t, "function", functionCall.Type)
+	require.Equal(t, "function_tool", functionCall.Function.Name)
+	require.Equal(t, "namespace", functionCall.Function.Namespace)
+	require.Equal(t, `{"query":"value"}`, functionCall.Function.Arguments)
+
+	customCall := messages[0].ToolCalls[1]
+	require.Equal(t, "call_custom", customCall.ID)
+	require.Equal(t, llm.ToolTypeResponsesCustomTool, customCall.Type)
+	require.NotNil(t, customCall.ResponseCustomToolCall)
+	require.Equal(t, "call_custom", customCall.ResponseCustomToolCall.CallID)
+	require.Equal(t, "custom_tool", customCall.ResponseCustomToolCall.Name)
+	require.Equal(t, "freeform input", customCall.ResponseCustomToolCall.Input)
+}
+
+func TestConvertInputToMessages_DoesNotGroupToolCallsAcrossBoundaries(t *testing.T) {
+	t.Run("tool output", func(t *testing.T) {
+		input := &Input{Items: []Item{
+			{Type: "function_call", CallID: "call_a", Name: "first_tool", Arguments: `{}`},
+			{Type: "function_call_output", CallID: "call_a", Output: &Input{Text: lo.ToPtr("result")}},
+			{Type: "function_call", CallID: "call_b", Name: "second_tool", Arguments: `{}`},
+		}}
+
+		messages, err := convertInputToMessages(input)
+		require.NoError(t, err)
+		require.Len(t, messages, 3)
+		require.Equal(t, []string{"assistant", "tool", "assistant"}, []string{
+			messages[0].Role,
+			messages[1].Role,
+			messages[2].Role,
+		})
+		require.Equal(t, "call_a", messages[0].ToolCalls[0].ID)
+		require.Equal(t, "call_b", messages[2].ToolCalls[0].ID)
+	})
+
+	t.Run("user message", func(t *testing.T) {
+		input := &Input{Items: []Item{
+			{Type: "function_call", CallID: "call_a", Name: "first_tool", Arguments: `{}`},
+			{Role: "user", Content: &Input{Text: lo.ToPtr("New turn.")}},
+			{Type: "function_call", CallID: "call_b", Name: "second_tool", Arguments: `{}`},
+		}}
+
+		messages, err := convertInputToMessages(input)
+		require.NoError(t, err)
+		require.Len(t, messages, 3)
+		require.Equal(t, []string{"assistant", "user", "assistant"}, []string{
+			messages[0].Role,
+			messages[1].Role,
+			messages[2].Role,
+		})
+		require.Equal(t, "call_a", messages[0].ToolCalls[0].ID)
+		require.Equal(t, "call_b", messages[2].ToolCalls[0].ID)
+	})
 }
 
 func TestConvertReasoningWithFollowing(t *testing.T) {


### PR DESCRIPTION
## 问题描述

Closes #2113

当 `/v1/responses` 请求包含连续的两个 `function_call` item（代表同一次 assistant turn 中的并行调用）时，入站转换器会将每个 call 分别转换为独立的 Chat Completions `assistant` 消息：

```text
function_call        call_a
function_call        call_b
function_call_output call_a
function_call_output call_b
```

当前会错误地转换为：

```text
assistant tool_calls=[call_a]
assistant tool_calls=[call_b]
tool      tool_call_id=call_a
tool      tool_call_id=call_b
```

这是非法的 Chat Completions 顺序 —— 第一条 assistant 声明 `call_a` 后必须立即跟随对应的 tool 消息，而非另一条 assistant。严格的上游（如 Kimi）会返回 HTTP 400。

## 修复方案

在 `convertInputToMessages()` 中，遇到裸 `function_call` 或 `custom_tool_call` 时，将源 input 中所有连续的同类型 item 收集到同一条 `llm.Message{Role: "assistant"}` 中。遇到 `function_call_output`、`custom_tool_call_output`、用户消息、reasoning 或其他 item 时停止合并，确保 turn 边界不被跨越。

修正后的转换：

```text
assistant tool_calls=[call_a, call_b]   ← 合并为一条
tool      tool_call_id=call_a
tool      tool_call_id=call_b
```

## 变更文件

- `llm/transformer/openai/responses/inbound.go` — `convertInputToMessages` 新增连续 tool-call 合并分支
- `llm/transformer/openai/responses/inbound_test.go` — 新增 4 个回归测试

## 测试覆盖

| 测试 | 场景 |
|------|------|
| `TestInboundTransformer_TransformRequest_GroupsConsecutiveFunctionCalls` | issue #2113 原始 JSON 请求全链路验证 |
| `TestConvertInputToMessages_GroupsConsecutiveToolCalls` | 连续 function_call → 一条 assistant + tool outputs |
| `TestConvertInputToMessages_GroupsMixedToolCallTypes` | function_call 与 custom_tool_call 混合合并，保留各自字段 |
| `TestConvertInputToMessages_DoesNotGroupToolCallsAcrossBoundaries` | tool output / user message 作为边界，不跨 turn 合并 |

## 验证

```text
go test ./transformer/openai/...
ok  github.com/looplj/axonhub/llm/transformer/openai
ok  github.com/looplj/axonhub/llm/transformer/openai/codex
ok  github.com/looplj/axonhub/llm/transformer/openai/copilot
ok  github.com/looplj/axonhub/llm/transformer/openai/responses
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consecutive tool calls are now combined into a single assistant message, preserving all associated tool calls.
  * Mixed tool call types are handled consistently.
  * Tool calls remain correctly separated when interrupted by tool outputs or user messages.

* **Tests**
  * Added coverage for grouped tool calls, mixed tool call types, and message-boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->