### PR TITLE
fix(prompts): parse project GUIDs in prompt schema

### DIFF
--- a/frontend/src/features/prompts/data/schema.ts
+++ b/frontend/src/features/prompts/data/schema.ts
@@ -24,7 +24,7 @@ export const promptSchema = z.object({
   id: z.string(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
-  projectID: z.number(),
+  projectID: z.string(),
   name: z.string(),
   description: z.string(),
   role: z.string(),


### PR DESCRIPTION
## Summary

Align the prompt frontend schema with the GraphQL `Prompt.projectID: ID!` contract.

## Root Cause

The prompt project ownership change introduced by `bc237f7b9431b525837c0b4099e085d4fa03d011` changed `Prompt.projectID` from `Int!` to `ID!`.

The backend serializes GraphQL IDs as GUID strings such as `gid://axonhub/Project/1`, but the frontend prompt schema still required `projectID` to be a number. As a result, `promptConnectionSchema.parse()` rejected otherwise valid `GetPrompts` responses. The prompts page then received no parsed data and rendered its empty-state fallback despite the API returning prompt records.

## Fix

Treat `Prompt.projectID` as a string in the frontend Zod schema, matching the GraphQL `ID!` response type.

## Validation

- `pnpm test:unit`

Fixes #2130
