### PR TITLE
feat: add configurable max_multipart_memory for backup restore

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -238,8 +238,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.disable_ssl_verify", false)
 
 	// Max multipart memory for file uploads (backup restore, etc.)
-	// Default: 32 MB (matching Gin's default). Increase for large backup files.
-	v.SetDefault("server.max_multipart_memory", 32<<20)
+	// Default: 32M (matching Gin's default). Supports K/M/G suffixes, e.g. "512M", "1G".
+	v.SetDefault("server.max_multipart_memory", "32M")
 
 	// CORS defaults
 	v.SetDefault("server.cors.enabled", false)

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -237,6 +237,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.debug", false)
 	v.SetDefault("server.disable_ssl_verify", false)
 
+	// Max multipart memory for file uploads (backup restore, etc.)
+	// Default: 32 MB (matching Gin's default). Increase for large backup files.
+	v.SetDefault("server.max_multipart_memory", 32<<20)
+
 	// CORS defaults
 	v.SetDefault("server.cors.enabled", false)
 	v.SetDefault("server.cors.debug", false)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -1,10 +1,62 @@
 package server
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/looplj/axonhub/internal/tracing"
 )
+
+// MemorySize represents a memory size that can be parsed from human-readable
+// strings like "512M", "1.5G", "64K". Supports K, M, G suffixes (case-insensitive,
+// optional 'B' suffix e.g. "512MB").
+type MemorySize int64
+
+// UnmarshalText implements encoding.TextUnmarshaler for human-readable config values.
+func (m *MemorySize) UnmarshalText(text []byte) error {
+	s := strings.TrimSpace(string(text))
+	if s == "" {
+		*m = 0
+		return nil
+	}
+
+	// Try plain int64 first (e.g. "536870912")
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		*m = MemorySize(v)
+		return nil
+	}
+
+	// Parse human-readable: "512M", "1.5G", "64K", "512MB"
+	s = strings.ToUpper(strings.TrimSuffix(s, "B"))
+	if len(s) < 2 {
+		return fmt.Errorf("invalid memory size: %q", string(text))
+	}
+
+	suffix := s[len(s)-1]
+	numStr := s[:len(s)-1]
+
+	val, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return fmt.Errorf("invalid memory size number: %q", string(text))
+	}
+
+	var multiplier int64
+	switch suffix {
+	case 'K':
+		multiplier = 1 << 10
+	case 'M':
+		multiplier = 1 << 20
+	case 'G':
+		multiplier = 1 << 30
+	default:
+		return fmt.Errorf("unknown memory size suffix: %q (use K, M, or G)", string(text))
+	}
+
+	*m = MemorySize(int64(val * float64(multiplier)))
+	return nil
+}
 
 type Config struct {
 	Host        string        `conf:"host" yaml:"host" json:"host"`
@@ -33,7 +85,7 @@ type Config struct {
 	// MaxMultipartMemory sets the maximum memory for parsing multipart forms (in bytes).
 	// This is important for backup restore which uploads large backup files.
 	// Default: 32 MB. Increase this if you have large backup files.
-	MaxMultipartMemory int64 `conf:"max_multipart_memory" yaml:"max_multipart_memory" json:"max_multipart_memory"`
+	MaxMultipartMemory MemorySize `conf:"max_multipart_memory" yaml:"max_multipart_memory" json:"max_multipart_memory"`
 }
 
 // Dashboard holds configuration for the dashboard cache settings.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -29,6 +29,11 @@ type Config struct {
 	CORS             CORS            `conf:"cors" yaml:"cors" json:"cors"`
 	API              API             `conf:"api" yaml:"api" json:"api"`
 	IPAccessControl  IPAccessControl `conf:"ip_access_control" yaml:"ip_access_control" json:"ip_access_control"`
+
+	// MaxMultipartMemory sets the maximum memory for parsing multipart forms (in bytes).
+	// This is important for backup restore which uploads large backup files.
+	// Default: 32 MB. Increase this if you have large backup files.
+	MaxMultipartMemory int64 `conf:"max_multipart_memory" yaml:"max_multipart_memory" json:"max_multipart_memory"`
 }
 
 // Dashboard holds configuration for the dashboard cache settings.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,13 @@ func New(config Config) *Server {
 	}
 
 	engine := gin.New()
+
+	// Set max multipart memory for file uploads (e.g., backup restore).
+	// Default 32 MB may be insufficient for large backup files.
+	if config.MaxMultipartMemory > 0 {
+		engine.MaxMultipartMemory = config.MaxMultipartMemory
+	}
+
 	engine.Use(middleware.Recovery())
 
 	return &Server{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,7 +35,7 @@ func New(config Config) *Server {
 	// Set max multipart memory for file uploads (e.g., backup restore).
 	// Default 32 MB may be insufficient for large backup files.
 	if config.MaxMultipartMemory > 0 {
-		engine.MaxMultipartMemory = config.MaxMultipartMemory
+		engine.MaxMultipartMemory = int64(config.MaxMultipartMemory)
 	}
 
 	engine.Use(middleware.Recovery())


### PR DESCRIPTION
## Problem
When restoring backups via multipart file upload, Gin's default `MaxMultipartMemory` (32MB) causes "request body too large" errors for backup files exceeding this limit.

## Solution
- Adds `server.max_multipart_memory` config field with a `MemorySize` type
- `MemorySize` implements `TextUnmarshaler`, supporting human-readable formats:
  - `"512M"` / `"1G"` / `"64K"` (suffix, case-insensitive)
  - `"512MB"` / `"1GB"` (optional B suffix)
  - `"536870912"` (plain integer bytes)
- Sets `engine.MaxMultipartMemory` from config in `server.New()`
- Defaults to `"32M"`, maintaining backward compatibility
- Supports both `config.yml` and env var `AXONHUB_SERVER_MAX_MULTIPART_MEMORY`

## Usage
```yaml
server:
  max_multipart_memory: "512M"  # or "1G", "536870912", etc.
```

## Files
- `conf/conf.go` - Default value
- `internal/server/config.go` - MemorySize type + Config field
- `internal/server/server.go` - Apply to Gin engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable memory limits for multipart form uploads.
  * Increased support for larger file uploads, including backup restores, when configured.
  * Added a default upload memory limit of 32 MiB.
  * Supports memory values in bytes or with K, M, and G suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->