### PR TITLE
fix(responses): preserve polymorphic reasoning and Codex metadata

### DIFF
--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -258,6 +258,9 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 	middlewares = append(middlewares,
 		// applyPassThroughBody runs first so that override operations can still modify the pass-through body.
 		applyPassThroughRequestBody(outbound, processor.SystemService),
+		// Codex Responses metadata must travel with a pass-through body so compatible
+		// upstreams preserve the client's protocol behavior.
+		applyPassThroughRequestHeaders(outbound),
 		applyOverrideRequestBody(outbound),
 		// applyUserAgentPassThrough runs before header overrides to set the initial
 		// User-Agent value (either from client pass-through or default "axonhub/1.0").

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -16,6 +16,20 @@ import (
 	"github.com/looplj/axonhub/llm/streams"
 )
 
+// codexResponsesPassThroughHeaders contains client metadata that Codex-compatible
+// Responses upstreams use to select protocol behavior. Keep this as an explicit
+// allowlist: inbound credentials and transport headers must never be copied.
+var codexResponsesPassThroughHeaders = []string{
+	"X-Codex-Turn-Metadata",
+	"X-Codex-Window-Id",
+	"X-Client-Request-Id",
+	"X-Codex-Beta-Features",
+	"Session-Id",
+	"Originator",
+	"X-OpenAI-Internal-Codex-Responses-Lite",
+	"Thread-Id",
+}
+
 // isPassThroughEnabled returns true when the effective pass-through flag for the current
 // channel is enabled and both the inbound and outbound API formats are identical.
 //
@@ -109,6 +123,39 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 
 		request.Body = body
 		outbound.state.PassThroughApplied = true
+
+		return request, nil
+	})
+}
+
+// applyPassThroughRequestHeaders forwards the Codex Responses metadata paired with
+// a pass-through body. These headers are part of the client's protocol negotiation;
+// dropping them while replaying the original body can change how a compatible
+// upstream interprets the same request.
+func applyPassThroughRequestHeaders(outbound *PersistentOutboundTransformer) pipeline.Middleware {
+	return pipeline.OnRawRequest("pass-through-request-headers", func(_ context.Context, request *httpclient.Request) (*httpclient.Request, error) {
+		if !outbound.state.PassThroughApplied || outbound.state.LlmRequest == nil ||
+			outbound.state.LlmRequest.APIFormat != llm.APIFormatOpenAIResponse ||
+			outbound.state.LlmRequest.RawRequest == nil {
+			return request, nil
+		}
+
+		if request.Headers == nil {
+			request.Headers = make(http.Header)
+		}
+
+		inboundHeaders := outbound.state.LlmRequest.RawRequest.Headers
+		for _, header := range codexResponsesPassThroughHeaders {
+			values := inboundHeaders.Values(header)
+			if len(values) == 0 {
+				continue
+			}
+
+			request.Headers.Del(header)
+			for _, value := range values {
+				request.Headers.Add(header, value)
+			}
+		}
 
 		return request, nil
 	})

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1383,6 +1383,81 @@ func TestApplyPassThroughBodyPreservesMappedModel(t *testing.T) {
 	require.Equal(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"temperature":0.4}`, string(outbound.state.LlmRequest.RawRequest.Body))
 }
 
+func TestApplyPassThroughRequestHeaders(t *testing.T) {
+	inboundHeaders := http.Header{
+		"X-Codex-Turn-Metadata":                  {`{"session_id":"session-123","turn_id":"turn-456"}`},
+		"X-Codex-Window-Id":                      {"window-123"},
+		"X-Client-Request-Id":                    {"request-123"},
+		"X-Codex-Beta-Features":                  {"js_repl"},
+		"Session-Id":                             {"session-123"},
+		"Originator":                             {"codex_desktop_rs"},
+		"X-OpenAI-Internal-Codex-Responses-Lite": {"true"},
+		"Thread-Id":                              {"thread-123"},
+		"Authorization":                          {"Bearer inbound-secret"},
+		"Cookie":                                 {"session=inbound-secret"},
+		"Host":                                   {"client.example"},
+		"Content-Length":                         {"12345"},
+		"X-Untrusted-Custom-Header":              {"do-not-forward"},
+	}
+	outbound := &PersistentOutboundTransformer{
+		state: &PersistenceState{
+			PassThroughApplied: true,
+			LlmRequest: &llm.Request{
+				APIFormat:  llm.APIFormatOpenAIResponse,
+				RawRequest: &httpclient.Request{Headers: inboundHeaders},
+			},
+		},
+	}
+	request := &httpclient.Request{Headers: http.Header{
+		"Authorization": {"Bearer provider-secret"},
+		"Originator":    {"axonhub"},
+	}}
+
+	processed, err := applyPassThroughRequestHeaders(outbound).OnOutboundRawRequest(context.Background(), request)
+	require.NoError(t, err)
+
+	for _, header := range codexResponsesPassThroughHeaders {
+		require.Equal(t, inboundHeaders.Values(header), processed.Headers.Values(header), header)
+	}
+	require.Equal(t, "Bearer provider-secret", processed.Headers.Get("Authorization"))
+	require.Empty(t, processed.Headers.Get("Cookie"))
+	require.Empty(t, processed.Headers.Get("Host"))
+	require.Empty(t, processed.Headers.Get("Content-Length"))
+	require.Empty(t, processed.Headers.Get("X-Untrusted-Custom-Header"))
+}
+
+func TestApplyPassThroughRequestHeadersRequiresResponsesBodyPassThrough(t *testing.T) {
+	tests := []struct {
+		name               string
+		passThroughApplied bool
+		apiFormat          llm.APIFormat
+	}{
+		{name: "body pass-through not applied", apiFormat: llm.APIFormatOpenAIResponse},
+		{name: "different API format", passThroughApplied: true, apiFormat: llm.APIFormatOpenAIChatCompletion},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outbound := &PersistentOutboundTransformer{
+				state: &PersistenceState{
+					PassThroughApplied: tt.passThroughApplied,
+					LlmRequest: &llm.Request{
+						APIFormat: tt.apiFormat,
+						RawRequest: &httpclient.Request{Headers: http.Header{
+							"X-Codex-Turn-Metadata": {"must-not-forward"},
+						}},
+					},
+				},
+			}
+			request := &httpclient.Request{Headers: make(http.Header)}
+
+			processed, err := applyPassThroughRequestHeaders(outbound).OnOutboundRawRequest(context.Background(), request)
+			require.NoError(t, err)
+			require.Empty(t, processed.Headers.Get("X-Codex-Turn-Metadata"))
+		})
+	}
+}
+
 func TestApplyPassThroughBodyPreservesMappedModelForJinaRerank(t *testing.T) {
 	ctx := context.Background()
 

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -577,7 +577,7 @@ type Item struct {
 	// Reasoning summary content - array of summary text items.
 	Summary []ReasoningSummary `json:"summary,omitempty"`
 	// Reasoning text content - array of reasoning text items.
-	ReasoningContent []ReasoningContent `json:"reasoning_content,omitempty"`
+	ReasoningContent *PolymorphicReasoningContent `json:"reasoning_content,omitempty"`
 	// The encrypted content of the reasoning item.
 	EncryptedContent *string `json:"encrypted_content,omitempty"`
 
@@ -761,6 +761,40 @@ type ReasoningSummary struct {
 	Text string `json:"text"`
 	// The type of the object. Always "summary_text".
 	Type string `json:"type"`
+}
+
+// PolymorphicReasoningContent handles reasoning_content fields that differ by item type:
+// - reasoning items use an array of {"type":"reasoning_text","text":"..."} objects.
+// - function_call items from Chat-compatible upstreams use a plain string.
+// The Input type (above) provides the same string-or-array pattern.
+type PolymorphicReasoningContent struct {
+	Text  *string
+	Items []ReasoningContent
+}
+
+func (p *PolymorphicReasoningContent) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		p.Text = &text
+		p.Items = nil
+		return nil
+	}
+
+	var items []ReasoningContent
+	if err := json.Unmarshal(data, &items); err == nil {
+		p.Text = nil
+		p.Items = items
+		return nil
+	}
+
+	return fmt.Errorf("invalid reasoning_content: %w", transformer.ErrInvalidRequest)
+}
+
+func (p PolymorphicReasoningContent) MarshalJSON() ([]byte, error) {
+	if p.Text != nil {
+		return json.Marshal(p.Text)
+	}
+	return json.Marshal(p.Items)
 }
 
 // ReasoningContent represents reasoning text from the model.

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -84,6 +84,70 @@ func TestItemMarshalJSON_ReasoningSummaryBehavior(t *testing.T) {
 	}
 }
 
+func TestItemUnmarshalJSON_PolymorphicReasoningContent(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		roundTrip string
+		validate  func(t *testing.T, content *PolymorphicReasoningContent)
+	}{
+		{
+			name:    "chat-compatible function call string",
+			payload: `{"type":"function_call","name":"get_weather","arguments":"{}","reasoning_content":"checking the weather"}`,
+			validate: func(t *testing.T, content *PolymorphicReasoningContent) {
+				require.NotNil(t, content)
+				require.NotNil(t, content.Text)
+				require.Equal(t, "checking the weather", *content.Text)
+				require.Nil(t, content.Items)
+			},
+		},
+		{
+			name:      "native responses reasoning array",
+			payload:   `{"type":"reasoning","reasoning_content":[{"type":"reasoning_text","text":"first"},{"type":"reasoning_text","text":"second"}]}`,
+			roundTrip: `{"type":"reasoning","summary":[],"reasoning_content":[{"type":"reasoning_text","text":"first"},{"type":"reasoning_text","text":"second"}]}`,
+			validate: func(t *testing.T, content *PolymorphicReasoningContent) {
+				require.NotNil(t, content)
+				require.Nil(t, content.Text)
+				require.Equal(t, []ReasoningContent{
+					{Type: "reasoning_text", Text: "first"},
+					{Type: "reasoning_text", Text: "second"},
+				}, content.Items)
+			},
+		},
+		{
+			name:      "null remains absent",
+			payload:   `{"type":"function_call","name":"get_weather","arguments":"{}","reasoning_content":null}`,
+			roundTrip: `{"type":"function_call","name":"get_weather","arguments":"{}"}`,
+			validate: func(t *testing.T, content *PolymorphicReasoningContent) {
+				require.Nil(t, content)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var item Item
+			err := json.Unmarshal([]byte(tt.payload), &item)
+			require.NoError(t, err)
+			tt.validate(t, item.ReasoningContent)
+
+			encoded, err := json.Marshal(item)
+			require.NoError(t, err)
+			expected := tt.payload
+			if tt.roundTrip != "" {
+				expected = tt.roundTrip
+			}
+			require.JSONEq(t, expected, string(encoded))
+		})
+	}
+}
+
+func TestItemUnmarshalJSON_RejectsInvalidReasoningContent(t *testing.T) {
+	var item Item
+	err := json.Unmarshal([]byte(`{"type":"function_call","arguments":"{}","reasoning_content":{"text":"invalid"}}`), &item)
+	require.ErrorContains(t, err, "invalid reasoning_content")
+}
+
 func TestItemMarshalJSON_Compaction(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- accept both string and array forms of Responses `reasoning_content`
- preserve the original representation during JSON round trips
- forward an explicit allowlist of Codex Responses metadata headers when body pass-through is active
- keep credentials and transport headers excluded from forwarding

## Why

Some Chat-compatible Responses upstreams attach a plain string `reasoning_content` to function-call items, while native Responses reasoning items use an array. Rejecting the string form breaks otherwise valid responses. In addition, dropping Codex protocol metadata while replaying the original body can change upstream behavior.

## Verification

- added transformer coverage for string, array, null, and invalid reasoning content
- added orchestrator coverage for allowed metadata and excluded sensitive headers
- no additional build or lint command was run while preparing this PR, following the repository workflow rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preserved approved Codex Responses metadata during pass-through requests.
  - Added support for reasoning content represented as either text or structured content.
- **Bug Fixes**
  - Prevented unapproved, sensitive, or transport-specific headers from being forwarded.
  - Improved compatibility with valid Responses request formats.
- **Tests**
  - Added coverage for metadata forwarding, header filtering, disabled pass-through, and reasoning-content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->