### PR TITLE
fix: correct currency code example from RMB to CNY

### DIFF
--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -106,7 +106,7 @@
   "system.general.title": "General Settings",
   "system.general.description": "Manage general system configuration options",
   "system.general.currencyCode.label": "Currency Code",
-  "system.general.currencyCode.placeholder": "e.g. USD, RMB",
+  "system.general.currencyCode.placeholder": "e.g. USD, CNY",
   "system.general.currencyCode.description": "For system fee display only, not used for actual billing, changes take effect in real-time",
   "system.general.timezone.label": "Timezone",
   "system.general.timezone.placeholder": "Select timezone",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -106,7 +106,7 @@
   "system.general.title": "常规设置",
   "system.general.description": "管理系统的通用配置选项",
   "system.general.currencyCode.label": "货币代码",
-  "system.general.currencyCode.placeholder": "例如：USD, RMB",
+  "system.general.currencyCode.placeholder": "例如：USD, CNY",
   "system.general.currencyCode.description": "仅供系统展示费用使用，不会用来实际计费，修改以后实时生效",
   "system.general.timezone.label": "时区",
   "system.general.timezone.placeholder": "选择时区",

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -123,7 +123,7 @@ const (
 
 // SystemGeneralSettings represents general system configuration settings.
 type SystemGeneralSettings struct {
-	// CurrencyCode is the code used for currency display (e.g., USD, RMB).
+	// CurrencyCode is the code used for currency display (e.g., USD, CNY).
 	CurrencyCode string `json:"currency_code"`
 	Timezone     string `json:"timezone"`
 }


### PR DESCRIPTION
## Summary

Replace the non-standard currency code "RMB" with the ISO 4217 code "CNY" in currency code examples, across three locations:

- `internal/server/biz/system.go` — code comment
- `frontend/src/locales/en/system.json` — English placeholder
- `frontend/src/locales/zh-CN/system.json` — Chinese placeholder

## Why

RMB is not a standard ISO 4217 currency code; CNY is the correct code for the Chinese Yuan. Using the standard code avoids confusion for users configuring the currency display setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated currency-code examples from “RMB” to “CNY” in English and Chinese settings text.
  * Aligned the currency-code example in system settings documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->