### PR TITLE
fix(responses): keep images in tool results instead of dropping them

### DIFF
--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -310,13 +310,40 @@ func convertToolMessageWithType(msg llm.Message, itemType string) Item {
 		output.Text = msg.Content.Content
 	} else if len(msg.Content.MultipleContent) > 0 {
 		for _, p := range msg.Content.MultipleContent {
-			if p.Type == "text" && p.Text != nil {
-				output.Items = append(output.Items, Item{
-					Type: "input_text",
-					Text: p.Text,
-				})
+			switch p.Type {
+			case "text":
+				if p.Text != nil {
+					output.Items = append(output.Items, Item{
+						Type: "input_text",
+						Text: p.Text,
+					})
+				}
+			case "image_url":
+				// Tool results can carry images (Codex's view_image, MCP screenshot
+				// tools, ...). Skipping them here leaves output empty, which the
+				// fallback below turns into "" — the model then sees a successful
+				// but blank tool result and has no way to tell that it lost data.
+				if p.ImageURL != nil {
+					output.Items = append(output.Items, Item{
+						Type:     "input_image",
+						ImageURL: &p.ImageURL.URL,
+						Detail:   p.ImageURL.Detail,
+					})
+				}
 			}
 		}
+	}
+
+	// Content was present but nothing survived the conversion (audio/video/document
+	// parts, which a tool result in this API cannot express). Name what was dropped
+	// rather than falling through to "": a blank-but-successful tool result is
+	// indistinguishable from a genuinely empty one, so the model reads lost data as
+	// "the tool returned nothing" and answers anyway.
+	if output.Text == nil && len(output.Items) == 0 && len(msg.Content.MultipleContent) > 0 {
+		dropped := lo.Uniq(lo.Map(msg.Content.MultipleContent, func(p llm.MessageContentPart, _ int) string {
+			return p.Type
+		}))
+		output.Text = lo.ToPtr("[axonhub] tool output omitted: unsupported content types: " + strings.Join(dropped, ", "))
 	}
 
 	// Some times the tool result is empty, so we need to add an empty string.

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -320,30 +320,23 @@ func convertToolMessageWithType(msg llm.Message, itemType string) Item {
 				}
 			case "image_url":
 				// Tool results can carry images (Codex's view_image, MCP screenshot
-				// tools, ...). Skipping them here leaves output empty, which the
-				// fallback below turns into "" — the model then sees a successful
-				// but blank tool result and has no way to tell that it lost data.
+				// tools, ...); the Responses schema allows text/image/file content in
+				// function_call_output and custom_tool_call_output. Skipping them left
+				// output empty, which the fallback below turned into "" — a blank but
+				// successful tool result the model cannot distinguish from a real one.
 				if p.ImageURL != nil {
+					// `detail` is required by InputImageContent, which is what a
+					// custom_tool_call_output's content array resolves to; the
+					// function_call_output param schema makes it optional. Both
+					// document "auto" as the default, so always send one.
 					output.Items = append(output.Items, Item{
 						Type:     "input_image",
 						ImageURL: &p.ImageURL.URL,
-						Detail:   p.ImageURL.Detail,
+						Detail:   lo.ToPtr(lo.FromPtrOr(p.ImageURL.Detail, "auto")),
 					})
 				}
 			}
 		}
-	}
-
-	// Content was present but nothing survived the conversion (audio/video/document
-	// parts, which a tool result in this API cannot express). Name what was dropped
-	// rather than falling through to "": a blank-but-successful tool result is
-	// indistinguishable from a genuinely empty one, so the model reads lost data as
-	// "the tool returned nothing" and answers anyway.
-	if output.Text == nil && len(output.Items) == 0 && len(msg.Content.MultipleContent) > 0 {
-		dropped := lo.Uniq(lo.Map(msg.Content.MultipleContent, func(p llm.MessageContentPart, _ int) string {
-			return p.Type
-		}))
-		output.Text = lo.ToPtr("[axonhub] tool output omitted: unsupported content types: " + strings.Join(dropped, ", "))
 	}
 
 	// Some times the tool result is empty, so we need to add an empty string.

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -142,6 +142,7 @@ func TestConvertToolMessage(t *testing.T) {
 					{
 						Type:     "input_image",
 						ImageURL: lo.ToPtr("https://example.com/image.jpg"),
+						Detail:   lo.ToPtr("auto"),
 					},
 					{
 						Type: "input_text",
@@ -210,6 +211,7 @@ func TestConvertToolMessage(t *testing.T) {
 						{
 							Type:     "input_image",
 							ImageURL: lo.ToPtr("https://example.com/image.jpg"),
+							Detail:   lo.ToPtr("auto"),
 						},
 					},
 				},
@@ -281,16 +283,52 @@ func TestConvertToolMessage(t *testing.T) {
 						{
 							Type:     "input_image",
 							ImageURL: lo.ToPtr("https://example.com/shot.png"),
+							Detail:   lo.ToPtr("auto"),
 						},
 					},
 				},
 			},
 		},
 		{
-			// A tool result whose parts cannot be expressed here must not look like
-			// an empty-but-successful result, otherwise the model cannot tell that
-			// data was lost.
-			name: "tool message with only unsupported parts reports what was dropped",
+			// custom_tool_call_output shares the FunctionAndCustomToolCallOutput
+			// content union with function_call_output, so images are allowed here too.
+			name: "custom tool output keeps images",
+			msg: llm.Message{
+				Role:       "tool",
+				ToolCallID: lo.ToPtr("call_custom_img"),
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "image_url",
+							ImageURL: &llm.ImageURL{
+								URL: "data:image/png;base64,iVBORw0KGgo=",
+							},
+						},
+					},
+				},
+			},
+			expected: Item{
+				Type:   "custom_tool_call_output",
+				CallID: "call_custom_img",
+				Output: &Input{
+					Items: []Item{
+						{
+							Type:     "input_image",
+							ImageURL: lo.ToPtr("data:image/png;base64,iVBORw0KGgo="),
+							Detail:   lo.ToPtr("auto"),
+						},
+					},
+				},
+			},
+		},
+		{
+			// Known gap, unchanged by this fix: part kinds the current AxonHub
+			// Responses Item model cannot express in a tool result are still dropped
+			// silently, and an all-dropped result is still indistinguishable from a
+			// genuinely empty one. Surfacing that needs structured logging (no logger
+			// reaches this pure converter), so it is left for a separate change rather
+			// than papered over with synthetic output text.
+			name: "tool message with only unsupported parts still degrades to empty string",
 			msg: llm.Message{
 				Role:       "tool",
 				ToolCallID: lo.ToPtr("call_audio_only"),
@@ -310,7 +348,7 @@ func TestConvertToolMessage(t *testing.T) {
 				Type:   "function_call_output",
 				CallID: "call_audio_only",
 				Output: &Input{
-					Text: lo.ToPtr("[axonhub] tool output omitted: unsupported content types: input_audio"),
+					Text: lo.ToPtr(""),
 				},
 			},
 		},
@@ -342,6 +380,86 @@ func TestConvertToolMessage(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// The wire shape matters as much as the struct: a tool result carrying an image
+// has to serialise as an output array of content parts, not as a string.
+func TestConvertToolMessageImageSerializesAsOutputArray(t *testing.T) {
+	item := convertToolMessageWithType(llm.Message{
+		Role:       "tool",
+		ToolCallID: lo.ToPtr("call_wire"),
+		Content: llm.MessageContent{
+			MultipleContent: []llm.MessageContentPart{
+				{Type: "text", Text: lo.ToPtr("look")},
+				{
+					Type: "image_url",
+					ImageURL: &llm.ImageURL{
+						URL:    "data:image/png;base64,iVBORw0KGgo=",
+						Detail: lo.ToPtr("high"),
+					},
+				},
+			},
+		},
+	}, "function_call_output")
+
+	raw, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Type   string `json:"type"`
+		CallID string `json:"call_id"`
+		Output []struct {
+			Type     string  `json:"type"`
+			Text     *string `json:"text"`
+			ImageURL *string `json:"image_url"`
+			Detail   *string `json:"detail"`
+		} `json:"output"`
+	}
+
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Equal(t, "function_call_output", decoded.Type)
+	require.Equal(t, "call_wire", decoded.CallID)
+	require.Len(t, decoded.Output, 2)
+	require.Equal(t, "input_text", decoded.Output[0].Type)
+	require.Equal(t, "look", lo.FromPtr(decoded.Output[0].Text))
+	require.Equal(t, "input_image", decoded.Output[1].Type)
+	require.Equal(t, "data:image/png;base64,iVBORw0KGgo=", lo.FromPtr(decoded.Output[1].ImageURL))
+	require.Equal(t, "high", lo.FromPtr(decoded.Output[1].Detail))
+}
+
+// custom_tool_call_output resolves to InputImageContent, which requires
+// `detail`; assert it reaches the wire even when the source part omits it.
+func TestConvertToolMessageCustomOutputImageCarriesDetail(t *testing.T) {
+	item := convertToolMessageWithType(llm.Message{
+		Role:       "tool",
+		ToolCallID: lo.ToPtr("call_custom_wire"),
+		Content: llm.MessageContent{
+			MultipleContent: []llm.MessageContentPart{
+				{Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://example.com/shot.png"}},
+			},
+		},
+	}, "custom_tool_call_output")
+
+	raw, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Type   string `json:"type"`
+		CallID string `json:"call_id"`
+		Output []struct {
+			Type     string  `json:"type"`
+			ImageURL *string `json:"image_url"`
+			Detail   *string `json:"detail"`
+		} `json:"output"`
+	}
+
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Equal(t, "custom_tool_call_output", decoded.Type)
+	require.Equal(t, "call_custom_wire", decoded.CallID)
+	require.Len(t, decoded.Output, 1)
+	require.Equal(t, "input_image", decoded.Output[0].Type)
+	require.Equal(t, "https://example.com/shot.png", lo.FromPtr(decoded.Output[0].ImageURL))
+	require.Equal(t, "auto", lo.FromPtr(decoded.Output[0].Detail))
 }
 
 func TestConvertWebSearchToTool(t *testing.T) {

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -108,7 +108,7 @@ func TestConvertToolMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "tool message with multiple content - mixed types (only text extracted)",
+			name: "tool message with multiple content - text and image preserved in order",
 			msg: llm.Message{
 				Role:       "tool",
 				ToolCallID: lo.ToPtr("call_789"),
@@ -138,6 +138,10 @@ func TestConvertToolMessage(t *testing.T) {
 					{
 						Type: "input_text",
 						Text: lo.ToPtr("Text result"),
+					},
+					{
+						Type:     "input_image",
+						ImageURL: lo.ToPtr("https://example.com/image.jpg"),
 					},
 					{
 						Type: "input_text",
@@ -176,7 +180,7 @@ func TestConvertToolMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "tool message with multiple content but no text parts",
+			name: "tool message with image and unsupported parts keeps the image",
 			msg: llm.Message{
 				Role:       "tool",
 				ToolCallID: lo.ToPtr("call_no_text"),
@@ -201,6 +205,125 @@ func TestConvertToolMessage(t *testing.T) {
 			expected: Item{
 				Type:   "function_call_output",
 				CallID: "call_no_text",
+				Output: &Input{
+					Items: []Item{
+						{
+							Type:     "input_image",
+							ImageURL: lo.ToPtr("https://example.com/image.jpg"),
+						},
+					},
+				},
+			},
+		},
+		{
+			// Shape produced by Codex's view_image tool: the result is a single
+			// base64 image with no text at all. Dropping it made the model see an
+			// empty-but-successful tool result and silently hallucinate instead.
+			name: "image-only tool result is preserved as input_image",
+			msg: llm.Message{
+				Role:       "tool",
+				ToolCallID: lo.ToPtr("call_view_image"),
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "image_url",
+							ImageURL: &llm.ImageURL{
+								URL:    "data:image/png;base64,iVBORw0KGgo=",
+								Detail: lo.ToPtr("high"),
+							},
+						},
+					},
+				},
+			},
+			expected: Item{
+				Type:   "function_call_output",
+				CallID: "call_view_image",
+				Output: &Input{
+					Items: []Item{
+						{
+							Type:     "input_image",
+							ImageURL: lo.ToPtr("data:image/png;base64,iVBORw0KGgo="),
+							Detail:   lo.ToPtr("high"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tool result with text and image keeps both in order",
+			msg: llm.Message{
+				Role:       "tool",
+				ToolCallID: lo.ToPtr("call_mixed"),
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "text",
+							Text: lo.ToPtr("screenshot attached"),
+						},
+						{
+							Type: "image_url",
+							ImageURL: &llm.ImageURL{
+								URL: "https://example.com/shot.png",
+							},
+						},
+					},
+				},
+			},
+			expected: Item{
+				Type:   "function_call_output",
+				CallID: "call_mixed",
+				Output: &Input{
+					Items: []Item{
+						{
+							Type: "input_text",
+							Text: lo.ToPtr("screenshot attached"),
+						},
+						{
+							Type:     "input_image",
+							ImageURL: lo.ToPtr("https://example.com/shot.png"),
+						},
+					},
+				},
+			},
+		},
+		{
+			// A tool result whose parts cannot be expressed here must not look like
+			// an empty-but-successful result, otherwise the model cannot tell that
+			// data was lost.
+			name: "tool message with only unsupported parts reports what was dropped",
+			msg: llm.Message{
+				Role:       "tool",
+				ToolCallID: lo.ToPtr("call_audio_only"),
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type: "input_audio",
+							InputAudio: &llm.InputAudio{
+								Data:   "audio-data",
+								Format: "wav",
+							},
+						},
+					},
+				},
+			},
+			expected: Item{
+				Type:   "function_call_output",
+				CallID: "call_audio_only",
+				Output: &Input{
+					Text: lo.ToPtr("[axonhub] tool output omitted: unsupported content types: input_audio"),
+				},
+			},
+		},
+		{
+			name: "tool message with no content at all still uses the empty string",
+			msg: llm.Message{
+				Role:       "tool",
+				ToolCallID: lo.ToPtr("call_truly_empty"),
+				Content:    llm.MessageContent{MultipleContent: []llm.MessageContentPart{}},
+			},
+			expected: Item{
+				Type:   "function_call_output",
+				CallID: "call_truly_empty",
 				Output: &Input{
 					Text: lo.ToPtr(""),
 				},


### PR DESCRIPTION
## The bug

`convertToolMessageWithType` ([outbound_convert.go:301](https://github.com/looplj/axonhub/blob/unstable/llm/transformer/openai/responses/outbound_convert.go#L301)) only copies `text` parts when turning an internal `role:"tool"` message back into a Responses `function_call_output`. An `image_url` part is skipped, and a tool result that carried **nothing but an image** then falls through to the empty-string fallback a few lines below:

```go
for _, p := range msg.Content.MultipleContent {
    if p.Type == "text" && p.Text != nil {   // image_url silently skipped
        ...
    }
}

// Some times the tool result is empty, so we need to add an empty string.
if output.Text == nil && len(output.Items) == 0 {
    output.Text = lo.ToPtr("")               // ...and the image becomes ""
}
```

So the model receives `{"type":"function_call_output","call_id":"...","output":""}` — a **successful, empty** tool result, indistinguishable from a tool that genuinely returned nothing.

Every other step of the path is already correct, which is what makes this a one-function bug:

| stage | image preserved? |
|---|---|
| inbound `convertContentItemToPart` (`inbound.go`) | yes — `input_image` → `image_url` part |
| internal `llm.Message{Role:"tool"}` `MultipleContent` | yes |
| **outbound `convertToolMessageWithType`** | **no** |

`convertUserMessage` in the *same file* has a `case "image_url"` branch, and the Anthropic outbound transformer preserves tool-result images via `convertToAnthropicTrivialContent` (including data-URL → base64 source). Only this converter drops them.

## Spec basis

From the official spec (`openai/openai-openapi`, `main`):

- `FunctionCallOutputItemParam.output` — `oneOf` a string, or *"An array of content outputs (text, image, file) for the function tool call"* whose items are `InputTextContentParam | InputImageContentParamAutoParam | InputFileContentParam`.
- `FunctionToolCallOutput.output` / `CustomToolCallOutput.output` — *"Can be a string or an list of output content."*, items `FunctionAndCustomToolCallOutput` = `InputTextContent | InputImageContent | InputFileContent`.

Images in a tool result are a documented, first-class part of the API for both `function_call_output` and `custom_tool_call_output`.

## Why this went unnoticed

Two things hide it:

1. **The failure is silent and looks successful.** The gateway returns 200 and the model gets a well-formed empty tool result, so it does what an LLM does with an empty result: it answers anyway. There is no error, no truncation, nothing in the logs.
2. **The most common client path is unaffected.** A human attaching an image goes through a user message `input_image`, which works. Only a tool that reads an image itself hits the broken field.

## Reproduction

Client: Codex CLI 0.144.3 → `/v1/responses`, model `gpt-5.5`. Codex's `view_image` tool returns **a single base64 image with no text**, i.e. exactly the shape that degrades to `""`.

Payload: N solid squares of one colour (N random 2..7, colour random of 6), so a correct answer cannot be guessed — 1/36 by chance. Same PNG generator in all arms.

| image delivery | correct |
|---|---|
| user message `input_image` (codex `-i`) | 1/1 |
| `view_image` → `function_call_output` (**before**) | **0/3** |
| `view_image` → `function_call_output` (**after this patch**) | **3/3** |

Before the patch the wrong answers were stereotyped ("3 red" twice out of three) — no visual information reached the model at all. Also reproduced 0/3 on `gpt-5.6-sol` before, 2/2 after.

In a real agent loop the effect was worse than a wrong colour: the model called `view_image` three times per run, received `""` each time, and then wrote confident descriptions of a rendered figure it had never seen — including describing a deliberately blank image as readable.

## The change

- `text`-only `if` becomes a `switch`, with `case "image_url"` → `input_image`, mirroring `convertUserMessage`.
- `detail` is now always populated (`lo.FromPtrOr(p.ImageURL.Detail, "auto")`). This matters because of an asymmetry in the request schemas: a `custom_tool_call_output` content array resolves to `InputImageContent`, whose `required` is `["type","detail"]`, while `function_call_output` resolves to `InputImageContentParamAutoParam`, where `detail` is optional. Both document `auto` as the default, so sending it explicitly is valid on either side and avoids branching on the item type.

## Tests

`TestConvertToolMessage` gains: image-only result, image + unsupported parts, a `custom_tool_call_output` carrying an image. Two new tests assert the serialised wire shape (that `output` is an array of content parts, and that a custom tool output's image carries `detail`).

**Two existing assertions changed**, since they pinned the drop:

- `"tool message with multiple content - mixed types (only text extracted)"` expected `text/image/text` to collapse to `text/text`; it now asserts the image survives in place, and is renamed accordingly.
- `"tool message with multiple content but no text parts"` expected an image to become `""`; it now asserts the image survives, and is renamed.

`go test ./...` in the `llm` module: 34 packages ok. `gofmt`/`go vet` clean.

## Deliberately not in this PR

- **Chat Completions outbound has the mirror-image bug.** `MessageContentFromLLM` ([openai/outbound_convert.go:217](https://github.com/looplj/axonhub/blob/unstable/llm/transformer/openai/outbound_convert.go#L217)) is role-agnostic and passes `image_url` straight into tool messages, but `ChatCompletionRequestToolMessage.content` says *"For tool messages, only type `text` is supported"* — so a strict upstream may 400. Whether to drop, annotate or reject there is a design call, and the compatibility surface is different, so it seemed wrong to bundle it here. Happy to open a separate issue.
- **Unrepresentable part kinds are still dropped silently.** `input_audio` / `video_url` / `document` in a tool result still vanish, and an all-dropped result still degrades to `""`. Surfacing that properly needs a logger or an error return, which this pure converter has no access to — a separate change. The audio-only case is kept as a test with a comment so the gap is explicit rather than looking intentional.
- **`input_file`.** The spec allows it in the output array, but the Responses `Item` type has no file fields at all (neither inbound nor outbound), so it is a symmetric feature gap rather than an asymmetric drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool results now preserve image content when sent through the Responses API, including `input_image` with `detail` defaulting to `"auto"`.
  * Mixed text and image results maintain their original order (including custom tool outputs).

* **Bug Fixes**
  * Image-only tool results are no longer discarded.
  * Tool results containing only unsupported content now fall back to an empty-string output instead of showing a placeholder.
  * Truly empty/no-content tool results are still handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->