### PR TITLE
fix(responses): retry incomplete streams before done

### DIFF
--- a/internal/server/orchestrator/retry.go
+++ b/internal/server/orchestrator/retry.go
@@ -54,7 +54,9 @@ func isRetryableTransportError(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, llm.ErrStreamIncomplete) {
 		return true
 	}
 

--- a/internal/server/orchestrator/retry_test.go
+++ b/internal/server/orchestrator/retry_test.go
@@ -371,6 +371,12 @@ func TestIsRetryableErrorForChannel(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "wrapped incomplete Responses stream is retryable without channel settings",
+			err:      fmt.Errorf("failed to stream request: %w", llm.ErrStreamIncomplete),
+			channel:  nil,
+			expected: true,
+		},
+		{
 			name:     "wrapped upstream EOF is retryable without channel settings",
 			err:      fmt.Errorf("failed to stream request: %w", io.EOF),
 			channel:  nil,

--- a/llm/model.go
+++ b/llm/model.go
@@ -18,6 +18,11 @@ var (
 	DoneResponse = &Response{
 		Object: "[DONE]",
 	}
+
+	// ErrStreamIncomplete means a streaming response ended without a protocol
+	// terminal event. Pipelines may retry it only before meaningful output is
+	// committed to the caller.
+	ErrStreamIncomplete = errors.New("stream ended without terminal event")
 )
 
 // Request is the unified llm request model for AxonHub, to keep compatibility with major app and framework.

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -21,7 +21,9 @@ import (
 
 // ErrStreamIncomplete is returned when the stream ends without a terminal event
 // (response.completed, response.failed, response.cancelled, or response.incomplete).
-var ErrStreamIncomplete = errors.New("stream ended without terminal event")
+// Keep this package alias for callers that already reference the Responses
+// transformer sentinel; retry policy should depend on the shared llm error.
+var ErrStreamIncomplete = llm.ErrStreamIncomplete
 
 // TransformStream transforms OpenAI Responses API SSE events to unified llm.Response stream.
 func (t *OutboundTransformer) TransformStream(
@@ -46,7 +48,8 @@ type responsesOutboundStream struct {
 	queueIndex int
 	err        error
 
-	// Track whether the response completed successfully
+	// Track whether the response reached a real terminal event. A synthetic or
+	// provider `[DONE]` marker is valid only after this becomes true.
 	responseCompleted bool
 }
 
@@ -107,11 +110,7 @@ func (s *responsesOutboundStream) Next() bool {
 		// Stream ended - check if we received a terminal event
 		// If not, this is an incomplete stream (e.g., upstream EOF)
 		if s.err == nil && !s.responseCompleted && s.stream.Err() == nil {
-			// Only set this error if we had started receiving response data
-			// This distinguishes between "no response" and "incomplete response"
-			if s.state.responseID != "" {
-				s.err = ErrStreamIncomplete
-			}
+			s.err = ErrStreamIncomplete
 		}
 		return false
 	}
@@ -137,8 +136,14 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		return nil
 	}
 
-	// Handle [DONE] marker
+	// Handle [DONE] marker only after a real Responses terminal event. A
+	// synthetic marker appended after a clean upstream EOF must surface the
+	// incomplete-stream error before retry, client, or persistence boundaries.
 	if string(event.Data) == "[DONE]" {
+		if !s.responseCompleted {
+			return ErrStreamIncomplete
+		}
+
 		s.enqueue(llm.DoneResponse)
 		return nil
 	}

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -121,6 +121,45 @@ func TestOutboundTransformer_StreamTransformation_WithTestData(t *testing.T) {
 	}
 }
 
+func TestOutboundTransformer_TransformStream_IncompleteResponseDoesNotEmitDone(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		events []*httpclient.StreamEvent
+	}{
+		{name: "empty upstream stream"},
+		{
+			name: "with response ID",
+			events: []*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_incomplete","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+			},
+		},
+		{
+			name: "with empty response ID",
+			events: []*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(tt.events))
+			require.NoError(t, err)
+
+			var responses []*llm.Response
+			for stream.Next() {
+				responses = append(responses, stream.Current())
+			}
+
+			require.ErrorIs(t, stream.Err(), ErrStreamIncomplete)
+			require.NotContains(t, responses, llm.DoneResponse)
+		})
+	}
+}
+
 func TestOutboundTransformer_StreamTransformation_ErrorEvent(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes #2092 by preventing a synthetic Responses `[DONE]` marker from crossing retry/client/persistence boundaries before a real terminal event is observed.

## Root cause

For `response.created -> clean EOF` without `response.completed|failed|incomplete|cancelled`, the Responses transformer appended `[DONE]` and exposed `llm.DoneResponse` before its delayed `ErrStreamIncomplete`. The pre-content probe therefore returned a seemingly successful stream and the configured retry/failover path never saw the incomplete-stream error in time.

## Changes

- reject `[DONE]` when a Responses request has started but no real terminal event was observed;
- surface `ErrStreamIncomplete` before any success terminator reaches the caller;
- classify wrapped `ErrStreamIncomplete` as retryable while the pipeline is still inside its pre-content retry boundary;
- preserve existing fail-closed behavior after text, reasoning, or tool-call content has been committed.

## Verification

- RED reproduced: `response.created -> clean EOF` leaked `llm.DoneResponse` before the error;
- GREEN: no `DoneResponse`, `ErrStreamIncomplete` is returned;
- retry classification RED/GREEN for wrapped incomplete Responses streams;
- `cd llm && go test ./...`;
- `go test ./...` from the repository root;
- independent exact-head review required before artifact delivery.

## Non-goals

- retrying after meaningful output or tool calls;
- changing retry budgets;
- hiding genuine upstream stream failures;
- deploying or restarting an AxonHub instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted streaming responses.
  * Incomplete streams are now reported consistently, including empty streams and streams missing a terminal event.
  * Prevented incomplete responses from being marked as successfully finished.
  * Automatically retries eligible incomplete stream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->