### PR TITLE
feat: persit chunks for failed stream request

### DIFF
--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -1243,6 +1243,24 @@ func (s *RequestService) LoadResponseBody(ctx context.Context, req *ent.Request)
 	return xjson.EmptyJSONRawMessage, nil
 }
 
+func isFinishedStreamStatus(status request.Status) bool {
+	switch status {
+	case request.StatusCompleted, request.StatusFailed, request.StatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func isFinishedExecutionStatus(status requestexecution.Status) bool {
+	switch status {
+	case requestexecution.StatusCompleted, requestexecution.StatusFailed, requestexecution.StatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
 // LoadResponseChunks returns the request response chunks, loading from external storage when necessary.
 func (s *RequestService) LoadResponseChunks(ctx context.Context, req *ent.Request) ([]objects.JSONRawMessage, error) {
 	if req == nil {
@@ -1253,13 +1271,19 @@ func (s *RequestService) LoadResponseChunks(ctx context.Context, req *ent.Reques
 		chunks := s.LiveStreamRegistry.GetRequestChunks(req.ID)
 		return chunks, nil
 	}
-	// Only load response chunks if request is completed and streaming.
-	if !req.Stream || req.Status != request.StatusCompleted {
+	// Load persisted chunks for finished streams, including failed/canceled ones
+	// that still buffered partial upstream output for debugging.
+	if !req.Stream || !isFinishedStreamStatus(req.Status) {
 		return []objects.JSONRawMessage{}, nil
 	}
 
 	dataStorage, err := s.getDataStorage(ctx, req.DataStorageID)
 	if err != nil {
+		// No external storage configured (common in tests / DB-only installs).
+		// Fall back to whatever was persisted on the request row.
+		if len(req.ResponseChunks) > 0 {
+			return req.ResponseChunks, nil
+		}
 		log.Warn(ctx, "Failed to get data storage for request response chunks", log.Cause(err), log.Int("request_id", req.ID))
 		return []objects.JSONRawMessage{}, nil
 	}
@@ -1374,13 +1398,19 @@ func (s *RequestService) LoadRequestExecutionResponseChunks(ctx context.Context,
 		chunks := s.LiveStreamRegistry.GetExecutionChunks(exec.ID)
 		return chunks, nil
 	}
-	// Only load response body if execution is completed
-	if !exec.Stream || exec.Status != requestexecution.StatusCompleted {
+	// Load persisted chunks for finished streams, including failed/canceled ones
+	// that still buffered partial upstream output for debugging.
+	if !exec.Stream || !isFinishedExecutionStatus(exec.Status) {
 		return []objects.JSONRawMessage{}, nil
 	}
 
 	dataStorage, err := s.getDataStorage(ctx, exec.DataStorageID)
 	if err != nil {
+		// No external storage configured (common in tests / DB-only installs).
+		// Fall back to whatever was persisted on the execution row.
+		if len(exec.ResponseChunks) > 0 {
+			return exec.ResponseChunks, nil
+		}
 		log.Warn(ctx, "Failed to get data storage for execution response chunks", log.Cause(err), log.Int("execution_id", exec.ID))
 		return []objects.JSONRawMessage{}, nil
 	}

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -167,9 +167,10 @@ func (ts *InboundPersistentStream) Close() error {
 	// regardless of what chunks we have. Stream errors indicate the upstream response
 	// was incomplete or corrupted.
 	if streamErr != nil && !errors.Is(streamErr, context.Canceled) && !errors.Is(streamErr, context.DeadlineExceeded) {
-		if ts.request != nil {
-			persistCtx := context.WithoutCancel(ctx)
+		persistCtx := context.WithoutCancel(ctx)
+		ts.persistFailureChunks(persistCtx)
 
+		if ts.request != nil {
 			if err := ts.requestService.UpdateRequestStatusFromError(persistCtx, ts.request.ID, streamErr); err != nil {
 				log.Warn(persistCtx, "Failed to update request status from error", log.Cause(err))
 			}
@@ -196,9 +197,10 @@ func (ts *InboundPersistentStream) Close() error {
 	// Check if context was canceled (client disconnected before [DONE]).
 	// Skip the error path if we determined the stream actually completed successfully above.
 	if (ctxErr != nil || streamErr != nil) && !ts.state.StreamCompleted {
-		if ts.request != nil {
-			persistCtx := context.WithoutCancel(ctx)
+		persistCtx := context.WithoutCancel(ctx)
+		ts.persistFailureChunks(persistCtx)
 
+		if ts.request != nil {
 			errToReport := ctxErr
 			if errToReport == nil {
 				errToReport = streamErr
@@ -219,9 +221,11 @@ func (ts *InboundPersistentStream) Close() error {
 	if !ts.state.StreamCompleted {
 		log.Debug(ctx, "Stream ended without terminal event or completed response, treating as incomplete")
 
-		if ts.request != nil {
-			persistCtx := context.WithoutCancel(ctx)
+		persistCtx := context.WithoutCancel(ctx)
+		// Persist partial chunks for debugging; do not mark the request completed.
+		ts.persistFailureChunks(persistCtx)
 
+		if ts.request != nil {
 			errToReport := ErrStreamIncomplete
 
 			if err := ts.requestService.UpdateRequestStatusFromError(persistCtx, ts.request.ID, errToReport); err != nil {
@@ -263,6 +267,19 @@ func (ts *InboundPersistentStream) persistResponseChunks(ctx context.Context) {
 	}
 
 	ts._persistResponse(persistCtx, responseBody, meta)
+}
+
+// persistFailureChunks stores buffered SSE chunks for a failed/incomplete stream
+// without marking the request completed. Used so truncated upstream responses remain
+// inspectable when store_chunks is enabled.
+func (ts *InboundPersistentStream) persistFailureChunks(ctx context.Context) {
+	if ts.request == nil || len(ts.responseChunks) == 0 {
+		return
+	}
+
+	if err := ts.requestService.SaveRequestChunks(ctx, ts.request.ID, ts.responseChunks); err != nil {
+		log.Warn(ctx, "Failed to save request chunks after stream failure", log.Cause(err))
+	}
 }
 
 // _persistResponse performs the actual persistence with pre-aggregated data.

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
@@ -271,6 +273,69 @@ func TestIsTerminalStreamEvent_AudioDoneEvents(t *testing.T) {
 	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "speech.audio.delta"}))
 	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "transcript.text.delta"}))
 	require.False(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: "audio/mpeg"}))
+}
+
+// TestInboundPersistentStream_Close_IncompleteStillPersistsChunks ensures a clean
+// upstream EOF without terminal/completion still saves buffered chunks when
+// store_chunks is on — without marking the request completed.
+func TestInboundPersistentStream_Close_IncompleteStillPersistsChunks(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+	project := createTestProject(t, ctx, client)
+	ch := createTestChannel(t, ctx, client)
+	_, requestService, systemService, _ := setupTestServices(t, client)
+	require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+		StoreChunks:       true,
+		StoreRequestBody:  true,
+		StoreResponseBody: true,
+	}))
+
+	req, err := client.Request.Create().
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("gpt-4").
+		SetStatus(request.StatusProcessing).
+		SetRequestBody([]byte(`{"stream":true}`)).
+		SetStream(true).
+		Save(ctx)
+	require.NoError(t, err)
+
+	partial := &httpclient.StreamEvent{
+		Type: "chunk",
+		Data: []byte(`{"id":"chatcmpl-partial","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`),
+	}
+	mockStream := &mockStream{events: []*httpclient.StreamEvent{partial}}
+	mockTransformer := &mockInboundTransformer{
+		aggregateErr: errors.New("incomplete aggregation"),
+	}
+	state := &PersistenceState{}
+
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		req,
+		&ent.RequestExecution{ID: 1},
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+	require.True(t, stream.Next())
+	_ = stream.Current()
+	require.NoError(t, stream.Close())
+
+	require.False(t, state.StreamCompleted)
+
+	dbReq, err := client.Request.Get(ctx, req.ID)
+	require.NoError(t, err)
+	require.Equal(t, request.StatusFailed, dbReq.Status)
+	require.NotEmpty(t, dbReq.ResponseChunks, "failed request should keep response_chunks in DB")
+
+	chunks, err := requestService.LoadResponseChunks(ctx, dbReq)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
 }
 
 func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -131,6 +131,8 @@ func (ts *OutboundPersistentStream) Close() error {
 		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
+		ts.persistFailureChunks(persistCtx)
+
 		if ts.requestExec != nil {
 			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, streamErr); err != nil {
 				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
@@ -163,6 +165,9 @@ func (ts *OutboundPersistentStream) Close() error {
 		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
+		// Keep partial chunks for debugging even when the request fails/cancels.
+		ts.persistFailureChunks(persistCtx)
+
 		errToReport := streamErr
 		if errToReport == nil {
 			errToReport = ctxErr
@@ -184,6 +189,10 @@ func (ts *OutboundPersistentStream) Close() error {
 		ts.logFinalizationDecision(ctx, "incomplete_stream_without_terminal_event", streamErr, ctxErr, aggregatedCompleted, aggErr)
 		persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 		defer cancel()
+
+		// Upstream dropped mid-stream (clean EOF, no terminal). Persist what we
+		// buffered so operators can inspect the truncated generation.
+		ts.persistFailureChunks(persistCtx)
 
 		errToReport := ErrStreamIncomplete
 		if ts.requestExec != nil {
@@ -254,6 +263,19 @@ func (ts *OutboundPersistentStream) persistResponseChunks(ctx context.Context) {
 		}
 
 		ts.persistAggregatedResponse(persistCtx, responseBody, meta)
+	}
+}
+
+// persistFailureChunks stores buffered SSE chunks for a failed/incomplete stream
+// without marking the execution completed or writing usage. Callers must already
+// hold a detached persist context so client cancel cannot abort the write.
+func (ts *OutboundPersistentStream) persistFailureChunks(ctx context.Context) {
+	if ts.requestExec == nil || len(ts.responseChunks) == 0 {
+		return
+	}
+
+	if err := ts.RequestService.SaveRequestExecutionChunks(ctx, ts.requestExec.ID, ts.responseChunks); err != nil {
+		log.Warn(ctx, "Failed to save request execution chunks after stream failure", log.Cause(err))
 	}
 }
 

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -800,7 +800,12 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 		ctx := ent.NewContext(ctx, client)
 		project := createTestProject(t, ctx, client)
 		ch := createTestChannel(t, ctx, client)
-		_, requestService, _, usageLogService := setupTestServices(t, client)
+		_, requestService, systemService, usageLogService := setupTestServices(t, client)
+		require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+			StoreChunks:       true,
+			StoreRequestBody:  true,
+			StoreResponseBody: true,
+		}))
 
 		req, err := client.Request.Create().
 			SetProjectID(project.ID).
@@ -823,8 +828,9 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 			Save(ctx)
 		require.NoError(t, err)
 
+		partialEvent := &httpclient.StreamEvent{Type: "response.in_progress", Data: []byte(`{"type":"response.in_progress"}`)}
 		stream := &sliceEventStream{
-			events: []*httpclient.StreamEvent{{Type: "response.in_progress", Data: []byte(`{"type":"response.in_progress"}`)}},
+			events: []*httpclient.StreamEvent{partialEvent},
 		}
 		transformer := &mockTransformer{
 			apiFormat:          llm.APIFormatOpenAIResponse,
@@ -844,6 +850,13 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 		require.Equal(t, requestexecution.StatusFailed, dbExec.Status)
 		require.Contains(t, dbExec.ErrorMessage, "stream ended without terminal event or completed response")
 		require.False(t, state.StreamCompleted)
+
+		storeChunks, err := systemService.StoreChunks(ctx)
+		require.NoError(t, err)
+		require.True(t, storeChunks, "store_chunks should be enabled for this test")
+
+		// Incomplete streams must still persist buffered chunks for debugging.
+		require.Len(t, dbExec.ResponseChunks, 1, "failed execution should keep response_chunks in DB")
 	})
 
 	t.Run("aggregated completed response without terminal event is completed", func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved buffered response content when inbound or outbound streams fail, are canceled, or end unexpectedly.
  - Improved visibility into incomplete requests by retaining partial responses for troubleshooting when storage is enabled.
  - Correctly marks interrupted requests and executions as failed rather than completed.
  - Restored access to saved response chunks even when the primary data-storage lookup is unavailable.
  - Prevented persistence errors from discarding already buffered response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->