### PR TITLE
fix(frontend): load theme fonts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,13 +23,13 @@
     <link
       rel="preload"
       as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Manrope:wght@200..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:wght@100..800&family=Manrope:wght@200..800&family=Montserrat:wght@100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Source+Serif+4:opsz,wght@8..60,200..900&display=swap"
       onload="this.onload=null;this.rel='stylesheet'"
     />
     <noscript>
       <link
         rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Manrope:wght@200..800&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:wght@100..800&family=Manrope:wght@200..800&family=Montserrat:wght@100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Source+Serif+4:opsz,wght@8..60,200..900&display=swap"
       />
     </noscript>
 


### PR DESCRIPTION
## Summary
- extend the Google Fonts preload and noscript URLs to include fonts already referenced by frontend themes
- keep the existing font stacks unchanged, including Apple native font fallbacks

## Verification
- lsp_diagnostics frontend/index.html: no diagnostics
- not run: build/lint (project instructions say not to run unless explicitly requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded font support with additional typefaces, including Fira Code, JetBrains Mono, Montserrat, Open Sans, and Source Serif 4.
  * Improved font loading and fallback behavior across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->