### PR TITLE
fix(responses): 兼容 Responses API created_at 的浮点整数形式

### DIFF
--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"strconv"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
@@ -895,6 +897,61 @@ type Response struct {
 
 	// A stable identifier for your end-users (deprecated, use safety_identifier).
 	User *string `json:"user,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Response so that created_at
+// accepts both integer (1786360449) and float-encoded integral (1786360449.0)
+// unix timestamps. Some Responses-compatible providers serialize integer
+// timestamps as JSON floats (e.g. Python's 1786360449.0); the value is always
+// kept as int64 internally. Every other field uses the default decoding.
+func (r *Response) UnmarshalJSON(data []byte) error {
+	type alias Response
+
+	var raw struct {
+		CreatedAt json.Number `json:"created_at"`
+		*alias
+	}
+	raw.alias = (*alias)(r)
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.CreatedAt == "" {
+		return nil
+	}
+
+	createdAt, err := parseCreatedAtSeconds(raw.CreatedAt.String())
+	if err != nil {
+		return fmt.Errorf("invalid responses api created_at: %w", err)
+	}
+	r.CreatedAt = createdAt
+
+	return nil
+}
+
+// parseCreatedAtSeconds converts a JSON created_at number lexeme to an int64
+// unix timestamp. The integer form (1786360449) is parsed directly; float
+// forms such as 1786360449.0 are validated with exact rational arithmetic so
+// that non-integral values (1786360449.5) and int64 overflow are rejected
+// rather than silently truncated or wrapped.
+func parseCreatedAtSeconds(raw string) (int64, error) {
+	if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return v, nil
+	}
+
+	rat, ok := new(big.Rat).SetString(raw)
+	if !ok {
+		return 0, fmt.Errorf("invalid created_at value %q", raw)
+	}
+	if !rat.IsInt() {
+		return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+	}
+	if !rat.Num().IsInt64() {
+		return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
+	}
+
+	return rat.Num().Int64(), nil
 }
 
 type ContentItem struct {

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -963,6 +963,13 @@ func parseCreatedAtSeconds(raw string) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid created_at value %q", raw)
 		}
+		// int64 holds at most 19 decimal digits, so any |exp| beyond that is
+		// guaranteed out of range. Bounding the exponent here also keeps the
+		// scale arithmetic below from overflowing machine integers on values
+		// such as 1e-9223372036854775808.
+		if e > 19 || e < -19 {
+			return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
+		}
 		exp = e
 		body = body[:i]
 	}
@@ -976,7 +983,8 @@ func parseCreatedAtSeconds(raw string) (int64, error) {
 		return 0, fmt.Errorf("invalid created_at value %q", raw)
 	}
 
-	// The value equals digits * 10^(exp - len(frac)).
+	// The value equals digits * 10^(exp - len(frac)). With |exp| <= 19 the
+	// scale below stays well within machine integer bounds.
 	digits := body + frac
 	scale := len(frac) - exp
 	switch {
@@ -990,8 +998,13 @@ func parseCreatedAtSeconds(raw string) (int64, error) {
 	case scale > 0:
 		// Strip trailing zeros: an insufficient zero tail means the value is
 		// not an integer (e.g. 1786360449.5).
-		if len(digits) <= scale || !strings.HasSuffix(digits, strings.Repeat("0", scale)) {
+		if len(digits) <= scale {
 			return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+		}
+		for _, c := range digits[len(digits)-scale:] {
+			if c != '0' {
+				return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+			}
 		}
 		digits = digits[:len(digits)-scale]
 	}

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -942,7 +942,8 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 // forms such as 1786360449.0 are validated with pure lexeme arithmetic so
 // that non-integral values (1786360449.5), int64 overflow, and excessive
 // exponents (1e1000000) are rejected without materializing arbitrary
-// precision numbers.
+// precision numbers. Non-normalized scientific notation such as
+// 170000000000000000000000000000e-20 (exactly 1700000000) is accepted.
 func parseCreatedAtSeconds(raw string) (int64, error) {
 	// Integer form: ParseInt handles int64 range checks directly.
 	if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
@@ -963,13 +964,6 @@ func parseCreatedAtSeconds(raw string) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid created_at value %q", raw)
 		}
-		// int64 holds at most 19 decimal digits, so any |exp| beyond that is
-		// guaranteed out of range. Bounding the exponent here also keeps the
-		// scale arithmetic below from overflowing machine integers on values
-		// such as 1e-9223372036854775808.
-		if e > 19 || e < -19 {
-			return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
-		}
 		exp = e
 		body = body[:i]
 	}
@@ -983,38 +977,60 @@ func parseCreatedAtSeconds(raw string) (int64, error) {
 		return 0, fmt.Errorf("invalid created_at value %q", raw)
 	}
 
-	// The value equals digits * 10^(exp - len(frac)). With |exp| <= 19 the
-	// scale below stays well within machine integer bounds.
+	// digits is the sign-free digit sequence; the value equals
+	// digits * 10^(exp - len(frac)).
 	digits := body + frac
+
+	// Leading zeros do not affect the value; all-zero input is exactly zero.
+	sig := strings.TrimLeft(digits, "0")
+	if sig == "" {
+		return 0, nil
+	}
+
+	// trailingZeros bounds how many zeros a negative exponent can cancel
+	// before the value stops being an integer (e.g. 1786360449.5).
+	trailingZeros := 0
+	for i := len(digits) - 1; i >= 0 && digits[i] == '0'; i-- {
+		trailingZeros++
+	}
+
+	// Bound the exponent against the mantissa before computing the scale, so
+	// machine integer arithmetic cannot overflow on values such as
+	// 1e-9223372036854775808. These bounds are exact: a non-zero value with
+	// exp > len(frac)+19 is at least 10^19 and overflows int64, while a
+	// negative exp beyond trailingZeros cannot be canceled into an integer.
+	switch {
+	case exp > len(frac)+19:
+		return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
+	case exp < -trailingZeros:
+		return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+	}
+
+	// scale = len(frac) - exp is now bounded: |scale| <= max(19, len(frac)+trailingZeros).
 	scale := len(frac) - exp
 	switch {
 	case scale < 0:
 		// Pad trailing zeros: a value larger than int64 can be rejected by
 		// digit count alone, before building the padded string.
-		if len(digits)+(-scale) > len(strconv.FormatInt(math.MaxInt64, 10)) {
+		if len(sig)+(-scale) > len(strconv.FormatInt(math.MaxInt64, 10)) {
 			return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
 		}
-		digits += strings.Repeat("0", -scale)
+		sig += strings.Repeat("0", -scale)
 	case scale > 0:
 		// Strip trailing zeros: an insufficient zero tail means the value is
 		// not an integer (e.g. 1786360449.5).
-		if len(digits) <= scale {
+		if len(sig) <= scale {
 			return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
 		}
-		for _, c := range digits[len(digits)-scale:] {
+		for _, c := range sig[len(sig)-scale:] {
 			if c != '0' {
 				return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
 			}
 		}
-		digits = digits[:len(digits)-scale]
+		sig = sig[:len(sig)-scale]
 	}
 
-	digits = strings.TrimLeft(digits, "0")
-	if digits == "" {
-		digits = "0"
-	}
-
-	v, err := strconv.ParseInt(sign+digits, 10, 64)
+	v, err := strconv.ParseInt(sign+sig, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
 	}

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
+	"math"
 	"strconv"
+	"strings"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/internal/pkg/xjson"
@@ -908,7 +909,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	type alias Response
 
 	var raw struct {
-		CreatedAt json.Number `json:"created_at"`
+		CreatedAt json.RawMessage `json:"created_at"`
 		*alias
 	}
 	raw.alias = (*alias)(r)
@@ -917,11 +918,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if raw.CreatedAt == "" {
+	if xjson.IsNull(raw.CreatedAt) {
 		return nil
 	}
 
-	createdAt, err := parseCreatedAtSeconds(raw.CreatedAt.String())
+	// created_at must be a JSON number. Reject string forms such as
+	// "1786360449" so the previous int64 field behavior is preserved.
+	if c := raw.CreatedAt[0]; c != '-' && (c < '0' || c > '9') {
+		return fmt.Errorf("invalid responses api created_at: must be a JSON number, got %q", string(raw.CreatedAt))
+	}
+
+	createdAt, err := parseCreatedAtSeconds(string(raw.CreatedAt))
 	if err != nil {
 		return fmt.Errorf("invalid responses api created_at: %w", err)
 	}
@@ -932,26 +939,84 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 
 // parseCreatedAtSeconds converts a JSON created_at number lexeme to an int64
 // unix timestamp. The integer form (1786360449) is parsed directly; float
-// forms such as 1786360449.0 are validated with exact rational arithmetic so
-// that non-integral values (1786360449.5) and int64 overflow are rejected
-// rather than silently truncated or wrapped.
+// forms such as 1786360449.0 are validated with pure lexeme arithmetic so
+// that non-integral values (1786360449.5), int64 overflow, and excessive
+// exponents (1e1000000) are rejected without materializing arbitrary
+// precision numbers.
 func parseCreatedAtSeconds(raw string) (int64, error) {
+	// Integer form: ParseInt handles int64 range checks directly.
 	if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
 		return v, nil
 	}
 
-	rat, ok := new(big.Rat).SetString(raw)
-	if !ok {
+	// Float form: split into sign / integer / fraction / exponent. The JSON
+	// lexeme is guaranteed valid by the caller, so these checks are defensive.
+	sign := ""
+	body := raw
+	if len(body) > 0 && (body[0] == '-' || body[0] == '+') {
+		sign, body = string(body[0]), body[1:]
+	}
+
+	exp := 0
+	if i := strings.IndexAny(body, "eE"); i >= 0 {
+		e, err := strconv.Atoi(body[i+1:])
+		if err != nil {
+			return 0, fmt.Errorf("invalid created_at value %q", raw)
+		}
+		exp = e
+		body = body[:i]
+	}
+
+	frac := ""
+	if i := strings.IndexByte(body, '.'); i >= 0 {
+		body, frac = body[:i], body[i+1:]
+	}
+
+	if body == "" || !isDecimalDigits(body) || !isDecimalDigits(frac) {
 		return 0, fmt.Errorf("invalid created_at value %q", raw)
 	}
-	if !rat.IsInt() {
-		return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+
+	// The value equals digits * 10^(exp - len(frac)).
+	digits := body + frac
+	scale := len(frac) - exp
+	switch {
+	case scale < 0:
+		// Pad trailing zeros: a value larger than int64 can be rejected by
+		// digit count alone, before building the padded string.
+		if len(digits)+(-scale) > len(strconv.FormatInt(math.MaxInt64, 10)) {
+			return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
+		}
+		digits += strings.Repeat("0", -scale)
+	case scale > 0:
+		// Strip trailing zeros: an insufficient zero tail means the value is
+		// not an integer (e.g. 1786360449.5).
+		if len(digits) <= scale || !strings.HasSuffix(digits, strings.Repeat("0", scale)) {
+			return 0, fmt.Errorf("created_at must be an integer number of seconds, got %q", raw)
+		}
+		digits = digits[:len(digits)-scale]
 	}
-	if !rat.Num().IsInt64() {
+
+	digits = strings.TrimLeft(digits, "0")
+	if digits == "" {
+		digits = "0"
+	}
+
+	v, err := strconv.ParseInt(sign+digits, 10, 64)
+	if err != nil {
 		return 0, fmt.Errorf("created_at %q is out of int64 range", raw)
 	}
 
-	return rat.Num().Int64(), nil
+	return v, nil
+}
+
+// isDecimalDigits reports whether s is empty or consists only of ASCII digits.
+func isDecimalDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 type ContentItem struct {

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -423,6 +423,11 @@ func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
 			want:    0,
 		},
 		{
+			name:    "non-normalized scientific notation with canceling exponent",
+			payload: `{"id":"resp_1","created_at":170000000000000000000000000000e-20,"model":"gpt-5","output":[]}`,
+			want:    1700000000,
+		},
+		{
 			name:    "max int64 created_at",
 			payload: `{"id":"resp_1","created_at":9223372036854775807,"model":"gpt-5","output":[]}`,
 			want:    9223372036854775807,
@@ -457,10 +462,10 @@ func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
 			errContains: "out of int64 range",
 		},
 		{
-			name:        "created_at with min-int exponent is rejected without overflow",
+			name:        "created_at with min-int exponent is rejected as non-integral",
 			payload:     `{"id":"resp_1","created_at":1e-9223372036854775808,"model":"gpt-5","output":[]}`,
 			wantErr:     true,
-			errContains: "out of int64 range",
+			errContains: "integer number of seconds",
 		},
 		{
 			name:        "created_at with max-int exponent is rejected without overflow",

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -2,6 +2,7 @@ package responses
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/samber/lo"
@@ -371,4 +372,173 @@ func TestToolChoiceMarshalJSON_PreservesStringModes(t *testing.T) {
 			require.JSONEq(t, tc.expected, string(data))
 		})
 	}
+}
+
+func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		want        int64
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "integer created_at",
+			payload: `{"id":"resp_1","created_at":1786360449,"model":"gpt-5","output":[]}`,
+			want:    1786360449,
+		},
+		{
+			name:    "float-encoded integral created_at",
+			payload: `{"id":"resp_1","created_at":1786360449.0,"model":"gpt-5","output":[]}`,
+			want:    1786360449,
+		},
+		{
+			name:    "float-encoded integral created_at with trailing zeros",
+			payload: `{"id":"resp_1","created_at":1786360449.000,"model":"gpt-5","output":[]}`,
+			want:    1786360449,
+		},
+		{
+			name:    "zero created_at",
+			payload: `{"id":"resp_1","created_at":0,"model":"gpt-5","output":[]}`,
+			want:    0,
+		},
+		{
+			name:    "zero created_at as float",
+			payload: `{"id":"resp_1","created_at":0.0,"model":"gpt-5","output":[]}`,
+			want:    0,
+		},
+		{
+			name:    "missing created_at keeps zero value",
+			payload: `{"id":"resp_1","model":"gpt-5","output":[]}`,
+			want:    0,
+		},
+		{
+			name:    "max int64 created_at",
+			payload: `{"id":"resp_1","created_at":9223372036854775807,"model":"gpt-5","output":[]}`,
+			want:    9223372036854775807,
+		},
+		{
+			name:    "min int64 created_at",
+			payload: `{"id":"resp_1","created_at":-9223372036854775808,"model":"gpt-5","output":[]}`,
+			want:    -9223372036854775808,
+		},
+		{
+			name:        "fractional created_at is rejected",
+			payload:     `{"id":"resp_1","created_at":1786360449.5,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "created_at",
+		},
+		{
+			name:        "created_at exceeding int64 is rejected",
+			payload:     `{"id":"resp_1","created_at":9223372036854775808,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "created_at",
+		},
+		{
+			name:        "created_at below int64 is rejected",
+			payload:     `{"id":"resp_1","created_at":-9223372036854775809,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "created_at",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp Response
+			err := json.Unmarshal([]byte(tt.payload), &resp)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, resp.CreatedAt)
+
+			// Other fields must keep their default decoding.
+			require.Equal(t, "resp_1", resp.ID)
+			require.Equal(t, "gpt-5", resp.Model)
+
+			// Marshaling always emits the integer form, never 1786360449.0.
+			data, err := json.Marshal(resp)
+			require.NoError(t, err)
+			require.Contains(t, string(data), `"created_at":`+strconv.FormatInt(tt.want, 10))
+			require.NotContains(t, string(data), ".0")
+		})
+	}
+}
+
+func TestResponseUnmarshalJSON_FullResponseWithAnnotations(t *testing.T) {
+	payload := `{
+		"id": "resp_xxx",
+		"object": "response",
+		"created_at": 1786360449.0,
+		"model": "parallel",
+		"status": "completed",
+		"output": [
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{
+						"type": "output_text",
+						"text": "测试内容",
+						"annotations": [
+							{
+								"type": "url_citation",
+								"start_index": 0,
+								"end_index": 4,
+								"title": "Example",
+								"url": "https://example.com"
+							}
+						]
+					}
+				]
+			}
+		],
+		"usage": {
+			"input_tokens": 3,
+			"output_tokens": 7,
+			"total_tokens": 10
+		}
+	}`
+
+	var resp Response
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1786360449), resp.CreatedAt)
+	require.Equal(t, "resp_xxx", resp.ID)
+	require.Equal(t, "response", resp.Object)
+	require.Equal(t, "parallel", resp.Model)
+	require.NotNil(t, resp.Status)
+	require.Equal(t, "completed", *resp.Status)
+
+	require.Len(t, resp.Output, 1)
+	msg := resp.Output[0]
+	require.Equal(t, "message", msg.Type)
+	require.Equal(t, "assistant", msg.Role)
+	require.NotNil(t, msg.Content)
+	require.Len(t, msg.Content.Items, 1)
+
+	textItem := msg.Content.Items[0]
+	require.Equal(t, "output_text", textItem.Type)
+	require.NotNil(t, textItem.Text)
+	require.Equal(t, "测试内容", *textItem.Text)
+
+	require.Len(t, textItem.Annotations, 1)
+	annotation := textItem.Annotations[0]
+	require.Equal(t, "url_citation", annotation.Type)
+	require.NotNil(t, annotation.StartIndex)
+	require.Equal(t, int64(0), *annotation.StartIndex)
+	require.NotNil(t, annotation.EndIndex)
+	require.Equal(t, int64(4), *annotation.EndIndex)
+	require.NotNil(t, annotation.URLCitation)
+	require.Equal(t, "Example", annotation.URLCitation.Title)
+	require.Equal(t, "https://example.com", annotation.URLCitation.URL)
+
+	require.NotNil(t, resp.Usage)
+	require.Equal(t, int64(3), resp.Usage.InputTokens)
+	require.Equal(t, int64(7), resp.Usage.OutputTokens)
+	require.Equal(t, int64(10), resp.Usage.TotalTokens)
 }

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -408,6 +408,16 @@ func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
 			want:    0,
 		},
 		{
+			name:    "zero created_at with trailing zero fraction",
+			payload: `{"id":"resp_1","created_at":0.000,"model":"gpt-5","output":[]}`,
+			want:    0,
+		},
+		{
+			name:    "exponent-form integral created_at",
+			payload: `{"id":"resp_1","created_at":1.7e9,"model":"gpt-5","output":[]}`,
+			want:    1700000000,
+		},
+		{
 			name:    "missing created_at keeps zero value",
 			payload: `{"id":"resp_1","model":"gpt-5","output":[]}`,
 			want:    0,
@@ -427,6 +437,24 @@ func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
 			payload:     `{"id":"resp_1","created_at":1786360449.5,"model":"gpt-5","output":[]}`,
 			wantErr:     true,
 			errContains: "created_at",
+		},
+		{
+			name:        "quoted created_at is rejected",
+			payload:     `{"id":"resp_1","created_at":"1786360449","model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "created_at",
+		},
+		{
+			name:        "quoted float created_at is rejected",
+			payload:     `{"id":"resp_1","created_at":"1786360449.0","model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "created_at",
+		},
+		{
+			name:        "created_at with excessive exponent is rejected without expansion",
+			payload:     `{"id":"resp_1","created_at":1e1000000,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "out of int64 range",
 		},
 		{
 			name:        "created_at exceeding int64 is rejected",

--- a/llm/transformer/openai/responses/model_test.go
+++ b/llm/transformer/openai/responses/model_test.go
@@ -457,6 +457,18 @@ func TestResponseUnmarshalJSON_CreatedAtCompatibility(t *testing.T) {
 			errContains: "out of int64 range",
 		},
 		{
+			name:        "created_at with min-int exponent is rejected without overflow",
+			payload:     `{"id":"resp_1","created_at":1e-9223372036854775808,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "out of int64 range",
+		},
+		{
+			name:        "created_at with max-int exponent is rejected without overflow",
+			payload:     `{"id":"resp_1","created_at":1e9223372036854775807,"model":"gpt-5","output":[]}`,
+			wantErr:     true,
+			errContains: "out of int64 range",
+		},
+		{
 			name:        "created_at exceeding int64 is rejected",
 			payload:     `{"id":"resp_1","created_at":9223372036854775808,"model":"gpt-5","output":[]}`,
 			wantErr:     true,

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -989,6 +990,64 @@ func TestOutboundTransformer_TransformStream_MapsCompletedStatusToFinishReason(t
 			}
 
 			require.Equal(t, []string{tt.expectedReason}, finishReasons)
+		})
+	}
+}
+
+func TestOutboundTransformer_TransformStream_CreatedAtCompatibility(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name      string
+		createdAt string
+	}{
+		{name: "integer created_at", createdAt: "1786360449"},
+		{name: "float-encoded integral created_at", createdAt: "1786360449.0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(fmt.Sprintf(`{"type":"response.created","response":{"id":"resp_parallel","object":"response","created_at":%s,"model":"parallel","status":"in_progress","output":[]}}`, tc.createdAt))},
+				{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"今日长鑫科技"}`)},
+				{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"的收盘价是多少。"}`)},
+				{Type: "response.completed", Data: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp_parallel","object":"response","created_at":%s,"model":"parallel","status":"completed","output":[]}}`, tc.createdAt))},
+			}
+
+			stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+			require.NoError(t, err)
+
+			responses, err := streams.All(stream)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(responses), 4)
+
+			// The response.created chunk carries the parsed unix timestamp.
+			require.Equal(t, int64(1786360449), responses[0].Created)
+			require.Equal(t, "resp_parallel", responses[0].ID)
+			require.Equal(t, "parallel", responses[0].Model)
+
+			// output_text.delta events must keep streaming past the float-encoded created_at.
+			var streamedText strings.Builder
+			for _, resp := range responses {
+				if len(resp.Choices) > 0 && resp.Choices[0].Delta != nil && resp.Choices[0].Delta.Content.Content != nil {
+					streamedText.WriteString(*resp.Choices[0].Delta.Content.Content)
+				}
+			}
+			require.Equal(t, "今日长鑫科技的收盘价是多少。", streamedText.String())
+
+			// response.completed emits finish_reason stop and preserves the timestamp.
+			var last *llm.Response
+			for i := len(responses) - 1; i >= 0; i-- {
+				if responses[i] != llm.DoneResponse {
+					last = responses[i]
+					break
+				}
+			}
+			require.NotNil(t, last)
+			require.Len(t, last.Choices, 1)
+			require.Equal(t, "stop", lo.FromPtr(last.Choices[0].FinishReason))
+			require.Equal(t, int64(1786360449), last.Created)
 		})
 	}
 }


### PR DESCRIPTION
## 问题描述

Parallel 等兼容 OpenAI Responses 协议的提供商会把整数 unix 时间戳序列化为 JSON 浮点形式（如 `1786360449.0`，常见于 Python 的 float 序列化）。当前 `Response` 结构体将 `created_at` 严格定义为 `int64`，导致两种模式均解析失败：

- 非流式：`cannot unmarshal number 1786360449.0 into ... Response.created_at of type int64`
- 流式：`cannot unmarshal number 1786360449.0 into ... Response.response.created_at of type int64`（`StreamEvent` 内嵌 `Response`）

即使渠道开启 Pass Through，失败也发生在 `Outbound.TransformResponse` 的解析阶段，后续透传流程没有机会执行，因此该问题必须在协议解析层修复。

## 解决方式

在 `Response` 结构体上增加自定义 `UnmarshalJSON`，仅在反序列化边界兼容 `created_at` 的两种合法输入：

| 输入 | 结果 |
|------|------|
| `1786360449`（整数） | 解析成功，内部为 `int64(1786360449)` |
| `1786360449.0`（整数值浮点） | 解析成功，内部为 `int64(1786360449)` |
| `1786360449.5`（真小数） | 明确报错，不静默截断 |
| 超出 int64 范围 | 明确报错 |

实现要点：

- 整数形式直接走 `strconv.ParseInt`，官方 OpenAI 路径零开销、行为不变；
- 浮点形式用 `math/big.Rat` 做精确有理数校验（stdlib，无新依赖），全程不经 `float64`，无大整数精度风险；`NaN`/`Inf` 天然被拒绝；
- 其余字段通过 alias 嵌入走默认解码，`created_at` 缺失或为 `null` 时保持旧行为（值为 0）；
- 未新增 `MarshalJSON`，对外输出仍为整数 `1786360449`，外部 API 无变化；
- 未引入任何 provider 特判，属于协议解析层的通用健壮性改进，适用于所有兼容 OpenAI Responses 的渠道。

## 不影响现有渠道及用户

- `Response.CreatedAt` 字段类型保持 `int64`，Go 层调用方无编译影响；
- OpenAI 官方整数 `created_at` 路径行为完全一致；非流式、流式、聚合、Pass Through、citation annotations、usage、previous_response_id、reasoning、tool calls 均走默认解码，行为不变；
- 全库检索确认无运行时代码依赖旧的 `cannot unmarshal ... created_at` 错误文案，错误消息变化无下游影响；
- 没有任何「从成功变为报错」的输入场景，差异仅为对浮点整数形式的合理放宽。

## 测试情况

新增测试（均位于 `llm/transformer/openai/responses/`）：

1. `TestResponseUnmarshalJSON_CreatedAtCompatibility` — 11 个子用例：整数、`.0`、尾零、`0`/`0.0`、缺失、int64 边界值、真小数报错、越界报错；每个成功用例同时断言 marshal 输出为整数形式；
2. `TestResponseUnmarshalJSON_FullResponseWithAnnotations` — 完整 Parallel 风格响应（`created_at: 1786360449.0` + message/output_text + url_citation + usage），验证文本、注解、用量均不丢失；
3. `TestOutboundTransformer_TransformStream_CreatedAtCompatibility` — 流式 SSE（`response.created` → `output_text.delta` → `response.completed`）分别用整数与 `.0` 两种形式跑两遍，验证解析成功且后续事件正常处理。

执行结果：

```
go test ./transformer/openai/responses/ -count=1   → ok
go test ./...（llm 模块全量）                        → 全部 ok
go test ./...（根模块全量，约 205s）                  → 0 失败
go vet ./transformer/openai/responses/              → 通过
```

改动文件：`llm/transformer/openai/responses/model.go`（+57）、`model_test.go`（+170）、`outbound_stream_test.go`（+59），共 286 行新增，0 行删除。

<img width="764" height="320" alt="image" src="https://github.com/user-attachments/assets/93e10917-5631-4961-8339-727057322c4a" />
<img width="767" height="468" alt="image" src="https://github.com/user-attachments/assets/eaf02010-1c17-4c07-abe1-d9ea2208671a" />
<img width="1202" height="533" alt="image" src="https://github.com/user-attachments/assets/105535c9-ddb6-426a-9e52-f326c29c7127" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when processing response timestamps represented as integers or integral decimal values.
  * Added validation to reject malformed, fractional, quoted, or out-of-range timestamps.
  * Preserved response metadata, annotations, usage details, and streamed content during decoding.
  * Ensured timestamps are serialized consistently as integers.

* **Tests**
  * Added coverage for complete responses and streamed responses, including metadata, annotations, usage details, and content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->