### PR TITLE
fix(responses): handle reasoning text stream events

### DIFF
--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1247,30 +1247,33 @@ func deepSeekResponsesReasoningEvents(reasoningCount int) []*httpclient.StreamEv
 		Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_deepseek_test","object":"response","created_at":1700000000,"status":"in_progress","model":"deepseek-v4-flash","output":[]}}`),
 	})
 
-	for i := 0; i < reasoningCount; i++ {
+	for i := range reasoningCount {
 		events = append(events, &httpclient.StreamEvent{
 			Type: "response.reasoning_text.delta",
-			Data: []byte(fmt.Sprintf(
+			Data: fmt.Appendf(
+				nil,
 				`{"type":"response.reasoning_text.delta","sequence_number":%d,"item_id":"reasoning_1","output_index":0,"content_index":0,"delta":"x"}`,
 				i+1,
-			)),
+			),
 		})
 	}
 
 	events = append(events,
 		&httpclient.StreamEvent{
 			Type: "response.output_text.delta",
-			Data: []byte(fmt.Sprintf(
+			Data: fmt.Appendf(
+				nil,
 				`{"type":"response.output_text.delta","sequence_number":%d,"item_id":"message_1","output_index":1,"content_index":0,"delta":"OK"}`,
 				reasoningCount+1,
-			)),
+			),
 		},
 		&httpclient.StreamEvent{
 			Type: "response.completed",
-			Data: []byte(fmt.Sprintf(
+			Data: fmt.Appendf(
+				nil,
 				`{"type":"response.completed","sequence_number":%d,"response":{"id":"resp_deepseek_test","object":"response","created_at":1700000000,"status":"completed","model":"deepseek-v4-flash","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
 				reasoningCount+2,
-			)),
+			),
 		},
 	)
 

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
+	responsestransformer "github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
 func testHTTPStream(events []*httpclient.StreamEvent) streams.Stream[*httpclient.StreamEvent] {
@@ -1137,6 +1139,142 @@ func TestPassThroughStream_LLMMiddlewareRuns(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return tracker.eventCount() == 2
 	}, time.Second, 10*time.Millisecond, "tracking middleware should process 2 events")
+}
+
+// TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock verifies that
+// provider-specific reasoning events cannot fill the raw pass-through buffer before
+// the inbound raw-stream consumer is attached.
+func TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock(t *testing.T) {
+	const model = "deepseek-v4-flash"
+
+	provider, err := responsestransformer.NewOutboundTransformer("https://api.deepseek.com/v1", "test-api-key")
+	require.NoError(t, err)
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "deepseek-responses",
+			Settings: &objects.ChannelSettings{
+				PassThroughBody: lo.ToPtr(true),
+			},
+		},
+		Outbound: provider,
+	}
+	candidate := &ChannelModelsCandidate{
+		Channel: channel,
+		Models: []biz.ChannelModelEntry{
+			{RequestModel: model, ActualModel: model, Source: "direct"},
+		},
+		APIFormat: string(llm.APIFormatOpenAIResponse),
+	}
+	state := &PersistenceState{
+		OriginalModel:           model,
+		ChannelModelsCandidates: []*ChannelModelsCandidate{candidate},
+	}
+	inbound, outbound := NewPersistentTransformers(state, responsestransformer.NewInboundTransformer())
+	executor := &mockExecutor{streamEvents: deepSeekResponsesReasoningEvents(80)}
+	pipe := pipeline.NewFactory(executor).Pipeline(
+		inbound,
+		outbound,
+		pipeline.WithEmptyResponseDetection(),
+		pipeline.WithMiddlewares(
+			applyPassThroughStream(outbound, nil),
+			applyPassThroughRequestBody(outbound, nil),
+			captureRawProviderStream(outbound, nil),
+		),
+	)
+
+	requestBody, err := json.Marshal(map[string]any{
+		"model":  model,
+		"stream": true,
+		"input":  "Reply with OK",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type processOutcome struct {
+		result *pipeline.Result
+		err    error
+	}
+	resultCh := make(chan processOutcome, 1)
+	go func() {
+		result, processErr := pipe.Process(ctx, &httpclient.Request{
+			Method:      http.MethodPost,
+			URL:         "/v1/responses",
+			ContentType: "application/json",
+			Headers:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:        requestBody,
+		})
+		resultCh <- processOutcome{result: result, err: processErr}
+	}()
+
+	var outcome processOutcome
+	select {
+	case outcome = <-resultCh:
+	case <-time.After(500 * time.Millisecond):
+		cancel()
+		select {
+		case stopped := <-resultCh:
+			if stopped.result != nil && stopped.result.EventStream != nil {
+				_ = stopped.result.EventStream.Close()
+			}
+		case <-time.After(time.Second):
+			t.Fatal("responses pass-through pipeline did not stop after cancellation")
+		}
+		t.Fatal("responses pass-through pipeline blocked before the raw stream consumer was attached")
+	}
+
+	require.NoError(t, outcome.err)
+	require.NotNil(t, outcome.result)
+	require.True(t, outcome.result.Stream)
+
+	var eventTypes []string
+	for outcome.result.EventStream.Next() {
+		eventTypes = append(eventTypes, outcome.result.EventStream.Current().Type)
+	}
+	require.NoError(t, outcome.result.EventStream.Err())
+	require.Contains(t, eventTypes, "response.output_text.delta")
+}
+
+// deepSeekResponsesReasoningEvents builds the provider-specific event ordering that
+// exposed the pass-through deadlock: many unknown reasoning deltas precede text output.
+func deepSeekResponsesReasoningEvents(reasoningCount int) []*httpclient.StreamEvent {
+	events := make([]*httpclient.StreamEvent, 0, reasoningCount+3)
+	events = append(events, &httpclient.StreamEvent{
+		Type: "response.created",
+		Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_deepseek_test","object":"response","created_at":1700000000,"status":"in_progress","model":"deepseek-v4-flash","output":[]}}`),
+	})
+
+	for i := 0; i < reasoningCount; i++ {
+		events = append(events, &httpclient.StreamEvent{
+			Type: "response.reasoning_text.delta",
+			Data: []byte(fmt.Sprintf(
+				`{"type":"response.reasoning_text.delta","sequence_number":%d,"item_id":"reasoning_1","output_index":0,"content_index":0,"delta":"x"}`,
+				i+1,
+			)),
+		})
+	}
+
+	events = append(events,
+		&httpclient.StreamEvent{
+			Type: "response.output_text.delta",
+			Data: []byte(fmt.Sprintf(
+				`{"type":"response.output_text.delta","sequence_number":%d,"item_id":"message_1","output_index":1,"content_index":0,"delta":"OK"}`,
+				reasoningCount+1,
+			)),
+		},
+		&httpclient.StreamEvent{
+			Type: "response.completed",
+			Data: []byte(fmt.Sprintf(
+				`{"type":"response.completed","sequence_number":%d,"response":{"id":"resp_deepseek_test","object":"response","created_at":1700000000,"status":"completed","model":"deepseek-v4-flash","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+				reasoningCount+2,
+			)),
+		},
+	)
+
+	return events
 }
 
 func TestPassThroughStream_ErrorPropagates(t *testing.T) {

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1145,7 +1145,10 @@ func TestPassThroughStream_LLMMiddlewareRuns(t *testing.T) {
 // provider-specific reasoning events cannot fill the raw pass-through buffer before
 // the inbound raw-stream consumer is attached.
 func TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock(t *testing.T) {
-	const model = "deepseek-v4-flash"
+	const (
+		model               = "deepseek-v4-flash"
+		reasoningEventCount = 80
+	)
 
 	provider, err := responsestransformer.NewOutboundTransformer("https://api.deepseek.com/v1", "test-api-key")
 	require.NoError(t, err)
@@ -1172,7 +1175,7 @@ func TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock(t *testing.
 		ChannelModelsCandidates: []*ChannelModelsCandidate{candidate},
 	}
 	inbound, outbound := NewPersistentTransformers(state, responsestransformer.NewInboundTransformer())
-	executor := &mockExecutor{streamEvents: deepSeekResponsesReasoningEvents(80)}
+	executor := &mockExecutor{streamEvents: deepSeekResponsesReasoningEvents(reasoningEventCount)}
 	pipe := pipeline.NewFactory(executor).Pipeline(
 		inbound,
 		outbound,
@@ -1231,10 +1234,16 @@ func TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock(t *testing.
 	require.True(t, outcome.result.Stream)
 
 	var eventTypes []string
+	reasoningDeltaCount := 0
 	for outcome.result.EventStream.Next() {
-		eventTypes = append(eventTypes, outcome.result.EventStream.Current().Type)
+		eventType := outcome.result.EventStream.Current().Type
+		eventTypes = append(eventTypes, eventType)
+		if eventType == "response.reasoning_text.delta" {
+			reasoningDeltaCount++
+		}
 	}
 	require.NoError(t, outcome.result.EventStream.Err())
+	require.Equal(t, reasoningEventCount, reasoningDeltaCount)
 	require.Contains(t, eventTypes, "response.output_text.delta")
 }
 

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1213,7 +1213,7 @@ func TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock(t *testing.
 	var outcome processOutcome
 	select {
 	case outcome = <-resultCh:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		cancel()
 		select {
 		case stopped := <-resultCh:

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -12,6 +12,10 @@ import (
 	"github.com/looplj/axonhub/llm/httpclient"
 )
 
+// maxAggregatedContentParts bounds provider-controlled content indexes before
+// the aggregator expands its dense content-part storage.
+const maxAggregatedContentParts = 1024
+
 // streamAggregator holds the state for aggregating stream chunks.
 type streamAggregator struct {
 	// Response metadata
@@ -86,8 +90,15 @@ func newAggregatedContentPart() *aggregatedContentPart {
 	}
 }
 
+// validAggregatedContentIndex reports whether an upstream content index is safe
+// to store in the aggregator's bounded dense representation.
+func validAggregatedContentIndex(contentIndex int) bool {
+	return contentIndex >= 0 && contentIndex < maxAggregatedContentParts
+}
+
+// ensureContentPart returns the content part at a validated bounded index.
 func ensureContentPart(item *aggregatedItem, contentIndex int) *aggregatedContentPart {
-	if item == nil || contentIndex < 0 {
+	if item == nil || !validAggregatedContentIndex(contentIndex) {
 		return nil
 	}
 
@@ -458,6 +469,11 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 		part.Final = true
 
 	case StreamEventTypeReasoningTextDelta:
+		contentIndex := lo.FromPtr(ev.ContentIndex)
+		if !validAggregatedContentIndex(contentIndex) {
+			return
+		}
+
 		item := a.getItemForEvent(ev.OutputIndex, ev.ItemID)
 		if item == nil {
 			item = newAggregatedItem()
@@ -470,11 +486,19 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			a.outputItems[ev.OutputIndex] = append(a.outputItems[ev.OutputIndex], item)
 		}
 
-		part := ensureContentPart(item, lo.FromPtr(ev.ContentIndex))
+		part := ensureContentPart(item, contentIndex)
+		if part == nil {
+			return
+		}
 		part.Type = "reasoning_text"
 		part.Text.WriteString(ev.Delta)
 
 	case StreamEventTypeReasoningTextDone:
+		contentIndex := lo.FromPtr(ev.ContentIndex)
+		if !validAggregatedContentIndex(contentIndex) {
+			return
+		}
+
 		item := a.getItemForEvent(ev.OutputIndex, ev.ItemID)
 		if item == nil {
 			item = newAggregatedItem()
@@ -487,7 +511,10 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			a.outputItems[ev.OutputIndex] = append(a.outputItems[ev.OutputIndex], item)
 		}
 
-		part := ensureContentPart(item, lo.FromPtr(ev.ContentIndex))
+		part := ensureContentPart(item, contentIndex)
+		if part == nil {
+			return
+		}
 		part.Type = "reasoning_text"
 		applyDoneText(part.Text, ev.Text)
 

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -457,6 +457,40 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 		applyDoneText(part.Text, ev.Text)
 		part.Final = true
 
+	case StreamEventTypeReasoningTextDelta:
+		item := a.getItemForEvent(ev.OutputIndex, ev.ItemID)
+		if item == nil {
+			item = newAggregatedItem()
+			item.Type = "reasoning"
+			item.Status = "in_progress"
+			if ev.ItemID != nil && *ev.ItemID != "" {
+				item.ID = *ev.ItemID
+				a.outputItemsByID[item.ID] = item
+			}
+			a.outputItems[ev.OutputIndex] = append(a.outputItems[ev.OutputIndex], item)
+		}
+
+		part := ensureContentPart(item, lo.FromPtr(ev.ContentIndex))
+		part.Type = "reasoning_text"
+		part.Text.WriteString(ev.Delta)
+
+	case StreamEventTypeReasoningTextDone:
+		item := a.getItemForEvent(ev.OutputIndex, ev.ItemID)
+		if item == nil {
+			item = newAggregatedItem()
+			item.Type = "reasoning"
+			item.Status = "in_progress"
+			if ev.ItemID != nil && *ev.ItemID != "" {
+				item.ID = *ev.ItemID
+				a.outputItemsByID[item.ID] = item
+			}
+			a.outputItems[ev.OutputIndex] = append(a.outputItems[ev.OutputIndex], item)
+		}
+
+		part := ensureContentPart(item, lo.FromPtr(ev.ContentIndex))
+		part.Type = "reasoning_text"
+		applyDoneText(part.Text, ev.Text)
+
 	case StreamEventTypeOutputItemDone:
 		// Mark item as completed and update with final data
 		if ev.Item != nil {
@@ -643,9 +677,9 @@ func (a *streamAggregator) buildResponse() *Response {
 				})
 
 			case "reasoning":
-				// ...existing reasoning handling...
 				{
 					var summary []ReasoningSummary
+					var content *Input
 
 					if len(item.SummaryParts) > 0 {
 						maxSummaryIndex := -1
@@ -677,11 +711,25 @@ func (a *streamAggregator) buildResponse() *Response {
 						}
 					}
 
+					if len(item.Content) > 0 {
+						contentItems := make([]Item, 0, len(item.Content))
+						for _, part := range item.Content {
+							text := part.Text.String()
+							contentType := part.Type
+							if contentType == "" {
+								contentType = "reasoning_text"
+							}
+							contentItems = append(contentItems, Item{Type: contentType, Text: &text})
+						}
+						content = &Input{Items: contentItems}
+					}
+
 					output = append(output, Item{
 						ID:               item.ID,
 						Type:             item.Type,
 						Status:           lo.ToPtr(item.Status),
 						Summary:          summary,
+						Content:          content,
 						EncryptedContent: item.EncryptedContent,
 					})
 				}

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -830,6 +830,51 @@ func TestAggregateStreamChunks_ReasoningText(t *testing.T) {
 	require.Equal(t, "first second", *response.Output[0].Content.Items[0].Text)
 }
 
+// TestAggregateStreamChunks_ReasoningTextRejectsInvalidContentIndex verifies that
+// provider-controlled indexes cannot panic or expand content storage without bounds.
+func TestAggregateStreamChunks_ReasoningTextRejectsInvalidContentIndex(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *httpclient.StreamEvent
+	}{
+		{
+			name:  "negative delta index",
+			event: &httpclient.StreamEvent{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":-1,"delta":"ignored"}`)},
+		},
+		{
+			name:  "negative done index",
+			event: &httpclient.StreamEvent{Type: "response.reasoning_text.done", Data: []byte(`{"type":"response.reasoning_text.done","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":-1,"text":"ignored"}`)},
+		},
+		{
+			name:  "oversized delta index",
+			event: &httpclient.StreamEvent{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":1024,"delta":"ignored"}`)},
+		},
+		{
+			name:  "oversized done index",
+			event: &httpclient.StreamEvent{Type: "response.reasoning_text.done", Data: []byte(`{"type":"response.reasoning_text.done","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":1024,"text":"ignored"}`)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := []*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"in_progress","output":[]}}`)},
+				{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"in_progress","summary":[],"content":[]}}`)},
+				tt.event,
+				{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"completed","output":[]}}`)},
+			}
+
+			resultBytes, _, err := AggregateStreamChunks(t.Context(), chunks)
+			require.NoError(t, err)
+
+			var response Response
+			require.NoError(t, json.Unmarshal(resultBytes, &response))
+			require.Len(t, response.Output, 1)
+			require.Nil(t, response.Output[0].Content)
+		})
+	}
+}
+
 func TestAggregateStreamChunks_ImageGenerationCall(t *testing.T) {
 	chunks := []*httpclient.StreamEvent{
 		{

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -812,7 +812,7 @@ func TestAggregateStreamChunks_ReasoningText(t *testing.T) {
 		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":0,"delta":"first"}`)},
 		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":3,"item_id":"rs_text","output_index":0,"content_index":0,"delta":" second"}`)},
 		{Type: "response.reasoning_text.done", Data: []byte(`{"type":"response.reasoning_text.done","sequence_number":4,"item_id":"rs_text","output_index":0,"content_index":0,"text":"first second"}`)},
-		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"completed","summary":[],"content":[{"type":"reasoning_text","text":"first second"}]}}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"completed","summary":[]}}`)},
 		{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"completed","output":[]}}`)},
 	}
 

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -803,6 +803,33 @@ func TestAggregateStreamChunks_ReasoningSummaryMultipleParts(t *testing.T) {
 	require.Equal(t, "", resp.Output[0].Summary[1].Text)
 }
 
+// TestAggregateStreamChunks_ReasoningText verifies that reasoning_text delta and
+// done events are reconstructed as the official reasoning item content array.
+func TestAggregateStreamChunks_ReasoningText(t *testing.T) {
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"in_progress","summary":[],"content":[]}}`)},
+		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":2,"item_id":"rs_text","output_index":0,"content_index":0,"delta":"first"}`)},
+		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","sequence_number":3,"item_id":"rs_text","output_index":0,"content_index":0,"delta":" second"}`)},
+		{Type: "response.reasoning_text.done", Data: []byte(`{"type":"response.reasoning_text.done","sequence_number":4,"item_id":"rs_text","output_index":0,"content_index":0,"text":"first second"}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"completed","summary":[],"content":[{"type":"reasoning_text","text":"first second"}]}}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"completed","output":[]}}`)},
+	}
+
+	resultBytes, _, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+
+	var response Response
+	require.NoError(t, json.Unmarshal(resultBytes, &response))
+	require.Len(t, response.Output, 1)
+	require.Equal(t, "reasoning", response.Output[0].Type)
+	require.NotNil(t, response.Output[0].Content)
+	require.Len(t, response.Output[0].Content.Items, 1)
+	require.Equal(t, "reasoning_text", response.Output[0].Content.Items[0].Type)
+	require.NotNil(t, response.Output[0].Content.Items[0].Text)
+	require.Equal(t, "first second", *response.Output[0].Content.Items[0].Text)
+}
+
 func TestAggregateStreamChunks_ImageGenerationCall(t *testing.T) {
 	chunks := []*httpclient.StreamEvent{
 		{

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -414,7 +414,7 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			},
 		}
 
-	case StreamEventTypeReasoningSummaryTextDelta:
+	case StreamEventTypeReasoningSummaryTextDelta, StreamEventTypeReasoningTextDelta:
 		// Reasoning content delta
 		s.state.reasoningContent.WriteString(streamEvent.Delta)
 		itemID := lo.FromPtr(streamEvent.ItemID)
@@ -441,7 +441,7 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		// Text content completed - skip, content was already streamed via deltas
 		return nil // Intentionally skip this event
 
-	case StreamEventTypeReasoningSummaryTextDone:
+	case StreamEventTypeReasoningSummaryTextDone, StreamEventTypeReasoningTextDone:
 		// Reasoning content completed - skip, content was already streamed via deltas
 		return nil // Intentionally skip this event
 

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -211,6 +211,45 @@ func TestOutboundTransformer_TransformStream_AssociatesReasoningSummaryWithItem(
 	require.Equal(t, []string{"rs_first", "rs_second"}, summaryItemIDs)
 }
 
+// TestOutboundTransformer_TransformStream_HandlesReasoningText verifies that
+// official reasoning_text events become unified reasoning deltas without duplication.
+func TestOutboundTransformer_TransformStream_HandlesReasoningText(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"in_progress","summary":[],"content":[]}}`)},
+		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","item_id":"rs_text","output_index":0,"content_index":0,"delta":"first"}`)},
+		{Type: "response.reasoning_text.delta", Data: []byte(`{"type":"response.reasoning_text.delta","item_id":"rs_text","output_index":0,"content_index":0,"delta":" second"}`)},
+		{Type: "response.reasoning_text.done", Data: []byte(`{"type":"response.reasoning_text.done","item_id":"rs_text","output_index":0,"content_index":0,"text":"first second"}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","output_index":0,"item":{"id":"rs_text","type":"reasoning","status":"completed","summary":[],"content":[{"type":"reasoning_text","text":"first second"}]}}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_reasoning_text","object":"response","created_at":1700000000,"model":"deepseek-v4-flash","status":"completed","output":[]}}`)},
+	}
+
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+
+	var deltas []string
+	var itemIDs []string
+	for _, response := range responses {
+		if response == llm.DoneResponse || len(response.Choices) == 0 || response.Choices[0].Delta == nil || response.Choices[0].Delta.ReasoningContent == nil {
+			continue
+		}
+
+		deltas = append(deltas, *response.Choices[0].Delta.ReasoningContent)
+		metadata, ok := getResponsesReasoningItemMetadata(response.TransformerMetadata)
+		require.True(t, ok)
+		itemIDs = append(itemIDs, metadata.ID)
+	}
+
+	require.Equal(t, []string{"first", " second"}, deltas)
+	require.Equal(t, []string{"rs_text", "rs_text"}, itemIDs)
+}
+
 func TestResponsesTransformer_StreamRoundTrip_PreservesCompactionSummary(t *testing.T) {
 	outbound, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)

--- a/llm/transformer/openai/responses/stream_event.go
+++ b/llm/transformer/openai/responses/stream_event.go
@@ -49,6 +49,8 @@ const (
 	StreamEventTypeReasoningSummaryPartDone  StreamEventType = "response.reasoning_summary_part.done"
 	StreamEventTypeReasoningSummaryTextDelta StreamEventType = "response.reasoning_summary_text.delta"
 	StreamEventTypeReasoningSummaryTextDone  StreamEventType = "response.reasoning_summary_text.done"
+	StreamEventTypeReasoningTextDelta        StreamEventType = "response.reasoning_text.delta"
+	StreamEventTypeReasoningTextDone         StreamEventType = "response.reasoning_text.done"
 
 	// Image generation events.
 
@@ -72,17 +74,17 @@ type StreamEvent struct {
 	OutputIndex int   `json:"output_index"`
 	Item        *Item `json:"item,omitempty"`
 
-	// For content_part.*, output_text.*, function_call_arguments.* events
+	// For content_part.*, output_text.*, reasoning_text.*, function_call_arguments.* events
 	ItemID       *string `json:"item_id,omitempty"`
 	ContentIndex *int    `json:"content_index,omitempty"`
 
 	// For content_part.added/done events
 	Part *StreamEventContentPart `json:"part,omitempty"`
 
-	// For output_text.delta and function_call_arguments.delta events
+	// For output_text.delta, reasoning_text.delta, and function_call_arguments.delta events
 	Delta string `json:"delta,omitempty"`
 
-	// For output_text.done events
+	// For output_text.done and reasoning_text.done events
 	Text string `json:"text,omitempty"`
 
 	// For function_call_arguments.done events

--- a/llm/transformer/openai/responses/stream_event.go
+++ b/llm/transformer/openai/responses/stream_event.go
@@ -74,17 +74,19 @@ type StreamEvent struct {
 	OutputIndex int   `json:"output_index"`
 	Item        *Item `json:"item,omitempty"`
 
-	// For content_part.*, output_text.*, reasoning_text.*, function_call_arguments.* events
+	// For content_part.*, output_text.*, reasoning_summary_text.*, reasoning_text.*,
+	// and function_call_arguments.* events.
 	ItemID       *string `json:"item_id,omitempty"`
 	ContentIndex *int    `json:"content_index,omitempty"`
 
 	// For content_part.added/done events
 	Part *StreamEventContentPart `json:"part,omitempty"`
 
-	// For output_text.delta, reasoning_text.delta, and function_call_arguments.delta events
+	// For output_text.delta, reasoning_summary_text.delta, reasoning_text.delta,
+	// and function_call_arguments.delta events.
 	Delta string `json:"delta,omitempty"`
 
-	// For output_text.done and reasoning_text.done events
+	// For output_text.done, reasoning_summary_text.done, and reasoning_text.done events.
 	Text string `json:"text,omitempty"`
 
 	// For function_call_arguments.done events


### PR DESCRIPTION
## Summary

- add support for the official `response.reasoning_text.delta` and `response.reasoning_text.done` Responses stream events
- map reasoning text deltas into AxonHub's unified `ReasoningContent` stream and aggregate them into `reasoning.content`
- add a deterministic DeepSeek pass-through regression test that sends more than 64 reasoning text deltas before output text

Fixes #2150

## Problem

DeepSeek's Responses API emits chain-of-thought content as `response.reasoning_text.delta/done`, rather than Reasoning Summary events.

AxonHub previously treated these events as unknown. With pass-through enabled, enough skipped reasoning events could fill the 64-entry raw stream channel before the pipeline reached an output-text event. The producer then waited for the raw consumer, while the raw consumer was not attached until pipeline pre-reading completed, causing the request to hang indefinitely.

## Solution

This PR implements the scoped schema-compatibility fix:

- recognize `response.reasoning_text.delta/done`
- transform deltas into `Choices[0].Delta.ReasoningContent`
- reconstruct official reasoning items during stream aggregation
- treat `.done` as a recognized terminal event without emitting duplicate reasoning content

The raw provider SSE remains unchanged for pass-through clients.

## Testing

Passed:

- from `llm/`: `go test ./transformer/openai/responses -run '^(TestOutboundTransformer_TransformStream_HandlesReasoningText|TestAggregateStreamChunks_ReasoningText)$' -count=1 -v`
- from the repository root: `go test ./internal/server/orchestrator -run '^TestPassThroughResponsesStream_DeepSeekReasoningDoesNotDeadlock$' -count=3 -v`
- from `llm/`: `go test ./transformer/openai/responses -run '^(TestAggregateStreamChunks|TestOutboundTransformer_TransformStream)' -count=1`
- from the repository root: `go test ./internal/server/orchestrator -run 'PassThrough' -count=1`

The complete Responses transformer package currently has an unrelated existing Windows-specific WebSocket failure in `TestWebSocketStreamReturnsErrorWhenReusedConnectionClosesBeforeEvent`: Windows returns a native `wsarecv` abort error instead of the test's expected `websocket closed before response event` message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for streaming reasoning text events.
  * Reasoning text is preserved, assembled, and included in final responses.
  * Improved handling of extended reasoning streams before generated output.

* **Bug Fixes**
  * Prevented pass-through streaming from deadlocking during long reasoning sequences.
  * Avoided duplicated reasoning deltas while retaining event identifiers.
  * Ignored invalid content indexes to prevent malformed reasoning content.
  * Improved consistency when reasoning events are completed or streamed incrementally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->