### PR TITLE
fix(responses): preserve mid-conversation system order

### DIFF
--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -56,11 +56,11 @@ func convertInstructionsFromMessages(msgs []llm.Message) string {
 
 	var instructions []string
 
-	// find the last user message
 	for _, msg := range msgs {
 		if msg.Role != "system" {
-			continue
+			break
 		}
+
 		// Collect text from either the simple string content or parts
 		if msg.Content.Content != nil {
 			instructions = append(instructions, *msg.Content.Content)
@@ -88,6 +88,16 @@ func convertInstructionsFromMessages(msgs []llm.Message) string {
 	return strings.Join(instructions, "\n")
 }
 
+func leadingSystemMessageCount(msgs []llm.Message) int {
+	for i, msg := range msgs {
+		if msg.Role != "system" {
+			return i
+		}
+	}
+
+	return len(msgs)
+}
+
 // convertInputFromMessages converts LLM messages to Responses API Input format.
 // User messages become items with content array containing input_text items.
 // Assistant messages become items with type "message" and content array containing output_text items.
@@ -99,7 +109,7 @@ func convertInputFromMessages(msgs []llm.Message, transformOptions llm.Transform
 
 	wasArrayFormat := transformOptions.ArrayInputs != nil && *transformOptions.ArrayInputs
 
-	if len(msgs) == 1 && msgs[0].Content.Content != nil && !wasArrayFormat {
+	if len(msgs) == 1 && msgs[0].Role != "system" && msgs[0].Content.Content != nil && !wasArrayFormat {
 		return Input{Text: msgs[0].Content.Content}
 	}
 
@@ -109,8 +119,17 @@ func convertInputFromMessages(msgs []llm.Message, transformOptions llm.Transform
 	// callID -> item type (function_call_output or custom_tool_call_output)
 	toolResultItemTypeByCallID := map[string]string{}
 
-	for _, msg := range msgs {
+	leadingSystemMessages := leadingSystemMessageCount(msgs)
+
+	for msgIndex, msg := range msgs {
+		if msgIndex < leadingSystemMessages {
+			continue
+		}
+
 		switch msg.Role {
+		case "system":
+			msg.Role = "developer"
+			items = append(items, convertUserMessage(msg))
 		case "user", "developer":
 			items = append(items, convertUserMessage(msg))
 		case "assistant":

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -826,7 +826,7 @@ func TestConvertInstructionsFromMessages(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "mixed system and developer messages",
+			name: "only leading system messages become instructions",
 			msgs: []llm.Message{
 				{
 					Role: "system",
@@ -844,6 +844,36 @@ func TestConvertInstructionsFromMessages(t *testing.T) {
 					Role: "system",
 					Content: llm.MessageContent{
 						Content: lo.ToPtr("system 2"),
+					},
+				},
+			},
+			expected: "system 1",
+		},
+		{
+			name: "contiguous leading system messages become instructions",
+			msgs: []llm.Message{
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("system 1"),
+					},
+				},
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("system 2"),
+					},
+				},
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("question"),
+					},
+				},
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("later system"),
 					},
 				},
 			},
@@ -866,6 +896,18 @@ func TestConvertInputFromMessages(t *testing.T) {
 		transformOptions llm.TransformOptions
 		expected         Input
 	}{
+		{
+			name: "single leading system message is excluded from input",
+			msgs: []llm.Message{
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("system instruction"),
+					},
+				},
+			},
+			expected: Input{},
+		},
 		{
 			name: "single developer message",
 			msgs: []llm.Message{
@@ -937,6 +979,92 @@ func TestConvertInputFromMessages(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "mid-conversation system message preserves chronology as developer",
+			msgs: []llm.Message{
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("top-level instruction"),
+					},
+				},
+				{
+					Role: "user",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("run the tool"),
+					},
+				},
+				{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "lookup",
+								Arguments: `{}`,
+							},
+						},
+					},
+				},
+				{
+					Role:       "tool",
+					ToolCallID: lo.ToPtr("call_1"),
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("tool result"),
+					},
+				},
+				{
+					Role: "system",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("harness reminder"),
+					},
+				},
+				{
+					Role: "assistant",
+					Content: llm.MessageContent{
+						Content: lo.ToPtr("done"),
+					},
+				},
+			},
+			expected: Input{
+				Items: []Item{
+					{
+						Type: "message",
+						Role: "user",
+						Content: &Input{Items: []Item{
+							{Type: "input_text", Text: lo.ToPtr("run the tool")},
+						}},
+					},
+					{
+						Type:      "function_call",
+						CallID:    "call_1",
+						Name:      "lookup",
+						Arguments: `{}`,
+					},
+					{
+						Type:   "function_call_output",
+						CallID: "call_1",
+						Output: &Input{Text: lo.ToPtr("tool result")},
+					},
+					{
+						Type: "message",
+						Role: "developer",
+						Content: &Input{Items: []Item{
+							{Type: "input_text", Text: lo.ToPtr("harness reminder")},
+						}},
+					},
+					{
+						Type:   "message",
+						Role:   "assistant",
+						Status: lo.ToPtr("completed"),
+						Content: &Input{Items: []Item{
+							{Type: "output_text", Text: lo.ToPtr("done")},
+						}},
 					},
 				},
 			},


### PR DESCRIPTION
关联 #2174 

由于完全是vibe的，主要目的是完善openai responses使用gpt接入cc的messages的协议转换，进一步提高缓存命中率。可能有些无关残留没有清除。

不知道其余模型的response兼容性如何，中转站gpt和自己的plus是没问题的。

补充：pr #2172 已修复此问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System instructions are now recognized only when they appear at the beginning of a conversation.
  * System messages appearing later are preserved in chronological order and treated as developer messages.
  * Single-message text conversion now correctly excludes system messages.

* **Tests**
  * Added coverage for leading system messages, later system messages, and conversations containing tool calls and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->