### PR TITLE
fix(cline): normalize empty message content

### DIFF
--- a/llm/transformer/cline/outbound.go
+++ b/llm/transformer/cline/outbound.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/tidwall/sjson"
+
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -53,7 +55,7 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 	return &OutboundTransformer{Outbound: t}, nil
 }
 
-// TransformRequest identifies Cline chat completion requests as originating from the Cline CLI.
+// TransformRequest identifies Cline chat requests and preserves its accepted empty text-part form.
 func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
 	httpReq, err := t.Outbound.TransformRequest(ctx, llmReq)
 	if err != nil {
@@ -64,7 +66,37 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		httpReq.Headers.Set("X-Client-Type", "cline-cli")
 	}
 
+	for i, message := range llmReq.Messages {
+		if !clineRequiresContent(message.Role) || !isEmptyClineContent(message.Content) {
+			continue
+		}
+
+		httpReq.Body, err = sjson.SetRawBytes(httpReq.Body, fmt.Sprintf("messages.%d.content", i), []byte(`[{"type":"text","text":""}]`))
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize Cline message content: %w", err)
+		}
+	}
+
 	return httpReq, nil
+}
+
+func clineRequiresContent(role string) bool {
+	switch role {
+	case "user", "system", "developer":
+		return true
+	default:
+		return false
+	}
+}
+
+func isEmptyClineContent(content llm.MessageContent) bool {
+	if len(content.MultipleContent) > 0 {
+		return len(content.MultipleContent) == 1 &&
+			content.MultipleContent[0].Type == "text" &&
+			(content.MultipleContent[0].Text == nil || *content.MultipleContent[0].Text == "")
+	}
+
+	return content.Content == nil || *content.Content == ""
 }
 
 // TransformResponse transforms the HTTP response to llm.Response.

--- a/llm/transformer/cline/outbound_test.go
+++ b/llm/transformer/cline/outbound_test.go
@@ -96,6 +96,7 @@ func TestOutboundTransformer_TransformRequest_NormalizesOnlyRequiredEmptyContent
 			{Role: "system"},
 			{Role: "developer", Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{}}},
 			{Role: "user", Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{Type: "text", Text: &empty}}}},
+			{Role: "user", Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{Type: "text"}}}},
 			{Role: "assistant", Content: llm.MessageContent{Content: &empty}},
 			{Role: "tool", Content: llm.MessageContent{Content: &empty}},
 			{Role: "user", Content: llm.MessageContent{Content: &whitespace}},
@@ -111,16 +112,17 @@ func TestOutboundTransformer_TransformRequest_NormalizesOnlyRequiredEmptyContent
 		} `json:"messages"`
 	}
 	require.NoError(t, json.Unmarshal(req.Body, &body))
-	require.Len(t, body.Messages, 7)
+	require.Len(t, body.Messages, 8)
 
 	const emptyTextPart = `[{"type":"text","text":""}]`
 	assert.JSONEq(t, emptyTextPart, string(body.Messages[0].Content))
 	assert.JSONEq(t, emptyTextPart, string(body.Messages[1].Content))
 	assert.JSONEq(t, emptyTextPart, string(body.Messages[2].Content))
 	assert.JSONEq(t, emptyTextPart, string(body.Messages[3].Content))
-	assert.Equal(t, `""`, string(body.Messages[4].Content))
+	assert.JSONEq(t, emptyTextPart, string(body.Messages[4].Content))
 	assert.Equal(t, `""`, string(body.Messages[5].Content))
-	assert.Equal(t, `"   "`, string(body.Messages[6].Content))
+	assert.Equal(t, `""`, string(body.Messages[6].Content))
+	assert.Equal(t, `"   "`, string(body.Messages[7].Content))
 }
 
 func TestOutboundTransformer_TransformResponse_UnwrapsClineData(t *testing.T) {

--- a/llm/transformer/cline/outbound_test.go
+++ b/llm/transformer/cline/outbound_test.go
@@ -84,6 +84,45 @@ func TestOutboundTransformer_TransformRequest_IdentifiesAsClineCLI(t *testing.T)
 	}
 }
 
+func TestOutboundTransformer_TransformRequest_NormalizesOnlyRequiredEmptyContent(t *testing.T) {
+	transformer := newTestTransformer(t)
+	empty := ""
+	whitespace := "   "
+
+	req, err := transformer.TransformRequest(context.Background(), &llm.Request{
+		Model: "cline-pass/deepseek-v4-flash",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: &empty}},
+			{Role: "system"},
+			{Role: "developer", Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{}}},
+			{Role: "user", Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{Type: "text", Text: &empty}}}},
+			{Role: "assistant", Content: llm.MessageContent{Content: &empty}},
+			{Role: "tool", Content: llm.MessageContent{Content: &empty}},
+			{Role: "user", Content: llm.MessageContent{Content: &whitespace}},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "cline-cli", req.Headers.Get("X-Client-Type"))
+
+	var body struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(req.Body, &body))
+	require.Len(t, body.Messages, 7)
+
+	const emptyTextPart = `[{"type":"text","text":""}]`
+	assert.JSONEq(t, emptyTextPart, string(body.Messages[0].Content))
+	assert.JSONEq(t, emptyTextPart, string(body.Messages[1].Content))
+	assert.JSONEq(t, emptyTextPart, string(body.Messages[2].Content))
+	assert.JSONEq(t, emptyTextPart, string(body.Messages[3].Content))
+	assert.Equal(t, `""`, string(body.Messages[4].Content))
+	assert.Equal(t, `""`, string(body.Messages[5].Content))
+	assert.Equal(t, `"   "`, string(body.Messages[6].Content))
+}
+
 func TestOutboundTransformer_TransformResponse_UnwrapsClineData(t *testing.T) {
 	transformer := newTestTransformer(t)
 


### PR DESCRIPTION
## Summary

- normalize empty `user`, `system`, and `developer` message content to Cline's accepted empty text-part form
- preserve empty `assistant` and `tool` content as well as whitespace-only text

## Why

Cline rejects empty string content for roles that require message content, while accepting an explicit empty text part:

```json
[{"type":"text","text":""}]
```

This keeps the request semantically empty without substituting whitespace or other artificial content.

## Tests

- `go test -count=10 ./transformer/cline`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when sending requests containing empty user, system, or developer messages.
  - Empty message content is now represented consistently, preventing transformation failures.
  - Assistant, tool, and whitespace-only content remains unchanged.
- **Tests**
  - Added coverage to verify normalization behavior across supported message roles and content formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->