### PR TITLE
fix(sqlite-time-format-compat): 兼容 SQLite TEXT 时间戳格式并修复 backup 注册时区退化

### DIFF
--- a/internal/server/backup/service.go
+++ b/internal/server/backup/service.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/internal/server/scheduler"
@@ -36,6 +37,15 @@ type BackupService struct {
 }
 
 func (svc *BackupService) RegisterScheduledTasks(ctx context.Context, s *scheduler.Scheduler) error {
+	// 启动时 fx OnStart 传入的 context 不含用户，读取系统配置会被 ent privacy
+	// 规则拒绝（"no user in context"），导致 TimeLocation 兜底返回 UTC、backup
+	// 任务时区从配置值退化为 UTC。与 video_storage 注册一致，使用系统级 bypass。
+	// The context passed by the fx OnStart hook has no user, so reading system
+	// config would be denied by the ent privacy policy ("no user in context"),
+	// making TimeLocation fall back to UTC and the backup task lose its
+	// configured timezone. Use a system-level bypass, matching video_storage.
+	ctx = authz.WithSystemBypass(ctx, "backup-register")
+
 	tz := svc.systemService.TimeLocation(ctx).String()
 	return s.Register(ctx, scheduler.TaskSpec{
 		Name:        "backup",

--- a/internal/server/backup/service_test.go
+++ b/internal/server/backup/service_test.go
@@ -1,0 +1,56 @@
+package backup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zhenzou/executors"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/internal/server/scheduler"
+)
+
+// TestBackupService_RegisterScheduledTasks_TimezoneFromSettings verifies that
+// registering the backup task at startup (fx OnStart context has no user) still
+// reads the configured timezone through the system bypass, instead of falling
+// back to UTC when the ent privacy policy denies the read.
+func TestBackupService_RegisterScheduledTasks_TimezoneFromSettings(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := ent.NewContext(context.Background(), client)
+	ctx = authz.WithTestBypass(ctx)
+
+	sysSvc := biz.NewSystemService(biz.SystemServiceParams{
+		CacheConfig: xcache.Config{Mode: xcache.ModeMemory},
+		Ent:         client,
+	})
+	require.NoError(t, sysSvc.SetGeneralSettings(ctx, biz.SystemGeneralSettings{
+		CurrencyCode: "USD",
+		Timezone:     "Asia/Hong_Kong",
+	}))
+
+	svc := &BackupService{
+		db:            client,
+		systemService: sysSvc,
+	}
+
+	exec := executors.NewPoolScheduleExecutor()
+	sched := scheduler.New(exec)
+	defer sched.Shutdown(context.Background())
+	defer exec.Shutdown(context.Background())
+
+	// Simulate startup registration: the context has no user; before the fix,
+	// TimeLocation would be denied by privacy and fall back to UTC.
+	require.NoError(t, svc.RegisterScheduledTasks(context.Background(), sched))
+
+	tasks := sched.List()
+	require.Len(t, tasks, 1)
+	require.Equal(t, "backup", tasks[0].Spec.Name)
+	require.Equal(t, "Asia/Hong_Kong", tasks[0].Spec.Timezone)
+}

--- a/internal/server/biz/channel_metrics.go
+++ b/internal/server/biz/channel_metrics.go
@@ -97,11 +97,17 @@ type channelMetricsResult struct {
 // loadAllChannelMetricsFromExecutions loads metrics for all channels using a single GROUP BY query.
 // Uses raw SQL via Modify to get request count and last failure time in one query.
 func (svc *ChannelService) loadAllChannelMetricsFromExecutions(ctx context.Context, client *ent.Client, since time.Time) (map[int]*channelMetricsResult, error) {
-	// Single query to get request count and last failure time for all channels
+	// Aggregate result columns (MAX(...)) lose their declared type in SQLite and
+	// are returned as TEXT, formatted according to the driver that wrote them
+	// (currently "2026-08-10 13:22:10.251164681 +0000 UTC"; older versions may
+	// carry a fixed 9-digit fraction ".000000000"). database/sql cannot scan such
+	// TEXT directly into time.Time, so read it as a string first and parse manually.
+	// When there are no failed records the column is NULL, which a string field
+	// safely receives as an empty string.
 	type queryResult struct {
-		ChannelID     int       `json:"channel_id"`
-		RequestCount  int64     `json:"request_count"`
-		LastFailureAt time.Time `json:"last_failure_at"`
+		ChannelID     int    `json:"channel_id"`
+		RequestCount  int64  `json:"request_count"`
+		LastFailureAt string `json:"last_failure_at"`
 	}
 
 	var results []queryResult
@@ -134,14 +140,44 @@ func (svc *ChannelService) loadAllChannelMetricsFromExecutions(ctx context.Conte
 			ChannelID:    r.ChannelID,
 			RequestCount: r.RequestCount,
 		}
-		if !r.LastFailureAt.IsZero() {
-			m.LastFailureAt = &r.LastFailureAt
+		if r.LastFailureAt != "" {
+			if t, parseErr := parseDBTime(r.LastFailureAt); parseErr == nil {
+				m.LastFailureAt = &t
+			} else {
+				log.Warn(ctx, "failed to parse last_failure_at",
+					log.String("value", r.LastFailureAt),
+					log.Cause(parseErr),
+				)
+			}
 		}
 
 		metricsMap[r.ChannelID] = m
 	}
 
 	return metricsMap, nil
+}
+
+// dbTimeFormats covers the time formats written by historical SQLite drivers:
+//   - time.Time.String() format (current modernc driver default, e.g. "2026-08-10 13:22:10.251164681 +0000 UTC")
+//   - the legacy fixed 9-digit fraction format (e.g. "2026-04-18 07:41:37.000000000 +0000 UTC",
+//     matched by the same layout's .999999999)
+//   - RFC3339 / RFC3339Nano as a fallback
+var dbTimeFormats = []string{
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05",
+}
+
+// parseDBTime parses a time stored as text in SQLite into time.Time.
+func parseDBTime(value string) (time.Time, error) {
+	for _, format := range dbTimeFormats {
+		if t, err := time.Parse(format, value); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unrecognized time format: %q", value)
 }
 
 // populateChannelMetrics populates channelMetrics from the aggregated result.

--- a/internal/server/biz/channel_metrics.go
+++ b/internal/server/biz/channel_metrics.go
@@ -102,8 +102,12 @@ func (svc *ChannelService) loadAllChannelMetricsFromExecutions(ctx context.Conte
 	// (currently "2026-08-10 13:22:10.251164681 +0000 UTC"; older versions may
 	// carry a fixed 9-digit fraction ".000000000"). database/sql cannot scan such
 	// TEXT directly into time.Time, so read it as a string first and parse manually.
-	// When there are no failed records the column is NULL, which a string field
-	// safely receives as an empty string.
+	// When there are no failed records the column is NULL: ent's struct scan wraps
+	// string fields in a *string intermediary (dialect/sql/scan.go), so NULL is
+	// safely received as an empty string instead of a scan error.
+	// Note: the lexical MAX(...) equals the chronologically latest failure because
+	// every write path (ent + the SQLite driver) serializes times with the same
+	// "YYYY-MM-DD HH:MM:SS" prefix, regardless of the fractional part.
 	type queryResult struct {
 		ChannelID     int    `json:"channel_id"`
 		RequestCount  int64  `json:"request_count"`

--- a/internal/server/biz/channel_metrics_test.go
+++ b/internal/server/biz/channel_metrics_test.go
@@ -2,6 +2,8 @@ package biz
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/objects"
 )
 
@@ -496,4 +499,144 @@ func TestPerformanceRecord_Methods(t *testing.T) {
 		}
 		require.False(t, invalidPerf2.IsValid())
 	})
+}
+
+// TestChannelMetrics_LoadAllFromExecutions_TimeFormatCompat covers SQLite
+// created_at stored as TEXT with formats from different driver generations:
+// the MAX(...) aggregate is returned as a string and must parse both the
+// current driver format and the legacy .000000000 format, and must not error
+// when there are no failed records (NULL).
+func TestChannelMetrics_LoadAllFromExecutions_TimeFormatCompat(t *testing.T) {
+	// Use a file database so legacy driver timestamp formats can be injected via raw SQL
+	dbPath := filepath.Join(t.TempDir(), "metrics.db")
+	client := enttest.NewEntClient(t, "sqlite3", "file:"+dbPath+"?_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	now := time.Now()
+	svc := &ChannelService{}
+
+	// failed record 1: current driver format (written via ent)
+	failed1 := client.RequestExecution.Create().
+		SetProjectID(1).
+		SetRequestID(1001).
+		SetChannelID(1).
+		SetModelID("gpt-4").
+		SetRequestBody(objects.JSONRawMessage(`{}`)).
+		SetStatus(requestexecution.StatusFailed).
+		SetCreatedAt(now.Add(-2 * time.Hour)).
+		SetUpdatedAt(now.Add(-2 * time.Hour)).
+		SaveX(ctx)
+
+	// failed record 2: created_at rewritten via raw SQL to the legacy .000000000 format
+	legacyAt := now.Add(-1 * time.Hour).Format("2006-01-02 15:04:05.000000000 -0700 MST")
+	failed2 := client.RequestExecution.Create().
+		SetProjectID(1).
+		SetRequestID(1002).
+		SetChannelID(1).
+		SetModelID("gpt-4").
+		SetRequestBody(objects.JSONRawMessage(`{}`)).
+		SetStatus(requestexecution.StatusFailed).
+		SetCreatedAt(now.Add(-1 * time.Hour)).
+		SetUpdatedAt(now.Add(-1 * time.Hour)).
+		SaveX(ctx)
+
+	sqlDB, err := sql.Open("sqlite3", "file:"+dbPath+"?_fk=0")
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	_, err = sqlDB.Exec("UPDATE request_executions SET created_at = ? WHERE id = ?", legacyAt, failed2.ID)
+	require.NoError(t, err)
+
+	// completed record: counts toward request_count but not last_failure_at
+	client.RequestExecution.Create().
+		SetProjectID(1).
+		SetRequestID(1003).
+		SetChannelID(1).
+		SetModelID("gpt-4").
+		SetRequestBody(objects.JSONRawMessage(`{}`)).
+		SetStatus(requestexecution.StatusCompleted).
+		SetCreatedAt(now.Add(-30 * time.Minute)).
+		SetUpdatedAt(now.Add(-30 * time.Minute)).
+		SaveX(ctx)
+
+	// channel with only completed records: MAX(CASE ...) is NULL and must not error
+	client.RequestExecution.Create().
+		SetProjectID(1).
+		SetRequestID(2001).
+		SetChannelID(2).
+		SetModelID("gpt-4").
+		SetRequestBody(objects.JSONRawMessage(`{}`)).
+		SetStatus(requestexecution.StatusCompleted).
+		SetCreatedAt(now.Add(-1 * time.Hour)).
+		SetUpdatedAt(now.Add(-1 * time.Hour)).
+		SaveX(ctx)
+
+	metrics, err := svc.loadAllChannelMetricsFromExecutions(ctx, client, now.Add(-6*time.Hour))
+	require.NoError(t, err)
+
+	// channel 1: 3 records, last_failure_at is the lexicographically largest failed
+	// record (failed2 at -1h)
+	require.Contains(t, metrics, 1)
+	require.Equal(t, int64(3), metrics[1].RequestCount)
+	require.NotNil(t, metrics[1].LastFailureAt)
+	require.Equal(t, now.Add(-1*time.Hour).Truncate(time.Second), metrics[1].LastFailureAt.Truncate(time.Second))
+	require.NotEqual(t, failed1.CreatedAt.Truncate(time.Second), metrics[1].LastFailureAt.Truncate(time.Second))
+
+	// channel 2: no failed records, LastFailureAt must be nil
+	require.Contains(t, metrics, 2)
+	require.Equal(t, int64(1), metrics[2].RequestCount)
+	require.Nil(t, metrics[2].LastFailureAt)
+}
+
+func TestParseDBTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:  "current driver String() format",
+			value: now.Format("2006-01-02 15:04:05.999999999 -0700 MST"),
+			want:  now,
+		},
+		{
+			name:  "legacy fixed 9-digit format",
+			value: "2026-04-18 07:41:37.000000000 +0000 UTC",
+			want:  time.Date(2026, 4, 18, 7, 41, 37, 0, time.UTC),
+		},
+		{
+			name:  "RFC3339Nano",
+			value: "2026-08-10T13:22:10.251164681Z",
+			want:  time.Date(2026, 8, 10, 13, 22, 10, 251164681, time.UTC),
+		},
+		{
+			name:  "sqlite CURRENT_TIMESTAMP format",
+			value: "2026-04-18 07:41:37",
+			want:  time.Date(2026, 4, 18, 7, 41, 37, 0, time.UTC),
+		},
+		{
+			name:    "unrecognized format",
+			value:   "not-a-time",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDBTime(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want.Unix(), got.Unix())
+		})
+	}
 }

--- a/internal/server/biz/channel_metrics_test.go
+++ b/internal/server/biz/channel_metrics_test.go
@@ -516,7 +516,7 @@ func TestChannelMetrics_LoadAllFromExecutions_TimeFormatCompat(t *testing.T) {
 	ctx = ent.NewContext(ctx, client)
 	ctx = authz.WithTestBypass(ctx)
 
-	now := time.Now()
+	now := time.Now().UTC()
 	svc := &ChannelService{}
 
 	// failed record 1: current driver format (written via ent)
@@ -579,12 +579,13 @@ func TestChannelMetrics_LoadAllFromExecutions_TimeFormatCompat(t *testing.T) {
 	require.NoError(t, err)
 
 	// channel 1: 3 records, last_failure_at is the lexicographically largest failed
-	// record (failed2 at -1h)
+	// record (failed2 at -1h). Compare absolute instants (Unix) instead of
+	// time.Time values, which are sensitive to the Location pointer.
 	require.Contains(t, metrics, 1)
 	require.Equal(t, int64(3), metrics[1].RequestCount)
 	require.NotNil(t, metrics[1].LastFailureAt)
-	require.Equal(t, now.Add(-1*time.Hour).Truncate(time.Second), metrics[1].LastFailureAt.Truncate(time.Second))
-	require.NotEqual(t, failed1.CreatedAt.Truncate(time.Second), metrics[1].LastFailureAt.Truncate(time.Second))
+	require.Equal(t, now.Add(-1*time.Hour).Truncate(time.Second).Unix(), metrics[1].LastFailureAt.Unix())
+	require.NotEqual(t, failed1.CreatedAt.Truncate(time.Second).Unix(), metrics[1].LastFailureAt.Unix())
 
 	// channel 2: no failed records, LastFailureAt must be nil
 	require.Contains(t, metrics, 2)

--- a/internal/server/biz/channel_metrics_test.go
+++ b/internal/server/biz/channel_metrics_test.go
@@ -637,7 +637,9 @@ func TestParseDBTime(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.want.Unix(), got.Unix())
+			// Compare full instants (including fractional seconds) with Equal,
+			// which ignores the Location pointer, unlike == / require.Equal.
+			require.True(t, got.Equal(tt.want), "parseDBTime(%q) = %v, want %v", tt.value, got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
## 问题

1. 启动 WARN `failed to load channel performances`：SQLite 聚合列 `MAX(CASE WHEN status='failed' THEN created_at END)` 以 TEXT 返回，`database/sql` 无法扫描进 `time.Time`（String() 格式与旧版 `.000000000` 格式均不识别）。
2. 启动 WARN `failed to get general settings: no user in context`：backup 任务注册（fx OnStart 无用户 context）读取配置被 privacy deny，时区从配置值退化为 UTC。

## 解决

- `channel_metrics.go`：`last_failure_at` 按字符串扫描，新增 `parseDBTime` 兼容 String()、`.000000000`、RFC3339 等格式；NULL 不报错，单行解析失败仅 WARN。
- `backup/service.go`：注册任务加 `authz.WithSystemBypass`（与 video_storage 一致），正确读取配置时区。

## 测试

- `go build ./...`、`go test ./internal/server/...` 全部通过。
- 新增 3 个测试：新旧时间格式与 NULL 场景、`parseDBTime` 单测、backup 无用户注册保留时区（含反向验证：移除 bypass 后测试失败、时区变 UTC）。
- 生产库副本端到端：`loadChannelPerformances` 由报错变为成功加载。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled backup tasks can now register successfully when system configuration requires authorization unavailable during startup.
  * Improved compatibility when loading channel metrics with timestamps from different SQLite and legacy formats.
  * Invalid metric timestamps are handled safely without preventing other metrics from loading.
* **Tests**
  * Added coverage for timezone-aware backup scheduling and supported database timestamp formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->