### PR TITLE
fix(frontend): align analytics filter UX

### DIFF
--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CheckIcon, Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons';
+import { CheckIcon, PlusCircledIcon } from '@radix-ui/react-icons';
 import { Column } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
@@ -8,12 +8,6 @@ import { Button } from '@/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
-
-/** Groups the complete controlled state for filters that are not backed by a table column. */
-interface ControlledSelection {
-  values: string[];
-  onChange: (values: string[]) => void;
-}
 
 interface DataTableFacetedFilterProps<TData, TValue> {
   column?: Column<TData, TValue>;
@@ -25,91 +19,58 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   }[];
   singleSelect?: boolean;
   footer?: React.ReactNode;
-  isLoading?: boolean;
-  controlledSelection?: ControlledSelection;
 }
 
-/** Renders the shared searchable faceted-filter UX for table-backed or controlled filters. */
+/** Renders the searchable faceted filter backed by a TanStack Table column. */
 export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options = [],
   singleSelect = false,
   footer,
-  isLoading = false,
-  controlledSelection,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
-  const columnSelectedValues = singleSelect ? (filterValue ? [filterValue as string] : []) : ((filterValue || []) as string[]);
-  const selectedValues = new Set(controlledSelection?.values ?? columnSelectedValues);
-  const selectedOptions = Array.from(
-    selectedValues,
-    (value) => options.find((option) => option.value === value) ?? { label: value, value }
-  );
-
-  /** Updates a controlled filter or falls back to the table column filter. */
-  const updateSelectedValues = (values: string[]) => {
-    if (controlledSelection) {
-      controlledSelection.onChange(values);
-      return;
-    }
-
-    column?.setFilterValue(singleSelect ? values[0] : values.length > 0 ? values : undefined);
-  };
-
-  /** Removes one visible selection without opening or closing the filter popover. */
-  const removeSelectedValue = (value: string) => {
-    updateSelectedValues(Array.from(selectedValues).filter((selectedValue) => selectedValue !== value));
-  };
+  const selectedValues = singleSelect ? new Set(filterValue ? [filterValue as string] : []) : new Set((filterValue || []) as string[]);
 
   return (
     <Popover>
-      <div className='bg-background dark:bg-input/30 dark:border-input flex h-8 w-fit items-center rounded-md border border-dashed shadow-xs'>
-        <PopoverTrigger asChild>
-          <Button variant='ghost' size='sm' className='h-full rounded-md border-0 shadow-none'>
-            <PlusCircledIcon className='h-4 w-4' />
-            {title}
-          </Button>
-        </PopoverTrigger>
-        {selectedValues.size > 0 && (
-          <>
-            <Separator orientation='vertical' className='mx-2 h-4' />
-            <Badge variant='secondary' className='mr-1 rounded-sm px-1 font-normal lg:hidden'>
-              {selectedValues.size}
-            </Badge>
-            <div className='mr-1 hidden space-x-1 lg:flex'>
-              {selectedValues.size > 2 ? (
-                <Badge variant='secondary' className='rounded-sm px-1 font-normal'>
-                  {t('common.selectedItems', { count: selectedValues.size })}
-                </Badge>
-              ) : (
-                selectedOptions.map((option) => (
-                  <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
-                    {option.label}
-                    <button
-                      type='button'
-                      aria-label={`${t('common.clearFilters')}: ${option.label}`}
-                      title={`${t('common.clearFilters')}: ${option.label}`}
-                      className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
-                      onClick={() => removeSelectedValue(option.value)}
-                    >
-                      <Cross2Icon className='size-3' />
-                    </button>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8 border-dashed'>
+          <PlusCircledIcon className='h-4 w-4' />
+          {title}
+          {selectedValues?.size > 0 && (
+            <>
+              <Separator orientation='vertical' className='mx-2 h-4' />
+              <Badge variant='secondary' className='rounded-sm px-1 font-normal lg:hidden'>
+                {selectedValues.size}
+              </Badge>
+              <div className='hidden space-x-1 lg:flex'>
+                {selectedValues.size > 2 ? (
+                  <Badge variant='secondary' className='rounded-sm px-1 font-normal'>
+                    {t('common.selectedItems', { count: selectedValues.size })}
                   </Badge>
-                ))
-              )}
-            </div>
-          </>
-        )}
-      </div>
+                ) : (
+                  options
+                    ?.filter((option) => selectedValues.has(option.value))
+                    .map((option) => (
+                      <Badge variant='secondary' key={option.value} className='rounded-sm px-1 font-normal'>
+                        {option.label}
+                      </Badge>
+                    ))
+                )}
+              </div>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
       <PopoverContent className='w-[200px] p-0' align='start'>
         <Command>
           <CommandInput placeholder={title} />
           <CommandList>
-            <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>
+            <CommandEmpty>{t('common.noResultsFound')}</CommandEmpty>
             <CommandGroup>
               {options?.map((option) => {
                 const isSelected = selectedValues.has(option.value);
@@ -118,16 +79,17 @@ export function DataTableFacetedFilter<TData, TValue>({
                     key={option.value}
                     onSelect={() => {
                       if (singleSelect) {
-                        // Single-select filters clear the active value when it is selected again.
-                        updateSelectedValues(isSelected ? [] : [option.value]);
+                        // Single select mode: set value directly or clear if already selected
+                        column?.setFilterValue(isSelected ? undefined : option.value);
                       } else {
-                        // Multi-select filters keep the shared trigger badges in sync with the caller.
+                        // Multi select mode: toggle selection
                         if (isSelected) {
                           selectedValues.delete(option.value);
                         } else {
                           selectedValues.add(option.value);
                         }
-                        updateSelectedValues(Array.from(selectedValues));
+                        const filterValues = Array.from(selectedValues);
+                        column?.setFilterValue(filterValues?.length ? filterValues : undefined);
                       }
                     }}
                   >
@@ -158,7 +120,7 @@ export function DataTableFacetedFilter<TData, TValue>({
               <>
                 <CommandSeparator />
                 <CommandGroup>
-                  <CommandItem onSelect={() => updateSelectedValues([])} className='justify-center text-center'>
+                  <CommandItem onSelect={() => column?.setFilterValue(undefined)} className='justify-center text-center'>
                     {t('common.clearFilters')}
                   </CommandItem>
                 </CommandGroup>

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -9,7 +9,14 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 
-interface DataTableFacetedFilterBaseProps {
+/** Groups the complete controlled state for filters that are not backed by a table column. */
+interface ControlledSelection {
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+interface DataTableFacetedFilterProps<TData, TValue> {
+  column?: Column<TData, TValue>;
   title?: string;
   options?: {
     label: string;
@@ -19,31 +26,25 @@ interface DataTableFacetedFilterBaseProps {
   singleSelect?: boolean;
   footer?: React.ReactNode;
   isLoading?: boolean;
+  controlledSelection?: ControlledSelection;
 }
 
-type DataTableFacetedFilterProps<TData, TValue> = DataTableFacetedFilterBaseProps &
-  (
-    | {
-        column?: Column<TData, TValue>;
-        selectedValues?: never;
-        onSelectedValuesChange?: never;
-      }
-    | {
-        column?: never;
-        selectedValues: string[];
-        onSelectedValuesChange: (values: string[]) => void;
-      }
-  );
-
 /** Renders the shared searchable faceted-filter UX for table-backed or controlled filters. */
-export function DataTableFacetedFilter<TData = unknown, TValue = unknown>(props: DataTableFacetedFilterProps<TData, TValue>) {
-  const { column, title, options = [], singleSelect = false, footer, isLoading = false } = props;
+export function DataTableFacetedFilter<TData, TValue>({
+  column,
+  title,
+  options = [],
+  singleSelect = false,
+  footer,
+  isLoading = false,
+  controlledSelection,
+}: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
   const columnSelectedValues = singleSelect ? (filterValue ? [filterValue as string] : []) : ((filterValue || []) as string[]);
-  const selectedValues = new Set(props.onSelectedValuesChange ? props.selectedValues : columnSelectedValues);
+  const selectedValues = new Set(controlledSelection?.values ?? columnSelectedValues);
   const selectedOptions = Array.from(
     selectedValues,
     (value) => options.find((option) => option.value === value) ?? { label: value, value }
@@ -51,8 +52,8 @@ export function DataTableFacetedFilter<TData = unknown, TValue = unknown>(props:
 
   /** Updates a controlled filter or falls back to the table column filter. */
   const updateSelectedValues = (values: string[]) => {
-    if (props.onSelectedValuesChange) {
-      props.onSelectedValuesChange(values);
+    if (controlledSelection) {
+      controlledSelection.onChange(values);
       return;
     }
 

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CheckIcon, PlusCircledIcon } from '@radix-ui/react-icons';
+import { CheckIcon, Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons';
 import { Column } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
@@ -19,20 +19,43 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   }[];
   singleSelect?: boolean;
   footer?: React.ReactNode;
+  selectedValues?: string[];
+  onSelectedValuesChange?: (values: string[]) => void;
+  isLoading?: boolean;
 }
 
+/** Renders the shared searchable faceted-filter UX for table-backed or controlled filters. */
 export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options = [],
   singleSelect = false,
   footer,
+  selectedValues: controlledSelectedValues,
+  onSelectedValuesChange,
+  isLoading = false,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
-  const selectedValues = singleSelect ? new Set(filterValue ? [filterValue as string] : []) : new Set((filterValue || []) as string[]);
+  const columnSelectedValues = singleSelect ? (filterValue ? [filterValue as string] : []) : ((filterValue || []) as string[]);
+  const selectedValues = new Set(controlledSelectedValues ?? columnSelectedValues);
+
+  /** Updates a controlled filter or falls back to the table column filter. */
+  const updateSelectedValues = (values: string[]) => {
+    if (onSelectedValuesChange) {
+      onSelectedValuesChange(values);
+      return;
+    }
+
+    column?.setFilterValue(singleSelect ? values[0] : values.length > 0 ? values : undefined);
+  };
+
+  /** Removes one visible selection without opening or closing the filter popover. */
+  const removeSelectedValue = (value: string) => {
+    updateSelectedValues(Array.from(selectedValues).filter((selectedValue) => selectedValue !== value));
+  };
 
   return (
     <Popover>
@@ -40,7 +63,7 @@ export function DataTableFacetedFilter<TData, TValue>({
         <Button variant='outline' size='sm' className='h-8 border-dashed'>
           <PlusCircledIcon className='h-4 w-4' />
           {title}
-          {selectedValues?.size > 0 && (
+          {selectedValues.size > 0 && (
             <>
               <Separator orientation='vertical' className='mx-2 h-4' />
               <Badge variant='secondary' className='rounded-sm px-1 font-normal lg:hidden'>
@@ -55,8 +78,24 @@ export function DataTableFacetedFilter<TData, TValue>({
                   options
                     ?.filter((option) => selectedValues.has(option.value))
                     .map((option) => (
-                      <Badge variant='secondary' key={option.value} className='rounded-sm px-1 font-normal'>
+                      <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
                         {option.label}
+                        <span
+                          title={`${t('common.clearFilters')}: ${option.label}`}
+                          className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
+                          onPointerDown={(event) => {
+                            // Removing a chip must not toggle the parent popover trigger.
+                            event.preventDefault();
+                            event.stopPropagation();
+                          }}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            removeSelectedValue(option.value);
+                          }}
+                        >
+                          <Cross2Icon className='size-3' />
+                        </span>
                       </Badge>
                     ))
                 )}
@@ -69,7 +108,7 @@ export function DataTableFacetedFilter<TData, TValue>({
         <Command>
           <CommandInput placeholder={title} />
           <CommandList>
-            <CommandEmpty>{t('common.noResultsFound')}</CommandEmpty>
+            <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>
             <CommandGroup>
               {options?.map((option) => {
                 const isSelected = selectedValues.has(option.value);
@@ -78,17 +117,16 @@ export function DataTableFacetedFilter<TData, TValue>({
                     key={option.value}
                     onSelect={() => {
                       if (singleSelect) {
-                        // Single select mode: set value directly or clear if already selected
-                        column?.setFilterValue(isSelected ? undefined : option.value);
+                        // Single-select filters clear the active value when it is selected again.
+                        updateSelectedValues(isSelected ? [] : [option.value]);
                       } else {
-                        // Multi select mode: toggle selection
+                        // Multi-select filters keep the shared trigger badges in sync with the caller.
                         if (isSelected) {
                           selectedValues.delete(option.value);
                         } else {
                           selectedValues.add(option.value);
                         }
-                        const filterValues = Array.from(selectedValues);
-                        column?.setFilterValue(filterValues?.length ? filterValues : undefined);
+                        updateSelectedValues(Array.from(selectedValues));
                       }
                     }}
                   >
@@ -119,7 +157,7 @@ export function DataTableFacetedFilter<TData, TValue>({
               <>
                 <CommandSeparator />
                 <CommandGroup>
-                  <CommandItem onSelect={() => column?.setFilterValue(undefined)} className='justify-center text-center'>
+                  <CommandItem onSelect={() => updateSelectedValues([])} className='justify-center text-center'>
                     {t('common.clearFilters')}
                   </CommandItem>
                 </CommandGroup>

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -81,6 +81,9 @@ export function DataTableFacetedFilter<TData, TValue>({
                       <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
                         {option.label}
                         <span
+                          role='button'
+                          tabIndex={0}
+                          aria-label={`${t('common.clearFilters')}: ${option.label}`}
                           title={`${t('common.clearFilters')}: ${option.label}`}
                           className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
                           onPointerDown={(event) => {
@@ -89,6 +92,13 @@ export function DataTableFacetedFilter<TData, TValue>({
                             event.stopPropagation();
                           }}
                           onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            removeSelectedValue(option.value);
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key !== 'Enter' && event.key !== ' ') return;
+
                             event.preventDefault();
                             event.stopPropagation();
                             removeSelectedValue(option.value);

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -9,8 +9,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 
-interface DataTableFacetedFilterProps<TData, TValue> {
-  column?: Column<TData, TValue>;
+interface DataTableFacetedFilterBaseProps {
   title?: string;
   options?: {
     label: string;
@@ -19,33 +18,41 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   }[];
   singleSelect?: boolean;
   footer?: React.ReactNode;
-  selectedValues?: string[];
-  onSelectedValuesChange?: (values: string[]) => void;
   isLoading?: boolean;
 }
 
+type DataTableFacetedFilterProps<TData, TValue> = DataTableFacetedFilterBaseProps &
+  (
+    | {
+        column?: Column<TData, TValue>;
+        selectedValues?: never;
+        onSelectedValuesChange?: never;
+      }
+    | {
+        column?: never;
+        selectedValues: string[];
+        onSelectedValuesChange: (values: string[]) => void;
+      }
+  );
+
 /** Renders the shared searchable faceted-filter UX for table-backed or controlled filters. */
-export function DataTableFacetedFilter<TData, TValue>({
-  column,
-  title,
-  options = [],
-  singleSelect = false,
-  footer,
-  selectedValues: controlledSelectedValues,
-  onSelectedValuesChange,
-  isLoading = false,
-}: DataTableFacetedFilterProps<TData, TValue>) {
+export function DataTableFacetedFilter<TData = unknown, TValue = unknown>(props: DataTableFacetedFilterProps<TData, TValue>) {
+  const { column, title, options = [], singleSelect = false, footer, isLoading = false } = props;
   const { t } = useTranslation();
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
   const columnSelectedValues = singleSelect ? (filterValue ? [filterValue as string] : []) : ((filterValue || []) as string[]);
-  const selectedValues = new Set(controlledSelectedValues ?? columnSelectedValues);
+  const selectedValues = new Set(props.onSelectedValuesChange ? props.selectedValues : columnSelectedValues);
+  const selectedOptions = Array.from(
+    selectedValues,
+    (value) => options.find((option) => option.value === value) ?? { label: value, value }
+  );
 
   /** Updates a controlled filter or falls back to the table column filter. */
   const updateSelectedValues = (values: string[]) => {
-    if (onSelectedValuesChange) {
-      onSelectedValuesChange(values);
+    if (props.onSelectedValuesChange) {
+      props.onSelectedValuesChange(values);
       return;
     }
 
@@ -59,61 +66,44 @@ export function DataTableFacetedFilter<TData, TValue>({
 
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <Button variant='outline' size='sm' className='h-8 border-dashed'>
-          <PlusCircledIcon className='h-4 w-4' />
-          {title}
-          {selectedValues.size > 0 && (
-            <>
-              <Separator orientation='vertical' className='mx-2 h-4' />
-              <Badge variant='secondary' className='rounded-sm px-1 font-normal lg:hidden'>
-                {selectedValues.size}
-              </Badge>
-              <div className='hidden space-x-1 lg:flex'>
-                {selectedValues.size > 2 ? (
-                  <Badge variant='secondary' className='rounded-sm px-1 font-normal'>
-                    {t('common.selectedItems', { count: selectedValues.size })}
+      <div className='bg-background dark:bg-input/30 dark:border-input flex h-8 w-fit items-center rounded-md border border-dashed shadow-xs'>
+        <PopoverTrigger asChild>
+          <Button variant='ghost' size='sm' className='h-full rounded-md border-0 shadow-none'>
+            <PlusCircledIcon className='h-4 w-4' />
+            {title}
+          </Button>
+        </PopoverTrigger>
+        {selectedValues.size > 0 && (
+          <>
+            <Separator orientation='vertical' className='mx-2 h-4' />
+            <Badge variant='secondary' className='mr-1 rounded-sm px-1 font-normal lg:hidden'>
+              {selectedValues.size}
+            </Badge>
+            <div className='mr-1 hidden space-x-1 lg:flex'>
+              {selectedValues.size > 2 ? (
+                <Badge variant='secondary' className='rounded-sm px-1 font-normal'>
+                  {t('common.selectedItems', { count: selectedValues.size })}
+                </Badge>
+              ) : (
+                selectedOptions.map((option) => (
+                  <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
+                    {option.label}
+                    <button
+                      type='button'
+                      aria-label={`${t('common.clearFilters')}: ${option.label}`}
+                      title={`${t('common.clearFilters')}: ${option.label}`}
+                      className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
+                      onClick={() => removeSelectedValue(option.value)}
+                    >
+                      <Cross2Icon className='size-3' />
+                    </button>
                   </Badge>
-                ) : (
-                  options
-                    ?.filter((option) => selectedValues.has(option.value))
-                    .map((option) => (
-                      <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
-                        {option.label}
-                        <span
-                          role='button'
-                          tabIndex={0}
-                          aria-label={`${t('common.clearFilters')}: ${option.label}`}
-                          title={`${t('common.clearFilters')}: ${option.label}`}
-                          className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
-                          onPointerDown={(event) => {
-                            // Removing a chip must not toggle the parent popover trigger.
-                            event.preventDefault();
-                            event.stopPropagation();
-                          }}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            removeSelectedValue(option.value);
-                          }}
-                          onKeyDown={(event) => {
-                            if (event.key !== 'Enter' && event.key !== ' ') return;
-
-                            event.preventDefault();
-                            event.stopPropagation();
-                            removeSelectedValue(option.value);
-                          }}
-                        >
-                          <Cross2Icon className='size-3' />
-                        </span>
-                      </Badge>
-                    ))
-                )}
-              </div>
-            </>
-          )}
-        </Button>
-      </PopoverTrigger>
+                ))
+              )}
+            </div>
+          </>
+        )}
+      </div>
       <PopoverContent className='w-[200px] p-0' align='start'>
         <Command>
           <CommandInput placeholder={title} />

--- a/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
+++ b/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
@@ -38,6 +38,11 @@ export function AnalyticsFacetedFilter({
   // Missing options are not available in the popover, so keep them individually removable beside the collapsed count.
   const removableSelectedOptions =
     selectedValueSet.size > 2 ? selectedOptions.filter((option) => !optionValueSet.has(option.value)) : selectedOptions;
+  // Keep selected options at the top while preserving the source order within both groups.
+  const orderedOptions = [
+    ...options.filter((option) => selectedValueSet.has(option.value)),
+    ...options.filter((option) => !selectedValueSet.has(option.value)),
+  ];
 
   /** Removes one selected value without opening the sibling popover trigger. */
   const removeSelectedValue = (value: string) => {
@@ -86,7 +91,7 @@ export function AnalyticsFacetedFilter({
           <CommandList>
             <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>
             <CommandGroup>
-              {options.map((option) => {
+              {orderedOptions.map((option) => {
                 const isSelected = selectedValueSet.has(option.value);
                 return (
                   <CommandItem

--- a/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
+++ b/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { CheckIcon, Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Separator } from '@/components/ui/separator';
+
+interface AnalyticsFacetedFilterProps {
+  title: string;
+  options?: {
+    label: string;
+    value: string;
+    icon?: React.ComponentType<{ className?: string }>;
+  }[];
+  selectedValues: string[];
+  onSelectedValuesChange: (values: string[]) => void;
+  isLoading?: boolean;
+}
+
+/** Renders a searchable faceted filter controlled by the analytics filter store. */
+export function AnalyticsFacetedFilter({
+  title,
+  options = [],
+  selectedValues,
+  onSelectedValuesChange,
+  isLoading = false,
+}: AnalyticsFacetedFilterProps) {
+  const { t } = useTranslation();
+  const selectedValueSet = new Set(selectedValues);
+  const optionValueSet = new Set(options.map((option) => option.value));
+  const selectedOptions = Array.from(
+    selectedValueSet,
+    (value) => options.find((option) => option.value === value) ?? { label: value, value }
+  );
+  // Missing options are not available in the popover, so keep them individually removable beside the collapsed count.
+  const removableSelectedOptions =
+    selectedValueSet.size > 2 ? selectedOptions.filter((option) => !optionValueSet.has(option.value)) : selectedOptions;
+
+  /** Removes one selected value without opening the sibling popover trigger. */
+  const removeSelectedValue = (value: string) => {
+    onSelectedValuesChange(selectedValues.filter((selectedValue) => selectedValue !== value));
+  };
+
+  return (
+    <Popover>
+      <div className='bg-background dark:bg-input/30 dark:border-input flex h-8 w-fit items-center rounded-md border border-dashed shadow-xs'>
+        <PopoverTrigger asChild>
+          <Button variant='ghost' size='sm' className='h-full rounded-md border-0 shadow-none'>
+            <PlusCircledIcon className='h-4 w-4' />
+            {title}
+          </Button>
+        </PopoverTrigger>
+        {selectedValueSet.size > 0 && (
+          <>
+            <Separator orientation='vertical' className='mx-2 h-4' />
+            <div className='mr-1 flex space-x-1'>
+              {selectedValueSet.size > 2 && (
+                <Badge variant='secondary' className='rounded-sm px-1 font-normal'>
+                  {t('common.selectedItems', { count: selectedValueSet.size })}
+                </Badge>
+              )}
+              {removableSelectedOptions.map((option) => (
+                <Badge variant='secondary' key={option.value} className='gap-0.5 rounded-sm py-0 pr-0.5 pl-1 font-normal'>
+                  {option.label}
+                  <button
+                    type='button'
+                    aria-label={`${t('common.clearFilters')}: ${option.label}`}
+                    title={`${t('common.clearFilters')}: ${option.label}`}
+                    className='text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground inline-flex size-4 items-center justify-center rounded-sm transition-colors'
+                    onClick={() => removeSelectedValue(option.value)}
+                  >
+                    <Cross2Icon className='size-3' />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      <PopoverContent className='w-[200px] p-0' align='start'>
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedValueSet.has(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() =>
+                      onSelectedValuesChange(
+                        isSelected
+                          ? selectedValues.filter((selectedValue) => selectedValue !== option.value)
+                          : [...selectedValues, option.value]
+                      )
+                    }
+                  >
+                    <div
+                      className={cn(
+                        'border-primary flex h-4 w-4 items-center justify-center rounded-sm border',
+                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
+                      )}
+                    >
+                      <CheckIcon className='h-4 w-4' />
+                    </div>
+                    {option.icon && <option.icon className='text-muted-foreground h-4 w-4' />}
+                    <span>{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedValueSet.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem onSelect={() => onSelectedValuesChange([])} className='justify-center text-center'>
+                    {t('common.clearFilters')}
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { IconCalendar, IconX, IconFilter } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
-import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -12,6 +11,7 @@ import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { useApiKeys } from '@/features/apikeys/data/apikeys';
 import { useUsers } from '@/features/users/data/users';
 import { useProjects } from '@/features/projects/data/projects';
+import { AnalyticsFacetedFilter } from './analytics-faceted-filter';
 
 // Calendar Date → 'YYYY-MM-DD' 字符串（直接取本地年月日，不做时区转换）
 function formatDate(date: Date): string {
@@ -291,38 +291,43 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
 
       {/* Dimension Filters */}
       <div className='flex flex-wrap items-center gap-2'>
-        <DataTableFacetedFilter
+        <AnalyticsFacetedFilter
           title={t('analytics.filter.project')}
           options={projectOptions}
-          controlledSelection={{ values: filter.projectIDs || [], onChange: setProjectIDs }}
+          selectedValues={filter.projectIDs || []}
+          onSelectedValuesChange={setProjectIDs}
           isLoading={isLoadingProjects}
         />
 
-        <DataTableFacetedFilter
+        <AnalyticsFacetedFilter
           title={t('analytics.filter.channel')}
           options={channelOptions}
-          controlledSelection={{ values: filter.channelIDs || [], onChange: setChannelIDs }}
+          selectedValues={filter.channelIDs || []}
+          onSelectedValuesChange={setChannelIDs}
           isLoading={isLoadingChannels}
         />
 
-        <DataTableFacetedFilter
+        <AnalyticsFacetedFilter
           title={t('analytics.filter.model')}
           options={modelOptions}
-          controlledSelection={{ values: filter.modelIDs || [], onChange: setModelIDs }}
+          selectedValues={filter.modelIDs || []}
+          onSelectedValuesChange={setModelIDs}
           isLoading={isLoadingChannels}
         />
 
-        <DataTableFacetedFilter
+        <AnalyticsFacetedFilter
           title={t('analytics.filter.apiKey')}
           options={apiKeyOptions}
-          controlledSelection={{ values: filter.apiKeyIDs || [], onChange: setAPIKeyIDs }}
+          selectedValues={filter.apiKeyIDs || []}
+          onSelectedValuesChange={setAPIKeyIDs}
           isLoading={isLoadingApiKeys}
         />
 
-        <DataTableFacetedFilter
+        <AnalyticsFacetedFilter
           title={t('analytics.filter.user')}
           options={userOptions}
-          controlledSelection={{ values: filter.userIDs || [], onChange: setUserIDs }}
+          selectedValues={filter.userIDs || []}
+          onSelectedValuesChange={setUserIDs}
           isLoading={isLoadingUsers}
         />
 

--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -294,40 +294,35 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
         <DataTableFacetedFilter
           title={t('analytics.filter.project')}
           options={projectOptions}
-          selectedValues={filter.projectIDs || []}
-          onSelectedValuesChange={setProjectIDs}
+          controlledSelection={{ values: filter.projectIDs || [], onChange: setProjectIDs }}
           isLoading={isLoadingProjects}
         />
 
         <DataTableFacetedFilter
           title={t('analytics.filter.channel')}
           options={channelOptions}
-          selectedValues={filter.channelIDs || []}
-          onSelectedValuesChange={setChannelIDs}
+          controlledSelection={{ values: filter.channelIDs || [], onChange: setChannelIDs }}
           isLoading={isLoadingChannels}
         />
 
         <DataTableFacetedFilter
           title={t('analytics.filter.model')}
           options={modelOptions}
-          selectedValues={filter.modelIDs || []}
-          onSelectedValuesChange={setModelIDs}
+          controlledSelection={{ values: filter.modelIDs || [], onChange: setModelIDs }}
           isLoading={isLoadingChannels}
         />
 
         <DataTableFacetedFilter
           title={t('analytics.filter.apiKey')}
           options={apiKeyOptions}
-          selectedValues={filter.apiKeyIDs || []}
-          onSelectedValuesChange={setAPIKeyIDs}
+          controlledSelection={{ values: filter.apiKeyIDs || [], onChange: setAPIKeyIDs }}
           isLoading={isLoadingApiKeys}
         />
 
         <DataTableFacetedFilter
           title={t('analytics.filter.user')}
           options={userOptions}
-          selectedValues={filter.userIDs || []}
-          onSelectedValuesChange={setUserIDs}
+          controlledSelection={{ values: filter.userIDs || [], onChange: setUserIDs }}
           isLoading={isLoadingUsers}
         />
 

--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -3,11 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { IconCalendar, IconX, IconFilter } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
+import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useAnalyticsFilterStore } from '@/stores/analyticsStore';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { useApiKeys } from '@/features/apikeys/data/apikeys';
@@ -26,77 +25,6 @@ function formatDate(date: Date): string {
 function parseDate(dateStr: string): Date {
   const [y, m, d] = dateStr.split('-').map(Number);
   return new Date(y, m - 1, d);
-}
-
-interface MultiSelectProps {
-  label: string;
-  placeholder: string;
-  options: { label: string; value: string }[];
-  selected: string[];
-  onChange: (values: string[]) => void;
-  isLoading?: boolean;
-}
-
-function MultiSelect({ label, placeholder, options, selected, onChange, isLoading }: MultiSelectProps) {
-  const [open, setOpen] = useState(false);
-
-  const toggle = (value: string) => {
-    if (selected.includes(value)) {
-      onChange(selected.filter((v) => v !== value));
-    } else {
-      onChange([...selected, value]);
-    }
-  };
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant='outline'
-          role='combobox'
-          aria-expanded={open}
-          className='h-8 min-w-[140px] justify-between text-xs font-normal'
-        >
-          <span className='truncate'>
-            {selected.length > 0 ? `${label} (${selected.length})` : placeholder}
-          </span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className='w-[220px] p-0' align='start'>
-        <div className='max-h-[300px] overflow-auto p-1'>
-          {isLoading ? (
-            <div className='flex items-center justify-center py-4'>
-              <Skeleton className='h-4 w-full' />
-            </div>
-          ) : options.length === 0 ? (
-            <div className='px-2 py-4 text-center text-xs text-muted-foreground'>
-              {placeholder}
-            </div>
-          ) : (
-            options.map((option) => (
-              <button
-                key={option.value}
-                type='button'
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-accent',
-                  selected.includes(option.value) && 'bg-accent'
-                )}
-                onClick={() => toggle(option.value)}
-              >
-                <input
-                  type='checkbox'
-                  checked={selected.includes(option.value)}
-                  onChange={() => {}}
-                  className='h-3 w-3'
-                />
-                <span className='truncate'>{option.label}</span>
-              </button>
-            ))
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
 }
 
 interface DateRangePickerProps {
@@ -363,48 +291,43 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
 
       {/* Dimension Filters */}
       <div className='flex flex-wrap items-center gap-2'>
-        <MultiSelect
-          label={t('analytics.filter.project')}
-          placeholder={t('analytics.filter.selectProject')}
+        <DataTableFacetedFilter
+          title={t('analytics.filter.project')}
           options={projectOptions}
-          selected={filter.projectIDs || []}
-          onChange={setProjectIDs}
+          selectedValues={filter.projectIDs || []}
+          onSelectedValuesChange={setProjectIDs}
           isLoading={isLoadingProjects}
         />
 
-        <MultiSelect
-          label={t('analytics.filter.channel')}
-          placeholder={t('analytics.filter.selectChannel')}
+        <DataTableFacetedFilter
+          title={t('analytics.filter.channel')}
           options={channelOptions}
-          selected={filter.channelIDs || []}
-          onChange={setChannelIDs}
+          selectedValues={filter.channelIDs || []}
+          onSelectedValuesChange={setChannelIDs}
           isLoading={isLoadingChannels}
         />
 
-        <MultiSelect
-          label={t('analytics.filter.model')}
-          placeholder={t('analytics.filter.selectModel')}
+        <DataTableFacetedFilter
+          title={t('analytics.filter.model')}
           options={modelOptions}
-          selected={filter.modelIDs || []}
-          onChange={setModelIDs}
+          selectedValues={filter.modelIDs || []}
+          onSelectedValuesChange={setModelIDs}
           isLoading={isLoadingChannels}
         />
 
-        <MultiSelect
-          label={t('analytics.filter.apiKey')}
-          placeholder={t('analytics.filter.selectAPIKey')}
+        <DataTableFacetedFilter
+          title={t('analytics.filter.apiKey')}
           options={apiKeyOptions}
-          selected={filter.apiKeyIDs || []}
-          onChange={setAPIKeyIDs}
+          selectedValues={filter.apiKeyIDs || []}
+          onSelectedValuesChange={setAPIKeyIDs}
           isLoading={isLoadingApiKeys}
         />
 
-        <MultiSelect
-          label={t('analytics.filter.user')}
-          placeholder={t('analytics.filter.selectUser')}
+        <DataTableFacetedFilter
+          title={t('analytics.filter.user')}
           options={userOptions}
-          selected={filter.userIDs || []}
-          onChange={setUserIDs}
+          selectedValues={filter.userIDs || []}
+          onSelectedValuesChange={setUserIDs}
           isLoading={isLoadingUsers}
         />
 
@@ -416,80 +339,6 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
           </Button>
         )}
       </div>
-
-      {/* Active Filters Display */}
-      {hasFilters && (
-        <div className='flex flex-wrap gap-1'>
-          {filter.startTime && (
-            <Badge variant='secondary' className='text-xs'>
-              {t('analytics.filter.startDate')}: {filter.startTime}
-              <button type='button' className='ml-1' onClick={() => setStartTime(null)}>
-                <IconX className='h-3 w-3' />
-              </button>
-            </Badge>
-          )}
-          {filter.endTime && (
-            <Badge variant='secondary' className='text-xs'>
-              {t('analytics.filter.endDate')}: {filter.endTime}
-              <button type='button' className='ml-1' onClick={() => setEndTime(null)}>
-                <IconX className='h-3 w-3' />
-              </button>
-            </Badge>
-          )}
-          {filter.projectIDs?.map((id) => {
-            const name = projectOptions.find((o) => o.value === id)?.label || id;
-            return (
-              <Badge key={id} variant='secondary' className='text-xs'>
-                {name}
-                <button type='button' className='ml-1' onClick={() => setProjectIDs(filter.projectIDs!.filter((i) => i !== id))}>
-                  <IconX className='h-3 w-3' />
-                </button>
-              </Badge>
-            );
-          })}
-          {filter.channelIDs?.map((id) => {
-            const name = channelOptions.find((o) => o.value === id)?.label || id;
-            return (
-              <Badge key={id} variant='secondary' className='text-xs'>
-                {name}
-                <button type='button' className='ml-1' onClick={() => setChannelIDs(filter.channelIDs!.filter((i) => i !== id))}>
-                  <IconX className='h-3 w-3' />
-                </button>
-              </Badge>
-            );
-          })}
-          {filter.modelIDs?.map((id) => (
-            <Badge key={id} variant='secondary' className='text-xs'>
-              {id}
-              <button type='button' className='ml-1' onClick={() => setModelIDs(filter.modelIDs!.filter((i) => i !== id))}>
-                <IconX className='h-3 w-3' />
-              </button>
-            </Badge>
-          ))}
-          {filter.apiKeyIDs?.map((id) => {
-            const name = apiKeyOptions.find((o) => o.value === id)?.label || id;
-            return (
-              <Badge key={id} variant='secondary' className='text-xs'>
-                {name}
-                <button type='button' className='ml-1' onClick={() => setAPIKeyIDs(filter.apiKeyIDs!.filter((i) => i !== id))}>
-                  <IconX className='h-3 w-3' />
-                </button>
-              </Badge>
-            );
-          })}
-          {filter.userIDs?.map((id) => {
-            const name = userOptions.find((o) => o.value === id)?.label || id;
-            return (
-              <Badge key={id} variant='secondary' className='text-xs'>
-                {name}
-                <button type='button' className='ml-1' onClick={() => setUserIDs(filter.userIDs!.filter((i) => i !== id))}>
-                  <IconX className='h-3 w-3' />
-                </button>
-              </Badge>
-            );
-          })}
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- add a dedicated controlled `AnalyticsFacetedFilter` modeled after the searchable `DataTableFacetedFilter` UX
- replace the analytics page's custom project, channel, model, API key, and user multiselects with the new component
- display selected values beside each trigger, prioritize selected options in the dropdown, support direct removal, keep unavailable selections removable by ID, and remove the duplicated active-filter row

## Why

The analytics dimension filters used a separate non-searchable dropdown, so their appearance and interaction differed from status, tag, and model filters elsewhere in the frontend.

The final implementation keeps the two state models separate: `DataTableFacetedFilter` remains backed exclusively by TanStack Table columns, while `AnalyticsFacetedFilter` receives controlled values from the analytics store. This avoids adding table-versus-controlled branching to the shared table component.

## Implementation

- add `frontend/src/features/analytics/components/analytics-faceted-filter.tsx` for searchable controlled multi-selection
- group selected options before unselected options while preserving the original order inside each group
- render the popover trigger and native remove buttons as sibling controls inside the same visual group
- fall back to the raw selected ID when an entity is missing from the current option query, so active filters remain visible and individually removable
- keep the existing `DataTableFacetedFilter` behavior unchanged
- remove the analytics-specific `MultiSelect` implementation and separate active-filter badge row

## Validation

- verified the `/analytics` filters in the running frontend: search, empty results, multi-selection, selected badges, direct removal, and reset
- verified selecting a lower option moves it above unselected options, and multiple selected options preserve their source order
- verified search still returns the expected option after selected-first ordering is applied
- verified selected values can be removed with the mouse, Enter, or Space without opening the sibling filter popover
- verified the existing `/channels` table-backed filters remain on the original `DataTableFacetedFilter` behavior
- confirmed no application console errors or Vite error overlay
- `git diff --check`
- GitHub Actions passed: backend build, frontend build, lint, and test
- CodeRabbit completed with no actionable comments; Greptile rated the final component implementation 5/5 and safe to merge
- local build and lint were not run, following the repository instruction not to run them unless explicitly requested

## Screenshots

### Analytics filter bar

<img width="1000" alt="Analytics filter bar with a selected searchable channel filter" src="https://github.com/user-attachments/assets/1d6ee830-5b4e-4317-b60f-988824041e03" />

### Searchable filter options

<img width="200" alt="Analytics channel filter searching for a DeepSeek channel" src="https://github.com/user-attachments/assets/3eaf344e-6ebd-4d87-b26a-87444fc62f6c" />

### Direct selection removal

<img width="214" alt="Selected analytics channel with a direct remove icon" src="https://github.com/user-attachments/assets/f2e78144-7685-4185-980d-c38e38a2c288" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent, searchable faceted filters across analytics dimensions.
  * Filters now support multi-select, loading states, option icons, and removable selected-value badges.
  * Added support for displaying and clearing selected values that are not currently available in the options list.

* **Bug Fixes**
  * Improved filter selection and reset behavior for more reliable analytics filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->