### PR TITLE
fix(stream): report incomplete streams to the client

### DIFF
--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -194,26 +194,11 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 	// contract that Next() returns false promptly once cancellation is observed and
 	// its buffer is drained; eventsAfterCancel bounds streams that violate it.
 	eventsAfterCancel := 0
+	terminalSeen := false
 
 	for {
 		if !stream.Next() {
-			if err := stream.Err(); err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-					clientDisconnected = true
-
-					// Keep genuine upstream failures visible even when the client is gone.
-					if !errors.Is(err, context.Canceled) {
-						log.Warn(ctx, "Stream error after client disconnected", log.Cause(err))
-					}
-				} else {
-					log.Error(ctx, "Error in stream", log.Cause(err))
-					c.SSEvent("error", formatErr(ctx, err))
-				}
-			} else if errors.Is(ctx.Err(), context.Canceled) {
-				clientDisconnected = true
-			}
-
-			c.Writer.Flush()
+			writeSSEStreamEnd(c, ctx, stream.Err(), formatErr, terminalSeen, &clientDisconnected)
 
 			return
 		}
@@ -231,6 +216,10 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 		}
 
 		cur := stream.Current()
+		if orchestrator.IsTerminalStreamEvent(cur) {
+			terminalSeen = true
+		}
+
 		c.SSEvent(cur.Type, cur.Data)
 		log.Debug(ctx, "write stream event", log.Any("event", cur))
 		c.Writer.Flush()
@@ -271,6 +260,7 @@ func writeSSEStreamWithHeartbeat(
 	timerC := timer.C
 	ctxDone := ctx.Done()
 	eventsAfterCancel := 0
+	terminalSeen := false
 
 	for {
 		select {
@@ -282,7 +272,7 @@ func writeSSEStreamWithHeartbeat(
 
 		case result := <-reader.Results():
 			if result.done {
-				writeSSEStreamEnd(c, ctx, result.err, formatErr, &clientDisconnected)
+				writeSSEStreamEnd(c, ctx, result.err, formatErr, terminalSeen, &clientDisconnected)
 				return
 			}
 
@@ -297,6 +287,10 @@ func writeSSEStreamWithHeartbeat(
 			}
 
 			cur := result.event
+			if orchestrator.IsTerminalStreamEvent(cur) {
+				terminalSeen = true
+			}
+
 			c.SSEvent(cur.Type, cur.Data)
 			log.Debug(ctx, "write stream event", log.Any("event", cur))
 			c.Writer.Flush()
@@ -318,14 +312,25 @@ func writeSSEStreamWithHeartbeat(
 	}
 }
 
+// writeSSEStreamEnd finalizes the SSE response once the stream is drained.
+//
+// terminalSeen reports whether a completion marker was actually written to the
+// client. An upstream that ends at EOF without one produces no stream error (see
+// the io.EOF branch in the SSE decoder), so without this check the response would
+// end silently and the client would read a truncated generation as a successful
+// completion. The orchestrator detects the same condition, but only in Close(),
+// which runs after this writer returns and the body is already flushed — too late
+// to tell the client anything.
 func writeSSEStreamEnd(
 	c *gin.Context,
 	ctx context.Context,
 	streamErr error,
 	formatErr StreamErrorFormatter,
+	terminalSeen bool,
 	clientDisconnected *bool,
 ) {
-	if streamErr != nil {
+	switch {
+	case streamErr != nil:
 		if errors.Is(streamErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 			*clientDisconnected = true
 
@@ -336,8 +341,12 @@ func writeSSEStreamEnd(
 			log.Error(ctx, "Error in stream", log.Cause(streamErr))
 			c.SSEvent("error", formatErr(ctx, streamErr))
 		}
-	} else if errors.Is(ctx.Err(), context.Canceled) {
+	case errors.Is(ctx.Err(), context.Canceled):
 		*clientDisconnected = true
+	case !terminalSeen:
+		log.Error(ctx, "Stream ended without terminal event, reporting incomplete stream to client",
+			log.Cause(orchestrator.ErrStreamIncomplete))
+		c.SSEvent("error", formatErr(ctx, orchestrator.ErrStreamIncomplete))
 	}
 
 	c.Writer.Flush()

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -784,3 +784,96 @@ func TestApplyUpstreamErrorPolicy_DoesNotRewriteLocalResponseError(t *testing.T)
 
 	assert.Equal(t, localErr, err)
 }
+
+// An upstream that ends at EOF without a terminal event produces no stream error,
+// so the client must be told explicitly instead of reading a truncated generation
+// as a successful completion.
+func TestWriteSSEStream_IncompleteStreamReportsErrorToClient(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Deltas only: no finish_reason, no usage, no [DONE].
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"role":"assistant"}}]}`)},
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"reasoning_content":"The"}}]}`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	body := w.Body.String()
+	require.Contains(t, body, "event:error")
+	require.Contains(t, body, orchestrator.ErrStreamIncomplete.Error())
+}
+
+func TestWriteSSEStream_IncompleteStreamReportsErrorWithHeartbeat(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)},
+	}
+
+	writeSSEStream(c, streams.SliceStream(events), FormatStreamError, SSEKeepAliveConfig{
+		Enabled:  true,
+		Interval: time.Hour,
+	}, sseHeartbeatOpenAI)
+
+	body := w.Body.String()
+	require.Contains(t, body, "event:error")
+	require.Contains(t, body, orchestrator.ErrStreamIncomplete.Error())
+}
+
+// A stream that carries finish_reason but no [DONE] is already complete; clients
+// commonly close right after that chunk, so it must not be flagged as incomplete.
+func TestWriteSSEStream_FinishReasonWithoutDoneIsNotIncomplete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)},
+		{Data: []byte(`{"id":"1","choices":[{"delta":{},"finish_reason":"stop"}]}`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	body := w.Body.String()
+	require.NotContains(t, body, "event:error")
+	require.NotContains(t, body, orchestrator.ErrStreamIncomplete.Error())
+}
+
+func TestWriteSSEStream_CompletedStreamReportsNoError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)},
+		{Data: []byte(`[DONE]`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	body := w.Body.String()
+	require.Contains(t, body, "[DONE]")
+	require.NotContains(t, body, "event:error")
+}
+
+// Anthropic streams terminate with message_stop rather than [DONE].
+func TestWriteSSEStream_MessageStopIsNotIncomplete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Type: "content_block_delta", Data: []byte(`{"type":"content_block_delta"}`)},
+		{Type: "message_stop", Data: []byte(`{"type":"message_stop"}`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	body := w.Body.String()
+	require.NotContains(t, body, "event:error")
+}

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -17,6 +17,11 @@ import (
 	"github.com/looplj/axonhub/llm/transformer"
 )
 
+// ErrStreamIncomplete reports an upstream stream that ended without a terminal
+// event and without an aggregated complete response. The same value is persisted
+// on the request and delivered to the client, so both sides agree on the reason.
+var ErrStreamIncomplete = errors.New("stream ended without terminal event or completed response")
+
 // InboundPersistentStream wraps a stream and tracks all responses for final saving to database.
 // It implements the streams.Stream interface and handles persistence in the Close method.
 //
@@ -72,7 +77,7 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
-		if isTerminalStreamEvent(event) {
+		if IsTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true
 		}
 	}
@@ -80,9 +85,11 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	return event
 }
 
-// isTerminalStreamEvent checks both SSE metadata and JSON data for a successful
-// protocol-level or semantic completion marker.
-func isTerminalStreamEvent(event *httpclient.StreamEvent) bool {
+// IsTerminalStreamEvent checks both SSE metadata and JSON data for a successful
+// protocol-level or semantic completion marker. The SSE writers use it to decide
+// whether the client actually received a completion marker, so this must stay the
+// single source of truth for "the stream ended properly".
+func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	if event == nil {
 		return false
 	}
@@ -215,7 +222,7 @@ func (ts *InboundPersistentStream) Close() error {
 		if ts.request != nil {
 			persistCtx := context.WithoutCancel(ctx)
 
-			errToReport := errors.New("stream ended without terminal event or completed response")
+			errToReport := ErrStreamIncomplete
 
 			if err := ts.requestService.UpdateRequestStatusFromError(persistCtx, ts.request.ID, errToReport); err != nil {
 				log.Warn(persistCtx, "Failed to update request status from error", log.Cause(err))

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -263,14 +263,14 @@ func TestInboundPersistentStream_Close_WithAggregationError(t *testing.T) {
 func TestIsTerminalStreamEvent_AudioDoneEvents(t *testing.T) {
 	// OpenAI audio SSE streams have no [DONE] sentinel; terminal completion is
 	// signaled by typed *.done events surfaced via StreamEvent.Type.
-	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.done"}))
-	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.done"}))
-	require.True(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: httpclient.BinaryStreamDoneEventType}))
+	require.True(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.done"}))
+	require.True(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.done"}))
+	require.True(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: httpclient.BinaryStreamDoneEventType}))
 
 	// Other events must not be treated as terminal.
-	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.delta"}))
-	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.delta"}))
-	require.False(t, isTerminalStreamEvent(&httpclient.StreamEvent{Type: "audio/mpeg"}))
+	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.delta"}))
+	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.delta"}))
+	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "audio/mpeg"}))
 }
 
 func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {
@@ -312,7 +312,7 @@ func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isTerminalStreamEvent(tt.event))
+			require.Equal(t, tt.want, IsTerminalStreamEvent(tt.event))
 		})
 	}
 }

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -85,7 +85,7 @@ func (ts *OutboundPersistentStream) Current() *httpclient.StreamEvent {
 		// Check if this is a terminal event, which indicates the stream completed successfully.
 		// For Chat Completions API this is the raw [DONE] event; for Responses API this is
 		// response.completed; for Anthropic Messages API this is message_stop.
-		if isTerminalStreamEvent(event) {
+		if IsTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true
 		}
 	}
@@ -167,7 +167,7 @@ func (ts *OutboundPersistentStream) Close() error {
 			errToReport = ctxErr
 		}
 		if errToReport == nil {
-			errToReport = errors.New("stream ended without terminal event or completed response")
+			errToReport = ErrStreamIncomplete
 		}
 
 		if ts.requestExec != nil {
@@ -184,7 +184,7 @@ func (ts *OutboundPersistentStream) Close() error {
 		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
-		errToReport := errors.New("stream ended without terminal event or completed response")
+		errToReport := ErrStreamIncomplete
 		if ts.requestExec != nil {
 			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport); err != nil {
 				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -903,7 +903,7 @@ func TestPassThroughChannelStream_DrainsBufferedEventsAfterCancel(t *testing.T) 
 
 	require.Len(t, events, 2)
 	assert.Equal(t, []byte("[DONE]"), events[1].Data)
-	assert.True(t, isTerminalStreamEvent(events[1]))
+	assert.True(t, IsTerminalStreamEvent(events[1]))
 }
 
 func TestPassThroughChannelStream_StopsAtEmptyBufferAfterCancel(t *testing.T) {


### PR DESCRIPTION
> 中文版见文末 [中文说明](#中文说明)。

Closes #2184.

## What

An upstream stream that ends at EOF **without a terminal event** was delivered to the client as a normal completion. The client saw a cleanly finished SSE stream that merely lacked `finish_reason` and `usage`, so a truncated generation was indistinguishable from a real one.

AxonHub already detected the condition — it just never told the caller.

## Why it stayed silent

Three things line up:

1. `llm/httpclient/decoder.go` returns `false` on `io.EOF` **without** setting an error, so `stream.Err()` is `nil` for a clean upstream end.
2. The SSE writers only emitted an `error` event when `stream.Err() != nil`. With a nil error and no client cancellation, both writers fell through every branch and simply returned, ending the response body silently.
3. `ChatCompletionStream.Close()` runs in a `defer`, i.e. **after** the writer returned and the body was flushed. That is where the orchestrator detects `!StreamCompleted` and persists `stream ended without terminal event or completed response` — correct, but far too late to add anything to the client's stream.

The result was a request marked failed in storage while the caller was told nothing.

Observed downstream (a coding agent on `openai-completions`), reproduced byte-for-byte against a fake upstream that sends two deltas and then closes the chunked body normally:

```json
{"role":"assistant",
 "content":[{"type":"thinking","thinking":"The","thinkingSignature":"reasoning_content"}],
 "usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0},
 "stopReason":"stop"}
```

`stopReason: "stop"` with zero usage. For contrast, when the upstream connection is aborted at TCP level the same client correctly reports `stopReason: "error"` — that path does surface an error.

## Changes

- **Both SSE writers track terminal events.** `writeSSEStreamWithoutHeartbeat` and `writeSSEStreamWithHeartbeat` each keep a `terminalSeen` flag, set from the events they actually write downstream.
- **`writeSSEStreamEnd` reports the incomplete stream.** A third branch emits an `error` SSE event when the stream drained without a terminal event, without an explicit stream error, and without client cancellation. The no-heartbeat writer's previously inlined finalization now goes through the same helper, so the two paths cannot drift.
- **`IsTerminalStreamEvent` is exported.** The writers and the persistence wrappers now share one definition of "the stream ended properly"; a divergence between them would produce false alarms.
- **`ErrStreamIncomplete` replaces three inline `errors.New` calls.** The persisted reason and the client-facing reason are now literally the same value.

The binary (audio) writer is deliberately unchanged: a raw response body has no error channel once headers are written, and its terminal marker is intentionally not forwarded.

## Compatibility

Only streams that would previously have ended silently are affected. Because the check reuses `IsTerminalStreamEvent`, which already accepts any chunk carrying a non-empty `finish_reason`, streams that omit the trailing `[DONE]` are still treated as complete — clients commonly close right after that chunk.

## Testing

- `go test ./internal/server/api/... ./internal/server/orchestrator/...` and `go vet` on both packages pass.
- Five new cases in `chat_test.go`: deltas-only stream reports an `error` event (plain and keep-alive writers); `finish_reason` without `[DONE]` is **not** flagged; a normal `[DONE]` stream is not flagged; an Anthropic `message_stop` stream is not flagged.
- Verified the new tests are not vacuous: temporarily disabling the new branch makes exactly the two incomplete-stream tests fail while the three regression guards keep passing.
- Reproduced the original symptom end to end against a local fake upstream, and confirmed the fix turns it into an `error` event.

---

## 中文说明

修复 #2184。

### 问题

上游流在 EOF 处**没有终止事件**就结束时，客户端收到的是一个"正常结束、只是缺了 `finish_reason` 和 `usage`"的 SSE 流，被截断的生成和真正完成的生成无法区分。AxonHub 其实已经识别出了这种情况，只是从没告诉调用方。

三处叠加导致沉默：

1. `llm/httpclient/decoder.go` 遇到 `io.EOF` 时返回 `false` 但**不设置错误**，所以上游干净结束时 `stream.Err()` 是 `nil`。
2. SSE 写出器只在 `stream.Err() != nil` 时发 `error` 事件。错误为 nil 且客户端未取消时，两个写出器都会穿过所有分支直接返回，响应体就这么静默结束了。
3. `ChatCompletionStream.Close()` 挂在 `defer` 上，在写出器返回、响应体已 flush **之后**才跑。orchestrator 正是在这里判出 `!StreamCompleted` 并落库 `stream ended without terminal event or completed response` —— 判断没错，但已经来不及往客户端流里补任何东西。

结果是：请求在存储里标为失败，调用方却一无所知。

### 改动

- **两个 SSE 写出器都跟踪终止事件**，`terminalSeen` 由实际写给客户端的事件置位。
- **`writeSSEStreamEnd` 补发 error 事件**：流耗尽、无显式错误、客户端也没取消，但从未见过终止事件时，发出 `error` SSE 事件。无心跳写出器原本内联的收尾逻辑也并入同一个 helper，避免两条路径今后走偏。
- **导出 `IsTerminalStreamEvent`**，让写出层和持久化层共用同一个"流正常结束"的定义 —— 两边一旦漂移就会误报。
- **新增 `ErrStreamIncomplete`** 替换三处内联 `errors.New`，落库的原因与发给客户端的原因现在是同一个值。

二进制（音频）写出器有意未改：headers 写出后裸响应体没有错误通道，且它的终止标记本就不转发给客户端。

### 兼容性

只影响原本会静默结束的流。由于复用了 `IsTerminalStreamEvent`（它已接受任何带非空 `finish_reason` 的分片），缺少末尾 `[DONE]` 的流仍判为完成 —— 客户端常在该分片后立即断开。

### 测试

- 两个包的 `go test` 与 `go vet` 均通过。
- `chat_test.go` 新增 5 个用例：只有 delta 的流会收到 `error` 事件（普通与心跳两条路径）；带 `finish_reason` 但无 `[DONE]` **不**报错；正常 `[DONE]` 不报错；Anthropic `message_stop` 不报错。
- 校验新测试非空跑：临时关掉新分支后，恰好是那两个 incomplete 用例失败，三个回归守卫仍通过。
- 用本地假上游端到端复现了原始现象，并确认修复后变成 `error` 事件。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Incomplete streaming responses now send an SSE `error` event to clients instead of ending silently.
  - Streams using heartbeats correctly report missing terminal events.
  - Valid completion markers continue to finish without errors, including `[DONE]`, `finish_reason`, and `message_stop`.

- **Documentation**
  - Updated the unreleased changelog to document incomplete-stream error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->