### PR TITLE
fix(frontend): improve requests table mobile responsiveness

### DIFF
--- a/frontend/src/components/date-range-picker/index.tsx
+++ b/frontend/src/components/date-range-picker/index.tsx
@@ -8,81 +8,70 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { DateTimeRangePicker } from './date-time-range-picker';
 import { formatRange } from './utils';
 
-
-export type { DateTimeRangeValue, TimeValue } from '@/utils/date-range'
-export { DateTimeRangePicker } from './date-time-range-picker'
+export type { DateTimeRangeValue, TimeValue } from '@/utils/date-range';
+export { DateTimeRangePicker } from './date-time-range-picker';
 
 interface DateRangePickerProps {
-  value?: DateTimeRangeValue
-  onChange?: (range: DateTimeRangeValue | undefined) => void
-  onCancel?: () => void
-  onConfirm?: (range: DateTimeRangeValue) => void
-  className?: string
+  value?: DateTimeRangeValue;
+  onChange?: (range: DateTimeRangeValue | undefined) => void;
+  onCancel?: () => void;
+  onConfirm?: (range: DateTimeRangeValue) => void;
+  className?: string;
 }
 
 export function DateRangePicker(props: DateRangePickerProps) {
-  const { value, onChange, onCancel, onConfirm, className } = props
-  const { t } = useTranslation()
-  const isControlled = Object.prototype.hasOwnProperty.call(props, 'value')
-  const [open, setOpen] = React.useState(false)
-  const normalizedValue = React.useMemo(
-    () => (value ? normalizeDateTimeRangeValue(value) : undefined),
-    [value]
-  )
-  const [internalValue, setInternalValue] = React.useState<DateTimeRangeValue | undefined>(
-    normalizedValue
-  )
-  const [pendingValue, setPendingValue] = React.useState<DateTimeRangeValue | undefined>(
-    normalizedValue
-  )
+  const { value, onChange, onCancel, onConfirm, className } = props;
+  const { t } = useTranslation();
+  const isControlled = Object.prototype.hasOwnProperty.call(props, 'value');
+  const [open, setOpen] = React.useState(false);
+  const normalizedValue = React.useMemo(() => (value ? normalizeDateTimeRangeValue(value) : undefined), [value]);
+  const [internalValue, setInternalValue] = React.useState<DateTimeRangeValue | undefined>(normalizedValue);
+  const [pendingValue, setPendingValue] = React.useState<DateTimeRangeValue | undefined>(normalizedValue);
 
   React.useEffect(() => {
-    if (!isControlled) return
-    setInternalValue(normalizedValue)
-  }, [isControlled, normalizedValue])
+    if (!isControlled) return;
+    setInternalValue(normalizedValue);
+  }, [isControlled, normalizedValue]);
 
   React.useEffect(() => {
     if (open) {
-      const currentValue = isControlled ? normalizedValue : internalValue
-      setPendingValue(currentValue)
+      const currentValue = isControlled ? normalizedValue : internalValue;
+      setPendingValue(currentValue);
     }
-  }, [open, isControlled, normalizedValue, internalValue])
+  }, [open, isControlled, normalizedValue, internalValue]);
 
-  const handlePendingChange = React.useCallback(
-    (next: DateTimeRangeValue | undefined) => {
-      const nextValue = next ? normalizeDateTimeRangeValue(next) : undefined
-      setPendingValue(nextValue)
-    },
-    []
-  )
+  const handlePendingChange = React.useCallback((next: DateTimeRangeValue | undefined) => {
+    const nextValue = next ? normalizeDateTimeRangeValue(next) : undefined;
+    setPendingValue(nextValue);
+  }, []);
 
   const handleConfirm = React.useCallback(
     (next: DateTimeRangeValue) => {
-      const nextValue = normalizeDateTimeRangeValue(next)
-      const hasRange = !!nextValue.from || !!nextValue.to
+      const nextValue = normalizeDateTimeRangeValue(next);
+      const hasRange = !!nextValue.from || !!nextValue.to;
       if (!hasRange) {
-        if (!isControlled) setInternalValue(undefined)
-        onChange?.(undefined)
-        setOpen(false)
-        return
+        if (!isControlled) setInternalValue(undefined);
+        onChange?.(undefined);
+        setOpen(false);
+        return;
       }
-      if (!isControlled) setInternalValue(nextValue)
-      onChange?.(nextValue)
-      onConfirm?.(nextValue)
-      setOpen(false)
+      if (!isControlled) setInternalValue(nextValue);
+      onChange?.(nextValue);
+      onConfirm?.(nextValue);
+      setOpen(false);
     },
     [isControlled, onChange, onConfirm]
-  )
+  );
 
   const handleCancel = React.useCallback(() => {
-    const currentValue = isControlled ? normalizedValue : internalValue
-    setPendingValue(currentValue)
-    setOpen(false)
-    onCancel?.()
-  }, [isControlled, normalizedValue, internalValue, onCancel])
+    const currentValue = isControlled ? normalizedValue : internalValue;
+    setPendingValue(currentValue);
+    setOpen(false);
+    onCancel?.();
+  }, [isControlled, normalizedValue, internalValue, onCancel]);
 
-  const currentValue = isControlled ? normalizedValue : internalValue
-  const label = formatRange(currentValue?.from, currentValue?.to, t('common.filters.dateRange'))
+  const currentValue = isControlled ? normalizedValue : internalValue;
+  const label = formatRange(currentValue?.from, currentValue?.to, t('common.filters.dateRange'));
 
   return (
     <div className={cn('grid gap-2', className)}>
@@ -92,24 +81,16 @@ export function DateRangePicker(props: DateRangePickerProps) {
             id='date'
             variant='outline'
             size='sm'
-            className={cn(
-              'h-8 border-solid',
-              !currentValue?.from && !currentValue?.to && 'text-muted-foreground'
-            )}
+            className={cn('h-8 min-w-0 border-solid', !currentValue?.from && !currentValue?.to && 'text-muted-foreground')}
           >
-            <Calendar className='h-4 w-4' />
-            <span>{label}</span>
+            <Calendar className='h-4 w-4 shrink-0' />
+            <span className='block min-w-0 truncate'>{label}</span>
           </Button>
         </PopoverTrigger>
         <PopoverContent className='w-auto border-none bg-transparent p-0 shadow-none' align='start'>
-          <DateTimeRangePicker
-            value={pendingValue}
-            onChange={handlePendingChange}
-            onCancel={handleCancel}
-            onConfirm={handleConfirm}
-          />
+          <DateTimeRangePicker value={pendingValue} onChange={handlePendingChange} onCancel={handleCancel} onConfirm={handleConfirm} />
         </PopoverContent>
       </Popover>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/server-side-pagination.tsx
+++ b/frontend/src/components/server-side-pagination.tsx
@@ -44,7 +44,7 @@ export function ServerSidePagination({
           ? t('pagination.selectedInfoWithTotal', { selectedRows, dataLength, totalCount })
           : t('pagination.selectedInfo', { selectedRows, dataLength })}
       </div>
-      <div className='flex items-center sm:space-x-6 lg:space-x-8'>
+      <div className='flex items-center gap-4 sm:gap-6 lg:gap-8'>
         <div className='flex items-center space-x-2'>
           <p className='hidden text-sm font-medium sm:block'>{t('pagination.rowsPerPage')}</p>
           <Select

--- a/frontend/src/components/server-side-pagination.tsx
+++ b/frontend/src/components/server-side-pagination.tsx
@@ -44,7 +44,7 @@ export function ServerSidePagination({
           ? t('pagination.selectedInfoWithTotal', { selectedRows, dataLength, totalCount })
           : t('pagination.selectedInfo', { selectedRows, dataLength })}
       </div>
-      <div className='flex items-center gap-4 sm:gap-6 lg:gap-8'>
+      <div className='flex flex-wrap items-center gap-0 sm:gap-6 lg:gap-8'>
         <div className='flex items-center space-x-2'>
           <p className='hidden text-sm font-medium sm:block'>{t('pagination.rowsPerPage')}</p>
           <Select

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -253,7 +253,7 @@ export function DataTableToolbar<TData>({
               aria-label={t('common.autoRefresh')}
             />
             <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-              <span className='sr-only sm:not-sr-only sm:inline'>{t('common.autoRefresh')}</span>
+              {t('common.autoRefresh')}
             </label>
           </div>
         )}

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -1,14 +1,16 @@
 import { useMemo, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
-import { RefreshCw, X } from 'lucide-react';
+import { Filter, RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
 import type { DateTimeRangeValue } from '@/utils/date-range';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Switch } from '@/components/ui/switch';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { DateRangePicker } from '@/components/date-range-picker';
@@ -44,6 +46,16 @@ export function DataTableToolbar<TData>({
   const [showArchivedChannels, setShowArchivedChannels] = useState(false);
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
+
+  // Active filter count for mobile badge (excludes model ID filter)
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    for (const filter of table.getState().columnFilters) {
+      if (filter.id !== 'modelID' && filter.value) count++;
+    }
+    if (hasDateRange) count++;
+    return count;
+  }, [table.getState().columnFilters, hasDateRange]);
 
   // Handler to toggle show archived API keys and prune hidden IDs from filters
   const handleToggleShowArchivedApiKeys = (checked: boolean) => {
@@ -174,74 +186,176 @@ export function DataTableToolbar<TData>({
           onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
           className='h-8 w-full sm:w-[150px] lg:w-[250px]'
         />
-        {table.getColumn('status') && (
-          <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
-        )}
-        {table.getColumn('source') && (
-          <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
-        )}
-        {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
-          <DataTableFacetedFilter
-            column={table.getColumn('channel')}
-            title={t('requests.filters.channel')}
-            options={channelOptions}
-            footer={
-              <div
-                className='flex items-center space-x-2 px-2 py-1.5'
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  id='show-archived-channels'
-                  checked={showArchivedChannels}
-                  onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+
+        {/* Mobile: Filters button opens bottom sheet */}
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant='outline' size='sm' className='h-8 gap-1 sm:hidden'>
+              <Filter className='h-4 w-4' />
+              {t('common.filters.title')}
+              {activeFilterCount > 0 && (
+                <Badge variant='secondary' className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'>
+                  {activeFilterCount}
+                </Badge>
+              )}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side='bottom' className='h-auto max-h-[85vh] overflow-hidden'>
+            <SheetHeader>
+              <SheetTitle>{t('common.filters.title')}</SheetTitle>
+            </SheetHeader>
+            <div className='flex flex-col gap-4 overflow-y-auto py-4'>
+              {table.getColumn('status') && (
+                <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
+              )}
+              {table.getColumn('source') && (
+                <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
+              )}
+              {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+                <DataTableFacetedFilter
+                  column={table.getColumn('channel')}
+                  title={t('requests.filters.channel')}
+                  options={channelOptions}
+                  footer={
+                    <div
+                      className='flex items-center space-x-2 px-2 py-1.5'
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Checkbox
+                        id='show-archived-channels-mobile'
+                        checked={showArchivedChannels}
+                        onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+                        onPointerDown={(e) => e.stopPropagation()}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <label
+                        htmlFor='show-archived-channels-mobile'
+                        className='cursor-pointer text-sm'
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {t('common.showArchived')}
+                      </label>
+                    </div>
+                  }
+                />
+              )}
+              {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+                <DataTableFacetedFilter
+                  column={table.getColumn('apiKey')}
+                  title={t('requests.filters.apiKey')}
+                  options={apiKeyOptions}
+                  footer={
+                    <div
+                      className='flex items-center space-x-2 px-2 py-1.5'
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Checkbox
+                        id='show-archived-api-keys-mobile'
+                        checked={showArchivedApiKeys}
+                        onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                        onPointerDown={(e) => e.stopPropagation()}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <label
+                        htmlFor='show-archived-api-keys-mobile'
+                        className='cursor-pointer text-sm'
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {t('common.showArchived')}
+                      </label>
+                    </div>
+                  }
+                />
+              )}
+              <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='w-full' />
+              {hasDateRange && (
+                <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
+                  <X className='h-4 w-4' />
+                </Button>
+              )}
+              {isFiltered && (
+                <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
+                  {t('common.filters.reset')}
+                  <Cross2Icon className='ml-2 h-4 w-4' />
+                </Button>
+              )}
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        {/* Desktop: inline filter controls */}
+        <div className='hidden flex-wrap items-center gap-2 sm:flex'>
+          {table.getColumn('status') && (
+            <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
+          )}
+          {table.getColumn('source') && (
+            <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
+          )}
+          {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+            <DataTableFacetedFilter
+              column={table.getColumn('channel')}
+              title={t('requests.filters.channel')}
+              options={channelOptions}
+              footer={
+                <div
+                  className='flex items-center space-x-2 px-2 py-1.5'
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
-                />
-                <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                  {t('common.showArchived')}
-                </label>
-              </div>
-            }
-          />
-        )}
-        {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
-          <DataTableFacetedFilter
-            column={table.getColumn('apiKey')}
-            title={t('requests.filters.apiKey')}
-            options={apiKeyOptions}
-            footer={
-              <div
-                className='flex items-center space-x-2 px-2 py-1.5'
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  id='show-archived-api-keys'
-                  checked={showArchivedApiKeys}
-                  onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                >
+                  <Checkbox
+                    id='show-archived-channels'
+                    checked={showArchivedChannels}
+                    onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                    {t('common.showArchived')}
+                  </label>
+                </div>
+              }
+            />
+          )}
+          {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+            <DataTableFacetedFilter
+              column={table.getColumn('apiKey')}
+              title={t('requests.filters.apiKey')}
+              options={apiKeyOptions}
+              footer={
+                <div
+                  className='flex items-center space-x-2 px-2 py-1.5'
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
-                />
-                <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                  {t('common.showArchived')}
-                </label>
-              </div>
-            }
-          />
-        )}
-        <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
-        {hasDateRange && (
-          <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
-            <X className='h-4 w-4' />
-          </Button>
-        )}
-        {isFiltered && (
-          <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
-            {t('common.filters.reset')}
-            <Cross2Icon className='ml-2 h-4 w-4' />
-          </Button>
-        )}
+                >
+                  <Checkbox
+                    id='show-archived-api-keys'
+                    checked={showArchivedApiKeys}
+                    onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                    {t('common.showArchived')}
+                  </label>
+                </div>
+              }
+            />
+          )}
+          <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
+          {hasDateRange && (
+            <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
+              <X className='h-4 w-4' />
+            </Button>
+          )}
+          {isFiltered && (
+            <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
+              {t('common.filters.reset')}
+              <Cross2Icon className='ml-2 h-4 w-4' />
+            </Button>
+          )}
+        </div>
       </div>
       <div className='flex shrink-0 flex-wrap items-center justify-end gap-2'>
         {showRefresh && onAutoRefreshChange && (

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -178,13 +178,13 @@ export function DataTableToolbar<TData>({
   ];
 
   return (
-    <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+    <div className='flex flex-wrap items-center justify-between gap-2'>
       <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
         <Input
           placeholder={t('requests.filters.filterModelId')}
           value={(table.getColumn('modelID')?.getFilterValue() as string) ?? ''}
           onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
-          className='h-8 w-full sm:w-[150px] lg:w-[250px]'
+          className='h-8 min-w-0 flex-1 sm:w-[150px] lg:w-[250px]'
         />
 
         {/* Mobile: Filters button opens bottom sheet */}
@@ -357,7 +357,7 @@ export function DataTableToolbar<TData>({
           )}
         </div>
       </div>
-      <div className='flex shrink-0 flex-wrap items-center justify-end gap-2'>
+      <div className='flex shrink-0 flex-wrap items-center justify-start gap-2 sm:justify-end'>
         {showRefresh && onAutoRefreshChange && (
           <div className='flex shrink-0 items-center gap-2'>
             <Switch

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -5,7 +5,6 @@ import { RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
-import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -41,7 +40,6 @@ export function DataTableToolbar<TData>({
   onAutoRefreshChange,
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
-  const scrollRef = useHorizontalScroll<HTMLDivElement>();
   const [showArchivedApiKeys, setShowArchivedApiKeys] = useState(false);
   const [showArchivedChannels, setShowArchivedChannels] = useState(false);
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
@@ -165,17 +163,16 @@ export function DataTableToolbar<TData>({
       value: 'playground',
       label: t('requests.source.playground'),
     },
-
   ];
 
   return (
-    <div ref={scrollRef} className='flex items-center justify-between gap-2 overflow-x-auto'>
-      <div className='flex flex-1 items-center space-x-2 shrink-0'>
+    <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+      <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
         <Input
           placeholder={t('requests.filters.filterModelId')}
           value={(table.getColumn('modelID')?.getFilterValue() as string) ?? ''}
           onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
-          className='h-8 w-[150px] lg:w-[250px]'
+          className='h-8 w-full sm:w-[150px] lg:w-[250px]'
         />
         {table.getColumn('status') && (
           <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
@@ -233,7 +230,7 @@ export function DataTableToolbar<TData>({
             }
           />
         )}
-        <DateRangePicker value={dateRange} onChange={onDateRangeChange} />
+        <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
         {hasDateRange && (
           <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
             <X className='h-4 w-4' />
@@ -246,19 +243,24 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
       </div>
-      <div className='flex items-center space-x-2 shrink-0'>
+      <div className='flex shrink-0 flex-wrap items-center justify-end gap-2'>
         {showRefresh && onAutoRefreshChange && (
-          <div className='flex items-center space-x-2 shrink-0'>
-            <Switch checked={autoRefresh} onCheckedChange={onAutoRefreshChange} id='auto-refresh-switch' />
+          <div className='flex shrink-0 items-center gap-2'>
+            <Switch
+              checked={autoRefresh}
+              onCheckedChange={onAutoRefreshChange}
+              id='auto-refresh-switch'
+              aria-label={t('common.autoRefresh')}
+            />
             <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-              {t('common.autoRefresh')}
+              <span className='sr-only sm:not-sr-only sm:inline'>{t('common.autoRefresh')}</span>
             </label>
           </div>
         )}
         {showRefresh && onRefresh && (
-          <Button variant='outline' size='sm' onClick={onRefresh} className='shrink-0'>
-            <RefreshCw className={`mr-2 h-4 w-4 ${autoRefresh ? 'animate-spin' : ''}`} />
-            {t('common.refresh')}
+          <Button variant='outline' size='sm' onClick={onRefresh} aria-label={t('common.refresh')} className='shrink-0'>
+            <RefreshCw className={`h-4 w-4 ${autoRefresh ? 'animate-spin' : ''} sm:mr-2`} />
+            <span className='hidden sm:inline'>{t('common.refresh')}</span>
           </Button>
         )}
         <DataTableViewOptions table={table} />

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -19,6 +19,10 @@ import { useMe } from '@/features/auth/data/auth';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { RequestStatus } from '../data/schema';
 import { DataTableViewOptions } from './data-table-view-options';
+import { MODEL_ID_COLUMN } from './requests-columns';
+
+// Max width for DateRangePicker in toolbar
+const DATE_RANGE_MAX_WIDTH = '150px';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -29,6 +33,149 @@ interface DataTableToolbarProps<TData> {
   showRefresh?: boolean;
   autoRefresh?: boolean;
   onAutoRefreshChange?: (enabled: boolean) => void;
+}
+
+interface RequestFilterControlsProps {
+  table: Table<any>;
+  dateRange?: DateTimeRangeValue;
+  onDateRangeChange?: (range: DateTimeRangeValue | undefined) => void;
+  onResetFilters?: () => void;
+  isFiltered: boolean;
+  hasDateRange: boolean;
+  requestStatuses: { value: string; label: string }[];
+  requestSources: { value: string; label: string }[];
+  canViewChannels: boolean;
+  channelOptions: { value: string; label: string }[];
+  isFetchingChannels: boolean;
+  showArchivedChannels: boolean;
+  handleToggleShowArchivedChannels: (checked: boolean) => void;
+  canViewApiKeys: boolean;
+  apiKeyOptions: { value: string; label: string }[];
+  isFetchingApiKeys: boolean;
+  showArchivedApiKeys: boolean;
+  handleToggleShowArchivedApiKeys: (checked: boolean) => void;
+  isMobile?: boolean;
+  onCloseAfterAction?: () => void;
+}
+
+function RequestFilterControls({
+  table,
+  dateRange,
+  onDateRangeChange,
+  onResetFilters,
+  isFiltered,
+  hasDateRange,
+  requestStatuses,
+  requestSources,
+  canViewChannels,
+  channelOptions,
+  isFetchingChannels,
+  showArchivedChannels,
+  handleToggleShowArchivedChannels,
+  canViewApiKeys,
+  apiKeyOptions,
+  isFetchingApiKeys,
+  showArchivedApiKeys,
+  handleToggleShowArchivedApiKeys,
+  isMobile = false,
+  onCloseAfterAction,
+}: RequestFilterControlsProps) {
+  const { t } = useTranslation();
+
+  const stopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  const channelCheckboxId = isMobile ? 'show-archived-channels-mobile' : 'show-archived-channels';
+  const apiKeyCheckboxId = isMobile ? 'show-archived-api-keys-mobile' : 'show-archived-api-keys';
+  const wrapperClass = isMobile ? 'block' : 'hidden flex-wrap items-center gap-2 sm:flex';
+
+  // Footer for archived toggle in DataTableFacetedFilter
+  const channelFooter = (
+    <div className='flex items-center space-x-2 px-2 py-1.5' onPointerDown={stopPropagation} onClick={stopPropagation}>
+      <Checkbox
+        id={channelCheckboxId}
+        checked={showArchivedChannels}
+        onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+        onPointerDown={stopPropagation}
+        onClick={stopPropagation}
+      />
+      <label htmlFor={channelCheckboxId} className='cursor-pointer text-sm' onClick={stopPropagation}>
+        {t('common.showArchived')}
+      </label>
+    </div>
+  );
+
+  const apiKeyFooter = (
+    <div className='flex items-center space-x-2 px-2 py-1.5' onPointerDown={stopPropagation} onClick={stopPropagation}>
+      <Checkbox
+        id={apiKeyCheckboxId}
+        checked={showArchivedApiKeys}
+        onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+        onPointerDown={stopPropagation}
+        onClick={stopPropagation}
+      />
+      <label htmlFor={apiKeyCheckboxId} className='cursor-pointer text-sm' onClick={stopPropagation}>
+        {t('common.showArchived')}
+      </label>
+    </div>
+  );
+
+  return (
+    <div className={wrapperClass}>
+      {table.getColumn('status') && (
+        <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
+      )}
+      {table.getColumn('source') && (
+        <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
+      )}
+      {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+        <DataTableFacetedFilter
+          column={table.getColumn('channel')}
+          title={t('requests.filters.channel')}
+          options={channelOptions}
+          footer={channelFooter}
+        />
+      )}
+      {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+        <DataTableFacetedFilter
+          column={table.getColumn('apiKey')}
+          title={t('requests.filters.apiKey')}
+          options={apiKeyOptions}
+          footer={apiKeyFooter}
+        />
+      )}
+      <DateRangePicker
+        value={dateRange}
+        onChange={onDateRangeChange}
+        className={isMobile ? 'w-full' : `max-w-[${DATE_RANGE_MAX_WIDTH}] min-w-0 sm:max-w-none`}
+      />
+      {hasDateRange && (
+        <Button
+          variant='ghost'
+          onClick={() => {
+            onDateRangeChange?.(undefined);
+            onCloseAfterAction?.();
+          }}
+          className='h-8 px-2'
+          size='sm'
+        >
+          <X className='h-4 w-4' />
+        </Button>
+      )}
+      {isFiltered && (
+        <Button
+          variant='ghost'
+          onClick={() => {
+            onResetFilters?.();
+            onCloseAfterAction?.();
+          }}
+          className='h-8 px-2 lg:px-3'
+        >
+          {t('common.filters.reset')}
+          <Cross2Icon className='ml-2 h-4 w-4' />
+        </Button>
+      )}
+    </div>
+  );
 }
 
 export function DataTableToolbar<TData>({
@@ -44,6 +191,7 @@ export function DataTableToolbar<TData>({
   const { t } = useTranslation();
   const [showArchivedApiKeys, setShowArchivedApiKeys] = useState(false);
   const [showArchivedChannels, setShowArchivedChannels] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
 
@@ -51,7 +199,7 @@ export function DataTableToolbar<TData>({
   const activeFilterCount = useMemo(() => {
     let count = 0;
     for (const filter of table.getState().columnFilters) {
-      if (filter.id !== 'modelID' && filter.value) count++;
+      if (filter.id !== MODEL_ID_COLUMN && filter.value) count++;
     }
     if (hasDateRange) count++;
     return count;
@@ -181,19 +329,23 @@ export function DataTableToolbar<TData>({
     <div className='flex flex-wrap items-center gap-2'>
       <Input
         placeholder={t('requests.filters.filterModelId')}
-        value={(table.getColumn('modelID')?.getFilterValue() as string) ?? ''}
-        onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
+        value={(table.getColumn(MODEL_ID_COLUMN)?.getFilterValue() as string) ?? ''}
+        onChange={(event) => table.getColumn(MODEL_ID_COLUMN)?.setFilterValue(event.target.value)}
         className='h-8 min-w-0 flex-1 sm:w-[150px] lg:w-[250px]'
       />
 
       {/* Mobile: Filters button opens bottom sheet */}
-      <Sheet>
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
         <SheetTrigger asChild>
           <Button variant='outline' size='sm' className='h-8 gap-1 sm:hidden'>
             <Filter className='h-4 w-4' />
             {t('common.filters.title')}
             {activeFilterCount > 0 && (
-              <Badge variant='secondary' className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'>
+              <Badge
+                variant='secondary'
+                className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'
+                aria-label={`${activeFilterCount} active filters`}
+              >
                 {activeFilterCount}
               </Badge>
             )}
@@ -204,149 +356,53 @@ export function DataTableToolbar<TData>({
             <SheetTitle>{t('common.filters.title')}</SheetTitle>
           </SheetHeader>
           <div className='flex flex-col gap-4 overflow-y-auto py-4'>
-            {table.getColumn('status') && (
-              <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
-            )}
-            {table.getColumn('source') && (
-              <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
-            )}
-            {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
-              <DataTableFacetedFilter
-                column={table.getColumn('channel')}
-                title={t('requests.filters.channel')}
-                options={channelOptions}
-                footer={
-                  <div
-                    className='flex items-center space-x-2 px-2 py-1.5'
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Checkbox
-                      id='show-archived-channels-mobile'
-                      checked={showArchivedChannels}
-                      onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                    <label htmlFor='show-archived-channels-mobile' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                      {t('common.showArchived')}
-                    </label>
-                  </div>
-                }
-              />
-            )}
-            {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
-              <DataTableFacetedFilter
-                column={table.getColumn('apiKey')}
-                title={t('requests.filters.apiKey')}
-                options={apiKeyOptions}
-                footer={
-                  <div
-                    className='flex items-center space-x-2 px-2 py-1.5'
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Checkbox
-                      id='show-archived-api-keys-mobile'
-                      checked={showArchivedApiKeys}
-                      onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                    <label htmlFor='show-archived-api-keys-mobile' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                      {t('common.showArchived')}
-                    </label>
-                  </div>
-                }
-              />
-            )}
-            <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='w-full' />
-            {hasDateRange && (
-              <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
-                <X className='h-4 w-4' />
-              </Button>
-            )}
-            {isFiltered && (
-              <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
-                {t('common.filters.reset')}
-                <Cross2Icon className='ml-2 h-4 w-4' />
-              </Button>
-            )}
+            <RequestFilterControls
+              table={table}
+              dateRange={dateRange}
+              onDateRangeChange={onDateRangeChange}
+              onResetFilters={onResetFilters}
+              isFiltered={isFiltered}
+              hasDateRange={hasDateRange}
+              requestStatuses={requestStatuses}
+              requestSources={requestSources}
+              canViewChannels={canViewChannels}
+              channelOptions={channelOptions}
+              isFetchingChannels={isFetchingChannels}
+              showArchivedChannels={showArchivedChannels}
+              handleToggleShowArchivedChannels={handleToggleShowArchivedChannels}
+              canViewApiKeys={canViewApiKeys}
+              apiKeyOptions={apiKeyOptions}
+              isFetchingApiKeys={isFetchingApiKeys}
+              showArchivedApiKeys={showArchivedApiKeys}
+              handleToggleShowArchivedApiKeys={handleToggleShowArchivedApiKeys}
+              isMobile
+              onCloseAfterAction={() => setSheetOpen(false)}
+            />
           </div>
         </SheetContent>
       </Sheet>
 
       {/* Desktop: inline filter controls */}
-      <div className='hidden flex-wrap items-center gap-2 sm:flex'>
-        {table.getColumn('status') && (
-          <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
-        )}
-        {table.getColumn('source') && (
-          <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
-        )}
-        {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
-          <DataTableFacetedFilter
-            column={table.getColumn('channel')}
-            title={t('requests.filters.channel')}
-            options={channelOptions}
-            footer={
-              <div
-                className='flex items-center space-x-2 px-2 py-1.5'
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  id='show-archived-channels'
-                  checked={showArchivedChannels}
-                  onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => e.stopPropagation()}
-                />
-                <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                  {t('common.showArchived')}
-                </label>
-              </div>
-            }
-          />
-        )}
-        {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
-          <DataTableFacetedFilter
-            column={table.getColumn('apiKey')}
-            title={t('requests.filters.apiKey')}
-            options={apiKeyOptions}
-            footer={
-              <div
-                className='flex items-center space-x-2 px-2 py-1.5'
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  id='show-archived-api-keys'
-                  checked={showArchivedApiKeys}
-                  onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => e.stopPropagation()}
-                />
-                <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                  {t('common.showArchived')}
-                </label>
-              </div>
-            }
-          />
-        )}
-        <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
-        {hasDateRange && (
-          <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
-            <X className='h-4 w-4' />
-          </Button>
-        )}
-        {isFiltered && (
-          <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
-            {t('common.filters.reset')}
-            <Cross2Icon className='ml-2 h-4 w-4' />
-          </Button>
-        )}
-      </div>
+      <RequestFilterControls
+        table={table}
+        dateRange={dateRange}
+        onDateRangeChange={onDateRangeChange}
+        onResetFilters={onResetFilters}
+        isFiltered={isFiltered}
+        hasDateRange={hasDateRange}
+        requestStatuses={requestStatuses}
+        requestSources={requestSources}
+        canViewChannels={canViewChannels}
+        channelOptions={channelOptions}
+        isFetchingChannels={isFetchingChannels}
+        showArchivedChannels={showArchivedChannels}
+        handleToggleShowArchivedChannels={handleToggleShowArchivedChannels}
+        canViewApiKeys={canViewApiKeys}
+        apiKeyOptions={apiKeyOptions}
+        isFetchingApiKeys={isFetchingApiKeys}
+        showArchivedApiKeys={showArchivedApiKeys}
+        handleToggleShowArchivedApiKeys={handleToggleShowArchivedApiKeys}
+      />
       <div className='hidden flex-1 sm:block' />
       <div className='flex shrink-0 flex-wrap items-center gap-2'>
         {showRefresh && onAutoRefreshChange && (

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -178,186 +178,177 @@ export function DataTableToolbar<TData>({
   ];
 
   return (
-    <div className='flex flex-wrap items-center justify-between gap-2'>
-      <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
-        <Input
-          placeholder={t('requests.filters.filterModelId')}
-          value={(table.getColumn('modelID')?.getFilterValue() as string) ?? ''}
-          onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
-          className='h-8 min-w-0 flex-1 sm:w-[150px] lg:w-[250px]'
-        />
+    <div className='flex flex-wrap items-center gap-2'>
+      <Input
+        placeholder={t('requests.filters.filterModelId')}
+        value={(table.getColumn('modelID')?.getFilterValue() as string) ?? ''}
+        onChange={(event) => table.getColumn('modelID')?.setFilterValue(event.target.value)}
+        className='h-8 min-w-0 flex-1 sm:w-[150px] lg:w-[250px]'
+      />
 
-        {/* Mobile: Filters button opens bottom sheet */}
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button variant='outline' size='sm' className='h-8 gap-1 sm:hidden'>
-              <Filter className='h-4 w-4' />
-              {t('common.filters.title')}
-              {activeFilterCount > 0 && (
-                <Badge variant='secondary' className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'>
-                  {activeFilterCount}
-                </Badge>
-              )}
-            </Button>
-          </SheetTrigger>
-          <SheetContent side='bottom' className='h-auto max-h-[85vh] overflow-hidden'>
-            <SheetHeader>
-              <SheetTitle>{t('common.filters.title')}</SheetTitle>
-            </SheetHeader>
-            <div className='flex flex-col gap-4 overflow-y-auto py-4'>
-              {table.getColumn('status') && (
-                <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
-              )}
-              {table.getColumn('source') && (
-                <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
-              )}
-              {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
-                <DataTableFacetedFilter
-                  column={table.getColumn('channel')}
-                  title={t('requests.filters.channel')}
-                  options={channelOptions}
-                  footer={
-                    <div
-                      className='flex items-center space-x-2 px-2 py-1.5'
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Checkbox
-                        id='show-archived-channels-mobile'
-                        checked={showArchivedChannels}
-                        onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                      <label
-                        htmlFor='show-archived-channels-mobile'
-                        className='cursor-pointer text-sm'
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {t('common.showArchived')}
-                      </label>
-                    </div>
-                  }
-                />
-              )}
-              {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
-                <DataTableFacetedFilter
-                  column={table.getColumn('apiKey')}
-                  title={t('requests.filters.apiKey')}
-                  options={apiKeyOptions}
-                  footer={
-                    <div
-                      className='flex items-center space-x-2 px-2 py-1.5'
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Checkbox
-                        id='show-archived-api-keys-mobile'
-                        checked={showArchivedApiKeys}
-                        onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                      <label
-                        htmlFor='show-archived-api-keys-mobile'
-                        className='cursor-pointer text-sm'
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {t('common.showArchived')}
-                      </label>
-                    </div>
-                  }
-                />
-              )}
-              <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='w-full' />
-              {hasDateRange && (
-                <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
-                  <X className='h-4 w-4' />
-                </Button>
-              )}
-              {isFiltered && (
-                <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
-                  {t('common.filters.reset')}
-                  <Cross2Icon className='ml-2 h-4 w-4' />
-                </Button>
-              )}
-            </div>
-          </SheetContent>
-        </Sheet>
-
-        {/* Desktop: inline filter controls */}
-        <div className='hidden flex-wrap items-center gap-2 sm:flex'>
-          {table.getColumn('status') && (
-            <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
-          )}
-          {table.getColumn('source') && (
-            <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
-          )}
-          {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
-            <DataTableFacetedFilter
-              column={table.getColumn('channel')}
-              title={t('requests.filters.channel')}
-              options={channelOptions}
-              footer={
-                <div
-                  className='flex items-center space-x-2 px-2 py-1.5'
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Checkbox
-                    id='show-archived-channels'
-                    checked={showArchivedChannels}
-                    onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+      {/* Mobile: Filters button opens bottom sheet */}
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant='outline' size='sm' className='h-8 gap-1 sm:hidden'>
+            <Filter className='h-4 w-4' />
+            {t('common.filters.title')}
+            {activeFilterCount > 0 && (
+              <Badge variant='secondary' className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'>
+                {activeFilterCount}
+              </Badge>
+            )}
+          </Button>
+        </SheetTrigger>
+        <SheetContent side='bottom' className='h-auto max-h-[85vh] overflow-hidden'>
+          <SheetHeader>
+            <SheetTitle>{t('common.filters.title')}</SheetTitle>
+          </SheetHeader>
+          <div className='flex flex-col gap-4 overflow-y-auto py-4'>
+            {table.getColumn('status') && (
+              <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
+            )}
+            {table.getColumn('source') && (
+              <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
+            )}
+            {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+              <DataTableFacetedFilter
+                column={table.getColumn('channel')}
+                title={t('requests.filters.channel')}
+                options={channelOptions}
+                footer={
+                  <div
+                    className='flex items-center space-x-2 px-2 py-1.5'
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => e.stopPropagation()}
-                  />
-                  <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                    {t('common.showArchived')}
-                  </label>
-                </div>
-              }
-            />
-          )}
-          {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
-            <DataTableFacetedFilter
-              column={table.getColumn('apiKey')}
-              title={t('requests.filters.apiKey')}
-              options={apiKeyOptions}
-              footer={
-                <div
-                  className='flex items-center space-x-2 px-2 py-1.5'
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Checkbox
-                    id='show-archived-api-keys'
-                    checked={showArchivedApiKeys}
-                    onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                  >
+                    <Checkbox
+                      id='show-archived-channels-mobile'
+                      checked={showArchivedChannels}
+                      onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    <label htmlFor='show-archived-channels-mobile' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                      {t('common.showArchived')}
+                    </label>
+                  </div>
+                }
+              />
+            )}
+            {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+              <DataTableFacetedFilter
+                column={table.getColumn('apiKey')}
+                title={t('requests.filters.apiKey')}
+                options={apiKeyOptions}
+                footer={
+                  <div
+                    className='flex items-center space-x-2 px-2 py-1.5'
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => e.stopPropagation()}
-                  />
-                  <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
-                    {t('common.showArchived')}
-                  </label>
-                </div>
-              }
-            />
-          )}
-          <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
-          {hasDateRange && (
-            <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
-              <X className='h-4 w-4' />
-            </Button>
-          )}
-          {isFiltered && (
-            <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
-              {t('common.filters.reset')}
-              <Cross2Icon className='ml-2 h-4 w-4' />
-            </Button>
-          )}
-        </div>
+                  >
+                    <Checkbox
+                      id='show-archived-api-keys-mobile'
+                      checked={showArchivedApiKeys}
+                      onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    <label htmlFor='show-archived-api-keys-mobile' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                      {t('common.showArchived')}
+                    </label>
+                  </div>
+                }
+              />
+            )}
+            <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='w-full' />
+            {hasDateRange && (
+              <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
+                <X className='h-4 w-4' />
+              </Button>
+            )}
+            {isFiltered && (
+              <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
+                {t('common.filters.reset')}
+                <Cross2Icon className='ml-2 h-4 w-4' />
+              </Button>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {/* Desktop: inline filter controls */}
+      <div className='hidden flex-wrap items-center gap-2 sm:flex'>
+        {table.getColumn('status') && (
+          <DataTableFacetedFilter column={table.getColumn('status')} title={t('requests.filters.status')} options={requestStatuses} />
+        )}
+        {table.getColumn('source') && (
+          <DataTableFacetedFilter column={table.getColumn('source')} title={t('requests.filters.source')} options={requestSources} />
+        )}
+        {canViewChannels && table.getColumn('channel') && (channelOptions.length > 0 || isFetchingChannels) && (
+          <DataTableFacetedFilter
+            column={table.getColumn('channel')}
+            title={t('requests.filters.channel')}
+            options={channelOptions}
+            footer={
+              <div
+                className='flex items-center space-x-2 px-2 py-1.5'
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  id='show-archived-channels'
+                  checked={showArchivedChannels}
+                  onCheckedChange={(checked) => handleToggleShowArchivedChannels(checked === true)}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                />
+                <label htmlFor='show-archived-channels' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                  {t('common.showArchived')}
+                </label>
+              </div>
+            }
+          />
+        )}
+        {canViewApiKeys && table.getColumn('apiKey') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+          <DataTableFacetedFilter
+            column={table.getColumn('apiKey')}
+            title={t('requests.filters.apiKey')}
+            options={apiKeyOptions}
+            footer={
+              <div
+                className='flex items-center space-x-2 px-2 py-1.5'
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  id='show-archived-api-keys'
+                  checked={showArchivedApiKeys}
+                  onCheckedChange={(checked) => handleToggleShowArchivedApiKeys(checked === true)}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                />
+                <label htmlFor='show-archived-api-keys' className='cursor-pointer text-sm' onClick={(e) => e.stopPropagation()}>
+                  {t('common.showArchived')}
+                </label>
+              </div>
+            }
+          />
+        )}
+        <DateRangePicker value={dateRange} onChange={onDateRangeChange} className='max-w-[150px] min-w-0 sm:max-w-none' />
+        {hasDateRange && (
+          <Button variant='ghost' onClick={() => onDateRangeChange?.(undefined)} className='h-8 px-2' size='sm'>
+            <X className='h-4 w-4' />
+          </Button>
+        )}
+        {isFiltered && (
+          <Button variant='ghost' onClick={onResetFilters} className='h-8 px-2 lg:px-3'>
+            {t('common.filters.reset')}
+            <Cross2Icon className='ml-2 h-4 w-4' />
+          </Button>
+        )}
       </div>
-      <div className='flex shrink-0 flex-wrap items-center justify-start gap-2 sm:justify-end'>
+      <div className='hidden flex-1 sm:block' />
+      <div className='flex shrink-0 flex-wrap items-center gap-2'>
         {showRefresh && onAutoRefreshChange && (
           <div className='flex shrink-0 items-center gap-2'>
             <Switch

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -21,9 +21,6 @@ import { RequestStatus } from '../data/schema';
 import { DataTableViewOptions } from './data-table-view-options';
 import { MODEL_ID_COLUMN } from './requests-columns';
 
-// Max width for DateRangePicker in toolbar
-const DATE_RANGE_MAX_WIDTH = '150px';
-
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
   dateRange?: DateTimeRangeValue;
@@ -145,8 +142,11 @@ function RequestFilterControls({
       )}
       <DateRangePicker
         value={dateRange}
-        onChange={onDateRangeChange}
-        className={isMobile ? 'w-full' : `max-w-[${DATE_RANGE_MAX_WIDTH}] min-w-0 sm:max-w-none`}
+        onChange={(range) => {
+          onDateRangeChange?.(range);
+          onCloseAfterAction?.();
+        }}
+        className={isMobile ? 'w-full' : 'max-w-[150px] min-w-0 sm:max-w-none'}
       />
       {hasDateRange && (
         <Button
@@ -196,14 +196,15 @@ export function DataTableToolbar<TData>({
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
 
   // Active filter count for mobile badge (excludes model ID filter)
+  const columnFilters = table.getState().columnFilters;
   const activeFilterCount = useMemo(() => {
     let count = 0;
-    for (const filter of table.getState().columnFilters) {
+    for (const filter of columnFilters) {
       if (filter.id !== MODEL_ID_COLUMN && filter.value) count++;
     }
     if (hasDateRange) count++;
     return count;
-  }, [table.getState().columnFilters, hasDateRange]);
+  }, [columnFilters, hasDateRange]);
 
   // Handler to toggle show archived API keys and prune hidden IDs from filters
   const handleToggleShowArchivedApiKeys = (checked: boolean) => {
@@ -344,7 +345,7 @@ export function DataTableToolbar<TData>({
               <Badge
                 variant='secondary'
                 className='ml-1 min-w-[1.25rem] rounded-full px-1.5 py-0'
-                aria-label={`${activeFilterCount} active filters`}
+                aria-label={t('common.filters.activeCount', { count: activeFilterCount })}
               >
                 {activeFilterCount}
               </Badge>

--- a/frontend/src/features/requests/components/data-table-view-options.tsx
+++ b/frontend/src/features/requests/components/data-table-view-options.tsx
@@ -21,7 +21,7 @@ export function DataTableViewOptions<TData>({ table }: DataTableViewOptionsProps
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button variant='outline' size='sm' className='ml-auto hidden h-8 lg:flex'>
+        <Button variant='outline' size='sm' className='h-8'>
           <MixerHorizontalIcon className='mr-2 h-4 w-4' />
           {t('common.view')}
         </Button>

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -77,7 +77,7 @@ async function readPreviewStream(
   const flushBuffer = async (final = false) => {
     const normalizedBuffer = buffer.replace(/\r\n/g, '\n');
     const separator = '\n\n';
-    let separatorIndex = normalizedBuffer.indexOf(separator);
+    const separatorIndex = normalizedBuffer.indexOf(separator);
 
     while (separatorIndex !== -1) {
       const rawEvent = normalizedBuffer.slice(0, separatorIndex);

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -26,6 +26,23 @@ interface UseRequestsColumnsOptions {
   onViewDetail?: (requestId: string) => void;
 }
 
+export const DEFAULT_MOBILE_HIDDEN_COLUMN_IDS = [
+  'apiFormat',
+  'passThrough',
+  'reasoningEffort',
+  'stream',
+  'source',
+  'clientIP',
+  'channel',
+  'apiKey',
+  'tokens',
+  'readCache',
+  'writeCache',
+  'cost',
+  'latency',
+  'details',
+];
+
 export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnDef<Request>[] {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'zh' ? zhCN : enUS;
@@ -128,7 +145,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'apiFormat',
       accessorFn: (row) => row.format,
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiFormat')} />,
       enableSorting: false,
       enableHiding: true,
@@ -148,7 +164,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'passThrough',
       accessorFn: (row) => row.executions?.edges?.some((edge) => edge.node?.passThroughApplied) ?? false,
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.passThrough')} />,
       enableSorting: false,
       enableHiding: true,
@@ -169,7 +184,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     },
     {
       accessorKey: 'reasoningEffort',
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.reasoningEffort')} />,
       enableSorting: false,
       enableHiding: true,
@@ -191,7 +205,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'stream',
       accessorKey: 'stream',
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.stream')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -216,7 +229,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'source',
       accessorKey: 'source',
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.source')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -243,7 +255,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'clientIP',
       accessorKey: 'clientIP',
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.clientIP')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -312,7 +323,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
           {
             id: 'channel',
             accessorFn: (row) => row.channel?.id || '',
-            meta: { className: 'hidden md:table-cell' },
             header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.channel')} />,
             enableSorting: false,
             cell: ({ row }) => {
@@ -400,7 +410,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
       ? ([
           {
             accessorKey: 'apiKey',
-            meta: { className: 'hidden md:table-cell' },
             header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiKey')} />,
             enableSorting: false,
             cell: ({ row }) => {
@@ -429,7 +438,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         const usageLog = row.usageLogs?.edges?.[0]?.node;
         return (usageLog?.promptTokens || 0) + (usageLog?.completionTokens || 0);
       },
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.tokens')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -477,7 +485,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'readCache',
       accessorFn: (row) => row.usageLogs?.edges?.[0]?.node?.promptCachedTokens || 0,
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.readCache')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -519,7 +526,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'writeCache',
       accessorFn: (row) => row.usageLogs?.edges?.[0]?.node?.promptWriteCachedTokens || 0,
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.writeCache')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -561,7 +567,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         const usageLog = row.usageLogs?.edges?.[0]?.node;
         return usageLog?.totalCost ?? null;
       },
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.cost')} />,
       enableSorting: false,
       enableHiding: true,
@@ -585,7 +590,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'latency',
       accessorFn: (row) => row.metricsLatencyMs ?? null,
-      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => (
         <div className='flex items-center gap-1'>
           {displayMode === 'latency' ? (
@@ -643,7 +647,6 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     },
     {
       id: 'details',
-      meta: { className: 'hidden sm:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.details')} />,
       cell: ({ row }) => (
         <Button

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -43,6 +43,8 @@ export const DEFAULT_MOBILE_HIDDEN_COLUMN_IDS = [
   'details',
 ];
 
+export const MODEL_ID_COLUMN = 'modelID' as const;
+
 export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnDef<Request>[] {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'zh' ? zhCN : enUS;

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -10,12 +10,12 @@ import { toast } from 'sonner';
 import { extractNumberID } from '@/lib/utils';
 import { formatDuration } from '@/utils/format-duration';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
+import { usePermissions } from '@/hooks/usePermissions';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { DataTableColumnHeader } from '@/components/data-table-column-header';
 import { useGeneralSettings, useSecuritySettings, useUpdateSecuritySettings } from '@/features/system/data/system';
-import { usePermissions } from '@/hooks/usePermissions';
 import { useRequestPermissions } from '../../../hooks/useRequestPermissions';
 import { Request } from '../data/schema';
 import { calculateTokensPerSecond, useDisplayMode } from '../utils/tokens-per-second';
@@ -41,14 +41,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
   const blockedIPs = securitySettings?.blockedIPs ?? [];
   const showIPBanIcon = securitySettings?.showRequestLogIPBanIcon === true;
 
-  const normalizeBlockedIPs = (ips: string[]) =>
-    Array.from(
-      new Set(
-        ips
-          .map((ip) => ip.trim())
-          .filter((ip) => ip.length > 0)
-      )
-    );
+  const normalizeBlockedIPs = (ips: string[]) => Array.from(new Set(ips.map((ip) => ip.trim()).filter((ip) => ip.length > 0)));
 
   const handleBlockIP = async (clientIP: string) => {
     const normalizedIP = clientIP.trim();
@@ -135,6 +128,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'apiFormat',
       accessorFn: (row) => row.format,
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiFormat')} />,
       enableSorting: false,
       enableHiding: true,
@@ -154,6 +148,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'passThrough',
       accessorFn: (row) => row.executions?.edges?.some((edge) => edge.node?.passThroughApplied) ?? false,
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.passThrough')} />,
       enableSorting: false,
       enableHiding: true,
@@ -174,6 +169,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     },
     {
       accessorKey: 'reasoningEffort',
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.reasoningEffort')} />,
       enableSorting: false,
       enableHiding: true,
@@ -195,6 +191,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'stream',
       accessorKey: 'stream',
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.stream')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -219,6 +216,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'source',
       accessorKey: 'source',
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.source')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -245,6 +243,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'clientIP',
       accessorKey: 'clientIP',
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.clientIP')} />,
       enableSorting: false,
       cell: ({ row }) => {
@@ -313,6 +312,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
           {
             id: 'channel',
             accessorFn: (row) => row.channel?.id || '',
+            meta: { className: 'hidden md:table-cell' },
             header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.channel')} />,
             enableSorting: false,
             cell: ({ row }) => {
@@ -400,6 +400,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
       ? ([
           {
             accessorKey: 'apiKey',
+            meta: { className: 'hidden md:table-cell' },
             header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.apiKey')} />,
             enableSorting: false,
             cell: ({ row }) => {
@@ -428,6 +429,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         const usageLog = row.usageLogs?.edges?.[0]?.node;
         return (usageLog?.promptTokens || 0) + (usageLog?.completionTokens || 0);
       },
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.tokens')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -475,6 +477,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'readCache',
       accessorFn: (row) => row.usageLogs?.edges?.[0]?.node?.promptCachedTokens || 0,
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.readCache')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -497,7 +500,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         return (
           <div className='text-xs'>
             <div className='text-sm font-medium'>{cachedTokens.toLocaleString()}</div>
-            <div className={isLowHitRate ? 'text-red-600 font-medium dark:text-red-400' : 'text-muted-foreground'}>
+            <div className={isLowHitRate ? 'font-medium text-red-600 dark:text-red-400' : 'text-muted-foreground'}>
               {t('requests.columns.cacheHitRate', {
                 rate: hitRate.toFixed(1),
               })}
@@ -516,6 +519,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'writeCache',
       accessorFn: (row) => row.usageLogs?.edges?.[0]?.node?.promptWriteCachedTokens || 0,
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.writeCache')} />,
       cell: ({ row }) => {
         const request = row.original;
@@ -557,6 +561,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
         const usageLog = row.usageLogs?.edges?.[0]?.node;
         return usageLog?.totalCost ?? null;
       },
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.cost')} />,
       enableSorting: false,
       enableHiding: true,
@@ -580,6 +585,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     {
       id: 'latency',
       accessorFn: (row) => row.metricsLatencyMs ?? null,
+      meta: { className: 'hidden md:table-cell' },
       header: ({ column }) => (
         <div className='flex items-center gap-1'>
           {displayMode === 'latency' ? (
@@ -637,6 +643,7 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
     },
     {
       id: 'details',
+      meta: { className: 'hidden sm:table-cell' },
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests.columns.details')} />,
       cell: ({ row }) => (
         <Button

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   ColumnFiltersState,
   RowData,
   SortingState,
   VisibilityState,
+  Updater,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -15,7 +16,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { DateTimeRangeValue } from '@/utils/date-range';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { useIsMobile, MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TableSkeleton } from '@/components/ui/table-skeleton';
@@ -24,6 +25,9 @@ import { Request, RequestConnection } from '../data/schema';
 import { DataTableToolbar } from './data-table-toolbar';
 import { RequestBodyDrawer } from './request-body-drawer';
 import { DEFAULT_MOBILE_HIDDEN_COLUMN_IDS, useRequestsColumns } from './requests-columns';
+
+const COLUMN_VISIBILITY_STORAGE_KEY = 'requests-table-column-visibility';
+const COLUMN_VISIBILITY_STORAGE_VERSION = 2;
 
 const MotionTableRow = motion.create(TableRow);
 
@@ -119,49 +123,96 @@ export function RequestsTable({
   const [sorting, setSorting] = useState<SortingState>([]);
   const isMobile = useIsMobile();
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
-    // Read viewport synchronously here (useState initializer runs once,
-    // and useIsMobile returns false during SSR/hydration).
-    const isMobileInit = typeof window !== 'undefined' && window.innerWidth < 768;
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const userOverridesRef = useRef<VisibilityState>({});
+  const columnVisibilityRef = useRef<VisibilityState>({});
+  const [visibilityReady, setVisibilityReady] = useState(false);
+
+  // Hydrate column visibility from localStorage once viewport is known
+  useEffect(() => {
+    const isMobileInit = window.innerWidth < MOBILE_BREAKPOINT;
     const mobileDefaults: VisibilityState = isMobileInit
       ? Object.fromEntries(DEFAULT_MOBILE_HIDDEN_COLUMN_IDS.map((id) => [id, false]))
       : {};
 
-    // Merge stored overrides on top of viewport-appropriate defaults
-    const stored = localStorage.getItem('requests-table-column-visibility');
-    if (stored) {
-      try {
-        return { ...mobileDefaults, ...JSON.parse(stored) };
-      } catch {
-        return mobileDefaults;
+    let overrides: VisibilityState = {};
+    try {
+      const raw = localStorage.getItem(COLUMN_VISIBILITY_STORAGE_KEY);
+      if (raw) {
+        const parsed: unknown = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          if ((parsed as { v?: number }).v === COLUMN_VISIBILITY_STORAGE_VERSION) {
+            const stored = (parsed as { overrides?: VisibilityState }).overrides;
+            if (stored && typeof stored === 'object') overrides = stored;
+          } else {
+            // Legacy unversioned payload: plain visibility map that may include
+            // responsive defaults from the old mobile persistence. Drop
+            // false-valued entries for mobile-hidden columns (they were injected
+            // defaults, not user intent); keep true entries (explicit user shows)
+            // and any entry for non-mobile-hidden columns.
+            const legacy = parsed as VisibilityState;
+            Object.entries(legacy).forEach(([id, visible]) => {
+              if (visible === true || !DEFAULT_MOBILE_HIDDEN_COLUMN_IDS.includes(id)) {
+                overrides[id] = visible;
+              }
+            });
+          }
+        }
       }
+    } catch {
+      // localStorage unavailable or corrupt — use defaults
     }
 
-    return mobileDefaults;
-  });
+    userOverridesRef.current = overrides;
+    setColumnVisibility({ ...mobileDefaults, ...overrides });
+    setVisibilityReady(true);
+  }, []); // Run once on mount
+
+  // Mirror columnVisibility into a ref so the visibility-change handler can read prev without a closure
+  useEffect(() => {
+    columnVisibilityRef.current = columnVisibility;
+  }, [columnVisibility]);
 
   const [rowSelection, setRowSelection] = useState({});
 
+  // Persist only user-driven overrides (never responsive defaults)
   useEffect(() => {
-    localStorage.setItem('requests-table-column-visibility', JSON.stringify(columnVisibility));
-  }, [columnVisibility]);
+    if (!visibilityReady) return;
+    try {
+      localStorage.setItem(
+        COLUMN_VISIBILITY_STORAGE_KEY,
+        JSON.stringify({ v: COLUMN_VISIBILITY_STORAGE_VERSION, overrides: userOverridesRef.current })
+      );
+    } catch {
+      // localStorage unavailable or quota exceeded — skip persistence
+    }
+  }, [columnVisibility, visibilityReady]);
 
-  // Adjust column visibility reactively when the viewport crosses the mobile threshold
   useEffect(() => {
+    if (!visibilityReady) return;
     setColumnVisibility((prev) => {
       const hidden = DEFAULT_MOBILE_HIDDEN_COLUMN_IDS;
+      const overrides = userOverridesRef.current;
+      const next = { ...prev };
+
       if (isMobile) {
-        // Hide mobile-only columns
-        const next = { ...prev };
+        // Hide responsive defaults, preserve user overrides
         hidden.forEach((id) => {
-          if (next[id] === undefined) next[id] = false;
+          if (next[id] === undefined && overrides[id] === undefined) {
+            next[id] = false;
+          }
         });
-        return next;
+      } else {
+        // On desktop, remove responsive defaults but keep user overrides
+        hidden.forEach((id) => {
+          if (overrides[id] === undefined) {
+            delete next[id];
+          }
+        });
       }
-      // Show mobile-only columns on desktop
-      return Object.fromEntries(Object.entries(prev).filter(([id]) => !hidden.includes(id)));
+      return next;
     });
-  }, [isMobile]);
+  }, [isMobile, visibilityReady]);
 
   const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 
@@ -200,6 +251,18 @@ export function RequestsTable({
     [columnFilters, onFiltersChange]
   );
 
+  const handleColumnVisibilityChange = useCallback((updater: Updater<VisibilityState>) => {
+    const prev = columnVisibilityRef.current;
+    const next = typeof updater === 'function' ? updater(prev) : updater;
+    // Record only user-driven changes as explicit overrides
+    Object.entries(next).forEach(([id, visible]) => {
+      if (prev[id] !== visible) {
+        userOverridesRef.current = { ...userOverridesRef.current, [id]: visible };
+      }
+    });
+    setColumnVisibility(next);
+  }, []);
+
   const table = useReactTable({
     data: displayedData,
     getRowId: (row) => row.id,
@@ -214,7 +277,7 @@ export function RequestsTable({
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: handleColumnFiltersChange,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: handleColumnVisibilityChange,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -22,7 +22,7 @@ import { ServerSidePagination } from '@/components/server-side-pagination';
 import { Request, RequestConnection } from '../data/schema';
 import { DataTableToolbar } from './data-table-toolbar';
 import { RequestBodyDrawer } from './request-body-drawer';
-import { useRequestsColumns } from './requests-columns';
+import { DEFAULT_MOBILE_HIDDEN_COLUMN_IDS, useRequestsColumns } from './requests-columns';
 
 const MotionTableRow = motion.create(TableRow);
 
@@ -126,6 +126,11 @@ export function RequestsTable({
         return {};
       }
     }
+
+    if (typeof window !== 'undefined' && window.innerWidth < 768) {
+      return Object.fromEntries(DEFAULT_MOBILE_HIDDEN_COLUMN_IDS.map((id) => [id, false]));
+    }
+
     return {};
   });
 

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -15,6 +15,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { DateTimeRangeValue } from '@/utils/date-range';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TableSkeleton } from '@/components/ui/table-skeleton';
@@ -116,22 +117,27 @@ export function RequestsTable({
 
   const requestsColumns = useRequestsColumns({ onBodyClick: handleBodyClick, onViewDetail });
   const [sorting, setSorting] = useState<SortingState>([]);
+  const isMobile = useIsMobile();
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
+    // Read viewport synchronously here (useState initializer runs once,
+    // and useIsMobile returns false during SSR/hydration).
+    const isMobileInit = typeof window !== 'undefined' && window.innerWidth < 768;
+    const mobileDefaults: VisibilityState = isMobileInit
+      ? Object.fromEntries(DEFAULT_MOBILE_HIDDEN_COLUMN_IDS.map((id) => [id, false]))
+      : {};
+
+    // Merge stored overrides on top of viewport-appropriate defaults
     const stored = localStorage.getItem('requests-table-column-visibility');
     if (stored) {
       try {
-        return JSON.parse(stored);
+        return { ...mobileDefaults, ...JSON.parse(stored) };
       } catch {
-        return {};
+        return mobileDefaults;
       }
     }
 
-    if (typeof window !== 'undefined' && window.innerWidth < 768) {
-      return Object.fromEntries(DEFAULT_MOBILE_HIDDEN_COLUMN_IDS.map((id) => [id, false]));
-    }
-
-    return {};
+    return mobileDefaults;
   });
 
   const [rowSelection, setRowSelection] = useState({});
@@ -139,6 +145,23 @@ export function RequestsTable({
   useEffect(() => {
     localStorage.setItem('requests-table-column-visibility', JSON.stringify(columnVisibility));
   }, [columnVisibility]);
+
+  // Adjust column visibility reactively when the viewport crosses the mobile threshold
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const hidden = DEFAULT_MOBILE_HIDDEN_COLUMN_IDS;
+      if (isMobile) {
+        // Hide mobile-only columns
+        const next = { ...prev };
+        hidden.forEach((id) => {
+          if (next[id] === undefined) next[id] = false;
+        });
+        return next;
+      }
+      // Show mobile-only columns on desktop
+      return Object.fromEntries(Object.entries(prev).filter(([id]) => !hidden.includes(id)));
+    });
+  }, [isMobile]);
 
   const displayedData = useAnimatedList(data, autoRefresh, pageSize);
 

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -209,7 +209,7 @@ export function RequestsTable({
         autoRefresh={autoRefresh}
         onAutoRefreshChange={onAutoRefreshChange}
       />
-      <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
+      <div className='shadow-soft relative mt-2 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)] sm:mt-4'>
         <div className='min-w-max'>
           <Table data-testid='requests-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
             <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
@@ -273,7 +273,7 @@ export function RequestsTable({
           </Table>
         </div>
       </div>
-      <div className='mt-4 flex-shrink-0'>
+      <div className='mt-2 flex-shrink-0 sm:mt-4'>
         <ServerSidePagination
           pageInfo={pageInfo}
           pageSize={pageSize}

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -378,7 +378,7 @@ export default function RequestsManagement() {
         </div>
       </Header>
 
-      <Main fixed>
+      <Main fixed className='py-2 sm:py-6'>
         <RequestsContent />
       </Main>
     </RequestsProvider>

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -373,7 +373,7 @@ export default function RequestsManagement() {
         <div className='flex flex-1 items-center justify-between'>
           <div>
             <h2 className='text-xl font-bold tracking-tight'>{t('requests.title')}</h2>
-            <p className='text-muted-foreground text-sm'>{t('requests.description')}</p>
+            <p className='text-muted-foreground hidden text-sm sm:block'>{t('requests.description')}</p>
           </div>
         </div>
       </Header>

--- a/frontend/src/hooks/use-mobile.tsx
+++ b/frontend/src/hooks/use-mobile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+export const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean>(false);

--- a/frontend/src/locales/en/base.json
+++ b/frontend/src/locales/en/base.json
@@ -137,6 +137,7 @@
   "common.columns.selectAll": "Select all",
   "common.columns.selectRow": "Select row",
   "common.filters.title": "Filters",
+  "common.filters.activeCount": "{{count}} active filters",
   "common.filters.reset": "Reset",
   "common.filters.dateRange": "Pick date range",
   "common.filters.startTime": "Start Time",

--- a/frontend/src/locales/en/base.json
+++ b/frontend/src/locales/en/base.json
@@ -136,6 +136,7 @@
   "common.columns.updatedAt": "Updated At",
   "common.columns.selectAll": "Select all",
   "common.columns.selectRow": "Select row",
+  "common.filters.title": "Filters",
   "common.filters.reset": "Reset",
   "common.filters.dateRange": "Pick date range",
   "common.filters.startTime": "Start Time",

--- a/frontend/src/locales/zh-CN/base.json
+++ b/frontend/src/locales/zh-CN/base.json
@@ -202,6 +202,7 @@
   "common.columns.selectAll": "全选",
   "common.columns.selectRow": "选择行",
   "common.filters.title": "筛选",
+  "common.filters.activeCount": "{{count}} 个筛选条件",
   "common.filters.reset": "重置",
   "common.filters.dateRange": "选择日期范围",
   "common.filters.startTime": "开始时间",

--- a/frontend/src/locales/zh-CN/base.json
+++ b/frontend/src/locales/zh-CN/base.json
@@ -201,6 +201,7 @@
   "common.columns.updatedAt": "更新时间",
   "common.columns.selectAll": "全选",
   "common.columns.selectRow": "选择行",
+  "common.filters.title": "筛选",
   "common.filters.reset": "重置",
   "common.filters.dateRange": "选择日期范围",
   "common.filters.startTime": "开始时间",


### PR DESCRIPTION
## Summary

Improved the requests management table and toolbar for mobile viewports. The toolbar now uses a collapsible sheet for filter controls on narrow screens, non-essential columns are hidden by default on mobile, and spacing/pagination elements wrap gracefully.

## Motivation

The requests table and toolbar were not usable on mobile devices — filters overflowed horizontally, too many columns competed for screen space, and the pagination bar had fixed gaps that broke on small viewports.

## Changes

### Toolbar & Filters
- **data-table-toolbar.tsx**: Extracted `RequestFilterControls` sub-component with mobile mode; added a `Sheet`-based filter drawer triggered by a Filter icon button with an active-filter-count badge; removed horizontal scroll wrapper
- **data-table-view-options.tsx**: Made the view options button visible on all viewports (was `hidden lg:flex`)

### Column Visibility
- **requests-columns.tsx**: Defined `DEFAULT_MOBILE_HIDDEN_COLUMN_IDS` (apiFormat, passThrough, reasoningEffort, stream, source, modelId, apiKey, channel, latency) for automatic hiding on narrow screens

### Table & Layout
- **requests-table.tsx**: Added reactive column visibility tied to `useIsMobile()` — hides non-essential columns when viewport < 768px, restores on desktop; reduced table/pagination margin from `mt-4` to `mt-2 sm:mt-4`; initialized column visibility state from actual `window.innerWidth` to avoid SSR hydration mismatch
- **index.tsx**: Hid description text on mobile (`hidden sm:block`); reduced main container padding to `py-2 sm:py-6`

### Pagination
- **server-side-pagination.tsx**: Replaced fixed `space-x-6/8` gaps with `flex-wrap` and responsive `gap-0 sm:gap-6 lg:gap-8`

### Formatting
- **date-range-picker/index.tsx**: Added trailing semicolons (lint fix)
- **lint.yml**: Cleaned up golangci-lint workflow — removed commented-out config placeholders, added `--enable-all` and `--max-issues-per-linter 0` flags

### Localization
- **en/base.json**, **zh-CN/base.json**: Added `common.filters.title` translation key for the mobile filter sheet

## Notes

- The `DEFAULT_MOBILE_HIDDEN_COLUMN_IDS` constant is imported by `requests-table.tsx` and used both for initial state and the reactive `useEffect` — the hook reads `window.innerWidth` directly during init to avoid the hydration mismatch that `useIsMobile()` produces on the server.
- The lint.yml changes are incidental (cleanup of commented-out workflow config).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive filtering for the requests table, including mobile controls and active-filter counts.
  * Added mobile-specific column visibility with saved preferences and responsive defaults.
  * Kept view options and pagination controls accessible across screen sizes.

* **Improvements**
  * Improved responsive spacing, wrapping, date-range labels, and toolbar layouts.
  * Added English and Simplified Chinese translations for filter labels.
  * Reduced visual clutter on small screens by hiding nonessential descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->