### PR TITLE
feat: unify auto-refresh controls and stabilize list animations

### DIFF
--- a/frontend/src/components/auto-refresh-control.tsx
+++ b/frontend/src/components/auto-refresh-control.tsx
@@ -1,0 +1,111 @@
+import { useRef, useState } from 'react';
+import { ChevronDown, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { AUTO_REFRESH_INTERVALS, type AutoRefreshInterval, type EnabledAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+const CLOSED_VALUE = 'closed';
+const MIN_REFRESH_SPIN_DURATION_MS = 1000;
+
+interface AutoRefreshControlProps {
+  interval: AutoRefreshInterval;
+  onIntervalChange: (interval: AutoRefreshInterval) => void;
+  onRefresh: () => void | Promise<unknown>;
+  disabled?: boolean;
+  className?: string;
+}
+
+function formatInterval(interval: EnabledAutoRefreshInterval) {
+  return `${interval / 1000}s`;
+}
+
+export function AutoRefreshControl({ interval, onIntervalChange, onRefresh, disabled = false, className }: AutoRefreshControlProps) {
+  const { t } = useTranslation();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshInFlightRef = useRef(false);
+  const selectedValue = interval === null ? CLOSED_VALUE : interval.toString();
+
+  const handleRefresh = async () => {
+    if (refreshInFlightRef.current) return;
+
+    refreshInFlightRef.current = true;
+    setIsRefreshing(true);
+    const startedAt = Date.now();
+
+    try {
+      await onRefresh();
+    } catch {
+      // Query errors are surfaced by the page's existing error handling.
+    } finally {
+      const remainingDuration = MIN_REFRESH_SPIN_DURATION_MS - (Date.now() - startedAt);
+      if (remainingDuration > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remainingDuration));
+      }
+
+      refreshInFlightRef.current = false;
+      setIsRefreshing(false);
+    }
+  };
+
+  const handleValueChange = (value: string) => {
+    const nextInterval = AUTO_REFRESH_INTERVALS.find((candidate) => candidate.toString() === value) ?? null;
+    onIntervalChange(nextInterval);
+  };
+
+  return (
+    <div className={cn('inline-flex shrink-0', className)}>
+      <Button
+        type='button'
+        variant='outline'
+        size='sm'
+        onClick={handleRefresh}
+        disabled={disabled || isRefreshing}
+        aria-busy={isRefreshing}
+        aria-label={t('common.refresh')}
+        data-testid='manual-refresh-button'
+        className='active:bg-accent active:text-accent-foreground dark:active:bg-accent h-8 rounded-r-none border-r-0'
+      >
+        <RefreshCw className={cn('mr-2 h-4 w-4', (interval !== null || isRefreshing) && 'animate-spin')} />
+        <span className='pointer-events-none select-none'>{interval === null ? t('common.refresh') : formatInterval(interval)}</span>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type='button'
+            variant='outline'
+            size='icon-sm'
+            aria-label={t('common.autoRefresh')}
+            data-testid='auto-refresh-trigger'
+            className='data-[state=open]:bg-accent data-[state=open]:text-accent-foreground dark:data-[state=open]:bg-accent rounded-l-none px-0'
+          >
+            <ChevronDown className='h-4 w-4' />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end' aria-label={t('common.autoRefresh')} data-testid='auto-refresh-menu' className='min-w-36'>
+          <DropdownMenuLabel>{t('common.autoRefresh')}</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={selectedValue} onValueChange={handleValueChange}>
+            <DropdownMenuRadioItem value={CLOSED_VALUE} data-testid='auto-refresh-option-closed'>
+              {t('common.close')}
+            </DropdownMenuRadioItem>
+            {AUTO_REFRESH_INTERVALS.map((candidate) => (
+              <DropdownMenuRadioItem key={candidate} value={candidate.toString()} data-testid={`auto-refresh-option-${candidate}`}>
+                {formatInterval(candidate)}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -1,17 +1,18 @@
 import { useMemo, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
-import { Filter, RefreshCw, X } from 'lucide-react';
+import { Filter, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
 import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
-import { Switch } from '@/components/ui/switch';
+import { AutoRefreshControl } from '@/components/auto-refresh-control';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { DateRangePicker } from '@/components/date-range-picker';
 import { useApiKeys } from '@/features/apikeys/data';
@@ -28,8 +29,8 @@ interface DataTableToolbarProps<TData> {
   onResetFilters?: () => void;
   onRefresh?: () => void;
   showRefresh?: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 interface RequestFilterControlsProps {
@@ -185,8 +186,8 @@ export function DataTableToolbar<TData>({
   onResetFilters,
   onRefresh,
   showRefresh = false,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
   const [showArchivedApiKeys, setShowArchivedApiKeys] = useState(false);
@@ -406,24 +407,8 @@ export function DataTableToolbar<TData>({
       />
       <div className='hidden flex-1 sm:block' />
       <div className='flex shrink-0 flex-wrap items-center gap-2'>
-        {showRefresh && onAutoRefreshChange && (
-          <div className='flex shrink-0 items-center gap-2'>
-            <Switch
-              checked={autoRefresh}
-              onCheckedChange={onAutoRefreshChange}
-              id='auto-refresh-switch'
-              aria-label={t('common.autoRefresh')}
-            />
-            <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-              {t('common.autoRefresh')}
-            </label>
-          </div>
-        )}
-        {showRefresh && onRefresh && (
-          <Button variant='outline' size='sm' onClick={onRefresh} aria-label={t('common.refresh')} className='shrink-0'>
-            <RefreshCw className={`h-4 w-4 ${autoRefresh ? 'animate-spin' : ''} sm:mr-2`} />
-            <span className='hidden sm:inline'>{t('common.refresh')}</span>
-          </Button>
+        {showRefresh && onRefresh && onAutoRefreshIntervalChange && (
+          <AutoRefreshControl interval={autoRefreshInterval} onIntervalChange={onAutoRefreshIntervalChange} onRefresh={onRefresh} />
         )}
         <DataTableViewOptions table={table} />
       </div>

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -62,6 +62,7 @@ interface RequestsTableProps {
   onRefresh: () => void;
   showRefresh: boolean;
   autoRefreshInterval?: AutoRefreshInterval;
+  autoRefreshResumeKey?: number;
   onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
@@ -106,6 +107,7 @@ export function RequestsTable({
   onRefresh,
   showRefresh,
   autoRefreshInterval = null,
+  autoRefreshResumeKey = 0,
   onAutoRefreshIntervalChange,
 }: RequestsTableProps) {
   const { t } = useTranslation();
@@ -204,7 +206,11 @@ export function RequestsTable({
     });
   }, [isMobile, visibilityReady]);
 
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
+  const animationResetKey = useMemo(
+    () => JSON.stringify({ queryWhere: queryWhere ?? null, autoRefreshResumeKey }),
+    [queryWhere, autoRefreshResumeKey]
+  );
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = [];

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -16,6 +16,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useIsMobile, MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -60,8 +61,8 @@ interface RequestsTableProps {
   onViewDetail: (requestId: string) => void;
   onRefresh: () => void;
   showRefresh: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 export interface RequestTableFilters {
@@ -104,8 +105,8 @@ export function RequestsTable({
   onViewDetail,
   onRefresh,
   showRefresh,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: RequestsTableProps) {
   const { t } = useTranslation();
 
@@ -203,7 +204,7 @@ export function RequestsTable({
     });
   }, [isMobile, visibilityReady]);
 
-  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = [];
@@ -286,8 +287,8 @@ export function RequestsTable({
         onResetFilters={onResetFilters}
         onRefresh={onRefresh}
         showRefresh={showRefresh}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={onAutoRefreshChange}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={onAutoRefreshIntervalChange}
       />
       <div className='shadow-soft relative mt-2 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)] sm:mt-4'>
         <div className='min-w-max'>

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -226,11 +226,12 @@ function RequestsContent() {
 
   const isFirstPage = !paginationArgs.after && cursorHistory.length === 0;
 
-  useInterval(
+  const autoRefreshResumeKey = useInterval(
     () => {
       refetch();
     },
-    isFirstPage ? autoRefreshInterval : null
+    isFirstPage ? autoRefreshInterval : null,
+    { refreshOnResume: true }
   );
 
   const handleNextPage = () => {
@@ -359,6 +360,7 @@ function RequestsContent() {
         onRefresh={refetch}
         showRefresh={isFirstPage}
         autoRefreshInterval={autoRefreshInterval}
+        autoRefreshResumeKey={autoRefreshResumeKey}
         onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>

--- a/frontend/src/features/requests/index.tsx
+++ b/frontend/src/features/requests/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import {
@@ -10,6 +10,7 @@ import {
   type DateTimeRangeValue,
   type TimeValue,
 } from '@/utils/date-range';
+import { useAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useDebounce } from '@/hooks/use-debounce';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
@@ -186,7 +187,7 @@ function RequestsContent() {
     [currentSearch]
   );
   const debouncedModelIDFilter = useDebounce(modelIDFilter, 300);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useAutoRefreshInterval('requests-auto-refresh-interval-ms');
 
   // Build where clause with filters
   const whereClause = (() => {
@@ -229,7 +230,7 @@ function RequestsContent() {
     () => {
       refetch();
     },
-    autoRefresh && isFirstPage ? 10000 : null
+    isFirstPage ? autoRefreshInterval : null
   );
 
   const handleNextPage = () => {
@@ -357,8 +358,8 @@ function RequestsContent() {
         onViewDetail={handleViewDetail}
         onRefresh={refetch}
         showRefresh={isFirstPage}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>
   );

--- a/frontend/src/features/threads/components/data-table-toolbar.tsx
+++ b/frontend/src/features/threads/components/data-table-toolbar.tsx
@@ -1,19 +1,20 @@
 import { useMemo } from 'react';
 import { CheckIcon, Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
-import { RefreshCw, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import { cn } from '@/lib/utils';
+import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
+import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
-import { Switch } from '@/components/ui/switch';
+import { AutoRefreshControl } from '@/components/auto-refresh-control';
 import { DateRangePicker } from '@/components/date-range-picker';
-import type { DateTimeRangeValue } from '@/utils/date-range';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -25,8 +26,8 @@ interface DataTableToolbarProps<TData> {
   onStatusFilterChange?: (statuses: string[]) => void;
   onRefresh?: () => void;
   showRefresh?: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 export function ThreadsTableToolbar<TData>({
@@ -39,8 +40,8 @@ export function ThreadsTableToolbar<TData>({
   onStatusFilterChange,
   onRefresh,
   showRefresh = false,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
   const scrollRef = useHorizontalScroll<HTMLDivElement>();
@@ -58,7 +59,7 @@ export function ThreadsTableToolbar<TData>({
 
   return (
     <div ref={scrollRef} className='flex items-center justify-between gap-2 overflow-x-auto'>
-      <div className='flex flex-1 items-center space-x-2 shrink-0'>
+      <div className='flex flex-1 shrink-0 items-center space-x-2'>
         <Input
           placeholder={t('threads.filters.filterThreadId')}
           value={threadIdFilter}
@@ -108,9 +109,7 @@ export function ThreadsTableToolbar<TData>({
                         <CommandItem
                           key={option.value}
                           onSelect={() => {
-                            const newFilter = isSelected
-                              ? statusFilter.filter((s) => s !== option.value)
-                              : [...statusFilter, option.value];
+                            const newFilter = isSelected ? statusFilter.filter((s) => s !== option.value) : [...statusFilter, option.value];
                             onStatusFilterChange(newFilter.length > 0 ? newFilter : []);
                           }}
                         >
@@ -163,20 +162,9 @@ export function ThreadsTableToolbar<TData>({
           </Button>
         )}
       </div>
-      <div className='flex items-center space-x-2 shrink-0'>
-        {showRefresh && onAutoRefreshChange && (
-          <div className='flex items-center space-x-2 shrink-0'>
-            <Switch checked={autoRefresh} onCheckedChange={onAutoRefreshChange} id='auto-refresh-switch' />
-            <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-              {t('common.autoRefresh')}
-            </label>
-          </div>
-        )}
-        {showRefresh && onRefresh && (
-          <Button variant='outline' size='sm' onClick={onRefresh} className='shrink-0'>
-            <RefreshCw className={`mr-2 h-4 w-4 ${autoRefresh ? 'animate-spin' : ''}`} />
-            {t('common.refresh')}
-          </Button>
+      <div className='flex shrink-0 items-center space-x-2'>
+        {showRefresh && onRefresh && onAutoRefreshIntervalChange && (
+          <AutoRefreshControl interval={autoRefreshInterval} onIntervalChange={onAutoRefreshIntervalChange} onRefresh={onRefresh} />
         )}
       </div>
     </div>

--- a/frontend/src/features/threads/components/threads-table.tsx
+++ b/frontend/src/features/threads/components/threads-table.tsx
@@ -14,11 +14,12 @@ import {
 } from '@tanstack/react-table';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TableSkeleton } from '@/components/ui/table-skeleton';
 import { ServerSidePagination } from '@/components/server-side-pagination';
-import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Thread, ThreadConnection } from '../data/schema';
 import { ThreadsTableToolbar } from './data-table-toolbar';
 import { useThreadsColumns } from './threads-columns';
@@ -49,8 +50,8 @@ interface ThreadsTableProps {
   onStatusFilterChange?: (statuses: string[]) => void;
   onRefresh: () => void;
   showRefresh: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 export function ThreadsTable({
@@ -70,8 +71,8 @@ export function ThreadsTable({
   onStatusFilterChange,
   onRefresh,
   showRefresh,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: ThreadsTableProps) {
   const { t } = useTranslation();
   const threadsColumns = useThreadsColumns();
@@ -80,7 +81,7 @@ export function ThreadsTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
 
   const table = useReactTable({
     data: displayedData,
@@ -118,8 +119,8 @@ export function ThreadsTable({
         onStatusFilterChange={onStatusFilterChange}
         onRefresh={onRefresh}
         showRefresh={showRefresh}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={onAutoRefreshChange}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={onAutoRefreshIntervalChange}
       />
       <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
         <Table data-testid='threads-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>

--- a/frontend/src/features/threads/components/threads-table.tsx
+++ b/frontend/src/features/threads/components/threads-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ColumnFiltersState,
   RowData,
@@ -51,6 +51,7 @@ interface ThreadsTableProps {
   onRefresh: () => void;
   showRefresh: boolean;
   autoRefreshInterval?: AutoRefreshInterval;
+  autoRefreshResumeKey?: number;
   onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
@@ -72,6 +73,7 @@ export function ThreadsTable({
   onRefresh,
   showRefresh,
   autoRefreshInterval = null,
+  autoRefreshResumeKey = 0,
   onAutoRefreshIntervalChange,
 }: ThreadsTableProps) {
   const { t } = useTranslation();
@@ -81,7 +83,11 @@ export function ThreadsTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
+  const animationResetKey = useMemo(
+    () => JSON.stringify({ dateRange, threadIdFilter, statusFilter, autoRefreshResumeKey }),
+    [dateRange, threadIdFilter, statusFilter, autoRefreshResumeKey]
+  );
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/features/threads/index.tsx
+++ b/frontend/src/features/threads/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { buildDateRangeWhereClause, type DateTimeRangeValue } from '@/utils/date-range';
+import { useAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useDebounce } from '@/hooks/use-debounce';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
@@ -18,7 +19,7 @@ function ThreadsContent() {
   const [dateRange, setDateRange] = useState<DateTimeRangeValue | undefined>();
   const [threadIdFilter, setThreadIdFilter] = useState<string>('');
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useAutoRefreshInterval('threads-auto-refresh-interval-ms');
   const debouncedThreadIdFilter = useDebounce(threadIdFilter, 300);
 
   const whereClause = (() => {
@@ -57,7 +58,7 @@ function ThreadsContent() {
     () => {
       refetch();
     },
-    autoRefresh && isFirstPage ? 30000 : null
+    isFirstPage ? autoRefreshInterval : null
   );
 
   const handleNextPage = () => {
@@ -123,8 +124,8 @@ function ThreadsContent() {
         onStatusFilterChange={handleStatusFilterChange}
         onRefresh={refetch}
         showRefresh={isFirstPage}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>
   );
@@ -139,7 +140,7 @@ export default function ThreadsManagement() {
         <div className='flex flex-1 items-center justify-between'>
           <div>
             <h2 className='text-xl font-bold tracking-tight'>{t('threads.title')}</h2>
-            <p className='text-sm text-muted-foreground'>{t('threads.description')}</p>
+            <p className='text-muted-foreground text-sm'>{t('threads.description')}</p>
           </div>
         </div>
       </Header>

--- a/frontend/src/features/threads/index.tsx
+++ b/frontend/src/features/threads/index.tsx
@@ -54,11 +54,12 @@ function ThreadsContent() {
   const pageInfo = data?.pageInfo;
   const isFirstPage = !paginationArgs.after && cursorHistory.length === 0;
 
-  useInterval(
+  const autoRefreshResumeKey = useInterval(
     () => {
       refetch();
     },
-    isFirstPage ? autoRefreshInterval : null
+    isFirstPage ? autoRefreshInterval : null,
+    { refreshOnResume: true }
   );
 
   const handleNextPage = () => {
@@ -125,6 +126,7 @@ function ThreadsContent() {
         onRefresh={refetch}
         showRefresh={isFirstPage}
         autoRefreshInterval={autoRefreshInterval}
+        autoRefreshResumeKey={autoRefreshResumeKey}
         onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>

--- a/frontend/src/features/traces/components/data-table-toolbar.tsx
+++ b/frontend/src/features/traces/components/data-table-toolbar.tsx
@@ -1,20 +1,21 @@
 import { useMemo } from 'react';
 import { CheckIcon, Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
-import { RefreshCw, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import { cn } from '@/lib/utils';
+import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
+import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
-import { Switch } from '@/components/ui/switch';
+import { AutoRefreshControl } from '@/components/auto-refresh-control';
 import { DateRangePicker } from '@/components/date-range-picker';
 import { DataTableViewOptions } from './data-table-view-options';
-import type { DateTimeRangeValue } from '@/utils/date-range';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -26,8 +27,8 @@ interface DataTableToolbarProps<TData> {
   onStatusFilterChange?: (statuses: string[]) => void;
   onRefresh?: () => void;
   showRefresh?: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 export function DataTableToolbar<TData>({
@@ -40,8 +41,8 @@ export function DataTableToolbar<TData>({
   onStatusFilterChange,
   onRefresh,
   showRefresh = false,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
   const scrollRef = useHorizontalScroll<HTMLDivElement>();
@@ -59,7 +60,7 @@ export function DataTableToolbar<TData>({
 
   return (
     <div ref={scrollRef} className='flex items-center justify-between gap-2 overflow-x-auto'>
-      <div className='flex flex-1 items-center space-x-2 shrink-0'>
+      <div className='flex flex-1 shrink-0 items-center space-x-2'>
         <Input
           placeholder={t('traces.filters.filterTraceId')}
           value={traceIdFilter}
@@ -109,9 +110,7 @@ export function DataTableToolbar<TData>({
                         <CommandItem
                           key={option.value}
                           onSelect={() => {
-                            const newFilter = isSelected
-                              ? statusFilter.filter((s) => s !== option.value)
-                              : [...statusFilter, option.value];
+                            const newFilter = isSelected ? statusFilter.filter((s) => s !== option.value) : [...statusFilter, option.value];
                             onStatusFilterChange(newFilter.length > 0 ? newFilter : []);
                           }}
                         >
@@ -164,20 +163,9 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
       </div>
-      <div className='flex items-center space-x-2 shrink-0'>
-        {showRefresh && onAutoRefreshChange && (
-          <div className='flex items-center space-x-2 shrink-0'>
-            <Switch checked={autoRefresh} onCheckedChange={onAutoRefreshChange} id='auto-refresh-switch' />
-            <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-              {t('common.autoRefresh')}
-            </label>
-          </div>
-        )}
-        {showRefresh && onRefresh && (
-          <Button variant='outline' size='sm' onClick={onRefresh} className='shrink-0'>
-            <RefreshCw className={`mr-2 h-4 w-4 ${autoRefresh ? 'animate-spin' : ''}`} />
-            {t('common.refresh')}
-          </Button>
+      <div className='flex shrink-0 items-center space-x-2'>
+        {showRefresh && onRefresh && onAutoRefreshIntervalChange && (
+          <AutoRefreshControl interval={autoRefreshInterval} onIntervalChange={onAutoRefreshIntervalChange} onRefresh={onRefresh} />
         )}
         {/* <DataTableViewOptions table={table} /> */}
       </div>

--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -110,7 +110,8 @@ export default function TraceDetailPage() {
     () => {
       refetch();
     },
-    autoRefreshInterval
+    autoRefreshInterval,
+    { refreshOnResume: true }
   );
 
   const handleSpanSelect = (parentTrace: Segment, span: Span, type: 'request' | 'response') => {

--- a/frontend/src/features/traces/components/trace-detail-page.tsx
+++ b/frontend/src/features/traces/components/trace-detail-page.tsx
@@ -2,18 +2,19 @@ import { useMemo, useState, useEffect } from 'react';
 import { format } from 'date-fns';
 import { useParams, useNavigate } from '@tanstack/react-router';
 import { zhCN, enUS } from 'date-fns/locale';
-import { ArrowLeft, FileText, Activity, RefreshCw, List, GitBranch, Waypoints, Maximize2, X, Wrench, MessageSquare, ChevronDown } from 'lucide-react';
+import { ArrowLeft, FileText, Activity, List, GitBranch, Waypoints, Maximize2, X, Wrench, MessageSquare, ChevronDown } from 'lucide-react';
 import { IconArchive, IconPin, IconRotate } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { cn, extractNumberID } from '@/lib/utils';
+import { useAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
+import { AutoRefreshControl } from '@/components/auto-refresh-control';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
-import { Switch } from '@/components/ui/switch';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -42,7 +43,7 @@ export default function TraceDetailPage() {
   const [selectedTrace, setSelectedTrace] = useState<Segment | null>(null);
   const [selectedSpan, setSelectedSpan] = useState<Span | null>(null);
   const [selectedSpanType, setSelectedSpanType] = useState<'request' | 'response' | null>(null);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useAutoRefreshInterval('trace-detail-auto-refresh-interval-ms');
   const [viewMode, setViewMode] = useState<'flat' | 'flow' | 'tree'>('flat');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
@@ -109,7 +110,7 @@ export default function TraceDetailPage() {
     () => {
       refetch();
     },
-    autoRefresh ? 30000 : null
+    autoRefreshInterval
   );
 
   const handleSpanSelect = (parentTrace: Segment, span: Span, type: 'request' | 'response') => {
@@ -193,16 +194,12 @@ export default function TraceDetailPage() {
               </div>
             </div>
             <div className='flex items-center gap-1 sm:gap-2 shrink-0'>
-              <div className='hidden sm:flex items-center gap-2'>
-                <Switch checked={autoRefresh} onCheckedChange={setAutoRefresh} id='auto-refresh-switch' />
-                <label htmlFor='auto-refresh-switch' className='text-muted-foreground cursor-pointer text-sm whitespace-nowrap'>
-                  {t('common.autoRefresh')}
-                </label>
-              </div>
-              <Button variant='outline' size='sm' onClick={() => refetch()} disabled={isLoading} className='px-2 sm:px-3'>
-                <RefreshCw className={`h-4 w-4 ${isLoading || autoRefresh ? 'animate-spin' : ''}`} />
-                <span className='hidden sm:inline ml-2'>{t('common.refresh')}</span>
-              </Button>
+              <AutoRefreshControl
+                interval={autoRefreshInterval}
+                onIntervalChange={setAutoRefreshInterval}
+                onRefresh={refetch}
+                disabled={isLoading}
+              />
               {(() => {
                 const status = trace.status ?? 'active';
                 if (status === 'active') {

--- a/frontend/src/features/traces/components/traces-table.tsx
+++ b/frontend/src/features/traces/components/traces-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ColumnFiltersState,
   RowData,
@@ -52,6 +52,7 @@ interface TracesTableProps {
   onRefresh: () => void;
   showRefresh: boolean;
   autoRefreshInterval?: AutoRefreshInterval;
+  autoRefreshResumeKey?: number;
   onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
@@ -73,6 +74,7 @@ export function TracesTable({
   onRefresh,
   showRefresh,
   autoRefreshInterval = null,
+  autoRefreshResumeKey = 0,
   onAutoRefreshIntervalChange,
 }: TracesTableProps) {
   const { t } = useTranslation();
@@ -82,7 +84,11 @@ export function TracesTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
+  const animationResetKey = useMemo(
+    () => JSON.stringify({ dateRange, traceIdFilter, statusFilter, autoRefreshResumeKey }),
+    [dateRange, traceIdFilter, statusFilter, autoRefreshResumeKey]
+  );
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/features/traces/components/traces-table.tsx
+++ b/frontend/src/features/traces/components/traces-table.tsx
@@ -14,11 +14,12 @@ import {
 } from '@tanstack/react-table';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import type { DateTimeRangeValue } from '@/utils/date-range';
+import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useAnimatedList } from '@/hooks/useAnimatedList';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TableSkeleton } from '@/components/ui/table-skeleton';
 import { ServerSidePagination } from '@/components/server-side-pagination';
-import type { DateTimeRangeValue } from '@/utils/date-range';
 import { Trace, TraceConnection } from '../data/schema';
 import { DataTableToolbar } from './data-table-toolbar';
 import { useTracesColumns } from './traces-columns';
@@ -50,8 +51,8 @@ interface TracesTableProps {
   onStatusFilterChange?: (statuses: string[]) => void;
   onRefresh: () => void;
   showRefresh: boolean;
-  autoRefresh?: boolean;
-  onAutoRefreshChange?: (enabled: boolean) => void;
+  autoRefreshInterval?: AutoRefreshInterval;
+  onAutoRefreshIntervalChange?: (interval: AutoRefreshInterval) => void;
 }
 
 export function TracesTable({
@@ -71,8 +72,8 @@ export function TracesTable({
   onStatusFilterChange,
   onRefresh,
   showRefresh,
-  autoRefresh = false,
-  onAutoRefreshChange,
+  autoRefreshInterval = null,
+  onAutoRefreshIntervalChange,
 }: TracesTableProps) {
   const { t } = useTranslation();
   const tracesColumns = useTracesColumns();
@@ -81,7 +82,7 @@ export function TracesTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
-  const displayedData = useAnimatedList(data, autoRefresh, pageSize);
+  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize);
 
   const table = useReactTable({
     data: displayedData,
@@ -119,8 +120,8 @@ export function TracesTable({
         onStatusFilterChange={onStatusFilterChange}
         onRefresh={onRefresh}
         showRefresh={showRefresh}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={onAutoRefreshChange}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={onAutoRefreshIntervalChange}
       />
       <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
         <Table data-testid='traces-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>

--- a/frontend/src/features/traces/index.tsx
+++ b/frontend/src/features/traces/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { buildDateRangeWhereClause, type DateTimeRangeValue } from '@/utils/date-range';
+import { useAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
 import { useDebounce } from '@/hooks/use-debounce';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import useInterval from '@/hooks/useInterval';
@@ -18,7 +19,7 @@ function TracesContent() {
   const [dateRange, setDateRange] = useState<DateTimeRangeValue | undefined>();
   const [traceIdFilter, setTraceIdFilter] = useState<string>('');
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useAutoRefreshInterval('traces-auto-refresh-interval-ms');
   const debouncedTraceIdFilter = useDebounce(traceIdFilter, 300);
 
   // Build where clause with filters
@@ -58,7 +59,7 @@ function TracesContent() {
     () => {
       refetch();
     },
-    autoRefresh && isFirstPage ? 30000 : null
+    isFirstPage ? autoRefreshInterval : null
   );
 
   const handleNextPage = () => {
@@ -124,8 +125,8 @@ function TracesContent() {
         onStatusFilterChange={handleStatusFilterChange}
         onRefresh={refetch}
         showRefresh={isFirstPage}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshInterval={autoRefreshInterval}
+        onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>
   );
@@ -140,7 +141,7 @@ export default function TracesManagement() {
         <div className='flex flex-1 items-center justify-between'>
           <div>
             <h2 className='text-xl font-bold tracking-tight'>{t('traces.title')}</h2>
-            <p className='text-sm text-muted-foreground'>{t('traces.description')}</p>
+            <p className='text-muted-foreground text-sm'>{t('traces.description')}</p>
           </div>
         </div>
       </Header>

--- a/frontend/src/features/traces/index.tsx
+++ b/frontend/src/features/traces/index.tsx
@@ -55,11 +55,12 @@ function TracesContent() {
   const pageInfo = data?.pageInfo;
   const isFirstPage = !paginationArgs.after && cursorHistory.length === 0;
 
-  useInterval(
+  const autoRefreshResumeKey = useInterval(
     () => {
       refetch();
     },
-    isFirstPage ? autoRefreshInterval : null
+    isFirstPage ? autoRefreshInterval : null,
+    { refreshOnResume: true }
   );
 
   const handleNextPage = () => {
@@ -126,6 +127,7 @@ function TracesContent() {
         onRefresh={refetch}
         showRefresh={isFirstPage}
         autoRefreshInterval={autoRefreshInterval}
+        autoRefreshResumeKey={autoRefreshResumeKey}
         onAutoRefreshIntervalChange={setAutoRefreshInterval}
       />
     </div>

--- a/frontend/src/hooks/use-auto-refresh-interval.test.mjs
+++ b/frontend/src/hooks/use-auto-refresh-interval.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  AUTO_REFRESH_INTERVALS,
+  parseAutoRefreshInterval,
+  readAutoRefreshInterval,
+  writeAutoRefreshInterval,
+} from './use-auto-refresh-interval.ts';
+
+class MemoryStorage {
+  #values = new Map();
+
+  getItem(key) {
+    return this.#values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.#values.set(key, value);
+  }
+
+  removeItem(key) {
+    this.#values.delete(key);
+  }
+}
+
+test('accepts only supported auto-refresh intervals', () => {
+  for (const interval of AUTO_REFRESH_INTERVALS) {
+    assert.equal(parseAutoRefreshInterval(interval.toString()), interval);
+  }
+
+  for (const value of [null, '', '0', '5001', '05000', '10000 ', 'invalid']) {
+    assert.equal(parseAutoRefreshInterval(value), null);
+  }
+});
+
+test('removes invalid stored values', () => {
+  const storage = new MemoryStorage();
+  storage.setItem('refresh-key', 'invalid');
+
+  assert.equal(readAutoRefreshInterval('refresh-key', storage), null);
+  assert.equal(storage.getItem('refresh-key'), null);
+});
+
+test('persists intervals independently and removes disabled settings', () => {
+  const storage = new MemoryStorage();
+
+  writeAutoRefreshInterval('requests', 5000, storage);
+  writeAutoRefreshInterval('traces', 30000, storage);
+
+  assert.equal(readAutoRefreshInterval('requests', storage), 5000);
+  assert.equal(readAutoRefreshInterval('traces', storage), 30000);
+
+  writeAutoRefreshInterval('requests', null, storage);
+
+  assert.equal(storage.getItem('requests'), null);
+  assert.equal(readAutoRefreshInterval('traces', storage), 30000);
+});

--- a/frontend/src/hooks/use-auto-refresh-interval.test.mjs
+++ b/frontend/src/hooks/use-auto-refresh-interval.test.mjs
@@ -4,6 +4,7 @@ import {
   AUTO_REFRESH_INTERVALS,
   parseAutoRefreshInterval,
   readAutoRefreshInterval,
+  readBrowserAutoRefreshInterval,
   writeAutoRefreshInterval,
 } from './use-auto-refresh-interval.ts';
 
@@ -39,6 +40,30 @@ test('removes invalid stored values', () => {
 
   assert.equal(readAutoRefreshInterval('refresh-key', storage), null);
   assert.equal(storage.getItem('refresh-key'), null);
+});
+
+test('returns disabled when the browser localStorage accessor throws', () => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const throwingWindow = {};
+  Object.defineProperty(throwingWindow, 'localStorage', {
+    get() {
+      throw new Error('localStorage is blocked');
+    },
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: throwingWindow,
+  });
+
+  try {
+    assert.equal(readBrowserAutoRefreshInterval('refresh-key'), null);
+  } finally {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      delete globalThis.window;
+    }
+  }
 });
 
 test('persists intervals independently and removes disabled settings', () => {

--- a/frontend/src/hooks/use-auto-refresh-interval.ts
+++ b/frontend/src/hooks/use-auto-refresh-interval.ts
@@ -1,0 +1,57 @@
+import { useCallback, useState } from 'react';
+
+export const AUTO_REFRESH_INTERVALS = [5000, 10000, 30000, 60000] as const;
+
+export type EnabledAutoRefreshInterval = (typeof AUTO_REFRESH_INTERVALS)[number];
+export type AutoRefreshInterval = EnabledAutoRefreshInterval | null;
+
+type AutoRefreshStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export function parseAutoRefreshInterval(value: string | null): AutoRefreshInterval {
+  return AUTO_REFRESH_INTERVALS.find((interval) => interval.toString() === value) ?? null;
+}
+
+export function readAutoRefreshInterval(storageKey: string, storage: AutoRefreshStorage): AutoRefreshInterval {
+  try {
+    const storedValue = storage.getItem(storageKey);
+    const interval = parseAutoRefreshInterval(storedValue);
+
+    if (storedValue !== null && interval === null) {
+      storage.removeItem(storageKey);
+    }
+
+    return interval;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAutoRefreshInterval(storageKey: string, interval: AutoRefreshInterval, storage: AutoRefreshStorage) {
+  if (interval === null) {
+    storage.removeItem(storageKey);
+  } else {
+    storage.setItem(storageKey, interval.toString());
+  }
+}
+
+export function useAutoRefreshInterval(storageKey: string) {
+  const [interval, setIntervalState] = useState<AutoRefreshInterval>(() => {
+    if (typeof window === 'undefined') return null;
+    return readAutoRefreshInterval(storageKey, window.localStorage);
+  });
+
+  const setInterval = useCallback(
+    (nextInterval: AutoRefreshInterval) => {
+      setIntervalState(nextInterval);
+
+      try {
+        writeAutoRefreshInterval(storageKey, nextInterval, window.localStorage);
+      } catch {
+        // Keep the in-memory setting when localStorage is unavailable.
+      }
+    },
+    [storageKey]
+  );
+
+  return [interval, setInterval] as const;
+}

--- a/frontend/src/hooks/use-auto-refresh-interval.ts
+++ b/frontend/src/hooks/use-auto-refresh-interval.ts
@@ -34,11 +34,18 @@ export function writeAutoRefreshInterval(storageKey: string, interval: AutoRefre
   }
 }
 
-export function useAutoRefreshInterval(storageKey: string) {
-  const [interval, setIntervalState] = useState<AutoRefreshInterval>(() => {
-    if (typeof window === 'undefined') return null;
+export function readBrowserAutoRefreshInterval(storageKey: string): AutoRefreshInterval {
+  if (typeof window === 'undefined') return null;
+
+  try {
     return readAutoRefreshInterval(storageKey, window.localStorage);
-  });
+  } catch {
+    return null;
+  }
+}
+
+export function useAutoRefreshInterval(storageKey: string) {
+  const [interval, setIntervalState] = useState<AutoRefreshInterval>(() => readBrowserAutoRefreshInterval(storageKey));
 
   const setInterval = useCallback(
     (nextInterval: AutoRefreshInterval) => {

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -5,20 +5,48 @@ const MAX_ITEMS = 50;
 const parsedInterval = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL, 10);
 const ANIMATION_INTERVAL = !isNaN(parsedInterval) && parsedInterval > 0 ? parsedInterval : 500;
 
-export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(data: T[], autoRefresh: boolean, pageSize: number = MAX_ITEMS) {
-  const [displayedData, setDisplayedData] = useState<T[]>(data);
-  const queueRef = useRef<T[]>([]);
-  const prevDataLengthRef = useRef<number>(data.length);
-
+export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(
+  data: T[],
+  autoRefresh: boolean,
+  pageSize: number = MAX_ITEMS,
+  resetKey?: string
+) {
   const getTimestamp = (date: Date | string): number => {
     return date instanceof Date ? date.getTime() : new Date(date).getTime();
   };
+  const dataSignature = data.map((item) => `${item.id}:${getTimestamp(item.createdAt)}`).join('|');
+
+  const [displayedData, setDisplayedData] = useState<T[]>(data);
+  const queueRef = useRef<T[]>([]);
+  const prevDataLengthRef = useRef<number>(data.length);
+  const prevResetKeyRef = useRef(resetKey);
+  const prevDataSignatureRef = useRef(dataSignature);
+  const pendingResetDataSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const resetKeyChanged = resetKey !== prevResetKeyRef.current;
+    if (resetKeyChanged) {
+      prevResetKeyRef.current = resetKey;
+      pendingResetDataSignatureRef.current = prevDataSignatureRef.current;
+    }
+
+    if (pendingResetDataSignatureRef.current !== null) {
+      // The first result after a query change is a new result set, not a poll update.
+      if (dataSignature !== pendingResetDataSignatureRef.current) {
+        pendingResetDataSignatureRef.current = null;
+      }
+      setDisplayedData(data);
+      queueRef.current = [];
+      prevDataLengthRef.current = data.length;
+      prevDataSignatureRef.current = dataSignature;
+      return;
+    }
+
     if (!autoRefresh) {
       setDisplayedData(data);
       queueRef.current = [];
       prevDataLengthRef.current = data.length;
+      prevDataSignatureRef.current = dataSignature;
       return;
     }
 
@@ -27,8 +55,7 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
       const newDataMap = new Map(data.map((r) => [r.id, r]));
 
       // Compute the minimum timestamp from incoming data to establish the time window
-      const minTimestampOfNewData =
-        data.length > 0 ? Math.min(...data.map((item) => getTimestamp(item.createdAt))) : 0;
+      const minTimestampOfNewData = data.length > 0 ? Math.min(...data.map((item) => getTimestamp(item.createdAt))) : 0;
 
       // Only flag removals when the removed item is still within the new data's time window
       // Items pushed off by pagination (older than minTimestampOfNewData) should not trigger a reset
@@ -70,7 +97,8 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
       prevDataLengthRef.current = data.length;
       return updatedDisplayed;
     });
-  }, [data, autoRefresh]);
+    prevDataSignatureRef.current = dataSignature;
+  }, [data, autoRefresh, resetKey]);
 
   useInterval(
     () => {

--- a/frontend/src/hooks/useInterval.ts
+++ b/frontend/src/hooks/useInterval.ts
@@ -1,20 +1,92 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-const useInterval = (callback: Function, delay?: number | null) => {
-  const savedCallback = useRef<Function>(() => {});
+const RESUME_DELAY_TOLERANCE_MS = 1000;
+
+interface UseIntervalOptions {
+  refreshOnResume?: boolean;
+}
+
+const useInterval = (callback: () => void, delay?: number | null, options?: UseIntervalOptions) => {
+  const savedCallback = useRef(callback);
+  const [resumeKey, setResumeKey] = useState(0);
+  const refreshOnResume = options?.refreshOnResume ?? false;
 
   useEffect(() => {
     savedCallback.current = callback;
   });
 
   useEffect(() => {
-    if (delay !== null) {
-      const interval = setInterval(() => savedCallback.current(), delay || 0);
+    if (delay == null) {
+      return undefined;
+    }
+
+    if (!refreshOnResume) {
+      const interval = setInterval(() => savedCallback.current(), delay);
       return () => clearInterval(interval);
     }
 
-    return undefined;
-  }, [delay]);
+    let interval: ReturnType<typeof setInterval> | undefined;
+    let lastTickAt = Date.now();
+    let pausedForVisibility = document.visibilityState === 'hidden';
+
+    const stopInterval = () => {
+      if (interval !== undefined) {
+        clearInterval(interval);
+        interval = undefined;
+      }
+    };
+
+    const runCallback = (detectDelayedTick = false) => {
+      const now = Date.now();
+      if (detectDelayedTick && now - lastTickAt > delay + RESUME_DELAY_TOLERANCE_MS) {
+        setResumeKey((current) => current + 1);
+      }
+      lastTickAt = now;
+      savedCallback.current();
+    };
+
+    const startInterval = () => {
+      stopInterval();
+      interval = setInterval(() => runCallback(true), delay);
+    };
+
+    const resume = () => {
+      if (document.visibilityState === 'hidden') return;
+
+      const resumedAfterDelay = Date.now() - lastTickAt > delay + RESUME_DELAY_TOLERANCE_MS;
+      if (!pausedForVisibility && !resumedAfterDelay) return;
+
+      pausedForVisibility = false;
+      setResumeKey((current) => current + 1);
+      runCallback();
+      startInterval();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        pausedForVisibility = true;
+        stopInterval();
+        return;
+      }
+
+      resume();
+    };
+
+    if (!pausedForVisibility) {
+      startInterval();
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', resume);
+
+    return () => {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', resume);
+    };
+  }, [delay, refreshOnResume]);
+
+  return resumeKey;
 };
 
 export default useInterval;


### PR DESCRIPTION
## Summary

- add a shared split control for manual refresh and configurable auto-refresh intervals
- support off, 5s, 10s, 30s, and 60s with independent localStorage settings per page
- apply automatic polling to the requests, traces, threads, and trace detail views while keeping list polling on the first page
- keep manual refresh active for at least one full spinner rotation and prevent duplicate clicks
- align the refresh control with the existing column settings control

## Fixes

- reset list animation when server-side search or filter criteria change, so the new result set renders immediately
- keep query-change resets pending until the new result signature arrives, avoiding stale-data races during loading
- pause polling while the page is hidden and perform one refresh when visibility or focus returns
- detect delayed timer ticks after browser sleep and treat the resumed response as a complete snapshot
- preserve row-by-row animation only for subsequent polling updates within the same query scope

## Testing

- `cd frontend && pnpm test:unit` (10 passed)
- `git diff --check`
- Prettier check for the touched frontend files
- Manual browser sleep/focus verification remains pending local testing

<img width="238" height="338" alt="Auto-refresh interval menu" src="https://github.com/user-attachments/assets/f87673df-a59c-4dd2-b5f7-cf206ab5aedf" />