### PR TITLE
fix: harden MemorySize parsing and document max_multipart_memory

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -21,6 +21,10 @@ server:
     codex_trace_enabled: false # Enable extracting trace IDs from Codex Session_id header (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)
   debug: false                  # Enable debug mode (env: AXONHUB_SERVER_DEBUG)
   disable_ssl_verify: false     # Disable SSL certificate verification for self-signed certificates (env: AXONHUB_SERVER_DISABLE_SSL_VERIFY)
+  # Max multipart form memory for large uploads (e.g. backup restore).
+  # Accepts plain bytes or K/M/G suffixes: "32M", "512MB", "1G", "536870912".
+  # Default: "32M" (env: AXONHUB_SERVER_MAX_MULTIPART_MEMORY)
+  max_multipart_memory: "32M"
   cors:
     enabled: true               # Enable CORS middleware (env: AXONHUB_SERVER_CORS_ENABLED)
     debug: false                # Enable CORS debug logging (env: AXONHUB_SERVER_CORS_DEBUG)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -24,12 +25,16 @@ func (m *MemorySize) UnmarshalText(text []byte) error {
 
 	// Try plain int64 first (e.g. "536870912")
 	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if v < 0 {
+			return fmt.Errorf("memory size must be non-negative: %q", string(text))
+		}
 		*m = MemorySize(v)
 		return nil
 	}
 
-	// Parse human-readable: "512M", "1.5G", "64K", "512MB"
-	s = strings.ToUpper(strings.TrimSuffix(s, "B"))
+	// Parse human-readable: "512M", "1.5G", "64K", "512MB", "512mb"
+	// Uppercase first so optional trailing "B"/"b" is trimmed correctly.
+	s = strings.TrimSuffix(strings.ToUpper(s), "B")
 	if len(s) < 2 {
 		return fmt.Errorf("invalid memory size: %q", string(text))
 	}
@@ -41,8 +46,14 @@ func (m *MemorySize) UnmarshalText(text []byte) error {
 	if err != nil {
 		return fmt.Errorf("invalid memory size number: %q", string(text))
 	}
+	if math.IsNaN(val) || math.IsInf(val, 0) {
+		return fmt.Errorf("invalid memory size number: %q", string(text))
+	}
+	if val < 0 {
+		return fmt.Errorf("memory size must be non-negative: %q", string(text))
+	}
 
-	var multiplier int64
+	var multiplier float64
 	switch suffix {
 	case 'K':
 		multiplier = 1 << 10
@@ -54,7 +65,12 @@ func (m *MemorySize) UnmarshalText(text []byte) error {
 		return fmt.Errorf("unknown memory size suffix: %q (use K, M, or G)", string(text))
 	}
 
-	*m = MemorySize(int64(val * float64(multiplier)))
+	scaled := val * multiplier
+	if scaled > float64(math.MaxInt64) {
+		return fmt.Errorf("memory size overflows int64: %q", string(text))
+	}
+
+	*m = MemorySize(int64(scaled))
 	return nil
 }
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -66,7 +66,9 @@ func (m *MemorySize) UnmarshalText(text []byte) error {
 	}
 
 	scaled := val * multiplier
-	if scaled > float64(math.MaxInt64) {
+	// float64(math.MaxInt64) rounds to exactly 2^63, so reject >= to also
+	// catch sizes that scale to 2^63 (the first unrepresentable int64 value).
+	if scaled >= float64(math.MaxInt64) {
 		return fmt.Errorf("memory size overflows int64: %q", string(text))
 	}
 

--- a/internal/server/memory_size_test.go
+++ b/internal/server/memory_size_test.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"math"
-	"strconv"
 	"testing"
 )
 
@@ -37,7 +35,6 @@ func TestMemorySizeUnmarshalText(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -62,8 +59,9 @@ func TestMemorySizeUnmarshalText(t *testing.T) {
 func TestMemorySizeRejectsScaledOverflow(t *testing.T) {
 	t.Parallel()
 
-	units := math.MaxInt64/(1<<30) + 1
-	input := strconv.FormatInt(units, 10) + "G"
+	// 2^33 G scales to exactly 2^63, the first value not representable in int64.
+	// float64(math.MaxInt64) rounds to 2^63, so the guard must use >= to reject it.
+	const input = "8589934592G"
 
 	var got MemorySize
 	if err := got.UnmarshalText([]byte(input)); err == nil {

--- a/internal/server/memory_size_test.go
+++ b/internal/server/memory_size_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestMemorySizeUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    MemorySize
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "plain bytes", input: "536870912", want: 536870912},
+		{name: "plain zero", input: "0", want: 0},
+		{name: "plain negative", input: "-1", wantErr: true},
+		{name: "K upper", input: "64K", want: 64 << 10},
+		{name: "M upper", input: "512M", want: 512 << 20},
+		{name: "G upper", input: "1G", want: 1 << 30},
+		{name: "MB upper", input: "512MB", want: 512 << 20},
+		{name: "mb lower", input: "512mb", want: 512 << 20},
+		{name: "m lower", input: "32m", want: 32 << 20},
+		{name: "gb mixed", input: "1.5Gb", want: MemorySize(int64(1.5 * float64(1<<30)))},
+		{name: "spaces", input: "  64K  ", want: 64 << 10},
+		{name: "nan", input: "NaNM", wantErr: true},
+		{name: "inf", input: "InfG", wantErr: true},
+		{name: "negative float", input: "-1.5M", wantErr: true},
+		{name: "overflow", input: "999999999999G", wantErr: true},
+		{name: "unknown suffix", input: "10T", wantErr: true},
+		{name: "invalid number", input: "abcM", wantErr: true},
+		{name: "too short", input: "M", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got MemorySize
+			err := got.UnmarshalText([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("input %q: expected error, got value %d", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("input %q: unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("input %q: got %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemorySizeRejectsScaledOverflow(t *testing.T) {
+	t.Parallel()
+
+	units := math.MaxInt64/(1<<30) + 1
+	input := strconv.FormatInt(units, 10) + "G"
+
+	var got MemorySize
+	if err := got.UnmarshalText([]byte(input)); err == nil {
+		t.Fatalf("expected overflow error for %q, got %d", input, got)
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to #2126 review feedback for `server.max_multipart_memory`.

## Fixes
1. **Case-insensitive MB/GB** — uppercase before trimming optional `B`, so `512mb` works
2. **Reject invalid values** — negative numbers, `NaN`, `Inf`, and int64 overflow now return parse errors
3. **Docs** — document `server.max_multipart_memory` in `config.example.yml`
4. **Tests** — add unit tests for `MemorySize.UnmarshalText`

## Files
- `internal/server/config.go`
- `internal/server/memory_size_test.go`
- `config.example.yml`

## Test plan
- [x] `go test ./internal/server/ -run TestMemorySize -count=1`
- [x] Valid cases: `512M`, `512mb`, `1G`, plain bytes
- [x] Invalid cases: `-1`, `NaNM`, `InfG`, overflow, unknown suffix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable multipart request memory limits, defaulting to 32 MB.
  * Documented supported byte-size formats and environment variable configuration.

* **Bug Fixes**
  * Improved validation for memory-size settings, including negative, invalid, non-finite, and overflowing values.
  * Added support for case variations, whitespace, fractional values, and optional byte suffixes.
  * Prevented invalid memory limits from being accepted during configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->