### PR TITLE
fix(analytics): support MySQL for channel stats

### DIFF
--- a/internal/server/gql/analytics_helpers.go
+++ b/internal/server/gql/analytics_helpers.go
@@ -163,7 +163,18 @@ type dimStats struct {
 }
 
 func (r *queryResolver) queryChannelStats(ctx context.Context, filter *AnalyticsFilter, apiKeyIDs []int, hasUserFilter bool, loc *time.Location) ([]dimStats, error) {
-	var results []dimStats
+	type channelStatsRaw struct {
+		ChannelID    int     `json:"channel_id"`
+		Name         string  `json:"name"`
+		RequestCount int     `json:"request_count"`
+		InputTokens  int64   `json:"input_tokens"`
+		CachedTokens int64   `json:"cached_tokens"`
+		OutputTokens int64   `json:"output_tokens"`
+		TotalTokens  int64   `json:"total_tokens"`
+		Cost         float64 `json:"cost"`
+	}
+
+	var rawResults []channelStatsRaw
 
 	err := r.client.UsageLog.Query().
 		Modify(func(s *sql.Selector) {
@@ -177,7 +188,7 @@ func (r *queryResolver) queryChannelStats(ctx context.Context, filter *Analytics
 			r.buildAnalyticsWhere(s, filter, apiKeyIDs, hasUserFilter, loc)
 
 			s.Select(
-				sql.As(fmt.Sprintf("CAST(%s AS TEXT)", s.C(usagelog.FieldChannelID)), "id"),
+				sql.As(s.C(usagelog.FieldChannelID), "channel_id"),
 				sql.As(channelTable.C(channel.FieldName), "name"),
 				sql.As(sql.Count(s.C(usagelog.FieldID)), "request_count"),
 				sql.As(fmt.Sprintf("COALESCE(SUM(%s), 0)", s.C(usagelog.FieldPromptTokens)), "input_tokens"),
@@ -189,9 +200,24 @@ func (r *queryResolver) queryChannelStats(ctx context.Context, filter *Analytics
 				GroupBy(s.C(usagelog.FieldChannelID), channelTable.C(channel.FieldName)).
 				OrderBy(sql.Desc("total_tokens"))
 		}).
-		Scan(ctx, &results)
+		Scan(ctx, &rawResults)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get analytics stats by channel: %w", err)
+	}
+
+	results := make([]dimStats, 0, len(rawResults))
+
+	for _, raw := range rawResults {
+		results = append(results, dimStats{
+			ID:           fmt.Sprintf("%d", raw.ChannelID),
+			Name:         raw.Name,
+			RequestCount: raw.RequestCount,
+			InputTokens:  raw.InputTokens,
+			CachedTokens: raw.CachedTokens,
+			OutputTokens: raw.OutputTokens,
+			TotalTokens:  raw.TotalTokens,
+			Cost:         raw.Cost,
+		})
 	}
 
 	return results, nil


### PR DESCRIPTION
## 问题

`analyticsDimensionStats` 的渠道（channel）维度查询在 MySQL 上报 SQL 语法错误 1064。
根因是 `queryChannelStats` 使用 `CAST(channel_id AS TEXT)` 构造 ID，而 MySQL 的 CAST 目标类型不支持 `TEXT`（只在 SQLite / PostgreSQL 下可用）。

## 修复

将 channel 维度改为与其他维度（apiKey / user）一致的既有范式：

- SQL 层直接扫描整型 `channel_id`，移除 `CAST(... AS TEXT)`
- Go 层用 `fmt.Sprintf("%d", ...)` 转为字符串 ID

SQL 层不再有任何方言相关的类型转换，MySQL / SQLite / PostgreSQL 均可正常执行。

Close #2096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading channel analytics by ensuring channel identifiers are handled consistently.
  * Preserved existing error handling for analytics queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->