### PR TITLE
fix: reuse bundled Windows binary

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -134,12 +134,6 @@ function Ensure-Dirs([string]$path){ if(-not (Test-Path $path)){ New-Item -ItemT
 # Main
 Write-Info 'Starting AxonHub installation...'
 
-$Platform = Get-Platform
-Write-Info "Detected platform: $Platform"
-
-if(-not $Version){ $Version = Get-LatestVersion $IncludeBeta $IncludeRC }
-Write-Info "Using version: $Version"
-
 $BaseDir   = Join-Path $env:LOCALAPPDATA 'AxonHub'
 $ConfigDir = $BaseDir
 $DataDir   = $BaseDir
@@ -147,20 +141,40 @@ $LogDir    = $BaseDir
 Ensure-Dirs $BaseDir
 Ensure-Dirs (Join-Path $BaseDir 'logs')
 
-$AssetUrl = Get-AssetUrl $Version $Platform
-$TempDir = New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())) -Force
-$ZipPath = Join-Path $TempDir 'axonhub.zip'
-Write-Info "Downloading: $AssetUrl"
-Invoke-WebRequest -Uri $AssetUrl -OutFile $ZipPath -UseBasicParsing
-
-Write-Info 'Extracting archive...'
-Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
-
-$BinaryPath = Get-ChildItem -Path $TempDir -Recurse -Filter 'axonhub.exe' -File | Select-Object -First 1 | ForEach-Object { $_.FullName }
-if(-not $BinaryPath){ Write-Err 'axonhub.exe not found in archive'; exit 1 }
-
 $TargetBinary = Join-Path $BaseDir 'axonhub.exe'
-Copy-Item -Path $BinaryPath -Destination $TargetBinary -Force
+$BundledBinary = Join-Path $PSScriptRoot 'axonhub.exe'
+$UseBundledBinary = (Test-Path -LiteralPath $BundledBinary -PathType Leaf) -and -not $Version -and -not $IncludeBeta -and -not $IncludeRC
+
+if($UseBundledBinary){
+  Write-Info "Using bundled binary: $BundledBinary"
+  $BundledFullPath = [IO.Path]::GetFullPath($BundledBinary)
+  $TargetFullPath = [IO.Path]::GetFullPath($TargetBinary)
+  if(-not [string]::Equals($BundledFullPath, $TargetFullPath, [StringComparison]::OrdinalIgnoreCase)){
+    Copy-Item -LiteralPath $BundledBinary -Destination $TargetBinary -Force
+  } else {
+    Write-Info 'Bundled binary is already in the installation directory'
+  }
+} else {
+  $Platform = Get-Platform
+  Write-Info "Detected platform: $Platform"
+
+  if(-not $Version){ $Version = Get-LatestVersion $IncludeBeta $IncludeRC }
+  Write-Info "Using version: $Version"
+
+  $AssetUrl = Get-AssetUrl $Version $Platform
+  $TempDir = New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())) -Force
+  $ZipPath = Join-Path $TempDir 'axonhub.zip'
+  Write-Info "Downloading: $AssetUrl"
+  Invoke-WebRequest -Uri $AssetUrl -OutFile $ZipPath -UseBasicParsing
+
+  Write-Info 'Extracting archive...'
+  Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
+
+  $BinaryPath = Get-ChildItem -Path $TempDir -Recurse -Filter 'axonhub.exe' -File | Select-Object -First 1 | ForEach-Object { $_.FullName }
+  if(-not $BinaryPath){ Write-Err 'axonhub.exe not found in archive'; exit 1 }
+
+  Copy-Item -Path $BinaryPath -Destination $TargetBinary -Force
+}
 
 # Create default config if missing
 $ConfigFile = Join-Path $BaseDir 'config.yml'
@@ -202,9 +216,14 @@ Write-Success 'AxonHub installation completed!'
 $port = 8090
 if(Test-Path $TargetBinary){
   try {
-    $configPort = & $TargetBinary config get server.port 2>$null
-    if($configPort -match '^[0-9]+$'){
-      $port = $configPort
+    Push-Location -LiteralPath $BaseDir
+    try {
+      $configPort = & $TargetBinary config get server.port 2>$null
+      if($configPort -match '^[0-9]+$'){
+        $port = $configPort
+      }
+    } finally {
+      Pop-Location
     }
   } catch {}
 }

--- a/deploy/start.ps1
+++ b/deploy/start.ps1
@@ -14,7 +14,13 @@ function Write-Err([string]$m){ Write-Host "[ERROR] $m" -ForegroundColor Red }
 $ServiceName = 'axonhub'
 $BaseDir = Join-Path $env:LOCALAPPDATA 'AxonHub'
 $ConfigFile = Join-Path $BaseDir 'config.yml'
-$BinaryPath = Join-Path $BaseDir 'axonhub.exe'
+$InstalledBinaryPath = Join-Path $BaseDir 'axonhub.exe'
+$BundledBinaryPath = Join-Path $PSScriptRoot 'axonhub.exe'
+$BinaryPath = $InstalledBinaryPath
+# Prefer the installed binary so upgrades take effect, but allow release archives to run in place.
+if(-not (Test-Path -LiteralPath $InstalledBinaryPath -PathType Leaf) -and (Test-Path -LiteralPath $BundledBinaryPath -PathType Leaf)){
+  $BinaryPath = $BundledBinaryPath
+}
 $PidFile = Join-Path $BaseDir 'axonhub.pid'
 $LogFile = Join-Path $BaseDir 'axonhub.log'
 $DefaultPort = 8090
@@ -40,12 +46,17 @@ function Ensure-Dirs([string]$path){ if(-not (Test-Path $path)){ New-Item -ItemT
 
 function Get-ConfiguredPort {
   $port = $DefaultPort
-  if(Test-Path $BinaryPath){
+  if(Test-Path -LiteralPath $BinaryPath -PathType Leaf){
     try {
-      $configPort = $null
-      $configPort = & $BinaryPath config get server.port 2>$null
-      if($configPort -match '^[0-9]+$'){
-        $port = [int]$configPort
+      Push-Location -LiteralPath $BaseDir
+      try {
+        $configPort = $null
+        $configPort = & $BinaryPath config get server.port 2>$null
+        if($configPort -match '^[0-9]+$'){
+          $port = [int]$configPort
+        }
+      } finally {
+        Pop-Location
       }
     } catch {}
   }
@@ -70,8 +81,8 @@ $stderrTempFile = Join-Path $env:TEMP ("axonhub-" + [guid]::NewGuid().ToString()
 
 Write-Info 'Starting AxonHub...'
 
-if(-not (Test-Path $BinaryPath)){
-  Write-Err "AxonHub binary not found at $BinaryPath"
+if(-not (Test-Path -LiteralPath $BinaryPath -PathType Leaf)){
+  Write-Err "AxonHub binary not found at $InstalledBinaryPath or $BundledBinaryPath"
   Write-Info 'Please run the installer first: install.bat'
   exit 1
 }
@@ -103,7 +114,7 @@ if(-not (Check-Port $port)){
 
 $ConfigArgs = @()
 if(Test-Path $ConfigFile){ 
-  # Config exists, binary will auto-detect it from $HOME/.config/axonhub/
+  # The process working directory below makes this config discoverable.
   Write-Info "Configuration found at $ConfigFile, binary will auto-detect it" 
 } else { 
   Write-Warn "Configuration not found at $ConfigFile, starting with defaults" 
@@ -112,9 +123,9 @@ if(Test-Path $ConfigFile){
 Write-Info 'Starting AxonHub process...'
 try {
   if($ConfigArgs.Count -gt 0){
-    $p = Start-Process -FilePath $BinaryPath -ArgumentList $ConfigArgs -RedirectStandardOutput $stdoutTempFile -RedirectStandardError $stderrTempFile -PassThru -WindowStyle Hidden
+    $p = Start-Process -FilePath $BinaryPath -ArgumentList $ConfigArgs -WorkingDirectory $BaseDir -RedirectStandardOutput $stdoutTempFile -RedirectStandardError $stderrTempFile -PassThru -WindowStyle Hidden
   } else {
-    $p = Start-Process -FilePath $BinaryPath -RedirectStandardOutput $stdoutTempFile -RedirectStandardError $stderrTempFile -PassThru -WindowStyle Hidden
+    $p = Start-Process -FilePath $BinaryPath -WorkingDirectory $BaseDir -RedirectStandardOutput $stdoutTempFile -RedirectStandardError $stderrTempFile -PassThru -WindowStyle Hidden
   }
   Start-Sleep -Seconds 2
   if($p -and (Get-Process -Id $p.Id -ErrorAction SilentlyContinue)){


### PR DESCRIPTION
## Summary

- reuse the `axonhub.exe` bundled with Windows release archives during a default install instead of downloading it again
- keep explicit version, beta, and release-candidate selections on the existing download path
- let `start.bat` fall back to the bundled executable when no installed binary exists
- run config lookups and the AxonHub process from `%LOCALAPPDATA%\AxonHub`

## Why

Windows release archives already contain `axonhub.exe`, but the scripts ignored it. A fresh archive therefore could not start directly, the installer downloaded the same binary again, and AxonHub inherited the extraction directory as its working directory. The latter caused the default SQLite files to be created beside the archive scripts rather than under LocalAppData.

The installed executable remains preferred when present so that `upgrade.bat` updates continue to take effect.

## Validation

- parsed `deploy/install.ps1` and `deploy/start.ps1` with the Windows PowerShell AST parser: zero errors
- verified both `--help` entry points under Windows PowerShell 5.1
- ran isolated fixtures covering bundled install without network access, bundled startup, installed-binary precedence, same source/target installation, explicit-version fallback, LocalAppData config/process working directories, and bracketed extraction paths
- ran `git diff --check upstream/unstable...HEAD`

Lint and build were not run per the repository's `AGENTS.md`; this change only affects Windows deployment scripts.

Closes #2098


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation and startup reliability when using bundled or installed application binaries.
  * Preserved the correct working directory during port detection and startup, enabling configuration files to be discovered consistently.
  * Enhanced binary validation and error reporting when executable files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->