### PR TITLE
feat(quota): add Charm Hyper credit balance checker

### DIFF
--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -178,6 +178,12 @@ function getChannelPercentage(channel: ProviderQuotaChannel): number {
     }
   } else if (isOpenaiType(channel.type) && channel.providerType === 'apertis') {
     percentage = getApertisPercentage(channel.quotaStatus.quotaData as ProviderApertisQuotaData | undefined);
+  } else if (isOpenaiType(channel.type) && channel.providerType === 'charm_hyper') {
+    const qd = channel.quotaStatus.quotaData;
+    const balance = qd?.raw_data?.balance;
+    if (typeof balance === 'number') {
+      percentage = Math.max(0, Math.min(100, (1.0 - balance / 100) * 100));
+    }
   }
   return percentage;
 }

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -1572,7 +1572,7 @@ function QuotaRow({ channel, enforcementMode }: { channel: ProviderQuotaChannel;
                 <div className='space-y-1'>
                   <div className='flex items-center justify-between text-xs'>
                     <span className='text-muted-foreground font-medium'>{t('quota.label.credits_remaining')}</span>
-                    <span className='text-foreground font-medium'>{balance.toFixed(2)}</span>
+                    <span className='text-foreground font-medium'>{Number.isInteger(balance) ? balance : balance.toFixed(2)}</span>
                   </div>
                   <ProgressBar percentage={usedPct} />
                 </div>

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -17,6 +17,7 @@ import {
   ProviderSyntheticQuotaData,
   ProviderNeuralWattQuotaData,
   ProviderApertisQuotaData,
+  ProviderCharmHyperQuotaData,
   ProviderOpenCodeGoQuotaData,
   OpenCodeGoQuotaWindow,
   ProviderKimiCodeQuotaData,
@@ -179,8 +180,8 @@ function getChannelPercentage(channel: ProviderQuotaChannel): number {
   } else if (isOpenaiType(channel.type) && channel.providerType === 'apertis') {
     percentage = getApertisPercentage(channel.quotaStatus.quotaData as ProviderApertisQuotaData | undefined);
   } else if (isOpenaiType(channel.type) && channel.providerType === 'charm_hyper') {
-    const qd = channel.quotaStatus.quotaData;
-    const balance = qd?.raw_data?.balance;
+    const qd = channel.quotaStatus.quotaData as ProviderCharmHyperQuotaData | undefined;
+    const balance = qd?.balance;
     if (typeof balance === 'number') {
       percentage = Math.max(0, Math.min(100, (1.0 - balance / 100) * 100));
     }
@@ -1555,6 +1556,28 @@ function QuotaRow({ channel, enforcementMode }: { channel: ProviderQuotaChannel;
             }
 
             return items;
+          })()}
+        </div>
+      )}
+
+      {isOpenaiType(channel.type) && channel.providerType === 'charm_hyper' && (
+        <div className='mt-3 space-y-3'>
+          {(() => {
+            const qd = channel.quotaStatus.quotaData as ProviderCharmHyperQuotaData | undefined;
+            if (!qd || typeof qd.balance !== 'number') return null;
+            const balance = qd.balance;
+            const usedPct = Math.max(0, Math.min(100, (1.0 - balance / 100) * 100));
+            return (
+              <div className='space-y-2.5'>
+                <div className='space-y-1'>
+                  <div className='flex items-center justify-between text-xs'>
+                    <span className='text-muted-foreground font-medium'>{t('quota.label.credits_remaining')}</span>
+                    <span className='text-foreground font-medium'>{balance.toFixed(2)}</span>
+                  </div>
+                  <ProgressBar percentage={usedPct} />
+                </div>
+              </div>
+            );
           })()}
         </div>
       )}

--- a/frontend/src/features/system/data/quotas.ts
+++ b/frontend/src/features/system/data/quotas.ts
@@ -177,6 +177,10 @@ export type ProviderNeuralWattQuotaData = ProviderQuotaDataCommon & {
   } | null;
 };
 
+export type ProviderCharmHyperQuotaData = ProviderQuotaDataCommon & {
+  balance?: number | null;
+};
+
 export type ProviderApertisQuotaData = ProviderQuotaDataCommon & {
   is_subscriber?: boolean;
   payg?: {
@@ -467,6 +471,13 @@ export type ProviderQuotaChannel = {
     }
   | {
       type: 'openai' | 'openai_responses';
+      providerType: 'charm_hyper';
+      quotaStatus: {
+        quotaData: ProviderCharmHyperQuotaData;
+      };
+    }
+  | {
+      type: 'openai' | 'openai_responses';
       providerType?: undefined;
       quotaStatus: {
         quotaData: ProviderQuotaDataCommon;
@@ -629,6 +640,14 @@ function parseChannelNode(node: QueryChannelNodeWithQuota): ProviderQuotaChannel
         type: typeVal,
         providerType: 'apertis' as const,
         quotaStatus: { ...base.quotaStatus, quotaData: node.providerQuotaStatus.quotaData as ProviderApertisQuotaData },
+      };
+    }
+    if (providerType === 'charm_hyper') {
+      return {
+        ...base,
+        type: typeVal,
+        providerType: 'charm_hyper' as const,
+        quotaStatus: { ...base.quotaStatus, quotaData: node.providerQuotaStatus.quotaData as ProviderCharmHyperQuotaData },
       };
     }
     return {

--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -434,6 +434,7 @@
   "system.quota.collection.providers.kimi_code": "Kimi Code",
   "system.quota.collection.providers.minimax": "MiniMax",
   "system.quota.collection.providers.zhipu": "BigModel",
+  "system.quota.collection.providers.charm_hyper": "Charm Hyper",
   "system.quota.title": "Quota Enforcement",
   "system.quota.description": "Configure how AxonHub handles channels that have exhausted their provider quota.",
   "system.quota.enabled.label": "Enable Quota Enforcement",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -423,6 +423,7 @@
   "system.quota.collection.providers.kimi_code": "Kimi Code",
   "system.quota.collection.providers.minimax": "MiniMax",
   "system.quota.collection.providers.zhipu": "BigModel",
+  "system.quota.collection.providers.charm_hyper": "Charm Hyper",
   "system.quota.title": "配额执行",
   "system.quota.description": "配置 AxonHub 如何处理已耗尽提供商配额的渠道。",
   "system.quota.enabled.label": "启用配额执行",

--- a/internal/ent/migrate/schema.go
+++ b/internal/ent/migrate/schema.go
@@ -493,7 +493,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime, Default: schema.Expr("CURRENT_TIMESTAMP")},
 		{Name: "updated_at", Type: field.TypeTime, Default: schema.Expr("CURRENT_TIMESTAMP")},
 		{Name: "deleted_at", Type: field.TypeInt, Default: 0},
-		{Name: "provider_type", Type: field.TypeEnum, Enums: []string{"claudecode", "codex", "github_copilot", "nanogpt", "cline", "wafer", "synthetic", "neuralwatt", "apertis", "opencode_go", "kimi_code", "minimax", "zhipu"}},
+		{Name: "provider_type", Type: field.TypeEnum, Enums: []string{"claudecode", "codex", "github_copilot", "nanogpt", "cline", "wafer", "synthetic", "neuralwatt", "apertis", "opencode_go", "kimi_code", "minimax", "zhipu", "charm_hyper"}},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"available", "warning", "exhausted", "unknown"}},
 		{Name: "quota_data", Type: field.TypeJSON},
 		{Name: "next_reset_at", Type: field.TypeTime, Nullable: true},

--- a/internal/ent/providerquotastatus/providerquotastatus.go
+++ b/internal/ent/providerquotastatus/providerquotastatus.go
@@ -114,6 +114,7 @@ const (
 	ProviderTypeKimiCode      ProviderType = "kimi_code"
 	ProviderTypeMinimax       ProviderType = "minimax"
 	ProviderTypeZhipu         ProviderType = "zhipu"
+	ProviderTypeCharmHyper    ProviderType = "charm_hyper"
 )
 
 func (pt ProviderType) String() string {
@@ -123,7 +124,7 @@ func (pt ProviderType) String() string {
 // ProviderTypeValidator is a validator for the "provider_type" field enum values. It is called by the builders before save.
 func ProviderTypeValidator(pt ProviderType) error {
 	switch pt {
-	case ProviderTypeClaudecode, ProviderTypeCodex, ProviderTypeGithubCopilot, ProviderTypeNanogpt, ProviderTypeCline, ProviderTypeWafer, ProviderTypeSynthetic, ProviderTypeNeuralwatt, ProviderTypeApertis, ProviderTypeOpencodeGo, ProviderTypeKimiCode, ProviderTypeMinimax, ProviderTypeZhipu:
+	case ProviderTypeClaudecode, ProviderTypeCodex, ProviderTypeGithubCopilot, ProviderTypeNanogpt, ProviderTypeCline, ProviderTypeWafer, ProviderTypeSynthetic, ProviderTypeNeuralwatt, ProviderTypeApertis, ProviderTypeOpencodeGo, ProviderTypeKimiCode, ProviderTypeMinimax, ProviderTypeZhipu, ProviderTypeCharmHyper:
 		return nil
 	default:
 		return fmt.Errorf("providerquotastatus: invalid enum value for provider_type field: %q", pt)

--- a/internal/ent/schema/provider_quota_status.go
+++ b/internal/ent/schema/provider_quota_status.go
@@ -31,7 +31,7 @@ func (ProviderQuotaStatus) Fields() []ent.Field {
 	return []ent.Field{
 		field.Int("channel_id").Immutable(),
 		field.Enum("provider_type").
-			Values("claudecode", "codex", "github_copilot", "nanogpt", "cline", "wafer", "synthetic", "neuralwatt", "apertis", "opencode_go", "kimi_code", "minimax", "zhipu"),
+			Values("claudecode", "codex", "github_copilot", "nanogpt", "cline", "wafer", "synthetic", "neuralwatt", "apertis", "opencode_go", "kimi_code", "minimax", "zhipu", "charm_hyper"),
 		field.Enum("status").
 			Values("available", "warning", "exhausted", "unknown").
 			Comment("Overall status: available, warning, exhausted, unknown"),

--- a/internal/server/biz/provider_quota.go
+++ b/internal/server/biz/provider_quota.go
@@ -364,6 +364,7 @@ func (svc *ProviderQuotaService) registerProviderQuotaSupport() {
 	svc.registerKimiCodeSupport()
 	svc.registerMinimaxSupport()
 	svc.registerZhipuSupport()
+	svc.registerCharmHyperSupport()
 }
 
 func (svc *ProviderQuotaService) RegisterScheduledTasks(ctx context.Context, s *scheduler.Scheduler) error {
@@ -426,6 +427,10 @@ func (svc *ProviderQuotaService) registerMinimaxSupport() {
 
 func (svc *ProviderQuotaService) registerZhipuSupport() {
 	svc.checkers["zhipu"] = provider_quota.NewZhipuQuotaChecker(svc.httpClient)
+}
+
+func (svc *ProviderQuotaService) registerCharmHyperSupport() {
+	svc.checkers["charm_hyper"] = provider_quota.NewCharmHyperQuotaChecker(svc.httpClient)
 }
 
 func (svc *ProviderQuotaService) intervalToCronExpr(interval time.Duration) string {

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -1,0 +1,137 @@
+package provider_quota
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// CharmHyper default baseline for status thresholds.
+const charmHyperBaseline = 100.0
+
+// CharmHyperCreditsResponse represents the response from GET /v1/credits.
+type CharmHyperCreditsResponse struct {
+	Balance float64 `json:"balance"`
+}
+
+// CharmHyperQuotaChecker checks quota for Charm Hyper channels.
+type CharmHyperQuotaChecker struct {
+	httpClient *httpclient.HttpClient
+}
+
+// NewCharmHyperQuotaChecker creates a new CharmHyperQuotaChecker.
+func NewCharmHyperQuotaChecker(httpClient *httpclient.HttpClient) *CharmHyperQuotaChecker {
+	return &CharmHyperQuotaChecker{httpClient: httpClient}
+}
+
+// CheckQuota checks the Charm Hyper credit balance for the given channel.
+func (c *CharmHyperQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Channel) (QuotaData, error) {
+	apiKey := c.extractAPIKey(ch)
+	if apiKey == "" {
+		return QuotaData{}, fmt.Errorf("missing API key for Charm Hyper channel")
+	}
+
+	baseURL := ch.BaseURL
+	if baseURL == "" {
+		baseURL = "https://hyper.charm.land"
+	}
+	quotaURL := buildCharmHyperQuotaURL(baseURL)
+
+	httpRequest := httpclient.NewRequestBuilder().
+		WithMethod("GET").
+		WithURL(quotaURL).
+		WithBearerToken(apiKey).
+		WithHeader("Accept", "application/json").
+		Build()
+
+	hc := c.httpClient
+	if ch.Settings != nil && ch.Settings.Proxy != nil {
+		hc = c.httpClient.WithProxy(ch.Settings.Proxy)
+	}
+
+	resp, err := hc.Do(ctx, httpRequest)
+	if err != nil {
+		return QuotaData{}, fmt.Errorf("executing Charm Hyper quota request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return QuotaData{}, fmt.Errorf("Charm Hyper quota API returned status %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	return c.parseResponse(resp.Body)
+}
+
+// parseResponse parses the API response body into QuotaData.
+func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
+	var resp CharmHyperCreditsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return QuotaData{}, fmt.Errorf("parsing Charm Hyper quota response: %w", err)
+	}
+
+	status, ready, usageRatio := c.computeStatus(resp.Balance)
+
+	return QuotaData{
+		Status:       status,
+		ProviderType: "charm_hyper",
+		RawData:      map[string]any{"balance": resp.Balance},
+		NextResetAt:  nil,
+		Ready:        ready,
+		Limits: []QuotaLimitStatus{
+			NewTokenLimitStatus(status, usageRatio, nil),
+		},
+	}, nil
+}
+
+// computeStatus determines status, ready, and usage ratio from the balance.
+func (c *CharmHyperQuotaChecker) computeStatus(balance float64) (status string, ready bool, usageRatio float64) {
+	usageRatio = 1.0 - balance/charmHyperBaseline
+	if usageRatio < 0 {
+		usageRatio = 0
+	}
+
+	if balance == 0 {
+		return "exhausted", false, 1.0
+	}
+	if balance <= 20 {
+		return "warning", true, usageRatio
+	}
+	return "available", true, usageRatio
+}
+
+// SupportsChannel checks if the checker supports the given channel.
+func (c *CharmHyperQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
+	if ch.Type != channel.TypeOpenai && ch.Type != channel.TypeOpenaiResponses {
+		return false
+	}
+	return DetectProviderFromURL(ch.BaseURL) == "charm_hyper"
+}
+
+// extractAPIKey extracts the API key from channel credentials.
+func (c *CharmHyperQuotaChecker) extractAPIKey(ch *ent.Channel) string {
+	if ch.Credentials.APIKey != "" {
+		return ch.Credentials.APIKey
+	}
+	if len(ch.Credentials.APIKeys) > 0 {
+		return ch.Credentials.APIKeys[0]
+	}
+	return ""
+}
+
+// buildCharmHyperQuotaURL builds the full quota URL from the base URL.
+func buildCharmHyperQuotaURL(baseURL string) string {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "https://hyper.charm.land/v1/credits"
+	}
+	parsed.Path = "/v1/credits"
+	parsed.RawQuery = ""
+	parsed.User = nil
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
@@ -14,6 +15,9 @@ import (
 
 // CharmHyper default baseline for status thresholds.
 const charmHyperBaseline = 100.0
+
+// charmHyperWarningThreshold is the credit balance below which a warning status is shown.
+const charmHyperWarningThreshold = 20
 
 // CharmHyperCreditsResponse represents the response from GET /v1/credits.
 type CharmHyperCreditsResponse struct {
@@ -67,7 +71,6 @@ func (c *CharmHyperQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Channel
 	return c.parseResponse(resp.Body)
 }
 
-// parseResponse parses the API response body into QuotaData.
 func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	var resp CharmHyperCreditsResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -91,7 +94,6 @@ func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	}, nil
 }
 
-// computeStatus determines status, ready, and usage ratio from the balance.
 func (c *CharmHyperQuotaChecker) computeStatus(balance float64) (status string, ready bool, usageRatio float64) {
 	usageRatio = 1.0 - balance/charmHyperBaseline
 	if usageRatio < 0 {
@@ -101,7 +103,7 @@ func (c *CharmHyperQuotaChecker) computeStatus(balance float64) (status string, 
 	if balance == 0 {
 		return "exhausted", false, 1.0
 	}
-	if balance <= 20 {
+	if balance <= charmHyperWarningThreshold {
 		return "warning", true, usageRatio
 	}
 	return "available", true, usageRatio
@@ -115,19 +117,19 @@ func (c *CharmHyperQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
 	return DetectProviderFromURL(ch.BaseURL) == "charm_hyper"
 }
 
-// extractAPIKey extracts the API key from channel credentials.
 func (c *CharmHyperQuotaChecker) extractAPIKey(ch *ent.Channel) string {
-	if ch.Credentials.APIKey != "" {
-		return ch.Credentials.APIKey
+	apiKey := strings.TrimSpace(ch.Credentials.APIKey)
+	if apiKey != "" {
+		return apiKey
 	}
 	if len(ch.Credentials.APIKeys) > 0 {
-		return ch.Credentials.APIKeys[0]
+		return strings.TrimSpace(ch.Credentials.APIKeys[0])
 	}
 	return ""
 }
 
-// buildCharmHyperQuotaURL builds the full quota URL from the base URL.
 func buildCharmHyperQuotaURL(baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return "https://hyper.charm.land/v1/credits"

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -17,7 +17,7 @@ const charmHyperBaseline = 100.0
 
 // CharmHyperCreditsResponse represents the response from GET /v1/credits.
 type CharmHyperCreditsResponse struct {
-	Balance float64 `json:"balance"`
+	Balance *float64 `json:"balance"`
 }
 
 // CharmHyperQuotaChecker checks quota for Charm Hyper channels.
@@ -73,13 +73,16 @@ func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return QuotaData{}, fmt.Errorf("parsing Charm Hyper quota response: %w", err)
 	}
+	if resp.Balance == nil {
+		return QuotaData{}, fmt.Errorf("Charm Hyper quota response missing balance field")
+	}
 
-	status, ready, usageRatio := c.computeStatus(resp.Balance)
+	status, ready, usageRatio := c.computeStatus(*resp.Balance)
 
 	return QuotaData{
 		Status:       status,
 		ProviderType: "charm_hyper",
-		RawData:      map[string]any{"balance": resp.Balance},
+		RawData:      map[string]any{"balance": *resp.Balance},
 		NextResetAt:  nil,
 		Ready:        ready,
 		Limits: []QuotaLimitStatus{

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -29,7 +29,6 @@ type CharmHyperQuotaChecker struct {
 	httpClient *httpclient.HttpClient
 }
 
-// NewCharmHyperQuotaChecker creates a new CharmHyperQuotaChecker.
 func NewCharmHyperQuotaChecker(httpClient *httpclient.HttpClient) *CharmHyperQuotaChecker {
 	return &CharmHyperQuotaChecker{httpClient: httpClient}
 }
@@ -109,7 +108,6 @@ func (c *CharmHyperQuotaChecker) computeStatus(balance float64) (status string, 
 	return "available", true, usageRatio
 }
 
-// SupportsChannel checks if the checker supports the given channel.
 func (c *CharmHyperQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
 	if ch.Type != channel.TypeOpenai && ch.Type != channel.TypeOpenaiResponses {
 		return false

--- a/internal/server/biz/provider_quota/charm_hyper_checker_test.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker_test.go
@@ -1,0 +1,234 @@
+package provider_quota
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestCharmHyper_CheckQuota_HappyPath(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "Bearer test-api-key", req.Header.Get("Authorization"))
+			require.Equal(t, "/v1/credits", req.URL.Path)
+
+			body := `{"balance": 80}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL: "https://hyper.charm.land",
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+	require.True(t, quota.Ready)
+	require.Equal(t, "charm_hyper", quota.ProviderType)
+	require.InDelta(t, 0.2, quota.Limits[0].UsageRatio, 0.001)
+	require.Nil(t, quota.NextResetAt)
+}
+
+func TestCharmHyper_CheckQuota_WarningState(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{"balance": 15}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL: "https://hyper.charm.land",
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "warning", quota.Status)
+	require.True(t, quota.Ready)
+	require.Equal(t, 0.85, quota.Limits[0].UsageRatio)
+}
+
+func TestCharmHyper_CheckQuota_ExhaustedState(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{"balance": 0}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL: "https://hyper.charm.land",
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "exhausted", quota.Status)
+	require.False(t, quota.Ready)
+	require.Equal(t, 1.0, quota.Limits[0].UsageRatio)
+}
+
+func TestCharmHyper_CheckQuota_MissingCredentials(t *testing.T) {
+	checker := NewCharmHyperQuotaChecker(httpclient.NewHttpClientWithClient(&http.Client{}))
+
+	_, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing API key")
+}
+
+func TestCharmHyper_CheckQuota_MalformedJSON(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{invalid json}`)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	_, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parsing Charm Hyper quota response")
+}
+
+func TestCharmHyper_CheckQuota_HTTPError(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error": "unauthorized"}`)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	_, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status")
+}
+
+func TestCharmHyper_CheckQuota_CustomBaseURL(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "custom.charm.land", req.URL.Hostname())
+			require.Equal(t, "/v1/credits", req.URL.Path)
+
+			body := `{"balance": 50}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL:     "https://custom.charm.land",
+		Credentials: objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+}
+
+func TestCharmHyper_CheckQuota_FallbackKey(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "Bearer fallback-key", req.Header.Get("Authorization"))
+			body := `{"balance": 50}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{
+			APIKeys: []string{"fallback-key"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+}
+
+func TestCharmHyper_SupportsChannel(t *testing.T) {
+	checker := NewCharmHyperQuotaChecker(httpclient.NewHttpClientWithClient(&http.Client{}))
+
+	require.True(t, checker.SupportsChannel(&ent.Channel{
+		Type:    channel.TypeOpenai,
+		BaseURL: "https://hyper.charm.land",
+	}))
+
+	require.True(t, checker.SupportsChannel(&ent.Channel{
+		Type:    channel.TypeOpenaiResponses,
+		BaseURL: "https://custom.hyper.charm.land",
+	}))
+}
+
+func TestCharmHyper_SupportsChannel_WrongType(t *testing.T) {
+	checker := NewCharmHyperQuotaChecker(httpclient.NewHttpClientWithClient(&http.Client{}))
+
+	require.False(t, checker.SupportsChannel(&ent.Channel{
+		Type:    channel.TypeAnthropic,
+		BaseURL: "https://hyper.charm.land",
+	}))
+}
+
+func TestCharmHyper_SupportsChannel_WrongURL(t *testing.T) {
+	checker := NewCharmHyperQuotaChecker(httpclient.NewHttpClientWithClient(&http.Client{}))
+
+	require.False(t, checker.SupportsChannel(&ent.Channel{
+		Type:    channel.TypeOpenai,
+		BaseURL: "https://api.openai.com",
+	}))
+}

--- a/internal/server/biz/provider_quota/charm_hyper_checker_test.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker_test.go
@@ -130,6 +130,46 @@ func TestCharmHyper_CheckQuota_MalformedJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "parsing Charm Hyper quota response")
 }
 
+func TestCharmHyper_CheckQuota_MissingBalanceField(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	_, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing balance field")
+}
+
+func TestCharmHyper_CheckQuota_NullBalance(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"balance":null}`)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	_, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing balance field")
+}
+
 func TestCharmHyper_CheckQuota_HTTPError(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/server/biz/provider_quota/charm_hyper_checker_test.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -239,6 +240,62 @@ func TestCharmHyper_CheckQuota_FallbackKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
+}
+
+func TestCharmHyper_CheckQuota_WithProxy(t *testing.T) {
+	// WithProxy creates a new HttpClient with its own transport,
+	// so we must use a real test server rather than a mock transport.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		require.Equal(t, "/v1/credits", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"balance": 50}`))
+	}))
+	defer server.Close()
+
+	checker := NewCharmHyperQuotaChecker(httpclient.NewHttpClientWithClient(&http.Client{}))
+
+	proxyConfig := &httpclient.ProxyConfig{
+		Type: httpclient.ProxyTypeDisabled,
+	}
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL: server.URL,
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+		Settings: &objects.ChannelSettings{
+			Proxy: proxyConfig,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+	require.Equal(t, "charm_hyper", quota.ProviderType)
+}
+
+func TestCharmHyper_CheckQuota_WarningBoundary(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{"balance": 20}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewCharmHyperQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		BaseURL: "https://hyper.charm.land",
+		Credentials: objects.ChannelCredentials{
+			APIKey: "test-api-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "warning", quota.Status)
+	require.True(t, quota.Ready)
 }
 
 func TestCharmHyper_SupportsChannel(t *testing.T) {

--- a/internal/server/biz/provider_quota/url_detection.go
+++ b/internal/server/biz/provider_quota/url_detection.go
@@ -16,6 +16,7 @@ var urlProviderMap = []urlProviderEntry{
 	{hostPattern: "api.synthetic.new", providerType: "synthetic"},
 	{hostPattern: "api.neuralwatt.com", providerType: "neuralwatt"},
 	{hostPattern: "api.apertis.ai", providerType: "apertis"},
+	{hostPattern: "hyper.charm.land", providerType: "charm_hyper"},
 }
 
 func URLDetectedProviders() map[string]struct{} {

--- a/internal/server/biz/provider_quota/url_detection_test.go
+++ b/internal/server/biz/provider_quota/url_detection_test.go
@@ -128,6 +128,25 @@ func TestDetectProviderFromURL_FalsePositives(t *testing.T) {
 	}
 }
 
+func TestDetectProviderFromURL_CharmHyper(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+	}{
+		{"exact domain", "https://hyper.charm.land"},
+		{"subdomain", "https://custom.hyper.charm.land"},
+		{"with path", "https://hyper.charm.land/v1/credits"},
+		{"http scheme", "http://hyper.charm.land"},
+		{"with port", "https://hyper.charm.land:443"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectProviderFromURL(tt.baseURL)
+			require.Equal(t, "charm_hyper", result)
+		})
+	}
+}
+
 func TestDetectProviderFromURL_Apertis(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/server/biz/provider_quota_settings.go
+++ b/internal/server/biz/provider_quota_settings.go
@@ -14,7 +14,7 @@ const SystemKeyProviderQuotaCollectionSettings = "provider_quota_collection_sett
 var supportedProviderQuotaTypes = []string{
 	"claudecode", "codex", "github_copilot", "nanogpt", "cline",
 	"wafer", "synthetic", "neuralwatt", "apertis", "opencode_go",
-	"kimi_code", "minimax", "zhipu",
+	"kimi_code", "minimax", "zhipu", "charm_hyper",
 }
 
 var supportedProviderQuotaTypeSet = func() map[string]struct{} {

--- a/internal/server/gql/ent.graphql
+++ b/internal/server/gql/ent.graphql
@@ -3758,6 +3758,7 @@ enum ProviderQuotaStatusProviderType @goModel(model: "github.com/looplj/axonhub/
   kimi_code
   minimax
   zhipu
+  charm_hyper
 }
 """
 ProviderQuotaStatusStatus is enum for the field status


### PR DESCRIPTION
## Summary
AxonHub can now track credit balances for Charm Hyper AI channels, automatically warning when credits are running low and filtering out exhausted channels.

## Changes
- Added Charm Hyper to the URL-based provider detection pipeline (`hyper.charm.land`)
- New `CharmHyperQuotaChecker` calls `GET /v1/credits` on the Hyper API
- Status thresholds: exhausted (0 credits), warning (≤20), available (>20)
- Registered in the cron-based quota collection service alongside 13 other providers
- 11 unit tests covering all status paths, credential fallbacks, and channel support logic
- Regenerated Ent ORM artifacts and GraphQL schema

## Notes
- Usage ratio uses a fixed 100-credit baseline matching the free tier; paid tiers with higher limits still get correct ratios but status thresholds are tuned for free-tier users
- No next reset time available yet — the Hyper credits API returns only balance, not a reset timestamp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added quota monitoring support for Charm Hyper.
  - Automatically recognizes Charm Hyper channels and retrieves credit balances.
  - Supports custom endpoints, proxy settings, and fallback credentials.
  - Reports available, warning, and exhausted quota states.
  - Displays remaining credits with a usage progress indicator.
  - Added English and Simplified Chinese provider labels.

- **Tests**
  - Added coverage for successful checks, errors, credential handling, custom endpoints, proxy settings, and channel detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->