### PR TITLE
feat(cline): fetch recommended models dynamically

### DIFF
--- a/internal/server/biz/channel_model_sync.go
+++ b/internal/server/biz/channel_model_sync.go
@@ -83,6 +83,9 @@ func (svc *ChannelService) syncChannelModelsForChannel(ctx context.Context, ch *
 	if result.Error != nil {
 		return nil, false, fmt.Errorf("model fetch returned error: %s", *result.Error)
 	}
+	if result.Fallback {
+		return nil, false, fmt.Errorf("model fetch returned fallback models")
+	}
 
 	// Extract model IDs from fetched models
 	fetchedModelIDs := lo.Map(result.Models, func(m ModelIdentify, _ int) string {

--- a/internal/server/biz/channel_model_sync_test.go
+++ b/internal/server/biz/channel_model_sync_test.go
@@ -3,8 +3,10 @@ package biz
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/samber/lo"
@@ -20,7 +22,14 @@ import (
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xcache/live"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/cline"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 type channelSyncNotifierSpy struct {
 	notifyCount int
@@ -176,6 +185,45 @@ func TestChannelService_SyncChannelModelsAutoConfiguresMissingPrices(t *testing.
 	require.NoError(t, err)
 	require.Len(t, retriedVersions, 1)
 	require.Equal(t, retriedPrice.ReferenceID, retriedVersions[0].ReferenceID)
+}
+
+func TestChannelService_ClineModelSyncPreservesModelsOnDiscoveryFallback(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+	svc.httpClient = httpclient.NewHttpClientWithClient(&http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, cline.RecommendedModelsURL, req.URL.String())
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Status:     "502 Bad Gateway",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"temporary outage"}`)),
+			Request:    req,
+		}, nil
+	})})
+
+	existingModels := []string{
+		"zai/glm-5.2",
+		"cline-free/glm-5.2",
+		"cline-pass/deepseek-v4-flash",
+	}
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeCline).
+		SetName("Cline degraded sync").
+		SetBaseURL("https://api.cline.bot/api/v1").
+		SetCredentials(objects.ChannelCredentials{APIKeys: []string{"test-key"}}).
+		SetSupportedModels(existingModels).
+		SetDefaultTestModel("cline-pass/deepseek-v4-flash").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = svc.SyncChannelModels(ctx, ch.ID, nil)
+	require.ErrorContains(t, err, "fallback")
+
+	persisted, err := client.Channel.Get(ctx, ch.ID)
+	require.NoError(t, err)
+	assert.Equal(t, existingModels, persisted.SupportedModels)
 }
 
 func TestChannelService_ModelSyncIgnoresProviderOnlyOrderChanges(t *testing.T) {

--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -209,22 +209,26 @@ func (f *ModelFetcher) fetchGeminiVertexModels(ctx context.Context) []ModelIdent
 	return f.geminiVertexFetcher.fetch(ctx, f.httpClient)
 }
 
+// clineRecommendedModel identifies a model returned by Cline's recommended-models endpoint.
 type clineRecommendedModel struct {
 	ID string `json:"id"`
 }
 
+// clineRecommendedModelsResponse groups Cline models by recommendation and billing category.
 type clineRecommendedModelsResponse struct {
 	Recommended []clineRecommendedModel `json:"recommended"`
 	Free        []clineRecommendedModel `json:"free"`
 	ClinePass   []clineRecommendedModel `json:"clinePass"`
 }
 
+// clineFallbackModels returns the static Cline Pass models used when discovery is degraded.
 func clineFallbackModels() []ModelIdentify {
 	return lo.Map(cline.DefaultModels(), func(id string, _ int) ModelIdentify {
 		return ModelIdentify{ID: id}
 	})
 }
 
+// appendUniqueClineModels appends non-empty model IDs while preserving their first-seen order.
 func appendUniqueClineModels(models []ModelIdentify, seen map[string]struct{}, entries []clineRecommendedModel) []ModelIdentify {
 	for _, entry := range entries {
 		id := strings.TrimSpace(entry.ID)
@@ -242,12 +246,14 @@ func appendUniqueClineModels(models []ModelIdentify, seen map[string]struct{}, e
 	return models
 }
 
+// hasUsableClineModel reports whether a model group contains at least one non-empty ID.
 func hasUsableClineModel(entries []clineRecommendedModel) bool {
 	return lo.SomeBy(entries, func(entry clineRecommendedModel) bool {
 		return strings.TrimSpace(entry.ID) != ""
 	})
 }
 
+// fetchClineRecommendedModels fetches the public Cline catalog and reports whether static fallback data was used.
 func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context, httpClient *httpclient.HttpClient) ([]ModelIdentify, bool) {
 	fallback := clineFallbackModels()
 	req := &httpclient.Request{
@@ -283,7 +289,7 @@ func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context, httpClie
 	usedFallback := !hasUsableClineModel(response.ClinePass)
 	if usedFallback {
 		fallbackEntries := lo.Map(fallback, func(model ModelIdentify, _ int) clineRecommendedModel {
-			return clineRecommendedModel{ID: model.ID}
+			return clineRecommendedModel(model)
 		})
 		models = appendUniqueClineModels(models, seen, fallbackEntries)
 	}

--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -30,10 +30,11 @@ const providerConfCacheDuration = 1 * time.Hour
 
 // ModelFetcher handles fetching models from provider APIs.
 type ModelFetcher struct {
-	httpClient          *httpclient.HttpClient
-	channelService      *ChannelService
-	copilotFetcher      *providerConfFetcher
-	geminiVertexFetcher *providerConfFetcher
+	httpClient                *httpclient.HttpClient
+	channelService            *ChannelService
+	clineRecommendedModelsURL string
+	copilotFetcher            *providerConfFetcher
+	geminiVertexFetcher       *providerConfFetcher
 }
 
 // providerConfFetcher handles fetching models from PublicProviderConf with caching.
@@ -141,8 +142,9 @@ func (f *providerConfFetcher) fetchFromSource(ctx context.Context, httpClient *h
 // NewModelFetcher creates a new ModelFetcher instance.
 func NewModelFetcher(httpClient *httpclient.HttpClient, channelService *ChannelService) *ModelFetcher {
 	return &ModelFetcher{
-		httpClient:     httpClient,
-		channelService: channelService,
+		httpClient:                httpClient,
+		channelService:            channelService,
+		clineRecommendedModelsURL: cline.RecommendedModelsURL,
 		copilotFetcher: &providerConfFetcher{
 			cacheDuration: providerConfCacheDuration,
 			providerURL:   copilot.ProviderConfURL,
@@ -178,8 +180,6 @@ func (f *ModelFetcher) getDefaultModelsByType(ctx context.Context, typ channel.T
 		return lo.Map(antigravity.DefaultModels(), func(id string, _ int) ModelIdentify { return ModelIdentify{ID: id} })
 	case channel.TypeCodex:
 		return lo.Map(codex.DefaultModels(), func(id string, _ int) ModelIdentify { return ModelIdentify{ID: id} })
-	case channel.TypeCline:
-		return lo.Map(cline.DefaultModels(), func(id string, _ int) ModelIdentify { return ModelIdentify{ID: id} })
 	case channel.TypeClaudecode:
 		return lo.Map(claudecode.DefaultModels(), func(id string, _ int) ModelIdentify { return ModelIdentify{ID: id} })
 	case channel.TypeGithubCopilot:
@@ -206,6 +206,91 @@ func (f *ModelFetcher) fetchCopilotModels(ctx context.Context) []ModelIdentify {
 // fetchGeminiVertexModels fetches Gemini Vertex models from PublicProviderConf with caching.
 func (f *ModelFetcher) fetchGeminiVertexModels(ctx context.Context) []ModelIdentify {
 	return f.geminiVertexFetcher.fetch(ctx, f.httpClient)
+}
+
+type clineRecommendedModel struct {
+	ID string `json:"id"`
+}
+
+type clineRecommendedModelsResponse struct {
+	Recommended []clineRecommendedModel `json:"recommended"`
+	Free        []clineRecommendedModel `json:"free"`
+	ClinePass   []clineRecommendedModel `json:"clinePass"`
+}
+
+func clineFallbackModels() []ModelIdentify {
+	return lo.Map(cline.DefaultModels(), func(id string, _ int) ModelIdentify {
+		return ModelIdentify{ID: id}
+	})
+}
+
+func appendUniqueClineModels(models []ModelIdentify, seen map[string]struct{}, entries []clineRecommendedModel) []ModelIdentify {
+	for _, entry := range entries {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		models = append(models, ModelIdentify{ID: id})
+	}
+
+	return models
+}
+
+func hasUsableClineModel(entries []clineRecommendedModel) bool {
+	return lo.SomeBy(entries, func(entry clineRecommendedModel) bool {
+		return strings.TrimSpace(entry.ID) != ""
+	})
+}
+
+func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context) []ModelIdentify {
+	fallback := clineFallbackModels()
+	req := &httpclient.Request{
+		Method: http.MethodGet,
+		URL:    f.clineRecommendedModelsURL,
+		Headers: http.Header{
+			"Accept": []string{"application/json"},
+		},
+	}
+
+	resp, err := f.httpClient.Do(ctx, req)
+	if err != nil {
+		slog.Warn("failed to fetch Cline recommended models", "error", err)
+		return fallback
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("failed to fetch Cline recommended models", "statusCode", resp.StatusCode)
+		return fallback
+	}
+
+	var response clineRecommendedModelsResponse
+	if err := json.Unmarshal(resp.Body, &response); err != nil {
+		slog.Warn("failed to parse Cline recommended models", "error", err)
+		return fallback
+	}
+
+	models := make([]ModelIdentify, 0, len(response.Recommended)+len(response.Free)+len(response.ClinePass))
+	seen := make(map[string]struct{}, cap(models))
+	models = appendUniqueClineModels(models, seen, response.Recommended)
+	models = appendUniqueClineModels(models, seen, response.Free)
+
+	models = appendUniqueClineModels(models, seen, response.ClinePass)
+	if !hasUsableClineModel(response.ClinePass) {
+		fallbackEntries := lo.Map(fallback, func(model ModelIdentify, _ int) clineRecommendedModel {
+			return clineRecommendedModel{ID: model.ID}
+		})
+		models = appendUniqueClineModels(models, seen, fallbackEntries)
+	}
+
+	if len(models) == 0 {
+		return fallback
+	}
+
+	return models
 }
 
 func (f *ModelFetcher) tryReturnDefaultModels(ctx context.Context, channelType string) (*FetchModelsResult, bool) {
@@ -239,6 +324,10 @@ func (f *ModelFetcher) FetchModels(ctx context.Context, input FetchModelsInput) 
 		return &FetchModelsResult{
 			Models: []ModelIdentify{},
 		}, nil
+	}
+
+	if input.ChannelType == channel.TypeCline.String() {
+		return &FetchModelsResult{Models: f.fetchClineRecommendedModels(ctx)}, nil
 	}
 
 	if result, ok := f.tryReturnDefaultModels(ctx, input.ChannelType); ok {

--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -167,8 +167,9 @@ type FetchModelsInput struct {
 
 // FetchModelsResult represents the result of fetching models.
 type FetchModelsResult struct {
-	Models []ModelIdentify
-	Error  *string
+	Models   []ModelIdentify
+	Error    *string
+	Fallback bool
 }
 
 var qiniuFallbackModels = []ModelIdentify{{ID: "deepseek-v3"}}
@@ -247,7 +248,7 @@ func hasUsableClineModel(entries []clineRecommendedModel) bool {
 	})
 }
 
-func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context) []ModelIdentify {
+func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context, httpClient *httpclient.HttpClient) ([]ModelIdentify, bool) {
 	fallback := clineFallbackModels()
 	req := &httpclient.Request{
 		Method: http.MethodGet,
@@ -257,20 +258,20 @@ func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context) []ModelI
 		},
 	}
 
-	resp, err := f.httpClient.Do(ctx, req)
+	resp, err := httpClient.Do(ctx, req)
 	if err != nil {
 		slog.Warn("failed to fetch Cline recommended models", "error", err)
-		return fallback
+		return fallback, true
 	}
 	if resp.StatusCode != http.StatusOK {
 		slog.Warn("failed to fetch Cline recommended models", "statusCode", resp.StatusCode)
-		return fallback
+		return fallback, true
 	}
 
 	var response clineRecommendedModelsResponse
 	if err := json.Unmarshal(resp.Body, &response); err != nil {
 		slog.Warn("failed to parse Cline recommended models", "error", err)
-		return fallback
+		return fallback, true
 	}
 
 	models := make([]ModelIdentify, 0, len(response.Recommended)+len(response.Free)+len(response.ClinePass))
@@ -279,7 +280,8 @@ func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context) []ModelI
 	models = appendUniqueClineModels(models, seen, response.Free)
 
 	models = appendUniqueClineModels(models, seen, response.ClinePass)
-	if !hasUsableClineModel(response.ClinePass) {
+	usedFallback := !hasUsableClineModel(response.ClinePass)
+	if usedFallback {
 		fallbackEntries := lo.Map(fallback, func(model ModelIdentify, _ int) clineRecommendedModel {
 			return clineRecommendedModel{ID: model.ID}
 		})
@@ -287,10 +289,10 @@ func (f *ModelFetcher) fetchClineRecommendedModels(ctx context.Context) []ModelI
 	}
 
 	if len(models) == 0 {
-		return fallback
+		return fallback, true
 	}
 
-	return models
+	return models, usedFallback
 }
 
 func (f *ModelFetcher) tryReturnDefaultModels(ctx context.Context, channelType string) (*FetchModelsResult, bool) {
@@ -327,7 +329,22 @@ func (f *ModelFetcher) FetchModels(ctx context.Context, input FetchModelsInput) 
 	}
 
 	if input.ChannelType == channel.TypeCline.String() {
-		return &FetchModelsResult{Models: f.fetchClineRecommendedModels(ctx)}, nil
+		httpClient := f.httpClient
+		if input.ChannelID != nil {
+			ch, err := f.channelService.entFromContext(ctx).Channel.Get(ctx, *input.ChannelID)
+			if err != nil {
+				return &FetchModelsResult{
+					Models: []ModelIdentify{},
+					Error:  lo.ToPtr(fmt.Sprintf("failed to get channel: %v", err)),
+				}, nil
+			}
+			if ch.Settings != nil && ch.Settings.Proxy != nil {
+				httpClient = f.httpClient.WithProxy(ch.Settings.Proxy)
+			}
+		}
+
+		models, fallback := f.fetchClineRecommendedModels(ctx, httpClient)
+		return &FetchModelsResult{Models: models, Fallback: fallback}, nil
 	}
 
 	if result, ok := f.tryReturnDefaultModels(ctx, input.ChannelType); ok {

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/enttest"
@@ -667,30 +670,168 @@ func TestProviderConfFetcher_Caching(t *testing.T) {
 	}
 }
 
-func TestModelFetcher_ClineReturnsDefaultModels(t *testing.T) {
-	fetcher := NewModelFetcher(nil, nil)
+func TestFetchModelsClineRecommendedModels(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("X-Api-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"recommended": [
+				{"id": "payg-1"},
+				{"id": " shared "},
+				{"id": " "}
+			],
+			"free": [
+				{"id": "shared"},
+				{"id": "free-1"}
+			],
+			"clinePass": [
+				{"id": "pass-1"},
+				{"id": "free-1"}
+			],
+			"futureField": true
+		}`))
+	}))
+	defer server.Close()
 
-	models := fetcher.getDefaultModelsByType(context.Background(), channel.TypeCline)
+	fetcher := NewModelFetcher(httpclient.NewHttpClientWithClient(server.Client()), nil)
+	fetcher.clineRecommendedModelsURL = server.URL
+	apiKey := "must-not-be-sent"
 
-	if len(models) == 0 {
-		t.Fatal("expected Cline default models, got none")
+	for range 2 {
+		result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{
+			ChannelType: channel.TypeCline.String(),
+			BaseURL:     "https://changed.example.invalid",
+			APIKey:      &apiKey,
+		})
+		require.NoError(t, err)
+		require.Nil(t, result.Error)
+		assert.Equal(t, []ModelIdentify{
+			{ID: "payg-1"},
+			{ID: "shared"},
+			{ID: "free-1"},
+			{ID: "pass-1"},
+		}, result.Models)
 	}
 
-	modelIDs := make(map[string]struct{}, len(models))
-	for _, m := range models {
-		modelIDs[m.ID] = struct{}{}
+	assert.Equal(t, int32(2), callCount.Load(), "Cline model discovery should fetch on demand without caching")
+}
+
+func TestFetchModelsClineDuplicatePassDoesNotAppendStaticFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"recommended": [{"id": "shared"}],
+			"clinePass": [{"id": " shared "}]
+		}`))
+	}))
+	defer server.Close()
+
+	fetcher := NewModelFetcher(httpclient.NewHttpClientWithClient(server.Client()), nil)
+	fetcher.clineRecommendedModelsURL = server.URL
+
+	result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	assert.Equal(t, []ModelIdentify{{ID: "shared"}}, result.Models)
+}
+
+func TestFetchModelsClineMissingPassAppendsStaticFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"recommended": [{"id": "payg-1"}, {"id": "cline-pass/deepseek-v4-flash"}],
+			"free": [{"id": "free-1"}],
+			"clinePass": [{"id": " "}]
+		}`))
+	}))
+	defer server.Close()
+
+	fetcher := NewModelFetcher(httpclient.NewHttpClientWithClient(server.Client()), nil)
+	fetcher.clineRecommendedModelsURL = server.URL
+
+	result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+
+	assert.Equal(t, []ModelIdentify{
+		{ID: "payg-1"},
+		{ID: "cline-pass/deepseek-v4-flash"},
+		{ID: "free-1"},
+		{ID: "cline-pass/deepseek-v4-pro"},
+		{ID: "cline-pass/qwen3.7-plus"},
+		{ID: "cline-pass/qwen3.7-max"},
+		{ID: "cline-pass/kimi-k3"},
+		{ID: "cline-pass/kimi-k2.7-code"},
+		{ID: "cline-pass/kimi-k2.6"},
+		{ID: "cline-pass/glm-5.2"},
+		{ID: "cline-pass/mimo-v2.5"},
+		{ID: "cline-pass/mimo-v2.5-pro"},
+		{ID: "cline-pass/minimax-m3"},
+	}, result.Models)
+}
+
+func TestFetchModelsClineFailuresReturnStaticFallback(t *testing.T) {
+	fallback := []ModelIdentify{
+		{ID: "cline-pass/deepseek-v4-flash"},
+		{ID: "cline-pass/deepseek-v4-pro"},
+		{ID: "cline-pass/qwen3.7-plus"},
+		{ID: "cline-pass/qwen3.7-max"},
+		{ID: "cline-pass/kimi-k3"},
+		{ID: "cline-pass/kimi-k2.7-code"},
+		{ID: "cline-pass/kimi-k2.6"},
+		{ID: "cline-pass/glm-5.2"},
+		{ID: "cline-pass/mimo-v2.5"},
+		{ID: "cline-pass/mimo-v2.5-pro"},
+		{ID: "cline-pass/minimax-m3"},
 	}
 
-	for _, expected := range []string{
-		"cline-pass/deepseek-v4-flash",
-		"cline-pass/deepseek-v4-pro",
-		"cline-pass/qwen3.7-plus",
-		"cline-pass/kimi-k2.7-code",
+	for _, tt := range []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "non-OK status", statusCode: http.StatusBadGateway, body: `{"error":"upstream unavailable"}`},
+		{name: "invalid JSON", statusCode: http.StatusOK, body: `{`},
+		{name: "empty groups", statusCode: http.StatusOK, body: `{"recommended":[],"free":[],"clinePass":[]}`},
 	} {
-		if _, ok := modelIDs[expected]; !ok {
-			t.Fatalf("expected model %s not found in %#v", expected, models)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			var callCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				callCount.Add(1)
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			fetcher := NewModelFetcher(httpclient.NewHttpClientWithClient(server.Client()), nil)
+			fetcher.clineRecommendedModelsURL = server.URL
+
+			result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
+			require.NoError(t, err)
+			require.Nil(t, result.Error)
+			assert.Equal(t, fallback, result.Models)
+			assert.Equal(t, int32(1), callCount.Load())
+		})
 	}
+
+	t.Run("request failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		client := server.Client()
+		server.Close()
+
+		fetcher := NewModelFetcher(httpclient.NewHttpClientWithClient(client), nil)
+		fetcher.clineRecommendedModelsURL = server.URL
+
+		result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
+		require.NoError(t, err)
+		require.Nil(t, result.Error)
+		assert.Equal(t, fallback, result.Models)
+	})
 }
 
 func TestFetchModelsGeminiVertex(t *testing.T) {

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -563,6 +563,65 @@ func TestFetchModelsWithChannelIDUsesStoredCredentialsOnlyForStoredEndpoint(t *t
 	}
 }
 
+func TestFetchModelsClineWithChannelIDUsesStoredProxyWithoutCredentials(t *testing.T) {
+	const catalogURL = "http://127.0.0.1:1/api/v1/ai/cline/recommended-models"
+
+	var proxyCalls atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyCalls.Add(1)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, catalogURL, r.URL.String())
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("X-Api-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"recommended": [{"id":"proxied-model"}],
+			"clinePass": [{"id":"cline-pass/proxied-model"}]
+		}`))
+	}))
+	defer proxy.Close()
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:fetch_models_cline_proxy?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithSystemBypass(context.Background(), "test")
+	ch, err := client.Channel.Create().
+		SetName("cline-proxy").
+		SetType(channel.TypeCline).
+		SetBaseURL("https://api.cline.bot/api/v1").
+		SetCredentials(objects.ChannelCredentials{APIKeys: []string{"stored-secret"}}).
+		SetSupportedModels([]string{"cline-pass/deepseek-v4-flash"}).
+		SetDefaultTestModel("cline-pass/deepseek-v4-flash").
+		SetSettings(&objects.ChannelSettings{Proxy: &httpclient.ProxyConfig{
+			Type: httpclient.ProxyTypeURL,
+			URL:  proxy.URL,
+		}}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	fetcher := NewModelFetcher(
+		httpclient.NewHttpClientWithProxy(&httpclient.ProxyConfig{Type: httpclient.ProxyTypeDisabled}),
+		&ChannelService{AbstractService: &AbstractService{db: client}},
+	)
+	fetcher.clineRecommendedModelsURL = catalogURL
+	inputKey := "input-secret"
+
+	result, err := fetcher.FetchModels(ctx, FetchModelsInput{
+		ChannelType: channel.TypeCline.String(),
+		BaseURL:     ch.BaseURL + "/",
+		APIKey:      &inputKey,
+		ChannelID:   &ch.ID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	assert.False(t, result.Fallback)
+	assert.Equal(t, []ModelIdentify{
+		{ID: "proxied-model"},
+		{ID: "cline-pass/proxied-model"},
+	}, result.Models)
+	assert.Equal(t, int32(1), proxyCalls.Load())
+}
+
 func TestFetchModelsWithChannelIDRejectsStoredCredentialForChangedEndpoint(t *testing.T) {
 	var attackerCalls atomic.Int32
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -710,6 +769,7 @@ func TestFetchModelsClineRecommendedModels(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Nil(t, result.Error)
+		assert.False(t, result.Fallback)
 		assert.Equal(t, []ModelIdentify{
 			{ID: "payg-1"},
 			{ID: "shared"},
@@ -737,6 +797,7 @@ func TestFetchModelsClineDuplicatePassDoesNotAppendStaticFallback(t *testing.T) 
 	result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
 	require.NoError(t, err)
 	require.Nil(t, result.Error)
+	assert.False(t, result.Fallback)
 	assert.Equal(t, []ModelIdentify{{ID: "shared"}}, result.Models)
 }
 
@@ -757,6 +818,7 @@ func TestFetchModelsClineMissingPassAppendsStaticFallback(t *testing.T) {
 	result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
 	require.NoError(t, err)
 	require.Nil(t, result.Error)
+	assert.True(t, result.Fallback)
 
 	assert.Equal(t, []ModelIdentify{
 		{ID: "payg-1"},
@@ -814,6 +876,7 @@ func TestFetchModelsClineFailuresReturnStaticFallback(t *testing.T) {
 			result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
 			require.NoError(t, err)
 			require.Nil(t, result.Error)
+			assert.True(t, result.Fallback)
 			assert.Equal(t, fallback, result.Models)
 			assert.Equal(t, int32(1), callCount.Load())
 		})
@@ -830,6 +893,7 @@ func TestFetchModelsClineFailuresReturnStaticFallback(t *testing.T) {
 		result, err := fetcher.FetchModels(context.Background(), FetchModelsInput{ChannelType: channel.TypeCline.String()})
 		require.NoError(t, err)
 		require.Nil(t, result.Error)
+		assert.True(t, result.Fallback)
 		assert.Equal(t, fallback, result.Models)
 	})
 }

--- a/llm/transformer/cline/constants.go
+++ b/llm/transformer/cline/constants.go
@@ -1,5 +1,6 @@
 package cline
 
+// RecommendedModelsURL is Cline's public model discovery endpoint.
 const RecommendedModelsURL = "https://api.cline.bot/api/v1/ai/cline/recommended-models"
 
 // DefaultModels returns known Cline Pass models used when dynamic discovery is unavailable.

--- a/llm/transformer/cline/constants.go
+++ b/llm/transformer/cline/constants.go
@@ -1,12 +1,15 @@
 package cline
 
-// DefaultModels returns a static list of known Cline model IDs.
+const RecommendedModelsURL = "https://api.cline.bot/api/v1/ai/cline/recommended-models"
+
+// DefaultModels returns known Cline Pass models used when dynamic discovery is unavailable.
 func DefaultModels() []string {
 	return []string{
 		"cline-pass/deepseek-v4-flash",
 		"cline-pass/deepseek-v4-pro",
 		"cline-pass/qwen3.7-plus",
 		"cline-pass/qwen3.7-max",
+		"cline-pass/kimi-k3",
 		"cline-pass/kimi-k2.7-code",
 		"cline-pass/kimi-k2.6",
 		"cline-pass/glm-5.2",

--- a/llm/transformer/cline/outbound.go
+++ b/llm/transformer/cline/outbound.go
@@ -53,6 +53,20 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 	return &OutboundTransformer{Outbound: t}, nil
 }
 
+// TransformRequest identifies Cline chat completion requests as originating from the Cline CLI.
+func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
+	httpReq, err := t.Outbound.TransformRequest(ctx, llmReq)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpReq.APIFormat == string(llm.APIFormatOpenAIChatCompletion) {
+		httpReq.Headers.Set("X-Client-Type", "cline-cli")
+	}
+
+	return httpReq, nil
+}
+
 // TransformResponse transforms the HTTP response to llm.Response.
 func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *httpclient.Response) (*llm.Response, error) {
 	if httpResp == nil {

--- a/llm/transformer/cline/outbound_test.go
+++ b/llm/transformer/cline/outbound_test.go
@@ -52,6 +52,38 @@ func TestOutboundTransformer_TransformRequest_UsesConfiguredEndpointPath(t *test
 	assert.Equal(t, "https://api.cline.bot/api/v1/custom/chat/completions", req.URL)
 }
 
+func TestOutboundTransformer_TransformRequest_IdentifiesAsClineCLI(t *testing.T) {
+	transformer := newTestTransformer(t)
+	content := "hello"
+
+	for _, model := range []string{
+		"cline-pass/deepseek-v4-flash",
+		"cline-free/glm-5.2",
+		"zai/glm-5.2",
+	} {
+		t.Run(model, func(t *testing.T) {
+			req, err := transformer.TransformRequest(context.Background(), &llm.Request{
+				Model: model,
+				Messages: []llm.Message{{
+					Role:    "user",
+					Content: llm.MessageContent{Content: &content},
+				}},
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, "cline-cli", req.Headers.Get("X-Client-Type"))
+			assert.Equal(t, string(llm.APIFormatOpenAIChatCompletion), req.APIFormat)
+
+			var body struct {
+				Model string `json:"model"`
+			}
+			require.NoError(t, json.Unmarshal(req.Body, &body))
+			assert.Equal(t, model, body.Model)
+		})
+	}
+}
+
 func TestOutboundTransformer_TransformResponse_UnwrapsClineData(t *testing.T) {
 	transformer := newTestTransformer(t)
 


### PR DESCRIPTION
## Summary

- send `X-Client-Type: cline-cli` for Cline Chat Completions requests
- fetch models from Cline's recommended-models endpoint with stable ordering, deduplication, and static Cline Pass fallback
- reuse the channel proxy without forwarding credentials, and preserve existing synced models when discovery falls back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic discovery of recommended Cline models, including deduplication and support for Cline Pass models.
  * Added fallback models when discovery is unavailable or returns invalid data.
  * Cline requests now identify themselves as coming from the Cline CLI.
  * Channel-specific proxy settings are respected during model discovery without forwarding credentials.

* **Bug Fixes**
  * Prevented fallback discovery results from overwriting existing supported models.
  * Improved handling of upstream errors and unavailable model data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->