### PR TITLE
opt: anthropic signature recognization

### DIFF
--- a/llm/transformer/anthropic/thinking_test.go
+++ b/llm/transformer/anthropic/thinking_test.go
@@ -1139,12 +1139,12 @@ func TestInboundTransformer_ThinkingWithOtherFields(t *testing.T) {
 func TestOutboundConvert_RedactedThinkingToAnthropic(t *testing.T) {
 	const (
 		thinking     = "Let me analyze this step by step..."
-		signature    = "EqQAAABBBCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPPQQQQRRRRSSSSTTTTUUUUVVVVWWWWXXXXYYYYZZZZaaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnooooppppqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzz0000111122223333444455556666777788889999"
+		signature    = "Eq0CCokBCBAYAipAmkim+S4ApjNpcVSh82hYj016e9aYlvNfdj8ZaVbASj64fkCHtgDxjvumIhTpVr6WsoYoGyBtZOuoFPg7JUV7vjIPY2xhdWRlLXNvbm5ldC01OABCCHRoaW5raW5nWiRjYTEwYTFhOS03ZWFmLTRiZDUtYWFkMy1iY2MyY2Q1MWQ1MDgSDETIROQHvz1/jQbeLxIMwjZzeFruDsqTqYxwGgy4ekwdZi3oeDEsWGsiMD3w0HGjBb28dNuTqZE1X2zCSndpSwOWYwRhbrXFV8RIg6jFiS+MSo6Gt0QUFWKh4CpD8q8wDmAKZYQ45z+1rFBwX7SWdXo02qQNUkGIwm1fTFf/GIRTRwIUTNdG35tcDHWh6pJ/if5LjcPdJTMiiw+bFgPTCBgB"
 		redactedData = "EmwKAhgBEgy3va3pzix/LafPsn4aDFIT2Xlxh0L5L8rLVyIwxtE3rAFBa8cr3qpPkNRj2YfWXGmKDxH4mPnZ5sQ7vB9URj2pLmN3kF8/dW5hR7xJ0aP1oLs9yTcMnKVf2wRpEGjH9XZaBt4UvDcPrQ..."
 		textContent  = "Based on my analysis..."
 	)
 
-	// Signatures in unified format are encoded with the Anthropic prefix + channel identity
+	// Signatures in unified format are Base64 encoded for transport.
 	encodedSignature := *shared.EncodeAnthropicSignature(lo.ToPtr(signature))
 
 	chatReq := &llm.Request{

--- a/llm/transformer/shared/README.md
+++ b/llm/transformer/shared/README.md
@@ -54,7 +54,7 @@ everything else (including `unknown`) is dropped.
 | Pattern | Provider |
 |---------|----------|
 | `gAAAA*` / `gAAA*` prefix | OpenAI |
-| `EqQ*` / `Eqo*` / `Eqr*` prefix | Anthropic |
+| standard base64 whose decoded bytes contain an Anthropic model marker such as `claude-sonnet-5` | Anthropic |
 | standard base64 with protobuf-like decoded bytes | Gemini |
 | anything else | `unknown` (filtered by all `Decode...` helpers) |
 

--- a/llm/transformer/shared/anthropic_test.go
+++ b/llm/transformer/shared/anthropic_test.go
@@ -24,9 +24,14 @@ func TestDecodeAnthropicSignature(t *testing.T) {
 			expected:  nil,
 		},
 		{
-			name:      "anthropic-like signature (Eq prefix)",
+			name:      "Eq prefix without model marker - rejected",
 			signature: new("EqQBCAEDEgQIAhAEGAAgAigBMOzOAg=="),
-			expected:  new("EqQBCAEDEgQIAhAEGAAgAigBMOzOAg=="),
+			expected:  nil,
+		},
+		{
+			name:      "decoded payload with Claude model marker",
+			signature: new(realAnthropicSignature),
+			expected:  new(realAnthropicSignature),
 		},
 		{
 			name:      "openai-like signature (gAAA prefix) - rejected",
@@ -95,7 +100,7 @@ func TestEncodeAnthropicSignature(t *testing.T) {
 }
 
 func TestAnthropicEncodeDecodeRoundTrip(t *testing.T) {
-	original := new("EqQBCAEDEgQIAhAEGAAgAigBMOzOAg==")
+	original := new(realAnthropicSignature)
 
 	encoded := EncodeAnthropicSignature(original)
 	require.NotNil(t, encoded)

--- a/llm/transformer/shared/signature.go
+++ b/llm/transformer/shared/signature.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"bytes"
 	"encoding/base64"
 	"strings"
 )
@@ -25,11 +26,14 @@ type GuessResult struct {
 //
 // Heuristics:
 //   - "gAAAA*" / "gAAA*" prefix → OpenAI
-//   - "EqQ*" / "Eqo*" / "Eqr*" prefix → Anthropic
+//   - standard base64 whose decoded bytes contain an Anthropic model marker
+//     (for example, "claude-sonnet-5") → Anthropic
 //   - standard base64 with protobuf-like decoded bytes → Gemini
 //   - otherwise → unknown
 func GuessSignatureProvider(raw string) GuessResult {
-	s := strings.Trim(raw, `"`)
+	s := strings.TrimSpace(raw)
+	s = strings.Trim(s, `"`)
+	s = strings.TrimSpace(s)
 
 	reason := make([]string, 0, 3)
 
@@ -42,21 +46,20 @@ func GuessSignatureProvider(raw string) GuessResult {
 		}
 	}
 
-	// Anthropic thinking signature common sample prefixes
-	if strings.HasPrefix(s, "EqQ") || strings.HasPrefix(s, "Eqo") || strings.HasPrefix(s, "Eqr") {
-		reason = append(reason, "starts with Eq*, commonly seen in Anthropic thinking.signature examples")
-		return GuessResult{
-			Provider: ProviderAnthropic,
-			Reasons:  reason,
-		}
-	}
-
 	isStdBase64 := isStdBase64String(s)
 
-	// Check standard base64 for protobuf-like bytes (Gemini).
-	// Valid standard base64 is never OpenAI — OpenAI uses base64url encoding.
 	if isStdBase64 {
-		bytes, err := base64.StdEncoding.DecodeString(s)
+		bytes, err := decodeStdBase64(s)
+		if err == nil && containsAnthropicModel(bytes) {
+			reason = append(reason, "standard base64 decoded bytes contain an Anthropic model marker")
+			return GuessResult{
+				Provider: ProviderAnthropic,
+				Reasons:  reason,
+			}
+		}
+
+		// Check standard base64 for protobuf-like bytes (Gemini).
+		// Valid standard base64 is never OpenAI — OpenAI uses base64url encoding.
 		if err == nil && looksLikeProto(bytes) {
 			reason = append(reason, "standard base64 and decoded bytes look protobuf-like, which fits Gemini thoughtSignature")
 			return GuessResult{
@@ -64,6 +67,7 @@ func GuessSignatureProvider(raw string) GuessResult {
 				Reasons:  reason,
 			}
 		}
+
 		reason = append(reason, "standard base64 without known provider prefix")
 		return GuessResult{
 			Provider: ProviderUnknown,
@@ -76,6 +80,25 @@ func GuessSignatureProvider(raw string) GuessResult {
 		Provider: ProviderUnknown,
 		Reasons:  reason,
 	}
+}
+
+// decodeStdBase64 accepts both padded and unpadded standard Base64. Anthropic
+// signatures are opaque bytes and commonly have a length divisible by three,
+// but accepting the unpadded form makes detection safe across proxies/clients.
+func decodeStdBase64(s string) ([]byte, error) {
+	if strings.ContainsRune(s, '=') {
+		return base64.StdEncoding.DecodeString(s)
+	}
+	return base64.RawStdEncoding.DecodeString(s)
+}
+
+// containsAnthropicModel checks for provider-specific model identifiers in the
+// decoded opaque payload. Signatures are binary (often protobuf-like), so the
+// model name is searched as an ASCII substring rather than treating the whole
+// payload as text or attempting to fully parse its wire format.
+func containsAnthropicModel(buf []byte) bool {
+	lower := bytes.ToLower(buf)
+	return bytes.Contains(lower, []byte("claude")) || bytes.Contains(lower, []byte("anthropic"))
 }
 
 // isStdBase64String checks if s matches standard base64 pattern [A-Za-z0-9+/]+={0,2}.

--- a/llm/transformer/shared/signature_test.go
+++ b/llm/transformer/shared/signature_test.go
@@ -7,7 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const realAnthropicSignature = "Eq0CCokBCBAYAipAmkim+S4ApjNpcVSh82hYj016e9aYlvNfdj8ZaVbASj64fkCHtgDxjvumIhTpVr6WsoYoGyBtZOuoFPg7JUV7vjIPY2xhdWRlLXNvbm5ldC01OABCCHRoaW5raW5nWiRjYTEwYTFhOS03ZWFmLTRiZDUtYWFkMy1iY2MyY2Q1MWQ1MDgSDETIROQHvz1/jQbeLxIMwjZzeFruDsqTqYxwGgy4ekwdZi3oeDEsWGsiMD3w0HGjBb28dNuTqZE1X2zCSndpSwOWYwRhbrXFV8RIg6jFiS+MSo6Gt0QUFWKh4CpD8q8wDmAKZYQ45z+1rFBwX7SWdXo02qQNUkGIwm1fTFf/GIRTRwIUTNdG35tcDHWh6pJ/if5LjcPdJTMiiw+bFgPTCBgB"
+
 func TestGuessSignatureProvider(t *testing.T) {
+	// Mirrors a current Anthropic signature: the encoded value starts with
+	// "Eq0C" and its opaque decoded payload contains a Claude model name.
+	anthropicBinarySignature := make([]byte, 306)
+	copy(anthropicBinarySignature, []byte{0x12, 0xad, 0x02, 0x0a, 0x89, 0x01})
+	copy(anthropicBinarySignature[6:], "claude-sonnet-5 thinking ca10a1a9-7eaf-4bd5-aad3-bcc2cd51d508")
+
 	tests := []struct {
 		name             string
 		raw              string
@@ -27,20 +35,32 @@ func TestGuessSignatureProvider(t *testing.T) {
 			expectReasons:    true,
 		},
 		{
-			name:             "Anthropic EqQ prefix",
+			name:             "EqQ prefix without decoded model marker",
 			raw:              "EqQBCAEDEgQIAhAEGAAgAigBMOzOAg==",
-			expectedProvider: ProviderAnthropic,
+			expectedProvider: ProviderUnknown,
 			expectReasons:    true,
 		},
 		{
-			name:             "Anthropic Eqo prefix",
+			name:             "Eqo prefix without decoded model marker",
 			raw:              "EqoBxxxxxxxx",
+			expectedProvider: ProviderUnknown,
+			expectReasons:    true,
+		},
+		{
+			name:             "Eqr prefix without decoded model marker",
+			raw:              "EqrBxxxxxxxx",
+			expectedProvider: ProviderUnknown,
+			expectReasons:    true,
+		},
+		{
+			name:             "Anthropic decoded payload with Claude model and Eq0 prefix",
+			raw:              base64.StdEncoding.EncodeToString(anthropicBinarySignature),
 			expectedProvider: ProviderAnthropic,
 			expectReasons:    true,
 		},
 		{
-			name:             "Anthropic Eqr prefix",
-			raw:              "EqrBxxxxxxxx",
+			name:             "real Anthropic claude-sonnet-5 signature",
+			raw:              realAnthropicSignature,
 			expectedProvider: ProviderAnthropic,
 			expectReasons:    true,
 		},
@@ -83,6 +103,41 @@ func TestGuessSignatureProvider(t *testing.T) {
 			if tt.expectReasons {
 				require.NotEmpty(t, result.Reasons)
 			}
+		})
+	}
+}
+
+func TestContainsAnthropicModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		buf      []byte
+		expected bool
+	}{
+		{
+			name:     "Claude model marker in binary payload",
+			buf:      []byte{0x12, 0x03, 0x00, 'C', 'l', 'a', 'u', 'd', 'e'},
+			expected: true,
+		},
+		{
+			name:     "Anthropic marker in binary payload",
+			buf:      []byte{0x00, 0x01, 'a', 'n', 't', 'h', 'r', 'o', 'p', 'i', 'c'},
+			expected: true,
+		},
+		{
+			name:     "generic protobuf without model marker",
+			buf:      []byte{0x0a, 0x02, 0x08, 0x01},
+			expected: false,
+		},
+		{
+			name:     "case insensitive marker",
+			buf:      []byte("CLAUDE-OPUS"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, containsAnthropicModel(tt.buf))
 		})
 	}
 }
@@ -282,9 +337,9 @@ func TestGuessSignatureProviderEdgeCases(t *testing.T) {
 			expectedProvider: ProviderOpenAI,
 		},
 		{
-			name:             "Anthropic prefix exact match EqQ",
+			name:             "EqQ prefix exact match is unknown",
 			raw:              "EqQ",
-			expectedProvider: ProviderAnthropic,
+			expectedProvider: ProviderUnknown,
 		},
 		{
 			name:             "Gemini empty protobuf",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Anthropic signatures across padded, unpadded, quoted, and whitespace-padded values.
  * Added case-insensitive recognition for Anthropic and Claude model markers, including newer Claude Sonnet signatures.
  * Generic or legacy prefix-only values are no longer incorrectly identified as Anthropic signatures.
  * Continued distinguishing Gemini signatures from generic protobuf data.

* **Documentation**
  * Clarified Anthropic signature detection guidance and supported signature formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->