### PR TITLE
feat(analytics): 展示性能指标并修复筛选查询

### DIFF
--- a/frontend/src/features/analytics/components/dimension-detail-table.tsx
+++ b/frontend/src/features/analytics/components/dimension-detail-table.tsx
@@ -96,17 +96,19 @@ export function DimensionDetailTable({
           </div>
         ) : (
           <div className='overflow-x-auto'>
-            <table className='w-full min-w-[800px] table-fixed caption-bottom text-sm'>
+            <table className='w-full min-w-[1100px] table-fixed caption-bottom text-sm'>
               <colgroup>
                 <col className='w-[20%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
-                <col className='w-[10%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
+                <col className='w-[8%]' />
               </colgroup>
               <thead className='[&_tr]:border-b'>
                 <tr className='border-b transition-colors hover:bg-muted/50'>
@@ -118,6 +120,8 @@ export function DimensionDetailTable({
                   <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.outputTokens')}</th>
                   <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.cacheHitRate')}</th>
                   <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.requests')}</th>
+                  <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.tokensPerSecond')}</th>
+                  <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.ttft')}</th>
                   <th className='px-4 py-2 text-right text-xs font-medium text-muted-foreground'>{t('analytics.table.cost')}</th>
                 </tr>
               </thead>
@@ -134,6 +138,12 @@ export function DimensionDetailTable({
                       {item.inputTokens > 0 ? ((item.cachedInputTokens / item.inputTokens) * 100).toFixed(1) : '0'}%
                     </td>
                     <td className='whitespace-nowrap px-4 py-2 text-right text-sm'>{formatExactNumber(item.requestCount)}</td>
+                    <td className='whitespace-nowrap px-4 py-2 text-right text-sm'>
+                      {item.tokensPerSecond == null ? '—' : item.tokensPerSecond.toFixed(2)}
+                    </td>
+                    <td className='whitespace-nowrap px-4 py-2 text-right text-sm'>
+                      {item.ttftMs == null ? '—' : Math.round(item.ttftMs).toLocaleString()}
+                    </td>
                     <td className='whitespace-nowrap px-4 py-2 text-right text-sm'>{formatCurrency(item.cost)}</td>
                   </tr>
                 ))}

--- a/frontend/src/features/analytics/data/analytics.ts
+++ b/frontend/src/features/analytics/data/analytics.ts
@@ -50,6 +50,8 @@ export const analyticsDimensionStatSchema = z.object({
   outputTokens: z.number(),
   totalTokens: z.number(),
   cost: z.number(),
+  tokensPerSecond: z.number().nullable(),
+  ttftMs: z.number().nullable(),
 });
 
 export type AnalyticsDimensionStat = z.infer<typeof analyticsDimensionStatSchema>;
@@ -110,6 +112,8 @@ const ANALYTICS_DIMENSION_STATS_QUERY = `
       outputTokens
       totalTokens
       cost
+      tokensPerSecond
+      ttftMs
     }
   }
 `;

--- a/frontend/src/locales/en/analytics.json
+++ b/frontend/src/locales/en/analytics.json
@@ -55,6 +55,8 @@
   "analytics.table.uncachedTokens": "Input Token (Uncached)",
   "analytics.table.outputTokens": "Output Token",
   "analytics.table.totalTokens": "Total Token",
+  "analytics.table.tokensPerSecond": "tok/s",
+  "analytics.table.ttft": "TTFT (ms)",
   "analytics.table.cost": "Cost",
   "analytics.table.noData": "No data available for the selected filters"
 }

--- a/frontend/src/locales/zh-CN/analytics.json
+++ b/frontend/src/locales/zh-CN/analytics.json
@@ -55,6 +55,8 @@
   "analytics.table.uncachedTokens": "输入 Token (未命中缓存)",
   "analytics.table.outputTokens": "输出 Token",
   "analytics.table.totalTokens": "总消耗 Token",
+  "analytics.table.tokensPerSecond": "tok/s",
+  "analytics.table.ttft": "TTFT (ms)",
   "analytics.table.cost": "费用",
   "analytics.table.noData": "当前筛选条件下没有数据"
 }

--- a/internal/server/gql/analytics.graphql
+++ b/internal/server/gql/analytics.graphql
@@ -68,6 +68,10 @@ type AnalyticsDimensionStat {
   outputTokens: Int!
   totalTokens: Int!
   cost: Float!
+  "Output token throughput in tokens per second, null when no valid latency metrics exist"
+  tokensPerSecond: Float
+  "Average time to first token in milliseconds, null when no streaming request recorded a first token"
+  ttftMs: Float
 }
 
 extend type Query {

--- a/internal/server/gql/analytics.resolvers.go
+++ b/internal/server/gql/analytics.resolvers.go
@@ -236,5 +236,17 @@ func (r *queryResolver) AnalyticsDimensionStats(ctx context.Context, filter *Ana
 		return nil, err
 	}
 
+	performanceByID, err := r.queryDimensionPerformanceStats(ctx, filter, apiKeyIDs, hasUserFilter, loc, dimension)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range results {
+		if performance, ok := performanceByID[results[i].ID]; ok {
+			results[i].TokensPerSecond = performance.TokensPerSecond
+			results[i].TtftMs = performance.TtftMs
+		}
+	}
+
 	return dimStatsToDimensionStats(results), nil
 }

--- a/internal/server/gql/analytics_helpers.go
+++ b/internal/server/gql/analytics_helpers.go
@@ -67,12 +67,12 @@ func (r *queryResolver) buildAnalyticsWhere(s *sql.Selector, filter *AnalyticsFi
 
 	if len(filter.ProjectIDs) > 0 {
 		ids := lo.Map(filter.ProjectIDs, func(g *objects.GUID, _ int) int { return g.ID })
-		s.Where(sql.InInts(usagelog.FieldProjectID, ids...))
+		s.Where(sql.InInts(s.C(usagelog.FieldProjectID), ids...))
 	}
 
 	if len(filter.ChannelIDs) > 0 {
 		ids := lo.Map(filter.ChannelIDs, func(g *objects.GUID, _ int) int { return g.ID })
-		s.Where(sql.InInts(usagelog.FieldChannelID, ids...))
+		s.Where(sql.InInts(s.C(usagelog.FieldChannelID), ids...))
 	}
 
 	if len(filter.ModelIDs) > 0 {
@@ -80,7 +80,7 @@ func (r *queryResolver) buildAnalyticsWhere(s *sql.Selector, filter *AnalyticsFi
 		for i, v := range filter.ModelIDs {
 			vals[i] = v
 		}
-		s.Where(sql.In(usagelog.FieldModelID, vals...))
+		s.Where(sql.In(s.C(usagelog.FieldModelID), vals...))
 	}
 
 	// API key / user filtering:
@@ -88,7 +88,7 @@ func (r *queryResolver) buildAnalyticsWhere(s *sql.Selector, filter *AnalyticsFi
 	// - apiKeyIDs == 0 && hasUserFilter: user filter matched no API keys → return empty
 	// - apiKeyIDs == 0 && !hasUserFilter: no API key filter → show all
 	if len(apiKeyIDs) > 0 {
-		s.Where(sql.InInts(usagelog.FieldAPIKeyID, apiKeyIDs...))
+		s.Where(sql.InInts(s.C(usagelog.FieldAPIKeyID), apiKeyIDs...))
 	} else if hasUserFilter {
 		s.Where(sql.False())
 	}

--- a/internal/server/gql/analytics_helpers.go
+++ b/internal/server/gql/analytics_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/ent/usagelog"
 	"github.com/looplj/axonhub/internal/objects"
 )
@@ -152,14 +153,145 @@ func trimSpace(s string) string {
 
 // dimStats holds aggregated dimension statistics from raw SQL queries.
 type dimStats struct {
-	ID           string  `json:"id"`
-	Name         string  `json:"name"`
-	RequestCount int     `json:"request_count"`
-	InputTokens  int64   `json:"input_tokens"`
-	CachedTokens int64   `json:"cached_tokens"`
-	OutputTokens int64   `json:"output_tokens"`
-	TotalTokens  int64   `json:"total_tokens"`
-	Cost         float64 `json:"cost"`
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	RequestCount    int      `json:"request_count"`
+	InputTokens     int64    `json:"input_tokens"`
+	CachedTokens    int64    `json:"cached_tokens"`
+	OutputTokens    int64    `json:"output_tokens"`
+	TotalTokens     int64    `json:"total_tokens"`
+	Cost            float64  `json:"cost"`
+	TokensPerSecond *float64 `json:"tokens_per_second"`
+	TtftMs          *float64 `json:"ttft_ms"`
+}
+
+// dimensionPerformanceStats contains the nullable performance measurements for one usage dimension item.
+// A nil value means the selected logs did not have a completed execution with the required metric.
+type dimensionPerformanceStats struct {
+	TokensPerSecond *float64 `json:"tokens_per_second"`
+	TtftMs          *float64 `json:"ttft_ms"`
+}
+
+// queryDimensionPerformanceStats aggregates performance for the same usage-log rows as the analytics table.
+// It uses the newest completed attempt for each request and channel so retried attempts cannot inflate metrics.
+func (r *queryResolver) queryDimensionPerformanceStats(
+	ctx context.Context,
+	filter *AnalyticsFilter,
+	apiKeyIDs []int,
+	hasUserFilter bool,
+	loc *time.Location,
+	dimension string,
+) (map[string]dimensionPerformanceStats, error) {
+	type rawPerformanceStats struct {
+		ID              string   `json:"id"`
+		TokensPerSecond *float64 `json:"tokens_per_second"`
+		TtftMs          *float64 `json:"ttft_ms"`
+	}
+
+	var rawResults []rawPerformanceStats
+
+	err := r.client.UsageLog.Query().
+		Modify(func(s *sql.Selector) {
+			executionTable := sql.Table(requestexecution.Table).As("analytics_execution")
+			latestExecutionTable := sql.Table(requestexecution.Table).As("latest_analytics_execution")
+
+			s.Join(executionTable).On(
+				s.C(usagelog.FieldRequestID),
+				executionTable.C(requestexecution.FieldRequestID),
+			)
+			s.OnP(sql.ColumnsEQ(
+				s.C(usagelog.FieldChannelID),
+				executionTable.C(requestexecution.FieldChannelID),
+			))
+
+			// The correlated subquery keeps the current table's date and dimension filters on usage_logs.
+			// It only selects a single completed attempt for a request/channel pair to avoid retry double counting.
+			latestExecutionID := sql.Select(sql.Max(latestExecutionTable.C(requestexecution.FieldID))).
+				From(latestExecutionTable).
+				Where(sql.And(
+					sql.ColumnsEQ(latestExecutionTable.C(requestexecution.FieldRequestID), s.C(usagelog.FieldRequestID)),
+					sql.ColumnsEQ(latestExecutionTable.C(requestexecution.FieldChannelID), s.C(usagelog.FieldChannelID)),
+					sql.EQ(latestExecutionTable.C(requestexecution.FieldStatus), requestexecution.StatusCompleted),
+					sql.GT(latestExecutionTable.C(requestexecution.FieldMetricsLatencyMs), 0),
+				))
+			s.Where(
+				sql.EQ(executionTable.C(requestexecution.FieldID), latestExecutionID),
+			)
+
+			r.buildAnalyticsWhere(s, filter, apiKeyIDs, hasUserFilter, loc)
+
+			var dimensionIDColumn string
+			switch dimension {
+			case "channel":
+				dimensionIDColumn = s.C(usagelog.FieldChannelID)
+			case "model":
+				dimensionIDColumn = s.C(usagelog.FieldModelID)
+			case "apiKey":
+				s.Where(sql.NotNull(s.C(usagelog.FieldAPIKeyID)))
+				dimensionIDColumn = s.C(usagelog.FieldAPIKeyID)
+			case "user":
+				apiKeyTable := sql.Table(apikey.Table)
+				userTable := sql.Table("users")
+				s.Join(apiKeyTable).On(
+					s.C(usagelog.FieldAPIKeyID),
+					apiKeyTable.C(apikey.FieldID),
+				)
+				s.Join(userTable).On(
+					apiKeyTable.C(apikey.FieldUserID),
+					userTable.C("id"),
+				)
+				s.Where(sql.EQ(apiKeyTable.C(apikey.FieldDeletedAt), 0))
+				dimensionIDColumn = userTable.C("id")
+			default:
+				return
+			}
+
+			completionTokens := fmt.Sprintf(
+				"COALESCE(%s, 0) + COALESCE(%s, 0) + COALESCE(%s, 0)",
+				s.C(usagelog.FieldCompletionTokens),
+				s.C(usagelog.FieldCompletionReasoningTokens),
+				s.C(usagelog.FieldCompletionAudioTokens),
+			)
+			effectiveLatency := fmt.Sprintf(
+				"CASE WHEN %s AND %s IS NOT NULL THEN CASE WHEN %s >= %s THEN 0 ELSE %s - %s END ELSE %s END",
+				executionTable.C(requestexecution.FieldStream),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsLatencyMs),
+			)
+			throughput := fmt.Sprintf(
+				"CASE WHEN SUM(%[1]s) > 0 THEN SUM(%[2]s) * 1000.0 / SUM(%[1]s) ELSE NULL END",
+				effectiveLatency,
+				completionTokens,
+			)
+			ttft := fmt.Sprintf(
+				"AVG(CASE WHEN %s AND %s IS NOT NULL AND %s > 0 THEN %s END)",
+				executionTable.C(requestexecution.FieldStream),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+				executionTable.C(requestexecution.FieldMetricsFirstTokenLatencyMs),
+			)
+
+			s.Select(
+				sql.As(dimensionIDColumn, "id"),
+				sql.As(throughput, "tokens_per_second"),
+				sql.As(ttft, "ttft_ms"),
+			).GroupBy(dimensionIDColumn)
+		}).
+		Scan(ctx, &rawResults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get analytics performance stats by %s: %w", dimension, err)
+	}
+
+	return lo.SliceToMap(rawResults, func(item rawPerformanceStats) (string, dimensionPerformanceStats) {
+		return item.ID, dimensionPerformanceStats{
+			TokensPerSecond: item.TokensPerSecond,
+			TtftMs:          item.TtftMs,
+		}
+	}), nil
 }
 
 func (r *queryResolver) queryChannelStats(ctx context.Context, filter *AnalyticsFilter, apiKeyIDs []int, hasUserFilter bool, loc *time.Location) ([]dimStats, error) {
@@ -410,6 +542,8 @@ func dimStatsToDimensionStats(items []dimStats) []*AnalyticsDimensionStat {
 			OutputTokens:      safeIntFromInt64(item.OutputTokens),
 			TotalTokens:       safeIntFromInt64(item.TotalTokens),
 			Cost:              item.Cost,
+			TokensPerSecond:   item.TokensPerSecond,
+			TtftMs:            item.TtftMs,
 		}
 	})
 }

--- a/internal/server/gql/analytics_performance_postgres_test.go
+++ b/internal/server/gql/analytics_performance_postgres_test.go
@@ -1,0 +1,71 @@
+package gql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"entgo.io/ent/dialect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/objects"
+)
+
+var errCaptureAnalyticsPerformanceQuery = errors.New("capture analytics performance query")
+
+// postgresQueryCaptureDriver captures the SQL emitted for a PostgreSQL analytics query.
+type postgresQueryCaptureDriver struct {
+	query string
+}
+
+// Exec stops unexpected write operations because this driver is only used for SELECT generation.
+func (*postgresQueryCaptureDriver) Exec(context.Context, string, any, any) error {
+	return errCaptureAnalyticsPerformanceQuery
+}
+
+// Query captures the generated SQL and stops execution before a database connection is required.
+func (d *postgresQueryCaptureDriver) Query(_ context.Context, query string, _ any, _ any) error {
+	d.query = query
+	return errCaptureAnalyticsPerformanceQuery
+}
+
+// Tx is unsupported because the analytics performance query does not open transactions.
+func (*postgresQueryCaptureDriver) Tx(context.Context) (dialect.Tx, error) {
+	return nil, errCaptureAnalyticsPerformanceQuery
+}
+
+// Close has no resources to release for the capture-only driver.
+func (*postgresQueryCaptureDriver) Close() error {
+	return nil
+}
+
+// Dialect makes Ent render the production query with PostgreSQL identifier rules.
+func (*postgresQueryCaptureDriver) Dialect() string {
+	return dialect.Postgres
+}
+
+// TestAnalyticsPerformanceStatsPostgresQualifiesUsageLogFilters verifies that
+// filters remain qualified after the performance query joins executions.
+func TestAnalyticsPerformanceStatsPostgresQualifiesUsageLogFilters(t *testing.T) {
+	driver := &postgresQueryCaptureDriver{}
+	resolver := &queryResolver{&Resolver{client: ent.NewClient(ent.Driver(driver))}}
+
+	ctx := authz.WithTestBypass(t.Context())
+	filter := &AnalyticsFilter{
+		ProjectIDs: []*objects.GUID{{ID: 1}},
+		ChannelIDs: []*objects.GUID{{ID: 2}},
+		ModelIDs:   []string{"test-model"},
+	}
+	_, err := resolver.queryDimensionPerformanceStats(ctx, filter, []int{3}, false, nil, "apiKey")
+	require.ErrorIs(t, err, errCaptureAnalyticsPerformanceQuery)
+	require.Contains(t, driver.query, `"usage_logs"."project_id" IN`)
+	require.Contains(t, driver.query, `"usage_logs"."channel_id" IN`)
+	require.Contains(t, driver.query, `"usage_logs"."model_id" IN`)
+	require.Contains(t, driver.query, `"usage_logs"."api_key_id" IN`)
+	require.NotContains(t, driver.query, ` AND "project_id" IN`)
+	require.NotContains(t, driver.query, ` AND "channel_id" IN`)
+	require.NotContains(t, driver.query, ` AND "model_id" IN`)
+	require.NotContains(t, driver.query, ` AND "api_key_id" IN`)
+}

--- a/internal/server/gql/analytics_performance_test.go
+++ b/internal/server/gql/analytics_performance_test.go
@@ -1,0 +1,98 @@
+package gql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+)
+
+// TestAnalyticsDimensionStatsIncludesPerformanceMetrics verifies that model rows
+// expose throughput and average TTFT calculated from their completed executions.
+func TestAnalyticsDimensionStatsIncludesPerformanceMetrics(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:analytics-performance?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+	resolver := &queryResolver{&Resolver{
+		client:        client,
+		systemService: biz.NewSystemService(biz.SystemServiceParams{Ent: client}),
+	}}
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenaiFake).
+		SetName("Performance channel").
+		SetStatus(channel.StatusEnabled).
+		SetSupportedModels([]string{"performance-model"}).
+		SetDefaultTestModel("performance-model").
+		SetCredentials(objects.ChannelCredentials{}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	for _, sample := range []struct {
+		completionTokens int64
+		reasoningTokens  int64
+		audioTokens      int64
+		latencyMs        int64
+		firstTokenMs     int64
+	}{
+		{completionTokens: 100, reasoningTokens: 20, audioTokens: 30, latencyMs: 2500, firstTokenMs: 500},
+		{completionTokens: 100, latencyMs: 2500, firstTokenMs: 1500},
+	} {
+		req, createErr := client.Request.Create().
+			SetModelID("performance-model").
+			SetRequestBody(objects.JSONRawMessage(`{}`)).
+			SetStatus(request.StatusCompleted).
+			SetChannelID(ch.ID).
+			SetStream(true).
+			Save(ctx)
+		require.NoError(t, createErr)
+
+		_, createErr = client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetChannelID(ch.ID).
+			SetModelID("performance-model").
+			SetRequestBody(objects.JSONRawMessage(`{}`)).
+			SetStatus(requestexecution.StatusCompleted).
+			SetStream(true).
+			SetMetricsLatencyMs(sample.latencyMs).
+			SetMetricsFirstTokenLatencyMs(sample.firstTokenMs).
+			Save(ctx)
+		require.NoError(t, createErr)
+
+		_, createErr = client.UsageLog.Create().
+			SetRequestID(req.ID).
+			SetChannelID(ch.ID).
+			SetModelID("performance-model").
+			SetCompletionTokens(sample.completionTokens).
+			SetCompletionReasoningTokens(sample.reasoningTokens).
+			SetCompletionAudioTokens(sample.audioTokens).
+			SetTotalTokens(sample.completionTokens + sample.reasoningTokens + sample.audioTokens).
+			Save(ctx)
+		require.NoError(t, createErr)
+	}
+
+	stats, err := resolver.AnalyticsDimensionStats(ctx, nil, "model")
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	require.NotNil(t, stats[0].TokensPerSecond)
+	require.InDelta(t, 250.0/3.0, *stats[0].TokensPerSecond, 0.001)
+	require.NotNil(t, stats[0].TtftMs)
+	require.InDelta(t, 1000.0, *stats[0].TtftMs, 0.001)
+
+	channelStats, err := resolver.AnalyticsDimensionStats(ctx, nil, "channel")
+	require.NoError(t, err)
+	require.Len(t, channelStats, 1)
+	require.NotNil(t, channelStats[0].TokensPerSecond)
+	require.InDelta(t, 250.0/3.0, *channelStats[0].TokensPerSecond, 0.001)
+	require.NotNil(t, channelStats[0].TtftMs)
+	require.InDelta(t, 1000.0, *channelStats[0].TtftMs, 0.001)
+}

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -247,7 +247,9 @@ type ComplexityRoot struct {
 		Name              func(childComplexity int) int
 		OutputTokens      func(childComplexity int) int
 		RequestCount      func(childComplexity int) int
+		TokensPerSecond   func(childComplexity int) int
 		TotalTokens       func(childComplexity int) int
+		TtftMs            func(childComplexity int) int
 	}
 
 	AnalyticsMetadata struct {
@@ -3072,12 +3074,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AnalyticsDimensionStat.RequestCount(childComplexity), true
+	case "AnalyticsDimensionStat.tokensPerSecond":
+		if e.complexity.AnalyticsDimensionStat.TokensPerSecond == nil {
+			break
+		}
+
+		return e.complexity.AnalyticsDimensionStat.TokensPerSecond(childComplexity), true
 	case "AnalyticsDimensionStat.totalTokens":
 		if e.complexity.AnalyticsDimensionStat.TotalTokens == nil {
 			break
 		}
 
 		return e.complexity.AnalyticsDimensionStat.TotalTokens(childComplexity), true
+	case "AnalyticsDimensionStat.ttftMs":
+		if e.complexity.AnalyticsDimensionStat.TtftMs == nil {
+			break
+		}
+
+		return e.complexity.AnalyticsDimensionStat.TtftMs(childComplexity), true
 
 	case "AnalyticsMetadata.earliestDate":
 		if e.complexity.AnalyticsMetadata.EarliestDate == nil {
@@ -18073,6 +18087,64 @@ func (ec *executionContext) _AnalyticsDimensionStat_cost(ctx context.Context, fi
 }
 
 func (ec *executionContext) fieldContext_AnalyticsDimensionStat_cost(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AnalyticsDimensionStat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AnalyticsDimensionStat_tokensPerSecond(ctx context.Context, field graphql.CollectedField, obj *AnalyticsDimensionStat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AnalyticsDimensionStat_tokensPerSecond,
+		func(ctx context.Context) (any, error) {
+			return obj.TokensPerSecond, nil
+		},
+		nil,
+		ec.marshalOFloat2ᚖfloat64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_AnalyticsDimensionStat_tokensPerSecond(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AnalyticsDimensionStat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AnalyticsDimensionStat_ttftMs(ctx context.Context, field graphql.CollectedField, obj *AnalyticsDimensionStat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AnalyticsDimensionStat_ttftMs,
+		func(ctx context.Context) (any, error) {
+			return obj.TtftMs, nil
+		},
+		nil,
+		ec.marshalOFloat2ᚖfloat64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_AnalyticsDimensionStat_ttftMs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AnalyticsDimensionStat",
 		Field:      field,
@@ -46527,6 +46599,10 @@ func (ec *executionContext) fieldContext_Query_analyticsDimensionStats(ctx conte
 				return ec.fieldContext_AnalyticsDimensionStat_totalTokens(ctx, field)
 			case "cost":
 				return ec.fieldContext_AnalyticsDimensionStat_cost(ctx, field)
+			case "tokensPerSecond":
+				return ec.fieldContext_AnalyticsDimensionStat_tokensPerSecond(ctx, field)
+			case "ttftMs":
+				return ec.fieldContext_AnalyticsDimensionStat_ttftMs(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AnalyticsDimensionStat", field.Name)
 		},
@@ -90130,6 +90206,10 @@ func (ec *executionContext) _AnalyticsDimensionStat(ctx context.Context, sel ast
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "tokensPerSecond":
+			out.Values[i] = ec._AnalyticsDimensionStat_tokensPerSecond(ctx, field, obj)
+		case "ttftMs":
+			out.Values[i] = ec._AnalyticsDimensionStat_ttftMs(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -80,6 +80,10 @@ type AnalyticsDimensionStat struct {
 	OutputTokens      int     `json:"outputTokens"`
 	TotalTokens       int     `json:"totalTokens"`
 	Cost              float64 `json:"cost"`
+	// Output token throughput in tokens per second, null when no valid latency metrics exist
+	TokensPerSecond *float64 `json:"tokensPerSecond,omitempty"`
+	// Average time to first token in milliseconds, null when no streaming request recorded a first token
+	TtftMs *float64 `json:"ttftMs,omitempty"`
 }
 
 // Filter input for analytics queries. All fields are optional and support multi-select.


### PR DESCRIPTION
## Summary

- Add **tok/s** and **TTFT** performance columns to the Analytics “Usage Details” table across channel, model, API key, and user dimensions.
- Fix PostgreSQL failures when performance stats are filtered: filter predicates now qualify usage-log columns with the active SQL selector.
- Add a PostgreSQL SQL-generation regression test for project, channel, model, and API-key filters.

## Root cause

`analyticsDimensionStats` joins `usage_logs` with `request_executions`. Both relations expose identifiers such as `channel_id`, so the previously unqualified filters generated ambiguous PostgreSQL references (SQLSTATE 42702).

## Testing

- `go test ./internal/server/gql -run '^(TestAnalyticsPerformanceStatsPostgresQualifiesUsageLogFilters|TestAnalyticsDimensionStatsIncludesPerformanceMetrics)$' -count=1 -v`
- `git diff --check upstream/unstable...HEAD`
- Local `/analytics` browser smoke check: the page loads without console errors. The local development dataset contains no historical requests, so the captured Usage Details view is its empty state rather than a fabricated data row.