### PR TITLE
fix(frontend): prevent system settings double scroll

### DIFF
--- a/frontend/src/authenticated-layout.tsx
+++ b/frontend/src/authenticated-layout.tsx
@@ -21,7 +21,7 @@ export function AuthenticatedLayout({ children }: Props) {
   useVersionCheck();
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen} className='h-screen flex-col overflow-hidden'>
+    <SidebarProvider defaultOpen={defaultOpen} className='fixed inset-0 min-h-0 flex-col overflow-hidden'>
       <AppHeader />
       <div className='flex flex-1 overflow-hidden'>
         <SkipToMain />

--- a/frontend/src/features/system/index.tsx
+++ b/frontend/src/features/system/index.tsx
@@ -14,7 +14,7 @@ interface SystemContentProps {
 
 function SystemContent({ initialTab }: SystemContentProps) {
   return (
-    <div className='-mx-4 flex-1 overflow-auto px-4 py-1 lg:flex-row lg:space-y-0 lg:space-x-12'>
+    <div className='-mx-4 flex-1 px-4 py-1 lg:flex-row lg:space-y-0 lg:space-x-12'>
       <SystemSettingsTabs initialTab={initialTab} />
     </div>
   );


### PR DESCRIPTION
## Summary

- constrain the authenticated application shell to the viewport
- remove the nested System Settings scroll container
- keep the app header fixed while allowing the System Settings title, tabs, and content to scroll together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout sizing and scrolling behavior in the authenticated application area.
  * Prevented conflicting overflow behavior in system content views for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->