### PR TITLE
fix(responses): report truncation and failure in streaming conversion

### DIFF
--- a/llm/transformer/openai/responses/inbound_stream.go
+++ b/llm/transformer/openai/responses/inbound_stream.go
@@ -129,7 +129,11 @@ func (s *responsesInboundStream) Next() bool {
 	if !s.source.Next() {
 		if s.err == nil && !s.errorEventEmitted && s.source.Err() == nil && s.hasFinished && !s.responseCompleted {
 			s.responseCompleted = true
-			s.aggregator.status = "completed"
+			// Only fall back to completed when no terminal status was mapped
+			// from a finish_reason (incomplete/failed/cancelled).
+			if s.aggregator.status == "" || s.aggregator.status == "in_progress" {
+				s.aggregator.status = "completed"
+			}
 			response := s.aggregator.buildResponse()
 			if s.usage != nil {
 				response.Usage = ConvertLLMUsageToResponsesUsage(s.usage)
@@ -295,6 +299,22 @@ func (s *responsesInboundStream) Next() bool {
 		if choice.FinishReason != nil && !s.hasFinished {
 			s.hasFinished = true
 
+			// Map the Chat Completions finish_reason onto the Responses status so
+			// the final response.completed event reports abnormal termination
+			// (truncation, content rejection, failure) instead of always claiming success.
+			switch *choice.FinishReason {
+			case "length":
+				s.aggregator.status = "incomplete"
+				s.aggregator.incompleteDetails = &ResponseIncompleteDetails{Reason: "max_output_tokens"}
+			case "content_filter":
+				s.aggregator.status = "incomplete"
+				s.aggregator.incompleteDetails = &ResponseIncompleteDetails{Reason: "content_filter"}
+			case "error":
+				s.aggregator.status = "failed"
+			case "cancelled", "canceled":
+				s.aggregator.status = "cancelled"
+			}
+
 			if err := s.flushPendingReasoning(); err != nil {
 				s.err = err
 				return false
@@ -320,7 +340,11 @@ func (s *responsesInboundStream) Next() bool {
 		s.usage = chunk.Usage
 
 		// Build final response using aggregator
-		s.aggregator.status = "completed"
+		// A mapped terminal status (incomplete/failed/cancelled) must win over
+		// the default; only fall back to completed when still in_progress.
+		if s.aggregator.status == "" || s.aggregator.status == "in_progress" {
+			s.aggregator.status = "completed"
+		}
 		response := s.aggregator.buildResponse()
 		response.Usage = ConvertLLMUsageToResponsesUsage(s.usage)
 		if calls := getResponseWebSearchCallsFromMetadata(s.transformerMetadata); len(calls) > 0 {

--- a/llm/transformer/openai/responses/inbound_stream_test.go
+++ b/llm/transformer/openai/responses/inbound_stream_test.go
@@ -522,3 +522,125 @@ func (s *errorResponseStream) Err() error {
 func (s *errorResponseStream) Close() error {
 	return nil
 }
+
+// Chat Completions finish_reason must be propagated onto the Responses
+// response.completed status: truncation and failure are otherwise silently
+// reported as a successful completion downstream.
+func TestInboundTransformer_TransformStream_MapsFinishReasonToCompletedStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		finishReason         string
+		expectedStatus       string
+		expectedIncomplete   *ResponseIncompleteDetails
+	}{
+		{name: "length maps to incomplete", finishReason: "length", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "max_output_tokens"}},
+		{name: "content_filter maps to incomplete", finishReason: "content_filter", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "content_filter"}},
+		{name: "error maps to failed", finishReason: "error", expectedStatus: "failed"},
+		{name: "cancelled maps to cancelled", finishReason: "cancelled", expectedStatus: "cancelled"},
+		{name: "canceled (US spelling) maps to cancelled", finishReason: "canceled", expectedStatus: "cancelled"},
+		{name: "unknown finish reason stays completed", finishReason: "bogus", expectedStatus: "completed"},
+		{name: "stop stays completed", finishReason: "stop", expectedStatus: "completed"},
+		{name: "tool_calls stays completed", finishReason: "tool_calls", expectedStatus: "completed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trans := NewInboundTransformer()
+
+			stream, err := trans.TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+				{
+					Object:  "chat.completion.chunk",
+					ID:      "resp_finish_reason_map",
+					Created: 1700000000,
+					Model:   "gpt-5",
+					Choices: []llm.Choice{{
+						Index:        0,
+						Delta:        &llm.Message{Role: "assistant"},
+						FinishReason: lo.ToPtr(tt.finishReason),
+					}},
+				},
+				{
+					Object:  "chat.completion.chunk",
+					ID:      "resp_finish_reason_map",
+					Created: 1700000000,
+					Model:   "gpt-5",
+					Usage:   &llm.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+				},
+			}))
+			require.NoError(t, err)
+
+			var completed *Response
+			for stream.Next() {
+				var ev StreamEvent
+				require.NoError(t, json.Unmarshal(stream.Current().Data, &ev))
+				if ev.Type == StreamEventTypeResponseCompleted && ev.Response != nil {
+					completed = ev.Response
+				}
+			}
+			require.NoError(t, stream.Err())
+
+			require.NotNil(t, completed)
+			require.NotNil(t, completed.Status)
+			require.Equal(t, tt.expectedStatus, *completed.Status)
+			if tt.expectedIncomplete != nil {
+				require.NotNil(t, completed.IncompleteDetails)
+				require.Equal(t, tt.expectedIncomplete.Reason, completed.IncompleteDetails.Reason)
+			} else {
+				require.Nil(t, completed.IncompleteDetails)
+			}
+		})
+	}
+}
+
+// When the usage chunk arrives before the finish_reason chunk, the terminal
+// status mapped from finish_reason must still be preserved by the stream-end
+// fallback path (it must not be overwritten with "completed").
+func TestInboundTransformer_TransformStream_UsageBeforeFinishReasonKeepsMappedStatus(t *testing.T) {
+	trans := NewInboundTransformer()
+
+	stream, err := trans.TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			Object:  "chat.completion.chunk",
+			ID:      "resp_usage_first",
+			Created: 1700000000,
+			Model:   "gpt-5",
+			Choices: []llm.Choice{{Index: 0, Delta: &llm.Message{Role: "assistant"}}},
+		},
+		// Usage arrives before the terminal finish_reason.
+		{
+			Object:  "chat.completion.chunk",
+			ID:      "resp_usage_first",
+			Created: 1700000000,
+			Model:   "gpt-5",
+			Usage:   &llm.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+		},
+		{
+			Object:  "chat.completion.chunk",
+			ID:      "resp_usage_first",
+			Created: 1700000000,
+			Model:   "gpt-5",
+			Choices: []llm.Choice{{
+				Index:        0,
+				Delta:        &llm.Message{},
+				FinishReason: lo.ToPtr("length"),
+			}},
+		},
+	}))
+	require.NoError(t, err)
+
+	var completed *Response
+	for stream.Next() {
+		var ev StreamEvent
+		require.NoError(t, json.Unmarshal(stream.Current().Data, &ev))
+		if ev.Type == StreamEventTypeResponseCompleted && ev.Response != nil {
+			completed = ev.Response
+		}
+	}
+	require.NoError(t, stream.Err())
+
+	require.NotNil(t, completed)
+	require.NotNil(t, completed.Status)
+	require.Equal(t, "incomplete", *completed.Status)
+	require.NotNil(t, completed.IncompleteDetails)
+	require.Equal(t, "max_output_tokens", completed.IncompleteDetails.Reason)
+}

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -591,9 +591,39 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			s.state.transformerMetadataEmitted = true
 		}
 
-		finishReason := "stop"
-		if len(s.state.toolCalls) > 0 {
-			finishReason = "tool_calls"
+		// The Responses API signals abnormal completion via response.completed
+		// with a status other than "completed" (incomplete/failed/cancelled) - it
+		// does not emit separate events for those cases. Map the status onto the
+		// Chat Completions finish_reason; fall back to the tool_calls/stop
+		// inference only when the status is absent or plain "completed".
+		finishReason := ""
+		if streamEvent.Response != nil && streamEvent.Response.Status != nil {
+			switch *streamEvent.Response.Status {
+			case "incomplete":
+				// Distinguish truncation from content-filter rejection via the
+				// incomplete details the upstream attached to the response.
+				reason := ""
+				if streamEvent.Response.IncompleteDetails != nil {
+					reason = streamEvent.Response.IncompleteDetails.Reason
+				}
+				switch reason {
+				case "content_filter":
+					finishReason = "content_filter"
+				default:
+					finishReason = "length"
+				}
+			case "failed":
+				finishReason = "error"
+			case "cancelled", "canceled":
+				finishReason = "cancelled"
+			}
+		}
+		if finishReason == "" {
+			if len(s.state.toolCalls) > 0 {
+				finishReason = "tool_calls"
+			} else {
+				finishReason = "stop"
+			}
 		}
 
 		// First event: finish_reason with empty delta

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -921,4 +922,73 @@ func TestOutboundTransformer_TransformStream_PreservesPreviousResponseID(t *test
 	require.NotNil(t, actual[2].PreviousResponseID)
 	require.Equal(t, "resp_prev_123", *actual[2].PreviousResponseID)
 	require.Equal(t, llm.DoneResponse, actual[3])
+}
+
+// The Responses API signals truncation/failure through response.completed with
+// status "incomplete"/"failed" rather than a dedicated event; the Chat
+// Completions finish_reason must reflect that instead of defaulting to stop.
+func TestOutboundTransformer_TransformStream_MapsCompletedStatusToFinishReason(t *testing.T) {
+	tests := []struct {
+		name            string
+		status          string
+		incompleteReason string
+		expectedReason  string
+		withToolCalls   bool
+	}{
+		{name: "incomplete maps to length", status: "incomplete", expectedReason: "length"},
+		{name: "incomplete with content_filter reason maps to content_filter", status: "incomplete", incompleteReason: "content_filter", expectedReason: "content_filter"},
+		{name: "failed maps to error", status: "failed", expectedReason: "error"},
+		{name: "cancelled maps to cancelled", status: "cancelled", expectedReason: "cancelled"},
+		{name: "canceled (US spelling) maps to cancelled", status: "canceled", expectedReason: "cancelled"},
+		{name: "nil status falls back to stop", status: "", expectedReason: "stop"},
+		{name: "completed falls back to stop", status: "completed", expectedReason: "stop"},
+		{name: "completed with tool calls maps to tool_calls", status: "completed", expectedReason: "tool_calls", withToolCalls: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+			require.NoError(t, err)
+
+			events := []*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_status_map","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+			}
+			if tt.withToolCalls {
+				events = append(events,
+					&httpclient.StreamEvent{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_status_map","type":"function_call","call_id":"call_status_map","name":"get_weather","arguments":""}}`)},
+					&httpclient.StreamEvent{Type: "response.function_call_arguments.done", Data: []byte(`{"type":"response.function_call_arguments.done","item_id":"fc_status_map","output_index":0,"name":"get_weather","arguments":"{}"}`)},
+				)
+			}
+
+			// Build the response.completed payload. A nil status is expressed by
+			// omitting the field entirely.
+			completePayload := fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp_status_map","object":"response","created_at":1700000000,"model":"gpt-5","status":%q,"output":[]}}`, tt.status)
+			if tt.status == "" {
+				completePayload = `{"type":"response.completed","response":{"id":"resp_status_map","object":"response","created_at":1700000000,"model":"gpt-5","output":[]}}`
+			}
+			if tt.incompleteReason != "" {
+				completePayload = fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp_status_map","object":"response","created_at":1700000000,"model":"gpt-5","status":"incomplete","incomplete_details":{"reason":%q},"output":[]}}`, tt.incompleteReason)
+			}
+			events = append(events, &httpclient.StreamEvent{
+				Type: "response.completed",
+				Data: []byte(completePayload),
+			})
+
+			stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+			require.NoError(t, err)
+
+			responses, err := streams.All(stream)
+			require.NoError(t, err)
+
+			var finishReasons []string
+			for _, resp := range responses {
+				if resp == llm.DoneResponse || len(resp.Choices) == 0 || resp.Choices[0].FinishReason == nil {
+					continue
+				}
+				finishReasons = append(finishReasons, *resp.Choices[0].FinishReason)
+			}
+
+			require.Equal(t, []string{tt.expectedReason}, finishReasons)
+		})
+	}
 }


### PR DESCRIPTION
## Problem

Two gaps in the Responses streaming conversion made abnormal terminations look like success.

1. **Upstream Responses -> Chat Completions client** (`outbound_stream.go`): `response.completed` always produced `finish_reason: stop` (or `tool_calls`), ignoring the `status` field on the response. A response truncated by `max_output_tokens` was reported to the client as a clean stop; a failed response was reported as a normal completion.

2. **Upstream Chat Completions -> Responses client** (`inbound_stream.go`): the final `response.completed` was always built with `status: completed`. A stream that ended with `finish_reason: length` (truncation) or `content_filter` (moderation rejection) reached the Responses client as a success.

## Changes

- `outbound_stream.go`: map `response.completed` status onto `finish_reason`:
  - `incomplete` -> `length`, or `content_filter` when `incomplete_details.reason` says so
  - `failed` -> `error`
  - `cancelled`/`canceled` -> `cancelled`
  - absent / `completed` status keeps the existing `stop`/`tool_calls` inference
- `inbound_stream.go`: map `finish_reason` onto the response status before building `response.completed`:
  - `length` -> `incomplete` with `incomplete_details.reason: max_output_tokens`
  - `content_filter` -> `incomplete` with `reason: content_filter`
  - `error` -> `failed`
  - `cancelled`/`canceled` -> `cancelled`
  - other values leave the default `completed`
- Both places that previously set `status: completed` unconditionally now only do so when no terminal status was mapped, so the finish-reason mapping survives both the usage-chunk path and the stream-end fallback.

## Tests

- `TestOutboundTransformer_TransformStream_MapsCompletedStatusToFinishReason`: incomplete / content_filter / failed / cancelled / canceled / nil status / completed + tool calls
- `TestInboundTransformer_TransformStream_MapsFinishReasonToCompletedStatus`: length / content_filter / error / cancelled / canceled / unknown / stop / tool_calls
- `TestInboundTransformer_TransformStream_UsageBeforeFinishReasonKeepsMappedStatus`: usage chunk arriving before the finish_reason chunk

`go test ./llm/transformer/openai/responses` passes (the websocket executor test fails locally on Windows with a `wsarecv` error unrelated to these changes; it passes in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream status handling so completion, incomplete, failed, and cancelled responses are preserved correctly.
  * Added accurate finish reasons for length limits, content filtering, errors, cancellations, and tool calls.
  * Prevented usage updates from overwriting previously determined terminal statuses.

* **Tests**
  * Added coverage for inbound and outbound status and finish-reason mappings, including usage events received before completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->