### PR TITLE
fix: 修正拼写错误“oltphttp”->“otlphttp”

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -144,7 +144,7 @@ log:
 metrics:
   enabled: false                 # Enable metrics collection (env: AXONHUB_METRICS_ENABLED)
   exporter: 
-    type: "oltphttp"          # Metrics exporter type: prometheus, console (env: AXONHUB_METRICS_EXPORTER_TYPE)
+    type: "otlphttp"          # Metrics exporter type: prometheus, console (env: AXONHUB_METRICS_EXPORTER_TYPE)
     endpoint: "localhost:8080" # Metrics exporter endpoint (env: AXONHUB_METRICS_EXPORTER_ENDPOINT)
     insecure: true             # Enable insecure connection (env: AXONHUB_METRICS_EXPORTER_INSECURE)
     

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -296,7 +296,7 @@ log:
 metrics:
   enabled: false                 # Enable metrics collection
   exporter:
-    type: "oltphttp"            # prometheus, console
+    type: "otlphttp"            # prometheus, console
     endpoint: "localhost:8080"  # Metrics exporter endpoint
     insecure: true              # Enable insecure connection
 ```

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -297,7 +297,7 @@ log:
 metrics:
   enabled: false                 # 启用指标收集
   exporter:
-    type: "oltphttp"            # prometheus, console
+    type: "otlphttp"            # prometheus, console
     endpoint: "localhost:8080"  # 指标导出器端点
     insecure: true              # 启用不安全连接
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the metrics exporter type value to `otlphttp`, ensuring valid configuration.

* **Documentation**
  * Updated English and Chinese configuration examples to use the corrected exporter type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->