### PR TITLE
feat: add sse keep alive, close #2146

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -221,6 +221,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.base_path", "")
 	v.SetDefault("server.request_timeout", "30s")
 	v.SetDefault("server.llm_request_timeout", "600s")
+	v.SetDefault("server.sse_keep_alive.enabled", false)
+	v.SetDefault("server.sse_keep_alive.interval", "15s")
 	v.SetDefault("server.trace.thread_header", "AH-Thread-Id")
 	v.SetDefault("server.trace.trace_header", "AH-Trace-Id")
 	v.SetDefault("server.trace.extra_trace_headers", []string{})

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zapcore"
 )
@@ -36,6 +37,41 @@ log:
 	}
 	if reloaded.Log.Level != zapcore.DebugLevel {
 		t.Fatalf("reloaded log level = %s, want %s", reloaded.Log.Level, zapcore.DebugLevel)
+	}
+}
+
+func TestSSEKeepAliveConfig(t *testing.T) {
+	configFile := writeTestConfig(t, `
+server:
+  sse_keep_alive:
+    enabled: true
+    interval: 30s
+`)
+
+	cfg, _, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if !cfg.APIServer.SSEKeepAlive.Enabled {
+		t.Fatal("SSE keep-alive should be enabled")
+	}
+	if cfg.APIServer.SSEKeepAlive.Interval != 30*time.Second {
+		t.Fatalf("SSE keep-alive interval = %s, want 30s", cfg.APIServer.SSEKeepAlive.Interval)
+	}
+}
+
+func TestSSEKeepAliveDefaultsToDisabled(t *testing.T) {
+	configFile := writeTestConfig(t, "")
+
+	cfg, _, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.APIServer.SSEKeepAlive.Enabled {
+		t.Fatal("SSE keep-alive should default to disabled")
+	}
+	if cfg.APIServer.SSEKeepAlive.Interval != 15*time.Second {
+		t.Fatalf("SSE keep-alive interval = %s, want 15s", cfg.APIServer.SSEKeepAlive.Interval)
 	}
 }
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -11,6 +11,9 @@ server:
   # pid_file: "~/.config/axonhub/axonhub.pid"  # PID file for axonhub reload (env: AXONHUB_SERVER_PID_FILE)
   request_timeout: "30s"        # Request timeout duration (env: AXONHUB_SERVER_REQUEST_TIMEOUT)
   llm_request_timeout: "600s"   # LLM request timeout duration (env: AXONHUB_SERVER_LLM_REQUEST_TIMEOUT)
+  sse_keep_alive:
+    enabled: false               # Send API-compatible heartbeats while an SSE stream is idle (env: AXONHUB_SERVER_SSE_KEEP_ALIVE_ENABLED)
+    interval: "15s"              # Idle duration between heartbeats (env: AXONHUB_SERVER_SSE_KEEP_ALIVE_INTERVAL)
   trace:
     thread_header: "AH-Thread-Id" # Thread ID header name (env: AXONHUB_SERVER_TRACE_THREAD_HEADER)
     trace_header: "AH-Trace-Id" # Trace ID header name (env: AXONHUB_SERVER_TRACE_TRACE_HEADER)

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -62,6 +62,9 @@ server:
   base_path: ""                 # Base path for API routes
   request_timeout: "30s"        # Request timeout duration
   llm_request_timeout: "600s"   # LLM request timeout duration
+  sse_keep_alive:
+    enabled: false               # Send API-compatible heartbeats while an SSE stream is idle
+    interval: "15s"              # Idle duration between heartbeats
   trace:
     thread_header: "AH-Thread-Id" # Thread ID header name
     trace_header: "AH-Trace-Id" # Trace ID header name
@@ -79,6 +82,8 @@ server:
 - `AXONHUB_SERVER_BASE_PATH`
 - `AXONHUB_SERVER_REQUEST_TIMEOUT`
 - `AXONHUB_SERVER_LLM_REQUEST_TIMEOUT`
+- `AXONHUB_SERVER_SSE_KEEP_ALIVE_ENABLED`
+- `AXONHUB_SERVER_SSE_KEEP_ALIVE_INTERVAL`
 - `AXONHUB_SERVER_TRACE_THREAD_HEADER`
 - `AXONHUB_SERVER_TRACE_TRACE_HEADER`
 - `AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS`
@@ -87,6 +92,8 @@ server:
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`
 - `AXONHUB_SERVER_DISABLE_SSL_VERIFY`
+
+SSE keep-alive currently applies to OpenAI-compatible and Anthropic-compatible streaming APIs. Gemini streaming APIs are excluded.
 
 ### Database Configuration
 

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -62,6 +62,9 @@ server:
   base_path: ""                 # API 路由的基础路径
   request_timeout: "30s"        # 请求超时时间
   llm_request_timeout: "600s"   # LLM 请求超时时间
+  sse_keep_alive:
+    enabled: false               # SSE 流空闲时发送与 API 格式兼容的心跳
+    interval: "15s"              # 两次心跳之间的空闲时长
   trace:
     thread_header: "AH-Thread-Id" # 线程 ID 请求头名称
     trace_header: "AH-Trace-Id" # 追踪 ID 请求头名称
@@ -79,6 +82,8 @@ server:
 - `AXONHUB_SERVER_BASE_PATH`
 - `AXONHUB_SERVER_REQUEST_TIMEOUT`
 - `AXONHUB_SERVER_LLM_REQUEST_TIMEOUT`
+- `AXONHUB_SERVER_SSE_KEEP_ALIVE_ENABLED`
+- `AXONHUB_SERVER_SSE_KEEP_ALIVE_INTERVAL`
 - `AXONHUB_SERVER_TRACE_THREAD_HEADER`
 - `AXONHUB_SERVER_TRACE_TRACE_HEADER`
 - `AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS`
@@ -87,6 +92,8 @@ server:
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`
 - `AXONHUB_SERVER_DISABLE_SSL_VERIFY`
+
+SSE 心跳目前应用于 OpenAI 兼容和 Anthropic 兼容的流式 API，暂不应用于 Gemini 流式 API。
 
 ### 数据库配置
 

--- a/internal/server/api/anthropic.go
+++ b/internal/server/api/anthropic.go
@@ -19,19 +19,20 @@ import (
 type AnthropicHandlersParams struct {
 	fx.In
 
-	ChannelService  *biz.ChannelService
-	ModelService    *biz.ModelService
-	DefaultSelector *orchestrator.DefaultSelector
-	RequestService  *biz.RequestService
-	SystemService   *biz.SystemService
-	UsageLogService *biz.UsageLogService
-	PromptService   *biz.PromptService
+	ChannelService              *biz.ChannelService
+	ModelService                *biz.ModelService
+	DefaultSelector             *orchestrator.DefaultSelector
+	RequestService              *biz.RequestService
+	SystemService               *biz.SystemService
+	UsageLogService             *biz.UsageLogService
+	PromptService               *biz.PromptService
 	PromptProtectionRuleService *biz.PromptProtectionRuleService
-	QuotaService    *biz.QuotaService
-	HttpClient      *httpclient.HttpClient
-	LiveStreamRegistry *biz.LiveStreamRegistry
+	QuotaService                *biz.QuotaService
+	HttpClient                  *httpclient.HttpClient
+	LiveStreamRegistry          *biz.LiveStreamRegistry
 	ChannelLimiterManager       *orchestrator.ChannelLimiterManager
 	ProviderQuotaStatusProvider orchestrator.ProviderQuotaStatusProvider
+	SSEKeepAliveConfig          SSEKeepAliveConfig
 }
 
 type AnthropicHandlers struct {
@@ -59,6 +60,8 @@ func NewAnthropicHandlers(params AnthropicHandlersParams) *AnthropicHandlers {
 				params.ChannelLimiterManager,
 				params.ProviderQuotaStatusProvider,
 			),
+			sseKeepAlive:       params.SSEKeepAliveConfig,
+			sseHeartbeatFormat: sseHeartbeatAnthropic,
 		},
 		ChannelService: params.ChannelService,
 		ModelService:   params.ModelService,

--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-contrib/sse"
 	"github.com/gin-gonic/gin"
@@ -26,9 +28,25 @@ const (
 // StreamWriter is a function type for writing stream events to the response.
 type StreamWriter func(c *gin.Context, stream streams.Stream[*httpclient.StreamEvent])
 
+// SSEKeepAliveConfig controls downstream heartbeats for SSE-compatible APIs.
+type SSEKeepAliveConfig struct {
+	Enabled  bool
+	Interval time.Duration
+}
+
+type sseHeartbeatFormat uint8
+
+const (
+	sseHeartbeatNone sseHeartbeatFormat = iota
+	sseHeartbeatOpenAI
+	sseHeartbeatAnthropic
+)
+
 type ChatCompletionHandlers struct {
 	ChatCompletionOrchestrator *orchestrator.ChatCompletionOrchestrator
 	StreamWriter               StreamWriter
+	sseKeepAlive               SSEKeepAliveConfig
+	sseHeartbeatFormat         sseHeartbeatFormat
 }
 
 func NewChatCompletionHandlers(orchestrator *orchestrator.ChatCompletionOrchestrator) *ChatCompletionHandlers {
@@ -106,12 +124,13 @@ func (handlers *ChatCompletionHandlers) ChatCompletionWithRequest(c *gin.Context
 
 		c.Header("Access-Control-Allow-Origin", "*")
 
-		streamWriter := handlers.StreamWriter
-		if streamWriter == nil {
-			streamWriter = WriteSSEStream
+		stream := newUpstreamErrorStream(ctx, result.ChatCompletionStream, handlers.ChatCompletionOrchestrator.SystemService)
+		if handlers.StreamWriter != nil {
+			handlers.StreamWriter(c, stream)
+			return
 		}
 
-		streamWriter(c, newUpstreamErrorStream(ctx, result.ChatCompletionStream, handlers.ChatCompletionOrchestrator.SystemService))
+		writeSSEStream(c, stream, FormatStreamError, handlers.sseKeepAlive, handlers.sseHeartbeatFormat)
 	}
 }
 
@@ -132,6 +151,25 @@ func WriteSSEStream(c *gin.Context, stream streams.Stream[*httpclient.StreamEven
 
 // WriteSSEStreamWithErrorFormatter writes stream events as SSE with a custom error formatter.
 func WriteSSEStreamWithErrorFormatter(c *gin.Context, stream streams.Stream[*httpclient.StreamEvent], formatErr StreamErrorFormatter) {
+	writeSSEStream(c, stream, formatErr, SSEKeepAliveConfig{}, sseHeartbeatNone)
+}
+
+func writeSSEStream(
+	c *gin.Context,
+	stream streams.Stream[*httpclient.StreamEvent],
+	formatErr StreamErrorFormatter,
+	keepAlive SSEKeepAliveConfig,
+	heartbeatFormat sseHeartbeatFormat,
+) {
+	if !keepAlive.Enabled || keepAlive.Interval <= 0 || heartbeatFormat == sseHeartbeatNone {
+		writeSSEStreamWithoutHeartbeat(c, stream, formatErr)
+		return
+	}
+
+	writeSSEStreamWithHeartbeat(c, stream, formatErr, keepAlive.Interval, heartbeatFormat)
+}
+
+func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpclient.StreamEvent], formatErr StreamErrorFormatter) {
 	ctx := c.Request.Context()
 	clientDisconnected := false
 
@@ -146,9 +184,7 @@ func WriteSSEStreamWithErrorFormatter(c *gin.Context, stream streams.Stream[*htt
 	}()
 
 	// Set SSE headers
-	c.Header("Content-Type", sse.ContentType)
-	c.Header("Cache-Control", "no-cache")
-	c.Header("Connection", "keep-alive")
+	setSSEHeaders(c)
 	c.Writer.Flush()
 
 	// Do not pre-check ctx.Done() before Next(). If the client disconnects right
@@ -198,6 +234,149 @@ func WriteSSEStreamWithErrorFormatter(c *gin.Context, stream streams.Stream[*htt
 		c.SSEvent(cur.Type, cur.Data)
 		log.Debug(ctx, "write stream event", log.Any("event", cur))
 		c.Writer.Flush()
+	}
+}
+
+func writeSSEStreamWithHeartbeat(
+	c *gin.Context,
+	stream streams.Stream[*httpclient.StreamEvent],
+	formatErr StreamErrorFormatter,
+	interval time.Duration,
+	heartbeatFormat sseHeartbeatFormat,
+) {
+	ctx := c.Request.Context()
+	clientDisconnected := false
+
+	if formatErr == nil {
+		formatErr = FormatStreamError
+	}
+
+	defer func() {
+		if clientDisconnected {
+			log.Warn(ctx, "Client disconnected")
+		}
+	}()
+
+	setSSEHeaders(c)
+	c.Writer.Flush()
+
+	reader := newSSEStreamReader(ctx, stream)
+	// The caller closes the stream after this function returns. Wait for the
+	// reader first so Close cannot race with Next or Current.
+	defer reader.Stop()
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	timerC := timer.C
+	ctxDone := ctx.Done()
+	eventsAfterCancel := 0
+
+	for {
+		select {
+		case <-ctxDone:
+			clientDisconnected = true
+			ctxDone = nil
+			stopTimer(timer)
+			timerC = nil
+
+		case result := <-reader.Results():
+			if result.done {
+				writeSSEStreamEnd(c, ctx, result.err, formatErr, &clientDisconnected)
+				return
+			}
+
+			if ctx.Err() != nil {
+				eventsAfterCancel++
+				if eventsAfterCancel > maxStreamEventsAfterCancel {
+					clientDisconnected = true
+					log.Warn(ctx, "Stream still producing after cancellation, aborting drain",
+						log.Int("events_after_cancel", eventsAfterCancel))
+					return
+				}
+			}
+
+			cur := result.event
+			c.SSEvent(cur.Type, cur.Data)
+			log.Debug(ctx, "write stream event", log.Any("event", cur))
+			c.Writer.Flush()
+
+			if timerC != nil {
+				resetTimer(timer, interval)
+			}
+
+		case <-timerC:
+			if err := writeSSEHeartbeat(c.Writer, heartbeatFormat); err != nil {
+				clientDisconnected = true
+				log.Warn(ctx, "Failed to write SSE heartbeat", log.Cause(err))
+				return
+			}
+
+			c.Writer.Flush()
+			timer.Reset(interval)
+		}
+	}
+}
+
+func writeSSEStreamEnd(
+	c *gin.Context,
+	ctx context.Context,
+	streamErr error,
+	formatErr StreamErrorFormatter,
+	clientDisconnected *bool,
+) {
+	if streamErr != nil {
+		if errors.Is(streamErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			*clientDisconnected = true
+
+			if !errors.Is(streamErr, context.Canceled) {
+				log.Warn(ctx, "Stream error after client disconnected", log.Cause(streamErr))
+			}
+		} else {
+			log.Error(ctx, "Error in stream", log.Cause(streamErr))
+			c.SSEvent("error", formatErr(ctx, streamErr))
+		}
+	} else if errors.Is(ctx.Err(), context.Canceled) {
+		*clientDisconnected = true
+	}
+
+	c.Writer.Flush()
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func resetTimer(timer *time.Timer, interval time.Duration) {
+	stopTimer(timer)
+	timer.Reset(interval)
+}
+
+func setSSEHeaders(c *gin.Context) {
+	setSSEResponseHeaders(c.Writer.Header())
+}
+
+func setSSEResponseHeaders(header http.Header) {
+	header.Set("Content-Type", sse.ContentType)
+	header.Set("Cache-Control", "no-cache")
+	header.Set("Connection", "keep-alive")
+}
+
+func writeSSEHeartbeat(writer io.Writer, format sseHeartbeatFormat) error {
+	switch format {
+	case sseHeartbeatOpenAI:
+		_, err := io.WriteString(writer, ": keep-alive\n\n")
+		return err
+	case sseHeartbeatAnthropic:
+		_, err := io.WriteString(writer, "event: ping\ndata: {\"type\":\"ping\"}\n\n")
+		return err
+	default:
+		return errors.New("unsupported SSE heartbeat format")
 	}
 }
 

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -104,6 +105,72 @@ func (s *trackingStream) Current() *httpclient.StreamEvent { return s.current }
 func (s *trackingStream) Err() error                       { return nil }
 func (s *trackingStream) Close() error                     { return nil }
 
+type delayedStream struct {
+	delay   time.Duration
+	event   *httpclient.StreamEvent
+	current *httpclient.StreamEvent
+	done    bool
+}
+
+func (s *delayedStream) Next() bool {
+	if s.done {
+		return false
+	}
+
+	time.Sleep(s.delay)
+	s.current = s.event
+	s.done = true
+
+	return true
+}
+
+func (s *delayedStream) Current() *httpclient.StreamEvent { return s.current }
+func (s *delayedStream) Err() error                       { return nil }
+func (s *delayedStream) Close() error                     { return nil }
+
+type blockingStream struct {
+	nextStarted  chan struct{}
+	nextReleased chan struct{}
+	nextReturned chan struct{}
+}
+
+func (s *blockingStream) Next() bool {
+	close(s.nextStarted)
+	<-s.nextReleased
+	close(s.nextReturned)
+
+	return false
+}
+
+func (s *blockingStream) Current() *httpclient.StreamEvent { return nil }
+func (s *blockingStream) Err() error                       { return nil }
+func (s *blockingStream) Close() error                     { return nil }
+
+type blockingEventStream struct {
+	event        *httpclient.StreamEvent
+	nextStarted  chan struct{}
+	nextReleased chan struct{}
+	current      *httpclient.StreamEvent
+	done         bool
+}
+
+func (s *blockingEventStream) Next() bool {
+	if s.done {
+		return false
+	}
+
+	close(s.nextStarted)
+	<-s.nextReleased
+	s.current = s.event
+	s.done = true
+
+	return true
+}
+
+func (s *blockingEventStream) Current() *httpclient.StreamEvent { return s.current }
+func (s *blockingEventStream) Err() error                       { return nil }
+func (s *blockingEventStream) Close() error                     { return nil }
+
 type failingResponseWriter struct {
 	gin.ResponseWriter
 
@@ -115,6 +182,26 @@ func (w *failingResponseWriter) Write(_ []byte) (int, error) {
 	w.writes++
 
 	return 0, w.err
+}
+
+type heartbeatFailingResponseWriter struct {
+	gin.ResponseWriter
+
+	err    error
+	failed chan struct{}
+}
+
+func (w *heartbeatFailingResponseWriter) Write(_ []byte) (int, error) {
+	select {
+	case w.failed <- struct{}{}:
+	default:
+	}
+
+	return 0, w.err
+}
+
+func (w *heartbeatFailingResponseWriter) WriteString(data string) (int, error) {
+	return w.Write([]byte(data))
 }
 
 func TestWriteSSEStream_Success(t *testing.T) {
@@ -133,6 +220,156 @@ func TestWriteSSEStream_Success(t *testing.T) {
 	body := w.Body.String()
 	assert.Contains(t, body, `{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)
 	assert.Contains(t, body, `[DONE]`)
+}
+
+func TestWriteSSEStream_OpenAIHeartbeat(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := &delayedStream{
+		delay: 25 * time.Millisecond,
+		event: &httpclient.StreamEvent{Data: []byte(`[DONE]`)},
+	}
+
+	writeSSEStream(c, stream, FormatStreamError, SSEKeepAliveConfig{
+		Enabled:  true,
+		Interval: 5 * time.Millisecond,
+	}, sseHeartbeatOpenAI)
+
+	body := w.Body.String()
+	require.Contains(t, body, ": keep-alive\n\n")
+	require.Contains(t, body, "data: [DONE]\n\n")
+}
+
+func TestWriteSSEStream_AnthropicHeartbeat(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := &delayedStream{
+		delay: 25 * time.Millisecond,
+		event: &httpclient.StreamEvent{Type: "message_stop", Data: []byte(`{"type":"message_stop"}`)},
+	}
+
+	writeSSEStream(c, stream, FormatStreamError, SSEKeepAliveConfig{
+		Enabled:  true,
+		Interval: 5 * time.Millisecond,
+	}, sseHeartbeatAnthropic)
+
+	body := w.Body.String()
+	require.Contains(t, body, "event: ping\ndata: {\"type\":\"ping\"}\n\n")
+	require.Contains(t, body, "event:message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+}
+
+func TestWriteSSEStream_HeartbeatWriteErrorWaitsForReader(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	failingWriter := &heartbeatFailingResponseWriter{
+		ResponseWriter: c.Writer,
+		err:            errors.New("broken pipe"),
+		failed:         make(chan struct{}, 1),
+	}
+	c.Writer = failingWriter
+
+	stream := &blockingStream{
+		nextStarted:  make(chan struct{}),
+		nextReleased: make(chan struct{}),
+		nextReturned: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		writeSSEStreamWithHeartbeat(c, stream, FormatStreamError, time.Millisecond, sseHeartbeatOpenAI)
+		close(done)
+	}()
+
+	select {
+	case <-failingWriter.failed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat write failure")
+	}
+
+	select {
+	case <-stream.nextStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream reader")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("writer returned before the stream reader stopped")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(stream.nextReleased)
+
+	select {
+	case <-stream.nextReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream reader to stop")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SSE writer")
+	}
+}
+
+func TestWriteSSEStream_CanceledContextDrainsHeartbeatReader(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	c.Request = httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+
+	stream := &blockingEventStream{
+		event:        &httpclient.StreamEvent{Data: []byte(`[DONE]`)},
+		nextStarted:  make(chan struct{}),
+		nextReleased: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		writeSSEStreamWithHeartbeat(c, stream, FormatStreamError, time.Hour, sseHeartbeatOpenAI)
+		close(done)
+	}()
+
+	select {
+	case <-stream.nextStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream reader")
+	}
+
+	cancel()
+	close(stream.nextReleased)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled SSE writer")
+	}
+
+	assert.Contains(t, w.Body.String(), "data: [DONE]\n\n")
+	assert.NotContains(t, w.Body.String(), "keep-alive")
+}
+
+func TestWriteSSEStream_DefaultHasNoHeartbeat(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := &delayedStream{
+		delay: 10 * time.Millisecond,
+		event: &httpclient.StreamEvent{Data: []byte(`[DONE]`)},
+	}
+
+	WriteSSEStream(c, stream)
+
+	require.NotContains(t, w.Body.String(), "keep-alive")
 }
 
 func TestWriteSSEStream_CanceledContextStillDrainsBufferedEvents(t *testing.T) {

--- a/internal/server/api/openai.go
+++ b/internal/server/api/openai.go
@@ -43,6 +43,7 @@ type OpenAIHandlersParams struct {
 	ChannelLimiterManager       *orchestrator.ChannelLimiterManager
 	ProviderQuotaStatusProvider orchestrator.ProviderQuotaStatusProvider
 	Client                      *ent.Client
+	SSEKeepAliveConfig          SSEKeepAliveConfig
 }
 
 type OpenAIHandlers struct {
@@ -76,7 +77,7 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 	videoInbound := openai.NewVideoInboundTransformer()
 	speechInbound := openai.NewSpeechInboundTransformer()
 
-	return &OpenAIHandlers{
+	handlers := &OpenAIHandlers{
 		ChatCompletionHandlers: &ChatCompletionHandlers{
 			ChatCompletionOrchestrator: orchestrator.NewChatCompletionOrchestrator(
 				params.ChannelService,
@@ -306,6 +307,21 @@ func NewOpenAIHandlers(params OpenAIHandlersParams) *OpenAIHandlers {
 			),
 		},
 	}
+
+	for _, handler := range []*ChatCompletionHandlers{
+		handlers.ChatCompletionHandlers,
+		handlers.CompletionHandlers,
+		handlers.ResponseCompletionHandlers,
+		handlers.CompactHandlers,
+		handlers.SpeechHandlers,
+		handlers.TranscriptionHandlers,
+		handlers.TranslationHandlers,
+	} {
+		handler.sseKeepAlive = params.SSEKeepAliveConfig
+		handler.sseHeartbeatFormat = sseHeartbeatOpenAI
+	}
+
+	return handlers
 }
 
 func (handlers *OpenAIHandlers) ChatCompletion(c *gin.Context) {

--- a/internal/server/api/sse_stream_reader.go
+++ b/internal/server/api/sse_stream_reader.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/looplj/axonhub/internal/log"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+type sseStreamReadResult struct {
+	event *httpclient.StreamEvent
+	err   error
+	done  bool
+}
+
+// sseStreamReader keeps blocking stream reads away from the response writer loop.
+type sseStreamReader struct {
+	results chan sseStreamReadResult
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+func newSSEStreamReader(ctx context.Context, stream streams.Stream[*httpclient.StreamEvent]) *sseStreamReader {
+	reader := &sseStreamReader{
+		results: make(chan sseStreamReadResult),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+
+	go reader.run(ctx, stream)
+
+	return reader
+}
+
+// Results returns stream events and the terminal stream result.
+func (reader *sseStreamReader) Results() <-chan sseStreamReadResult {
+	return reader.results
+}
+
+// Stop stops delivering results and waits for the blocking reader to exit.
+func (reader *sseStreamReader) Stop() {
+	close(reader.stop)
+	<-reader.done
+}
+
+func (reader *sseStreamReader) run(ctx context.Context, stream streams.Stream[*httpclient.StreamEvent]) {
+	defer close(reader.done)
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Error(ctx, "Panic while reading SSE stream", log.Any("panic", recovered))
+			reader.send(sseStreamReadResult{
+				err:  errors.New("stream reader stopped unexpectedly"),
+				done: true,
+			})
+		}
+	}()
+
+	for stream.Next() {
+		if !reader.send(sseStreamReadResult{event: stream.Current()}) {
+			return
+		}
+	}
+
+	reader.send(sseStreamReadResult{err: stream.Err(), done: true})
+}
+
+func (reader *sseStreamReader) send(result sseStreamReadResult) bool {
+	select {
+	case reader.results <- result:
+		return true
+	case <-reader.stop:
+		return false
+	}
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	// LLMRequestTimeout is the maximum duration for processing a request to LLM.
 	LLMRequestTimeout time.Duration `conf:"llm_request_timeout" yaml:"llm_request_timeout" json:"llm_request_timeout"`
 
+	SSEKeepAlive SSEKeepAlive `conf:"sse_keep_alive" yaml:"sse_keep_alive" json:"sse_keep_alive"`
+
 	Trace     tracing.Config `conf:"trace" yaml:"trace" json:"trace"`
 	Dashboard Dashboard      `conf:"dashboard" yaml:"dashboard" json:"dashboard"`
 
@@ -104,6 +106,11 @@ type Config struct {
 	// This is important for backup restore which uploads large backup files.
 	// Default: 32 MB. Increase this if you have large backup files.
 	MaxMultipartMemory MemorySize `conf:"max_multipart_memory" yaml:"max_multipart_memory" json:"max_multipart_memory"`
+}
+
+type SSEKeepAlive struct {
+	Enabled  bool          `conf:"enabled" yaml:"enabled" json:"enabled"`
+	Interval time.Duration `conf:"interval" yaml:"interval" json:"interval"`
 }
 
 // Dashboard holds configuration for the dashboard cache settings.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,6 +106,12 @@ func Run(opts ...fx.Option) {
 			video_storage.Module,
 			api.Module,
 			fx.Provide(fx.Annotate(func(cfg Config) string { return cfg.PublicURL }, fx.ResultTags(`name:"public_url"`))),
+			fx.Provide(func(cfg Config) api.SSEKeepAliveConfig {
+				return api.SSEKeepAliveConfig{
+					Enabled:  cfg.SSEKeepAlive.Enabled,
+					Interval: cfg.SSEKeepAlive.Interval,
+				}
+			}),
 			fx.Invoke(func(cfg log.Config) {
 				log.SetGlobalConfig(cfg)
 				tracing.SetupLogger(log.GetGlobalLogger())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SSE keep-alive heartbeats for OpenAI- and Anthropic-compatible streaming APIs.
  * Heartbeats can be enabled and assigned custom intervals through server configuration or environment variables.
  * Supports provider-specific heartbeat formats to help maintain connections while waiting for upstream responses.
  * Heartbeats are disabled by default and are not supported for Gemini streaming APIs.

* **Documentation**
  * Added English and Chinese configuration guidance, including supported APIs and default settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->