### PR TITLE
fix(openai): keep message content valid for strict upstreams

### DIFF
--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -186,6 +186,16 @@ func MessageFromLLMWithConfig(m llm.Message, reasoningField ReasoningField) Mess
 		})
 	}
 
+	// An assistant turn that only requests tool calls has no content to send, and
+	// a message whose parts were all filtered out (e.g. compaction) is left with an
+	// empty part list. Both cases would reach the wire as a missing or null content
+	// field, which the OpenAI spec permits but stricter OpenAI-compatible upstreams
+	// reject because their schema only accepts a string or an array. Normalize to an
+	// empty string, which every implementation accepts and OpenAI treats as no content.
+	if len(msg.ToolCalls) > 0 && msg.Content.Content == nil && len(msg.Content.MultipleContent) == 0 {
+		msg.Content = MessageContent{Content: lo.ToPtr("")}
+	}
+
 	// Convert Annotations
 	if len(m.Annotations) > 0 {
 		msg.Annotations = lo.Map(m.Annotations, func(a llm.Annotation, _ int) Annotation {
@@ -237,7 +247,7 @@ func MessageContentFromLLM(c llm.MessageContent) MessageContent {
 // MessageContentPartFromLLM creates OpenAI MessageContentPart from unified llm.MessageContentPart.
 func MessageContentPartFromLLM(p llm.MessageContentPart) MessageContentPart {
 	part := MessageContentPart{
-		Type: p.Type,
+		Type: normalizeContentPartType(p.Type),
 		Text: p.Text,
 	}
 
@@ -262,6 +272,20 @@ func MessageContentPartFromLLM(p llm.MessageContentPart) MessageContentPart {
 	}
 
 	return part
+}
+
+// normalizeContentPartType maps Responses-only text part types onto the plain
+// "text" type used by Chat Completions. The Responses API distinguishes input
+// from output text, but Chat Completions has a single text part type, and strict
+// OpenAI-compatible upstreams reject the ones they do not know. Types that Chat
+// Completions does understand (image_url, video_url, input_audio, ...) pass through.
+func normalizeContentPartType(partType string) string {
+	switch partType {
+	case "input_text", "output_text":
+		return "text"
+	default:
+		return partType
+	}
 }
 
 // ToolFromLLM creates OpenAI Tool from unified llm.Tool.

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/samber/lo"
@@ -628,4 +629,152 @@ func TestRequestFromLLM_PreservesReasoningEffort(t *testing.T) {
 
 	require.NotNil(t, req)
 	require.Equal(t, "xhigh", req.ReasoningEffort, "RequestFromLLM must keep reasoning_effort unchanged; mapping happens in TransformRequest")
+}
+
+// Assistant messages that carry tool calls but no content must still serialize a
+// content field. Omitting it (nil content) or emitting null (all parts filtered
+// out) is accepted by OpenAI but rejected by stricter OpenAI-compatible upstreams
+// whose schema only allows a string or an array.
+func TestMessageFromLLM_ToolCallOnlyMessageKeepsContentField(t *testing.T) {
+	toolCalls := []llm.ToolCall{
+		{
+			ID:   "call_1",
+			Type: "function",
+			Function: llm.FunctionCall{
+				Name:      "shell_command",
+				Arguments: `{"command":"ls"}`,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		message llm.Message
+	}{
+		{
+			name: "no content at all",
+			message: llm.Message{
+				Role:      "assistant",
+				ToolCalls: toolCalls,
+			},
+		},
+		{
+			name: "every content part filtered out",
+			message: llm.Message{
+				Role: "assistant",
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{
+							Type:    "compaction",
+							Compact: &llm.CompactContent{ID: "cmp_1", EncryptedContent: "secret"},
+						},
+					},
+				},
+				ToolCalls: toolCalls,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := MessageFromLLM(tt.message)
+
+			data, err := json.Marshal(msg)
+			require.NoError(t, err)
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(data, &decoded))
+
+			content, ok := decoded["content"]
+			require.True(t, ok, "content field must be present, got %s", data)
+			require.NotNil(t, content, "content must not be null, got %s", data)
+			require.Equal(t, "", content)
+		})
+	}
+}
+
+// Content that survives conversion must be preserved as-is.
+func TestMessageFromLLM_ToolCallMessageKeepsExistingContent(t *testing.T) {
+	msg := MessageFromLLM(llm.Message{
+		Role:    "assistant",
+		Content: llm.MessageContent{Content: lo.ToPtr("calling a tool")},
+		ToolCalls: []llm.ToolCall{
+			{
+				ID:       "call_1",
+				Type:     "function",
+				Function: llm.FunctionCall{Name: "shell_command", Arguments: "{}"},
+			},
+		},
+	})
+
+	require.NotNil(t, msg.Content.Content)
+	require.Equal(t, "calling a tool", *msg.Content.Content)
+}
+
+// Messages without tool calls keep their existing serialization, so the
+// normalization above cannot change unrelated payloads.
+func TestMessageFromLLM_WithoutToolCallsContentUnchanged(t *testing.T) {
+	msg := MessageFromLLM(llm.Message{Role: "user"})
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	_, ok := decoded["content"]
+	require.False(t, ok, "content must stay omitted for messages without tool calls, got %s", data)
+}
+
+// Responses splits text parts into input_text/output_text, but Chat Completions
+// only knows "text". Types it does understand must not be rewritten.
+func TestMessageContentPartFromLLM_NormalizesTextPartTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		partType string
+		expected string
+	}{
+		{name: "input_text becomes text", partType: "input_text", expected: "text"},
+		{name: "output_text becomes text", partType: "output_text", expected: "text"},
+		{name: "text is unchanged", partType: "text", expected: "text"},
+		{name: "image_url is unchanged", partType: "image_url", expected: "image_url"},
+		{name: "video_url is unchanged", partType: "video_url", expected: "video_url"},
+		{name: "input_audio is unchanged", partType: "input_audio", expected: "input_audio"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			part := MessageContentPartFromLLM(llm.MessageContentPart{
+				Type: tt.partType,
+				Text: lo.ToPtr("hello"),
+			})
+
+			require.Equal(t, tt.expected, part.Type)
+		})
+	}
+}
+
+// Multi-part content is the path where Responses text types actually reach an
+// upstream: a lone text part is collapsed into a plain string before this point.
+func TestRequestFromLLM_NormalizesTextPartTypesInMessages(t *testing.T) {
+	req := RequestFromLLM(&llm.Request{
+		Model: "gpt-4o",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					MultipleContent: []llm.MessageContentPart{
+						{Type: "input_text", Text: lo.ToPtr("describe this")},
+						{Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://example.com/a.png"}},
+					},
+				},
+			},
+		},
+	}, ReasoningFieldNone)
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 1)
+	require.Len(t, req.Messages[0].Content.MultipleContent, 2)
+	require.Equal(t, "text", req.Messages[0].Content.MultipleContent[0].Type)
+	require.Equal(t, "image_url", req.Messages[0].Content.MultipleContent[1].Type)
 }


### PR DESCRIPTION
## Problem

Two issues make requests fail against strict OpenAI-compatible upstreams when a Responses-protocol client (e.g. Codex CLI) is routed to a Chat Completions channel.

**1. Missing or null `content`**

An assistant message that only requests tool calls has no content, so `content` is omitted entirely by `omitzero`. A message whose content parts were all filtered out (compaction) serializes as `content: null` instead, because `lo.FilterMap` returns a non-nil empty slice and `MarshalJSON` falls through to the nil `Content` pointer.

Both are legal per the OpenAI spec, but upstreams whose schema types content as `string | ContentPart[]` reject them:

```
{"error":{"message":"body/messages/6/content Invalid input","type":"invalid_request_error"}}
```

This surfaces mid-conversation — the first turns succeed, and the request only fails once the assistant emits a turn with no text alongside its tool call.

**2. Responses-only content part types**

Responses distinguishes `input_text` from `output_text`; Chat Completions has a single `text` part type. `MessageContentPartFromLLM` copied the type verbatim, so upstreams saw part types they don't know.

Single text parts are collapsed into a plain string earlier in `convertToMessageContent`, which is why this only shows up with multi-part content (e.g. text alongside an image).

## Fix

- Normalize content to `""` for assistant messages that have tool calls but no usable content. OpenAI treats it the same as null, and strict upstreams accept it. The condition is scoped to messages with tool calls, so every other message keeps its current serialization.
- Map `input_text`/`output_text` onto `text`. Types Chat Completions does understand (`image_url`, `video_url`, `input_audio`) pass through untouched.

## Tests

Five new tests in `outbound_convert_test.go`:

- tool-call-only messages keep a `content` field, for both the missing-field and the all-parts-filtered cases
- existing content on a tool-call message is preserved
- messages without tool calls keep their current serialization (content stays omitted)
- part type normalization, including the types that must not be rewritten
- end-to-end through `RequestFromLLM` with multi-part content

`internal/server/orchestrator` and `internal/server/biz` suites pass. Three pre-existing failures in the `llm` module (two missing testdata fixtures, one Windows-specific websocket error string) are unrelated and reproduce on an unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with stricter Chat Completions providers when sending assistant messages containing tool calls.
  * Ensured tool-call messages use valid empty content when no text is present.
  * Preserved existing message content while filtering unsupported or empty content parts.
  * Normalized supported input and output text parts to the standard `text` format.
  * Preserved non-text content types and multipart message content where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->