### PR TITLE
fix(codex): fix HTTP 400 missing reasoning.context all_turns

### DIFF
--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -203,6 +203,22 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 			// Enable reasoning summary for Codex CLI requests.
 			reqCopy.ReasoningSummary = lo.ToPtr("auto")
 		}
+
+		// Responses Lite (signaled on the raw request above) rejects requests
+		// whose reasoning context is not "all_turns"; clients that never sent a
+		// reasoning block would otherwise fail upstream with HTTP 400. Only fill
+		// in a missing context — never override what the client explicitly sent.
+		if providerExt := reqCopy.ProviderExtensions; providerExt == nil || providerExt.OpenAIResponses == nil ||
+			providerExt.OpenAIResponses.Request == nil || providerExt.OpenAIResponses.Request.ReasoningContext == "" {
+			oaiExt := llm.EnsureOpenAIResponsesProviderExtensions(&reqCopy)
+			if oaiExt != nil {
+				if oaiExt.Request == nil {
+					oaiExt.Request = &llm.OpenAIResponsesRequestExtensions{ReasoningContext: "all_turns"}
+				} else {
+					oaiExt.Request.ReasoningContext = "all_turns"
+				}
+			}
+		}
 	}
 
 	// Codex Responses rejects token limit fields, so strip them out.

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -519,7 +519,71 @@ func TestCodexOutbound_AppliesReasoningDefaultsWhenMissing(t *testing.T) {
 	assert.Equal(t, true, body["parallel_tool_calls"])
 	assert.Equal(t, []any{"reasoning.encrypted_content"}, body["include"])
 	assert.Equal(t, "auto", reasoning["summary"])
+	assert.Equal(t, "all_turns", reasoning["context"])
 	assert.NotContains(t, body, "metadata")
+}
+
+func TestCodexOutbound_FillsMissingReasoningContextForResponsesLite(t *testing.T) {
+	ctx := context.Background()
+	outbound := newTestCodexOutbound(t)
+
+	t.Run("plain chat request gets all_turns context", func(t *testing.T) {
+		hreq, err := outbound.TransformRequest(ctx, &llm.Request{
+			Model: "gpt-5-codex",
+			Messages: []llm.Message{{
+				Role:    "user",
+				Content: llm.MessageContent{Content: lo.ToPtr("Hello")},
+			}},
+			Stream: lo.ToPtr(true),
+		})
+		require.NoError(t, err)
+
+		body := decodeCodexRequestBody(t, hreq)
+		reasoning, ok := body["reasoning"].(map[string]any)
+		require.True(t, ok, "reasoning block must be emitted for Responses Lite")
+		assert.Equal(t, "all_turns", reasoning["context"])
+	})
+
+	t.Run("client-sent reasoning without context gets all_turns", func(t *testing.T) {
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+		headers.Set(responses.ResponsesLiteHeader, "true")
+		inboundRequest := &httpclient.Request{
+			Headers: headers,
+			Body: []byte(`{
+				"model": "gpt-5.6-sol",
+				"input": "Hello",
+				"stream": true,
+				"reasoning": {"effort": "xhigh"}
+			}`),
+		}
+
+		llmRequest, err := responses.NewInboundTransformer().TransformRequest(ctx, inboundRequest)
+		require.NoError(t, err)
+		llmRequest.RawRequest = inboundRequest
+
+		outboundRequest, err := outbound.TransformRequest(ctx, llmRequest)
+		require.NoError(t, err)
+
+		body := decodeCodexRequestBody(t, outboundRequest)
+		reasoning, ok := body["reasoning"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "all_turns", reasoning["context"])
+		assert.Equal(t, "xhigh", reasoning["effort"])
+	})
+
+	t.Run("image requests do not get a fabricated reasoning context", func(t *testing.T) {
+		req, err := outbound.TransformRequest(ctx, &llm.Request{
+			Model:       "gpt-image-2",
+			RequestType: llm.RequestTypeImage,
+			APIFormat:   llm.APIFormatOpenAIImageGeneration,
+			RawRequest:  &httpclient.Request{Headers: http.Header{}},
+			Image:       &llm.ImageRequest{Prompt: "a cat"},
+		})
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(req.Body), `"context"`)
+	})
 }
 
 func TestCodexOutbound_ForcesArrayInputsForSingleMessage(t *testing.T) {

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -171,6 +171,7 @@ type Prompt struct {
 // Reasoning represents configuration options for reasoning models.
 type Reasoning struct {
 	// The reasoning context scope requested by internal Responses features.
+	// Responses Lite requires "all_turns" when this field is emitted.
 	Context string `json:"context,omitempty"`
 	// The effort level for reasoning. Any of "low", "medium", "high".
 	Effort string `json:"effort,omitempty"`


### PR DESCRIPTION
## Summary

Fixes `"X-OpenAI-Internal-Codex-Responses-Lite requires reasoning.context to be all_turns"` HTTP 400 errors on all Codex channel requests — by ensuring `reasoning.context: "all_turns"` is always present in the outbound body.

## Motivation

Commit c0233704 fabricates the Responses Lite header for all Codex channel requests. Inbound clients that do not send a `reasoning` block were rejected upstream with HTTP 400 because Responses Lite requires `reasoning.context` to be set to `all_turns` on every request. This matches an identical upstream fix in oh-my-pi (b6818ab).

## Changes

- Fill `reasoning.context` with `all_turns` in Codex outbound transformer when the client does not provide it
- Add test coverage for plain chat, Responses inbound without context, and image requests
- Document the `Context` field on `responses.Prompt` struct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI Responses requests now default missing reasoning context to `all_turns`.
  * Existing reasoning settings remain unchanged.
  * Image requests no longer receive an unintended reasoning context.

* **Documentation**
  * Clarified the required reasoning context for Responses Lite requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->