### PR TITLE
fix(quota): color Codex quota bars by usage

### DIFF
--- a/frontend/src/components/quota-badges.test.mjs
+++ b/frontend/src/components/quota-badges.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const componentsDir = import.meta.dirname;
+const srcRoot = join(componentsDir, '..');
+
+function read(relativePath) {
+  return readFileSync(join(srcRoot, relativePath), 'utf8');
+}
+
+// Isolate the Codex render branch (between the Codex and Cline branch
+// markers) so assertions about the usage bars cannot bleed into Claude Code
+// or Cline, which legitimately keep duration-aware severity.
+function isolateCodexBlock(source) {
+  const start = source.indexOf("{channel.type === 'codex' &&");
+  const end = source.indexOf("{channel.type === 'cline' &&", start);
+
+  assert.ok(start !== -1, 'Codex render branch should exist in quota-badges source');
+  assert.ok(end !== -1 && end > start, 'Cline render branch should follow the Codex branch');
+
+  return source.slice(start, end);
+}
+
+test('Codex usage bar color tracks used percentage, not reset-window elapsed time', () => {
+  const quotaBadges = read('components/quota-badges.tsx');
+  const codexBlock = isolateCodexBlock(quotaBadges);
+
+  // Both usage bars must render the user-visible used percentage so their
+  // severity reflects actual usage rather than elapsed reset-window time.
+  assert.match(
+    codexBlock,
+    /percentage=\{qd\.rate_limit\.primary_window\.used_percent/,
+    'Codex primary usage bar should render the primary window used percentage'
+  );
+  assert.match(
+    codexBlock,
+    /percentage=\{qd\.rate_limit\.secondary_window\.used_percent/,
+    'Codex secondary usage bar should render the secondary window used percentage'
+  );
+
+  // Reset-window elapsed time stays on separate duration bars...
+  assert.equal(
+    (codexBlock.match(/ProgressBar\s*\n?\s*type='duration'/g) || []).length,
+    2,
+    'Codex should keep a separate duration bar for the primary and secondary windows'
+  );
+
+  // ...so the usage bars must NOT feed durationPercentage into ProgressBar,
+  // which would severity-adjust their color by elapsed window time.
+  assert.doesNotMatch(
+    codexBlock,
+    /durationPercentage/,
+    'Codex usage bar color must not be severity-adjusted by reset-window elapsed time'
+  );
+});

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -666,14 +666,6 @@ function QuotaRow({ channel, enforcementMode }: { channel: ProviderQuotaChannel;
                       </div>
                       <ProgressBar
                         percentage={qd.rate_limit.primary_window.used_percent || 0}
-                        durationPercentage={
-                          qd.rate_limit.primary_window.limit_window_seconds
-                            ? calcDurationPercent(
-                                qd.rate_limit.primary_window.limit_window_seconds,
-                                qd.rate_limit.primary_window.reset_after_seconds
-                              )
-                            : undefined
-                        }
                       />
                     </div>
 
@@ -721,14 +713,6 @@ function QuotaRow({ channel, enforcementMode }: { channel: ProviderQuotaChannel;
                       </div>
                       <ProgressBar
                         percentage={qd.rate_limit.secondary_window.used_percent}
-                        durationPercentage={
-                          qd.rate_limit.secondary_window.limit_window_seconds
-                            ? calcDurationPercent(
-                                qd.rate_limit.secondary_window.limit_window_seconds,
-                                qd.rate_limit.secondary_window.reset_after_seconds
-                              )
-                            : undefined
-                        }
                       />
                     </div>
 


### PR DESCRIPTION
## Summary

Codex usage bars were colored from the reset-window elapsed time instead of the actual usage percentage, so low usage could appear red near the start of a window. The usage bars now color from the used percentage, while the separate duration bars keep showing reset-window elapsed time.

## Motivation

The severity color of the primary/secondary usage bars reflected how much of the reset window had elapsed, not how much quota had been consumed. Right after a window reset, usage bars could render in the red range even though usage was near zero, making them visually misleading.

## Changes

- Color the Codex primary and secondary usage bars from their used-percentage values.
- Keep reset-window elapsed time on the separate duration bars.
- Add a focused regression test asserting the Codex branch renders the used percentage into both usage bars, keeps two duration bars, and does not pass `durationPercentage` into the usage `ProgressBar`s.

## Notes

The dedicated regression test passes, and no matching upstream issue was found for this behavior during PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex quota usage indicators to reflect actual primary and secondary usage levels.
  * Preserved separate reset-window duration indicators and reset information.
  * Corrected severity coloring so it is no longer influenced by reset-window progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->