### PR TITLE
perf(frontend): virtualize model price dialog to fix lag with many models

### DIFF
--- a/frontend/src/components/model-price-editor.tsx
+++ b/frontend/src/components/model-price-editor.tsx
@@ -58,7 +58,13 @@ function asFieldArrayPath(path: string) {
 }
 
 function usePriceEditorWatch<TValue>(control: Control<PriceEditorFormValues>, name: string) {
-  return useWatch({ control, name: asFieldPath(name) }) as unknown as TValue;
+  // compute + deepEqual guard: value-unchanged broadcasts (e.g. deleting a card elsewhere)
+  // must not force this subscriber to re-render.
+  return useWatch({
+    control,
+    name: asFieldPath(name),
+    compute: (value) => value,
+  }) as unknown as TValue;
 }
 
 type PriceItem = PriceEditorFormValues['prices'][number]['price']['items'][number];

--- a/frontend/src/components/price-schedule-editor.tsx
+++ b/frontend/src/components/price-schedule-editor.tsx
@@ -83,7 +83,13 @@ function asFieldArrayPath(path: string) {
 }
 
 function useScheduleWatch<TValue>(control: Control<ScheduleFormValues>, name: string) {
-  return useWatch({ control, name: asFieldPath(name) }) as unknown as TValue;
+  // compute + deepEqual guard: value-unchanged broadcasts (e.g. deleting a card elsewhere)
+  // must not force this subscriber to re-render.
+  return useWatch({
+    control,
+    name: asFieldPath(name),
+    compute: (value) => value,
+  }) as unknown as TValue;
 }
 
 function pad2(n: number) {
@@ -746,6 +752,7 @@ const OverrideItemsEditor = memo(function OverrideItemsEditor({
   const items = useWatch({
     control,
     name: asFieldPath(`prices.${priceIndex}.price.schedule.overrides.${overrideIndex}.items`) as FieldPath<ScheduleFormValues>,
+    compute: (value) => value,
   }) as unknown as ScheduleFormValues['prices'][number]['price']['schedule']['overrides'][number]['items'] | undefined;
 
   const handleAddItem = useCallback(() => {

--- a/frontend/src/features/channels/components/channels-model-price-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-price-dialog.tsx
@@ -1,7 +1,8 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useFieldArray, useForm, useWatch, type Control } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { IconPlus, IconTrash, IconCopy } from '@tabler/icons-react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
@@ -12,7 +13,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ModelPriceEditor } from '@/components/model-price-editor';
 import { PriceScheduleEditor } from '@/components/price-schedule-editor';
@@ -514,9 +514,9 @@ const PriceCard = memo(function PriceCard({
   return (
     <Card className='overflow-hidden'>
       <CardContent className='pt-6'>
-        {/* Mobile: single column layout */}
-        <div className='flex flex-col gap-3 md:hidden'>
-          <div className='flex h-8 items-center justify-between'>
+        {/* Single responsive layout: 1 column on mobile, [model | editors | actions] grid on desktop */}
+        <div className='grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] md:gap-x-4 md:gap-y-3'>
+          <div className='flex h-8 min-w-0 items-center justify-between'>
             <FormLabel className='truncate pr-2'>{t('price.model')}</FormLabel>
             <div className='flex gap-1'>
               <Button
@@ -532,83 +532,19 @@ const PriceCard = memo(function PriceCard({
                 type='button'
                 variant='ghost'
                 size='icon-sm'
-                className='text-destructive'
+                className='text-destructive md:hidden'
                 onClick={() => onRemovePrice(priceIndex)}
               >
                 <IconTrash size={16} />
               </Button>
             </div>
           </div>
-          <FormField
-            control={control}
-            name={`prices.${priceIndex}.modelId`}
-            render={({ field }) => (
-              <FormItem>
-                <Select
-                  onValueChange={(value) => {
-                    field.onChange(value);
-                    onModelSelected(priceIndex, value);
-                  }}
-                  value={field.value}
-                >
-                  <FormControl>
-                    <SelectTrigger size='sm' className='h-8 w-full' title={field.value || ''}>
-                      <SelectValue placeholder={t('price.model')} className='truncate' />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {availableModels.map((model) => (
-                      <SelectItem key={model} value={model} title={model}>
-                        {model}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <div className='flex h-8 items-center'>
-            <FormLabel className='truncate'>{t('price.items')}</FormLabel>
-          </div>
-          <ModelPriceEditor
-            control={control}
-            priceIndex={priceIndex}
-            currencyCode={currencyCode}
-            hideHeader
-            onAddItem={onAddItem}
-            onRemoveItem={onRemoveItem}
-            onAddVariant={onAddVariant}
-            onRemoveVariant={onRemoveVariant}
-          />
-          <PriceScheduleEditor
-            control={control}
-            priceIndex={priceIndex}
-            currencyCode={currencyCode}
-            defaultTimezone={defaultTimezone}
-          />
-        </div>
 
-        {/* Desktop: grid layout */}
-        <div className='hidden md:grid md:grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] md:gap-x-4 md:gap-y-3'>
-          <div className='flex h-8 min-w-0 items-center justify-between'>
-            <FormLabel className='truncate pr-2'>{t('price.model')}</FormLabel>
-            <Button
-              type='button'
-              variant='ghost'
-              size='icon-sm'
-              onClick={() => onDuplicatePrice(priceIndex)}
-              title={t('common.actions.duplicate')}
-            >
-              <IconCopy size={14} />
-            </Button>
-          </div>
-
-          <div className='flex h-8 min-w-0 items-center'>
+          <div className='hidden h-8 min-w-0 items-center md:flex'>
             <FormLabel className='truncate'>{t('price.items')}</FormLabel>
           </div>
 
-          <div className='flex items-start justify-end'>
+          <div className='hidden items-start justify-end md:flex'>
             <Button
               type='button'
               variant='ghost'
@@ -653,6 +589,9 @@ const PriceCard = memo(function PriceCard({
           </div>
 
           <div className='min-w-0'>
+            <div className='flex h-8 items-center md:hidden'>
+              <FormLabel className='truncate'>{t('price.items')}</FormLabel>
+            </div>
             <ModelPriceEditor
               control={control}
               priceIndex={priceIndex}
@@ -703,12 +642,44 @@ export function ChannelsModelPriceDialog() {
     name: 'prices',
   });
 
+  const priceListRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: fields.length,
+    getScrollElement: () => priceListRef.current,
+    estimateSize: () => 300,
+    overscan: 6,
+    getItemKey: (index) => fields[index]?.id ?? index,
+  });
+
+  // Appended cards must scroll into view only AFTER fields render (virtualizer count
+  // updates), otherwise scrollToIndex clamps to the previous last card.
+  const pendingScrollToNewCardRef = useRef(false);
+  useEffect(() => {
+    if (pendingScrollToNewCardRef.current && fields.length > 0) {
+      pendingScrollToNewCardRef.current = false;
+      rowVirtualizer.scrollToIndex(fields.length - 1, { align: 'auto' });
+    }
+  }, [fields.length, rowVirtualizer]);
+
   const supportedModels = useMemo(() => currentRow?.supportedModels || [], [currentRow?.supportedModels]);
-  const watchedPrices = useWatch({ control, name: 'prices' });
-  const availableModelsByIndex = useMemo(
-    () => buildAvailableModelsByIndex(watchedPrices || [], supportedModels),
-    [supportedModels, watchedPrices]
-  );
+  const watchedPrices = useWatch({
+    control,
+    name: 'prices',
+    // deep-equal guard: identical values (e.g. deleting an empty card) must not
+    // trigger re-renders of the dialog or invalidate the availableModels cache.
+    compute: (value) => value,
+  });
+  // Cache per-card available model lists by (selected modelIds, supportedModels) signature.
+  // Editing a price field or deleting an empty card changes `watchedPrices` but not the
+  // signature, so the memoized arrays keep their references and every PriceCard memo holds.
+  const availableModelsCache = useRef<{ key: string; value: string[][] }>({ key: '', value: [] });
+  const availableModelsByIndex = useMemo(() => {
+    const key = `${(watchedPrices || []).map((p) => p?.modelId || '').join('\u0000')}\u0001${supportedModels.join('\u0000')}`;
+    if (availableModelsCache.current.key === key) return availableModelsCache.current.value;
+    const value = buildAvailableModelsByIndex(watchedPrices || [], supportedModels);
+    availableModelsCache.current = { key, value };
+    return value;
+  }, [supportedModels, watchedPrices]);
 
   const { data: providersData } = useProvidersData();
 
@@ -763,6 +734,17 @@ export function ChannelsModelPriceDialog() {
 
   const onSubmitError = useCallback(
     (errors: Record<string, any>) => {
+      // Virtualized list: the first invalid card may be outside the rendered range,
+      // so scroll it into view before surfacing the error message.
+      const priceErrors = errors?.prices;
+      if (Array.isArray(priceErrors)) {
+        const firstIndex = priceErrors.findIndex(
+          (e) => e && typeof e === 'object' && Object.keys(e).length > 0
+        );
+        if (firstIndex >= 0) {
+          rowVirtualizer.scrollToIndex(firstIndex, { align: 'start' });
+        }
+      }
       const messages: string[] = [];
       const collectErrors = (obj: any, path: string = '') => {
         if (!obj) return;
@@ -782,7 +764,7 @@ export function ChannelsModelPriceDialog() {
         toast.error(messages[0]);
       }
     },
-    []
+    [rowVirtualizer]
   );
 
   const onSubmit = useCallback(
@@ -875,6 +857,8 @@ export function ChannelsModelPriceDialog() {
   );
 
   const addPrice = useCallback(() => {
+    // New card is appended at the end; scroll into view once it renders.
+    pendingScrollToNewCardRef.current = true;
     append({
       modelId: '',
       price: {
@@ -916,6 +900,8 @@ export function ChannelsModelPriceDialog() {
         return;
       }
 
+      // New card is appended at the end; scroll into view once it renders.
+      pendingScrollToNewCardRef.current = true;
       append({
         modelId,
         price: { items: buildItemsFromProviderModel(found.model, multiplier) },
@@ -1011,6 +997,8 @@ export function ChannelsModelPriceDialog() {
   const duplicatePrice = useCallback(
     (index: number) => {
       const priceData = getValues(`prices.${index}.price`);
+      // New card is appended at the end; scroll into view once it renders.
+      pendingScrollToNewCardRef.current = true;
       append({
         modelId: '',
         price: structuredClone(priceData),
@@ -1114,6 +1102,11 @@ export function ChannelsModelPriceDialog() {
                           added += 1;
                         });
 
+                        if (added > 0) {
+                          // New cards are appended at the end; scroll into view once rendered.
+                          pendingScrollToNewCardRef.current = true;
+                        }
+
                         if (applied || added) {
                           toast.success(t('price.apply.bulkSuccess', { applied, added }));
                         }
@@ -1130,34 +1123,45 @@ export function ChannelsModelPriceDialog() {
                 </div>
               </CardContent>
             </Card>
-            <ScrollArea className='min-h-40 min-w-0 w-full flex-1 md:min-h-0 [&>[data-slot=scroll-area-viewport]]:!overflow-x-hidden'>
-              <div className='space-y-4 py-4 pr-4'>
-                {fields.map((field, index) => (
-                  <PriceCard
-                    key={field.id}
-                    availableModels={availableModelsByIndex[index] || supportedModels}
-                    control={control}
-                    t={t}
-                    priceIndex={index}
-                    currencyCode={settings?.currencyCode}
-                    defaultTimezone={settings?.timezone || 'UTC'}
-                    onAddItem={addItem}
-                    onModelSelected={onModelSelected}
-                    onDuplicatePrice={duplicatePrice}
-                    onRemoveItem={removeItem}
-                    onRemovePrice={removePrice}
-                    onAddVariant={addVariant}
-                    onRemoveVariant={removeVariant}
-                  />
-                ))}
-
-                {fields.length === 0 && !isLoading && (
-                  <div className='text-muted-foreground flex flex-col items-center justify-center py-12'>
-                    <p>{t('price.noPrices')}</p>
-                  </div>
-                )}
+            <div ref={priceListRef} className='min-h-40 min-w-0 w-full flex-1 overflow-y-auto overflow-x-hidden pt-4 pr-4 md:min-h-0'>
+              {fields.length === 0 && !isLoading && (
+                <div className='text-muted-foreground flex flex-col items-center justify-center py-12'>
+                  <p>{t('price.noPrices')}</p>
+                </div>
+              )}
+              <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
+                {rowVirtualizer.getVirtualItems().map((vi) => {
+                  const index = vi.index;
+                  const field = fields[index];
+                  if (!field) return null;
+                  return (
+                    <div
+                      key={vi.key}
+                      data-index={index}
+                      ref={rowVirtualizer.measureElement}
+                      className='absolute top-0 left-0 w-full pb-4'
+                      style={{ transform: `translateY(${vi.start}px)` }}
+                    >
+                      <PriceCard
+                        availableModels={availableModelsByIndex[index] || supportedModels}
+                        control={control}
+                        t={t}
+                        priceIndex={index}
+                        currencyCode={settings?.currencyCode}
+                        defaultTimezone={settings?.timezone || 'UTC'}
+                        onAddItem={addItem}
+                        onModelSelected={onModelSelected}
+                        onDuplicatePrice={duplicatePrice}
+                        onRemoveItem={removeItem}
+                        onRemovePrice={removePrice}
+                        onAddVariant={addVariant}
+                        onRemoveVariant={removeVariant}
+                      />
+                    </div>
+                  );
+                })}
               </div>
-            </ScrollArea>
+            </div>
 
             <DialogFooter className='mt-6 shrink-0 gap-2 sm:justify-between'>
               <Button type='button' variant='outline' onClick={addPrice}>


### PR DESCRIPTION
## Problem

With many models configured, the model pricing dialog is very laggy:

- **Opening / closing** the dialog mounts/unmounts the full price-card list (hundreds of DOM nodes per card, two editor subtrees per card).
- **Deleting** a price card re-renders every card: every `useWatch` in the form re-renders on every RHF broadcast (unconditional `setState`), `availableModels` arrays were recreated on any change (defeating `memo(PriceCard)`), and `mode: 'onChange'` runs the full-tree zod resolver after every field-array action.
- **Adding** a card also triggers the same broadcast storm (less noticeable only because a new empty card is small).

The cost scales linearly with the number of price rows (P) — everything is O(P) or worse per interaction.

## Changes

All in the pricing dialog + its two editor components (frontend only, no API/backend change):

1. **Virtualize the price-card list** (`@tanstack/react-virtual`, already a dependency). Only the visible range (+overscan) is mounted, so open/close/delete cost no longer scales with row count. Values/errors of unmounted cards are preserved (RHF `shouldUnregister` default).
2. **Merge the duplicate mobile + desktop editor subtrees** into a single responsive grid (`grid-cols-1 md:grid-cols-[model|editors|actions]`). This halves DOM nodes and RHF subscriptions per card and removes the duplicate `useFieldArray` instances on the same name.
3. **Guard every `useWatch` with `compute: (v) => v`** (RHF deepEqual guard): broadcasts that don't change a subscriber's value no longer re-render it.
4. **Cache `availableModelsByIndex` by (selected modelIds, supportedModels) signature** so unrelated edits (typing a price, deleting an empty card) keep stable array references and `memo(PriceCard)` holds.
5. **Scroll appended cards into view after render** (add price, duplicate, apply provider model, bulk apply) — `scrollToIndex` must run after the virtualizer count updates, otherwise it clamps to the previous last card.
6. **Locate the first invalid card on submit failure** — extract the first errored `priceIndex` and scroll it into view, since invalid cards outside the virtualized range are not mounted (RHF's default focus-on-error cannot reach them).

## Verification

- `tsc` (exact dependency versions, run inside the docker build stage): zero new type errors (repo baseline 177 pre-existing errors unchanged).
- Deployed and smoke-tested on the production host (Docker Compose, image `looplj/axonhub:perf-price-delete-v4-*`), `/health` healthy, no errors in logs.
- Manual testing on production with a large channel model list: opening/closing/delete/add no longer lag; new cards are scrolled into view; submit failure scrolls to the invalid card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved price editor responsiveness by reducing unnecessary updates when form values remain unchanged.
  * Optimized large price-card lists for smoother scrolling and rendering.

* **User Experience**
  * Automatically scrolls to newly added price cards and the first invalid card after submission errors.
  * Improved responsive behavior with a unified layout across mobile and desktop.
  * Preserved efficient model-list loading while applying or duplicating pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->