### PR TITLE
fix(responses): preserve image tool_choice without pass-through

### DIFF
--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -312,12 +312,12 @@ func convertToolChoiceToLLM(src *ToolChoice) *llm.ToolChoice {
 
 	if src.Mode != nil {
 		result.ToolChoice = src.Mode
-	} else if src.Type != nil && src.Name != nil {
+	} else if src.Type != nil {
 		result.NamedToolChoice = &llm.NamedToolChoice{
 			Type: *src.Type,
-			Function: llm.ToolFunction{
-				Name: *src.Name,
-			},
+		}
+		if src.Name != nil {
+			result.NamedToolChoice.Function.Name = *src.Name
 		}
 	}
 

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -1413,6 +1413,19 @@ func TestConvertToolChoiceToLLM(t *testing.T) {
 				require.Equal(t, "get_weather", result.NamedToolChoice.Function.Name)
 			},
 		},
+		{
+			name: "specific non-function tool without name",
+			input: &ToolChoice{
+				Type: lo.ToPtr("image_generation"),
+			},
+			validate: func(t *testing.T, result *llm.ToolChoice) {
+				require.NotNil(t, result)
+				require.Nil(t, result.ToolChoice)
+				require.NotNil(t, result.NamedToolChoice)
+				require.Equal(t, "image_generation", result.NamedToolChoice.Type)
+				require.Empty(t, result.NamedToolChoice.Function.Name)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -506,7 +506,9 @@ func convertToolChoice(src *llm.ToolChoice) *ToolChoice {
 	} else if src.NamedToolChoice != nil {
 		// Specific tool choice
 		result.Type = &src.NamedToolChoice.Type
-		result.Name = &src.NamedToolChoice.Function.Name
+		if src.NamedToolChoice.Function.Name != "" {
+			result.Name = &src.NamedToolChoice.Function.Name
+		}
 	}
 
 	return result

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -224,6 +224,42 @@ func TestOutboundTransformer_TransformRequest_WebSearchRequiredToolChoice(t *tes
 	require.Equal(t, "required", payload["tool_choice"])
 }
 
+func TestOutboundTransformer_TransformRequest_ImageGenerationToolChoice(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model:     "gpt-5.5",
+		APIFormat: llm.APIFormatOpenAIResponse,
+		Messages: []llm.Message{{
+			Role: "user",
+			Content: llm.MessageContent{
+				Content: lo.ToPtr("Generate an image."),
+			},
+		}},
+		Tools: []llm.Tool{{
+			Type: llm.ToolTypeImageGeneration,
+			ImageGeneration: &llm.ImageGeneration{
+				Model: "gpt-image-2",
+			},
+		}},
+		ToolChoice: &llm.ToolChoice{
+			NamedToolChoice: &llm.NamedToolChoice{Type: llm.ToolTypeImageGeneration},
+		},
+	}
+
+	hreq, err := transformer.TransformRequest(context.Background(), req)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(hreq.Body, &payload)
+	require.NoError(t, err)
+	require.Equal(t, "image_generation", payload["tool_choice"].(map[string]any)["type"])
+	require.NotContains(t, payload["tool_choice"].(map[string]any), "name")
+	require.Equal(t, "image_generation", payload["tools"].([]any)[0].(map[string]any)["type"])
+	require.Equal(t, "gpt-image-2", payload["tools"].([]any)[0].(map[string]any)["model"])
+}
+
 func TestOutboundTransformer_TransformRequest_ReplaysProviderRawToolsAndToolChoice(t *testing.T) {
 	inbound := NewInboundTransformer()
 	inboundReq := &httpclient.Request{


### PR DESCRIPTION
## Summary
- preserve Responses type-only tool choices such as `{"type":"image_generation"}` during inbound conversion
- omit `tool_choice.name` on outbound unless a function name is present
- add regression coverage for `gpt-5.5` + `image_generation` using `gpt-image-2` when body pass-through is disabled

## Scope
This is intentionally separate from #2217. This PR only fixes the non-pass-through transformer path where `tool_choice` became `{}` and Codex returned `Missing required parameter: 'tool_choice.type'.`

## Test
- `cd llm && go test ./transformer/openai/responses -run 'Test(OutboundTransformer_TransformRequest_ImageGenerationToolChoice|ConvertToolChoiceToLLM)' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image-generation tool choices when no function name is provided.
  * Requests now correctly omit an unnecessary tool name while preserving the selected tool type.
  * Ensured image-generation requests retain the appropriate model and tool configuration.

* **Tests**
  * Added coverage for inbound and outbound image-generation tool choice conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->