### PR TITLE
fix(codex): skip pass-through for unsupported response limits

### DIFF
--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -14,6 +14,7 @@ import (
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer"
 )
 
 // codexResponsesPassThroughHeaders contains client metadata that Codex-compatible
@@ -97,6 +98,9 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 
 		channel := outbound.GetCurrentChannel()
 		llmReq := outbound.state.LlmRequest
+		if !outbound.allowPassThroughBody(ctx, llmReq, request) {
+			return request, nil
+		}
 
 		// Multipart bodies cannot be reused: the outbound transformer rebuilds the
 		// multipart payload with a new boundary in Content-Type, so replaying the inbound
@@ -126,6 +130,15 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 
 		return request, nil
 	})
+}
+
+func (p *PersistentOutboundTransformer) allowPassThroughBody(ctx context.Context, llmReq *llm.Request, providerReq *httpclient.Request) bool {
+	policy, ok := p.wrapped.(transformer.PassThroughBodyPolicy)
+	if !ok {
+		return true
+	}
+
+	return policy.AllowPassThroughBody(ctx, llmReq, providerReq)
 }
 
 // applyPassThroughRequestHeaders forwards the Codex Responses metadata paired with

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1009,6 +1009,12 @@ type passthroughOutbound struct {
 	format llm.APIFormat
 }
 
+type passthroughPolicyOutbound struct {
+	passthroughOutbound
+
+	allow bool
+}
+
 func (t *passthroughOutbound) APIFormat() llm.APIFormat { return t.format }
 
 func (t *passthroughOutbound) TransformRequest(ctx context.Context, req *llm.Request) (*httpclient.Request, error) {
@@ -1031,6 +1037,10 @@ func (t *passthroughOutbound) TransformError(ctx context.Context, err *httpclien
 
 func (t *passthroughOutbound) AggregateStreamChunks(ctx context.Context, _ *httpclient.Request, chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {
 	return nil, llm.ResponseMeta{}, nil
+}
+
+func (t *passthroughPolicyOutbound) AllowPassThroughBody(ctx context.Context, llmReq *llm.Request, providerReq *httpclient.Request) bool {
+	return t.allow
 }
 
 // passthroughInbound is an inbound transformer that maps llm responses 1:1 to raw events.
@@ -1381,6 +1391,51 @@ func TestApplyPassThroughBodyPreservesMappedModel(t *testing.T) {
 
 	processed.Body[0] = '['
 	require.Equal(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"temperature":0.4}`, string(outbound.state.LlmRequest.RawRequest.Body))
+}
+
+func TestApplyPassThroughBodySkipsWhenOutboundPolicyRejects(t *testing.T) {
+	ctx := context.Background()
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "policy-pass-through",
+			Settings: &objects.ChannelSettings{
+				PassThroughBody: lo.ToPtr(true),
+			},
+		},
+	}
+
+	outbound := &PersistentOutboundTransformer{
+		wrapped: &passthroughPolicyOutbound{
+			passthroughOutbound: passthroughOutbound{format: llm.APIFormatOpenAIResponse},
+			allow:               false,
+		},
+		state: &PersistenceState{
+			CurrentCandidate:      &ChannelModelsCandidate{Channel: channel},
+			OriginalRequestStream: lo.ToPtr(true),
+			LlmRequest: &llm.Request{
+				Model:     "gpt-5.4-mini",
+				APIFormat: llm.APIFormatOpenAIResponse,
+				Stream:    lo.ToPtr(true),
+				RawRequest: &httpclient.Request{
+					APIFormat: string(llm.APIFormatOpenAIResponse),
+					Body:      []byte(`{"model":"gpt-5.4-mini","input":"hi","stream":true,"temperature":0.4}`),
+				},
+			},
+		},
+	}
+
+	request := &httpclient.Request{
+		APIFormat: string(llm.APIFormatOpenAIResponse),
+		Body:      []byte(`{"model":"gpt-5.4-mini","input":[{"role":"user","content":"hi"}],"stream":true}`),
+	}
+
+	processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(ctx, request)
+	require.NoError(t, err)
+	require.False(t, outbound.state.PassThroughApplied)
+	require.Equal(t, request, processed)
+	require.False(t, gjson.GetBytes(processed.Body, "temperature").Exists())
 }
 
 func TestApplyPassThroughRequestHeaders(t *testing.T) {

--- a/llm/transformer/interfaces.go
+++ b/llm/transformer/interfaces.go
@@ -61,6 +61,11 @@ type Outbound interface {
 	AggregateStreamChunks(ctx context.Context, req *httpclient.Request, chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error)
 }
 
+// PassThroughBodyPolicy lets outbound transformers veto raw body pass-through.
+type PassThroughBodyPolicy interface {
+	AllowPassThroughBody(ctx context.Context, llmReq *llm.Request, providerReq *httpclient.Request) bool
+}
+
 // VideoTaskOutbound is an optional extension interface for outbound transformers that support
 // video task query/delete operations (async task model).
 type VideoTaskOutbound interface {

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"github.com/tidwall/gjson"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
@@ -44,8 +45,15 @@ type OutboundTransformer struct {
 
 var (
 	_ transformer.Outbound               = (*OutboundTransformer)(nil)
+	_ transformer.PassThroughBodyPolicy  = (*OutboundTransformer)(nil)
 	_ pipeline.ChannelCustomizedExecutor = (*OutboundTransformer)(nil)
 )
+
+var responsesBlockedPassThroughFields = []string{
+	"max_output_tokens",
+	"max_completion_tokens",
+	"max_tokens",
+}
 
 type Params struct {
 	TokenProvider oauth.TokenGetter
@@ -92,6 +100,20 @@ func (t *OutboundTransformer) TokenProvider() oauth.TokenGetter {
 	}
 
 	return t.tokens
+}
+
+func (t *OutboundTransformer) AllowPassThroughBody(_ context.Context, llmReq *llm.Request, _ *httpclient.Request) bool {
+	if llmReq == nil || llmReq.APIFormat != llm.APIFormatOpenAIResponse || llmReq.RawRequest == nil {
+		return true
+	}
+
+	for _, field := range responsesBlockedPassThroughFields {
+		if gjson.GetBytes(llmReq.RawRequest.Body, field).Exists() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (t *OutboundTransformer) TransformError(ctx context.Context, rawErr *httpclient.Error) *llm.ResponseError {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -72,6 +72,43 @@ func TestCodexOutbound_StreamAcceptHeader(t *testing.T) {
 	assert.Equal(t, "Bearer "+accessToken, headers.Get("Authorization"))
 }
 
+func TestCodexOutbound_RejectsPassThroughBodyWithTokenLimitFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "max_output_tokens", body: `{"model":"gpt-5.4-mini","input":"hi","stream":true,"max_output_tokens":12000}`},
+		{name: "max_completion_tokens", body: `{"model":"gpt-5.4-mini","input":"hi","stream":true,"max_completion_tokens":12000}`},
+		{name: "max_tokens", body: `{"model":"gpt-5.4-mini","input":"hi","stream":true,"max_tokens":12000}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outbound := &OutboundTransformer{}
+			llmReq := &llm.Request{
+				APIFormat: llm.APIFormatOpenAIResponse,
+				RawRequest: &httpclient.Request{
+					Body: []byte(tt.body),
+				},
+			}
+
+			require.False(t, outbound.AllowPassThroughBody(context.Background(), llmReq, &httpclient.Request{}))
+		})
+	}
+}
+
+func TestCodexOutbound_AllowsPassThroughBodyWithoutTokenLimitFields(t *testing.T) {
+	outbound := &OutboundTransformer{}
+	llmReq := &llm.Request{
+		APIFormat: llm.APIFormatOpenAIResponse,
+		RawRequest: &httpclient.Request{
+			Body: []byte(`{"model":"gpt-5.4-mini","input":"hi","stream":true}`),
+		},
+	}
+
+	require.True(t, outbound.AllowPassThroughBody(context.Background(), llmReq, &httpclient.Request{}))
+}
+
 func TestCodexOutbound_StreamAllowsDownstreamIdentityOverrides(t *testing.T) {
 	ctx := context.Background()
 	accessToken := testAccessTokenWithAccountID(t)


### PR DESCRIPTION
## Summary
- add an optional outbound pass-through body policy so provider-specific veto rules do not live in the generic orchestrator pass-through middleware
- make Codex veto OpenAI Responses raw body pass-through when the client body contains token limit fields Codex rejects
- keep non-Codex channels on the existing generic pass-through rules

## Root cause
Codex outbound removes token limit fields before sending upstream, but the generic pass-through middleware could later restore the original OpenAI Responses body. Requests with fields like `max_output_tokens` then reached Codex unchanged and failed with HTTP 400, while fallback OpenAI Responses-compatible channels such as ZenMux succeeded.

## Current pass-through enablement
Body pass-through is enabled only when all generic orchestrator checks pass: current channel exists, provider request has an API format, inbound LLM API format equals outbound provider API format, original/effective stream semantics match, and channel/global pass-through setting is enabled. After that, an optional outbound policy can veto pass-through for provider-specific incompatibilities.

## Tests
- `go test ./internal/server/orchestrator -run 'TestApplyPassThroughBody(SkipsWhenOutboundPolicyRejects|PreservesMappedModel|PreservesAlignedStreamWithoutPatchingIt)' -count=1`\n- `cd llm && go test ./transformer/openai/codex -run 'TestCodexOutbound_(RejectsPassThroughBodyWithTokenLimitFields|AllowsPassThroughBodyWithoutTokenLimitFields|StreamAcceptHeader)' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex Responses request handling when unsupported token-limit fields are provided.
  * Requests containing unsupported token-limit fields are now processed through supported transformations instead of being passed through unchanged.
  * Preserved model mappings and supported token-limit settings for OpenAI Responses.
  * Requests without conflicting token-limit fields continue to use the original request body when appropriate.
  * Added safeguards to prevent unsupported request fields from reaching providers unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->