### PR TITLE
fix(gemini): preserve concrete MIME types for remote media

### DIFF
--- a/llm/model.go
+++ b/llm/model.go
@@ -574,6 +574,9 @@ type ImageURL struct {
 type VideoURL struct {
 	// URL is the URL of the video.
 	URL string `json:"url"`
+
+	// MIMEType is the MIME type of the video when provided by the source protocol.
+	MIMEType string `json:"mime_type,omitempty"`
 }
 
 // DocumentURL represents a document URL (PDF, Word, etc.)
@@ -594,6 +597,12 @@ type InputAudio struct {
 
 	// Base64 encoded audio data.
 	Data string `json:"data"`
+
+	// URL is the URL of remote audio data.
+	URL string `json:"url,omitempty"`
+
+	// MIMEType is the MIME type of the audio when provided by the source protocol.
+	MIMEType string `json:"mime_type,omitempty"`
 }
 
 // CompactContent represents compact content from OpenAI Responses API compaction.

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -175,20 +175,38 @@ func convertVideoURLToGeminiPart(video *llm.VideoURL) *Part {
 	return &Part{
 		FileData: &FileData{
 			FileURI:  video.URL,
-			MIMEType: "video/*",
+			MIMEType: mediaMIMEType(video.MIMEType, video.URL, isVideoMIMEType),
 		},
 	}
 }
 
 func convertAudioToGeminiPart(audio *llm.InputAudio) *Part {
-	if audio == nil || audio.Data == "" {
+	if audio == nil {
+		return nil
+	}
+
+	if audio.Data != "" {
+		mimeType := audio.MIMEType
+		if mimeType == "" {
+			mimeType = audioFormatToMIMEType(audio.Format)
+		}
+
+		return &Part{
+			InlineData: &Blob{
+				MIMEType: mimeType,
+				Data:     audio.Data,
+			},
+		}
+	}
+
+	if audio.URL == "" {
 		return nil
 	}
 
 	return &Part{
-		InlineData: &Blob{
-			MIMEType: audioFormatToMIMEType(audio.Format),
-			Data:     audio.Data,
+		FileData: &FileData{
+			FileURI:  audio.URL,
+			MIMEType: mediaMIMEType(audio.MIMEType, audio.URL, isAudioMIMEType),
 		},
 	}
 }
@@ -215,13 +233,10 @@ func convertDocumentURLToGeminiPart(doc *llm.DocumentURL) *Part {
 		}
 	}
 
-	// Regular URL - use FileData
-	mimeType := doc.MIMEType
-
 	return &Part{
 		FileData: &FileData{
 			FileURI:  doc.URL,
-			MIMEType: mimeType,
+			MIMEType: mediaMIMEType(doc.MIMEType, doc.URL, isDocumentMIMEType),
 		},
 	}
 }

--- a/llm/transformer/gemini/convert.go
+++ b/llm/transformer/gemini/convert.go
@@ -153,7 +153,7 @@ func convertImageURLToGeminiPart(image *llm.ImageURL) *Part {
 	return &Part{
 		FileData: &FileData{
 			FileURI:  image.URL,
-			MIMEType: image.MIMEType,
+			MIMEType: imageMIMEType(image),
 		},
 	}
 }

--- a/llm/transformer/gemini/convert_test.go
+++ b/llm/transformer/gemini/convert_test.go
@@ -66,7 +66,7 @@ func TestConvertDocumentURLToGeminiPart(t *testing.T) {
 				require.NotNil(t, result)
 				require.NotNil(t, result.FileData)
 				assert.Equal(t, "https://example.com/report.pdf", result.FileData.FileURI)
-				assert.Equal(t, "", result.FileData.MIMEType)
+				assert.Equal(t, "application/pdf", result.FileData.MIMEType)
 			},
 		},
 		{
@@ -127,6 +127,36 @@ func TestConvertAudioToGeminiPart(t *testing.T) {
 				require.NotNil(t, result.InlineData)
 				assert.Equal(t, "audio/wav", result.InlineData.MIMEType)
 				assert.Equal(t, "UklGRiQAAABXQVZF", result.InlineData.Data)
+			},
+		},
+		{
+			name: "remote mp3 audio",
+			audio: &llm.InputAudio{
+				URL: "https://assets.example.com/audio/input.mp3?token=test",
+			},
+			validate: func(t *testing.T, result *Part) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.NotNil(t, result.FileData)
+				assert.Equal(t, "audio/mpeg", result.FileData.MIMEType)
+				assert.Equal(t, "https://assets.example.com/audio/input.mp3?token=test", result.FileData.FileURI)
+			},
+		},
+		{
+			name: "inline audio takes precedence over URL",
+			audio: &llm.InputAudio{
+				Format:   "wav",
+				Data:     "UklGRiQAAABXQVZF",
+				URL:      "https://assets.example.com/audio/input.mp3",
+				MIMEType: "audio/wav",
+			},
+			validate: func(t *testing.T, result *Part) {
+				t.Helper()
+				require.NotNil(t, result)
+				require.NotNil(t, result.InlineData)
+				assert.Equal(t, "audio/wav", result.InlineData.MIMEType)
+				assert.Equal(t, "UklGRiQAAABXQVZF", result.InlineData.Data)
+				assert.Nil(t, result.FileData)
 			},
 		},
 	}

--- a/llm/transformer/gemini/filedata_mimetype_test.go
+++ b/llm/transformer/gemini/filedata_mimetype_test.go
@@ -2,11 +2,13 @@ package gemini
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
 func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
@@ -47,4 +49,45 @@ func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
 	require.Len(t, got.Contents[0].Parts, 1)
 	require.NotNil(t, got.Contents[0].Parts[0].FileData)
 	require.Equal(t, "image/png", got.Contents[0].Parts[0].FileData.MIMEType)
+}
+
+func TestOpenAIImageURLToVertexFileData_infersMIMETypeFromURLPath(t *testing.T) {
+	// Given
+	inbound := openai.NewInboundTransformer()
+	outbound, err := NewOutboundTransformerWithConfig(Config{
+		BaseURL:      "https://aiplatform.googleapis.com/v1",
+		PlatformType: PlatformVertex,
+	})
+	require.NoError(t, err)
+
+	inboundRequest := &httpclient.Request{
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body: []byte(`{
+			"model": "gemini-test-model",
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "image_url",
+					"image_url": {
+						"url": "https://assets.example.com/images/input.jpg?token=test"
+					}
+				}]
+			}]
+		}`),
+	}
+
+	// When
+	llmRequest, err := inbound.TransformRequest(t.Context(), inboundRequest)
+	require.NoError(t, err)
+	vertexRequest, err := outbound.TransformRequest(t.Context(), llmRequest)
+	require.NoError(t, err)
+
+	var got GenerateContentRequest
+	require.NoError(t, json.Unmarshal(vertexRequest.Body, &got))
+
+	// Then
+	require.Len(t, got.Contents, 1)
+	require.Len(t, got.Contents[0].Parts, 1)
+	require.NotNil(t, got.Contents[0].Parts[0].FileData)
+	require.Equal(t, "image/jpeg", got.Contents[0].Parts[0].FileData.MIMEType)
 }

--- a/llm/transformer/gemini/filedata_mimetype_test.go
+++ b/llm/transformer/gemini/filedata_mimetype_test.go
@@ -54,6 +54,42 @@ func TestGeminiToVertexFileData_preservesMediaMIMETypes(t *testing.T) {
 	require.Equal(t, "audio/mpeg", got.Contents[0].Parts[3].FileData.MIMEType)
 }
 
+func TestGeminiToVertexFileData_infersMIMEWhenDeclaredTypeIsUnsupported(t *testing.T) {
+	inbound := NewInboundTransformer()
+	outbound, err := NewOutboundTransformerWithConfig(Config{
+		BaseURL:      "https://us-central1-aiplatform.googleapis.com",
+		PlatformType: PlatformVertex,
+	})
+	require.NoError(t, err)
+
+	inboundRequest := &httpclient.Request{
+		Path: "/v1beta/models/gemini-test-model:generateContent",
+		Body: []byte(`{
+			"contents": [{
+				"role": "user",
+				"parts": [{
+					"fileData": {
+						"mimeType": "application/octet-stream",
+						"fileUri": "https://assets.example.com/audio/input.mp3"
+					}
+				}]
+			}]
+		}`),
+	}
+
+	llmRequest, err := inbound.TransformRequest(t.Context(), inboundRequest)
+	require.NoError(t, err)
+	vertexRequest, err := outbound.TransformRequest(t.Context(), llmRequest)
+	require.NoError(t, err)
+
+	var got GenerateContentRequest
+	require.NoError(t, json.Unmarshal(vertexRequest.Body, &got))
+	require.Len(t, got.Contents, 1)
+	require.Len(t, got.Contents[0].Parts, 1)
+	require.NotNil(t, got.Contents[0].Parts[0].FileData)
+	require.Equal(t, "audio/mpeg", got.Contents[0].Parts[0].FileData.MIMEType)
+}
+
 func TestImageMIMEType_leavesUnknownURLTypesEmpty(t *testing.T) {
 	tests := []struct {
 		name string

--- a/llm/transformer/gemini/filedata_mimetype_test.go
+++ b/llm/transformer/gemini/filedata_mimetype_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/looplj/axonhub/llm"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -28,7 +29,7 @@ func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
 				"parts": [{
 					"fileData": {
 						"mimeType": "image/png",
-						"fileUri": "gs://example-bucket/image.png"
+						"fileUri": "gs://example-bucket/image.jpg"
 					}
 				}]
 			}]
@@ -49,6 +50,24 @@ func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
 	require.Len(t, got.Contents[0].Parts, 1)
 	require.NotNil(t, got.Contents[0].Parts[0].FileData)
 	require.Equal(t, "image/png", got.Contents[0].Parts[0].FileData.MIMEType)
+}
+
+func TestImageMIMEType_leavesUnknownURLTypesEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "extensionless", url: "https://assets.example.com/images/input"},
+		{name: "unknown extension", url: "https://assets.example.com/images/input.axonhubtest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			image := &llm.ImageURL{URL: tt.url}
+
+			require.Empty(t, imageMIMEType(image))
+		})
+	}
 }
 
 func TestOpenAIImageURLToVertexFileData_infersMIMETypeFromURLPath(t *testing.T) {

--- a/llm/transformer/gemini/filedata_mimetype_test.go
+++ b/llm/transformer/gemini/filedata_mimetype_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
-func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
+func TestGeminiToVertexFileData_preservesMediaMIMETypes(t *testing.T) {
 	// Given
 	inbound := NewInboundTransformer()
 	outbound, err := NewOutboundTransformerWithConfig(Config{
@@ -26,12 +26,12 @@ func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
 		Body: []byte(`{
 			"contents": [{
 				"role": "user",
-				"parts": [{
-					"fileData": {
-						"mimeType": "image/png",
-						"fileUri": "gs://example-bucket/image.jpg"
-					}
-				}]
+				"parts": [
+					{"fileData": {"mimeType": "image/png", "fileUri": "gs://example-bucket/image.jpg"}},
+					{"fileData": {"mimeType": "video/quicktime", "fileUri": "gs://example-bucket/video.mp4"}},
+					{"fileData": {"mimeType": "application/pdf", "fileUri": "gs://example-bucket/document.pdf"}},
+					{"fileData": {"mimeType": "audio/mpeg", "fileUri": "gs://example-bucket/audio.mp3"}}
+				]
 			}]
 		}`),
 	}
@@ -47,9 +47,11 @@ func TestGeminiToVertexFileData_preservesMIMEType(t *testing.T) {
 
 	// Then
 	require.Len(t, got.Contents, 1)
-	require.Len(t, got.Contents[0].Parts, 1)
-	require.NotNil(t, got.Contents[0].Parts[0].FileData)
+	require.Len(t, got.Contents[0].Parts, 4)
 	require.Equal(t, "image/png", got.Contents[0].Parts[0].FileData.MIMEType)
+	require.Equal(t, "video/quicktime", got.Contents[0].Parts[1].FileData.MIMEType)
+	require.Equal(t, "application/pdf", got.Contents[0].Parts[2].FileData.MIMEType)
+	require.Equal(t, "audio/mpeg", got.Contents[0].Parts[3].FileData.MIMEType)
 }
 
 func TestImageMIMEType_leavesUnknownURLTypesEmpty(t *testing.T) {
@@ -59,6 +61,8 @@ func TestImageMIMEType_leavesUnknownURLTypesEmpty(t *testing.T) {
 	}{
 		{name: "extensionless", url: "https://assets.example.com/images/input"},
 		{name: "unknown extension", url: "https://assets.example.com/images/input.axonhubtest"},
+		{name: "document extension", url: "https://assets.example.com/images/input.pdf"},
+		{name: "video extension", url: "https://assets.example.com/images/input.mp4"},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +70,66 @@ func TestImageMIMEType_leavesUnknownURLTypesEmpty(t *testing.T) {
 			image := &llm.ImageURL{URL: tt.url}
 
 			require.Empty(t, imageMIMEType(image))
+		})
+	}
+}
+
+func TestMediaMIMEType(t *testing.T) {
+	tests := []struct {
+		name         string
+		explicitMIME string
+		url          string
+		accepts      func(string) bool
+		expected     string
+	}{
+		{
+			name:         "explicit MIME takes precedence",
+			explicitMIME: "video/quicktime",
+			url:          "https://assets.example.com/video/input.mp4",
+			accepts:      isVideoMIMEType,
+			expected:     "video/quicktime",
+		},
+		{
+			name:     "video from URL",
+			url:      "https://assets.example.com/video/input.mp4?token=test",
+			accepts:  isVideoMIMEType,
+			expected: "video/mp4",
+		},
+		{
+			name:     "Word document from URL",
+			url:      "https://assets.example.com/documents/input.docx?token=test",
+			accepts:  isDocumentMIMEType,
+			expected: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		},
+		{
+			name:     "Excel document from URL",
+			url:      "https://assets.example.com/documents/input.xlsx?token=test",
+			accepts:  isDocumentMIMEType,
+			expected: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		},
+		{
+			name:     "PowerPoint document from URL",
+			url:      "https://assets.example.com/documents/input.pptx?token=test",
+			accepts:  isDocumentMIMEType,
+			expected: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		},
+		{
+			name:     "audio from URL",
+			url:      "https://assets.example.com/audio/input.mp3?token=test",
+			accepts:  isAudioMIMEType,
+			expected: "audio/mpeg",
+		},
+		{
+			name:     "modality mismatch",
+			url:      "https://assets.example.com/documents/input.pdf",
+			accepts:  isVideoMIMEType,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, mediaMIMEType(tt.explicitMIME, tt.url, tt.accepts))
 		})
 	}
 }

--- a/llm/transformer/gemini/image_mime.go
+++ b/llm/transformer/gemini/image_mime.go
@@ -1,0 +1,28 @@
+package gemini
+
+import (
+	"mime"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/looplj/axonhub/llm"
+)
+
+func imageMIMEType(image *llm.ImageURL) string {
+	if image.MIMEType != "" {
+		return image.MIMEType
+	}
+
+	parsed, err := url.Parse(image.URL)
+	if err != nil {
+		return ""
+	}
+
+	mediaType := mime.TypeByExtension(path.Ext(parsed.Path))
+	if value, _, ok := strings.Cut(mediaType, ";"); ok {
+		return value
+	}
+
+	return mediaType
+}

--- a/llm/transformer/gemini/image_mime.go
+++ b/llm/transformer/gemini/image_mime.go
@@ -9,20 +9,31 @@ import (
 	"github.com/looplj/axonhub/llm"
 )
 
-func imageMIMEType(image *llm.ImageURL) string {
-	if image.MIMEType != "" {
-		return image.MIMEType
+func mediaMIMEType(explicitMIMEType, rawURL string, accepts func(string) bool) string {
+	if explicitMIMEType != "" {
+		return explicitMIMEType
 	}
 
-	parsed, err := url.Parse(image.URL)
+	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return ""
 	}
 
-	mediaType := mime.TypeByExtension(path.Ext(parsed.Path))
+	extension := strings.ToLower(path.Ext(parsed.Path))
+	mediaType := mime.TypeByExtension(extension)
 	if value, _, ok := strings.Cut(mediaType, ";"); ok {
-		return value
+		mediaType = value
 	}
 
-	return mediaType
+	if accepts(mediaType) {
+		return mediaType
+	}
+
+	return ""
+}
+
+func imageMIMEType(image *llm.ImageURL) string {
+	return mediaMIMEType(image.MIMEType, image.URL, func(mediaType string) bool {
+		return strings.HasPrefix(mediaType, "image/")
+	})
 }

--- a/llm/transformer/gemini/image_mime.go
+++ b/llm/transformer/gemini/image_mime.go
@@ -10,7 +10,7 @@ import (
 )
 
 func mediaMIMEType(explicitMIMEType, rawURL string, accepts func(string) bool) string {
-	if explicitMIMEType != "" {
+	if explicitMIMEType != "" && accepts(explicitMIMEType) {
 		return explicitMIMEType
 	}
 

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -335,15 +335,17 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "video_url",
 					VideoURL: &llm.VideoURL{
-						URL: dataURL,
+						URL:      dataURL,
+						MIMEType: part.InlineData.MIMEType,
 					},
 				})
 			} else if isAudioMIMEType(part.InlineData.MIMEType) {
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "input_audio",
 					InputAudio: &llm.InputAudio{
-						Format: audioMIMETypeToFormat(part.InlineData.MIMEType),
-						Data:   part.InlineData.Data,
+						Format:   audioMIMETypeToFormat(part.InlineData.MIMEType),
+						Data:     part.InlineData.Data,
+						MIMEType: part.InlineData.MIMEType,
 					},
 				})
 			} else {
@@ -359,7 +361,10 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 
 		case part.FileData != nil:
 			// Convert file data based on MIME type or URL extension
-			mimeType := part.FileData.MIMEType
+			mimeType := mediaMIMEType(part.FileData.MIMEType, part.FileData.FileURI, func(mediaType string) bool {
+				return isDocumentMIMEType(mediaType) || isVideoMIMEType(mediaType) ||
+					isAudioMIMEType(mediaType) || strings.HasPrefix(mediaType, "image/")
+			})
 			if isDocumentMIMEType(mimeType) {
 				// Document type (PDF, Word, etc.)
 				textParts = append(textParts, llm.MessageContentPart{
@@ -373,14 +378,17 @@ func convertGeminiContentToLLMMessage(content *Content, previousContents []*Cont
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "video_url",
 					VideoURL: &llm.VideoURL{
-						URL: part.FileData.FileURI,
+						URL:      part.FileData.FileURI,
+						MIMEType: mimeType,
 					},
 				})
 			} else if isAudioMIMEType(mimeType) {
 				textParts = append(textParts, llm.MessageContentPart{
 					Type: "input_audio",
 					InputAudio: &llm.InputAudio{
-						Format: audioMIMETypeToFormat(mimeType),
+						Format:   audioMIMETypeToFormat(mimeType),
+						URL:      part.FileData.FileURI,
+						MIMEType: mimeType,
 					},
 				})
 			} else {

--- a/llm/transformer/gemini/outbound_convert.go
+++ b/llm/transformer/gemini/outbound_convert.go
@@ -380,7 +380,7 @@ func convertLLMMessageToGeminiContent(msg *llm.Message) *Content {
 					}
 				}
 			case "input_audio":
-				if part.InputAudio != nil && part.InputAudio.Data != "" {
+				if part.InputAudio != nil && (part.InputAudio.Data != "" || part.InputAudio.URL != "") {
 					geminiPart := convertAudioToGeminiPart(part.InputAudio)
 					if geminiPart != nil {
 						parts = append(parts, geminiPart)

--- a/llm/transformer/gemini/outbound_convert_test.go
+++ b/llm/transformer/gemini/outbound_convert_test.go
@@ -546,7 +546,8 @@ func TestConvertLLMToGeminiRequest_VideoURL(t *testing.T) {
 						{
 							Type: "video_url",
 							VideoURL: &llm.VideoURL{
-								URL: "https://example.com/example.mp4",
+								URL:      "https://example.com/example.mp4",
+								MIMEType: "video/quicktime",
 							},
 						},
 					},
@@ -560,7 +561,47 @@ func TestConvertLLMToGeminiRequest_VideoURL(t *testing.T) {
 	require.Len(t, result.Contents[0].Parts, 1)
 	require.NotNil(t, result.Contents[0].Parts[0].FileData)
 	require.Equal(t, "https://example.com/example.mp4", result.Contents[0].Parts[0].FileData.FileURI)
-	require.Equal(t, "video/*", result.Contents[0].Parts[0].FileData.MIMEType)
+	require.Equal(t, "video/quicktime", result.Contents[0].Parts[0].FileData.MIMEType)
+}
+
+func TestConvertLLMToGeminiRequest_VideoURLWithoutKnownMIME(t *testing.T) {
+	req := &llm.Request{
+		Messages: []llm.Message{{
+			Role: "user",
+			Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{
+				Type:     "video_url",
+				VideoURL: &llm.VideoURL{URL: "https://assets.example.com/video/input"},
+			}}},
+		}},
+	}
+
+	result := convertLLMToGeminiRequest(req)
+	require.Len(t, result.Contents, 1)
+	require.Len(t, result.Contents[0].Parts, 1)
+	require.NotNil(t, result.Contents[0].Parts[0].FileData)
+	require.Empty(t, result.Contents[0].Parts[0].FileData.MIMEType)
+}
+
+func TestConvertLLMToGeminiRequest_RemoteAudio(t *testing.T) {
+	req := &llm.Request{
+		Messages: []llm.Message{{
+			Role: "user",
+			Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{
+				Type: "input_audio",
+				InputAudio: &llm.InputAudio{
+					URL:      "https://assets.example.com/audio/input.mp3",
+					MIMEType: "audio/mpeg",
+				},
+			}}},
+		}},
+	}
+
+	result := convertLLMToGeminiRequest(req)
+	require.Len(t, result.Contents, 1)
+	require.Len(t, result.Contents[0].Parts, 1)
+	require.NotNil(t, result.Contents[0].Parts[0].FileData)
+	require.Equal(t, "https://assets.example.com/audio/input.mp3", result.Contents[0].Parts[0].FileData.FileURI)
+	require.Equal(t, "audio/mpeg", result.Contents[0].Parts[0].FileData.MIMEType)
 }
 
 func TestConvertLLMToGeminiRequest_ResponseFormat(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve explicit Gemini/Vertex MIME metadata for remote images, videos, documents, and audio
- infer missing MIME types from URL path extensions with Go's `mime.TypeByExtension`
- emit only modality-appropriate concrete MIME types; never infer cross-modality values or fall back to invalid wildcards such as `video/*`
- keep OpenAI wire payloads unchanged while extending the unified media model for Gemini/Vertex round trips

## Root cause

PR #2091 preserved `fileData.mimeType` when Gemini supplied it for images. Other paths still lost or fabricated media metadata:

- OpenAI image URLs have no MIME field, so Vertex received empty `fileData.mimeType`
- Gemini video `fileData.mimeType` was dropped and later replaced with `video/*`
- remote documents did not infer MIME when metadata was absent
- remote Gemini audio lost its URI in the unified model and could not be emitted again

Vertex requires `fileData.mimeType` to be a concrete fixed IANA type/subtype.

## Behavior

Resolution order is:

1. preserve an explicit source MIME value
2. otherwise parse the URL path and call `mime.TypeByExtension`
3. accept the inferred value only when it matches the media modality
4. leave it empty when it cannot be determined, rather than fabricating an invalid wildcard

No remote file is downloaded or inspected.

## Verification

- `go test -race -shuffle=on -count=1 ./transformer/gemini ./transformer/openai .`
- full `llm` module race suite in an isolated review worktree
- manual Vertex outbound transformer QA produced:
  - image: `image/jpeg`
  - video: `video/mp4`
  - document: `application/pdf`
  - audio: `audio/mpeg`
- synthetic coverage includes explicit MIME precedence, query-string URLs, unknown extensions, modality mismatches, Office extensions, and removal of the `video/*` fallback

All fixtures use reserved/example domains and synthetic object paths. No production request content, credentials, prompts, or file URLs are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media type detection for remote image, video, audio, and document URLs.
  * Preserved explicitly provided MIME types during media conversion.
  * Added support for remote audio URLs, including MP3 files and audio without inline data.
  * Improved handling of query parameters, unknown extensions, and extensionless paths.
  * Preserved media URLs and formats while prioritizing inline audio data when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->