### PR TITLE
fix(nanogpt): escalate quota status to exhausted at 100%

### DIFF
--- a/internal/server/biz/provider_quota/nanogpt_checker.go
+++ b/internal/server/biz/provider_quota/nanogpt_checker.go
@@ -116,12 +116,13 @@ func (c *NanoGPTQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 
 	limits := buildNanoGPTLimitStatuses(response.DailyImages, response.DailyInputTokens, response.WeeklyInputTokens)
 
-	// Check for warning state: any window with percentUsed >= WarningThresholdRatio
-	if normalizedStatus == "available" {
+	// Escalate to the worst per-limit status (available < warning < exhausted).
+	// Only escalate from available/warning bases so that state-driven statuses
+	// (inactive→exhausted, unrecognized→unknown) are never overridden.
+	if normalizedStatus == "available" || normalizedStatus == "warning" {
 		for i := range limits {
-			if limits[i].Status == "warning" || limits[i].Status == "exhausted" {
-				normalizedStatus = "warning"
-				break
+			if quotaStatusRank(limits[i].Status) > quotaStatusRank(normalizedStatus) {
+				normalizedStatus = limits[i].Status
 			}
 		}
 	}

--- a/internal/server/biz/provider_quota/nanogpt_checker_test.go
+++ b/internal/server/biz/provider_quota/nanogpt_checker_test.go
@@ -480,7 +480,8 @@ func TestNanoGPT_CheckQuota_PerLimitStatuses_Exhausted(t *testing.T) {
 		Credentials: objects.ChannelCredentials{APIKey: "test-api-key"},
 	})
 	require.NoError(t, err)
-	require.Equal(t, "warning", quota.Status, "overall should be warning because some limits are exhausted but state is active")
+	require.Equal(t, "exhausted", quota.Status, "overall should be exhausted because some limits are exhausted")
+	require.False(t, quota.Ready)
 	require.Len(t, quota.Limits, 3)
 
 	imgLimit := quota.Limits[0]
@@ -525,4 +526,37 @@ func TestNanoGPT_CheckQuota_PerLimitStatuses_PercentUsedExhausted_NoRemaining(t 
 	require.Equal(t, "exhausted", dailyTokenLimit.Status, "percentUsed>=1.0 with nil Remaining should be exhausted")
 	require.InDelta(t, 1.0, dailyTokenLimit.UsageRatio, 0.001)
 	require.False(t, dailyTokenLimit.Ready)
+}
+
+func TestNanoGPT_CheckQuota_WeeklyExhausted(t *testing.T) {
+	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{
+				"active": true,
+				"state": "active",
+				"weeklyInputTokens": {"used": 1000000, "remaining": 0, "percentUsed": 1.0, "resetAt": 1717804800000}
+			}`
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	})
+
+	checker := NewNanoGPTQuotaChecker(httpClient)
+
+	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
+		Credentials: objects.ChannelCredentials{APIKey: "test-api-key"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "exhausted", quota.Status)
+	require.False(t, quota.Ready)
+	require.Len(t, quota.Limits, 1)
+
+	weeklyLimit := quota.Limits[0]
+	require.Equal(t, QuotaLimitTypeToken, weeklyLimit.Type)
+	require.Equal(t, "exhausted", weeklyLimit.Status)
+	require.InDelta(t, 1.0, weeklyLimit.UsageRatio, 0.001)
 }


### PR DESCRIPTION
## Summary

NanoGPT provider channels now report `exhausted` — and the red "Blocked" badge under `EXHAUSTED_ONLY` enforcement — when any usage window reaches 100%, instead of staying at `warning`.

## Motivation

A NanoGPT channel with its weekly input-tokens window fully used showed "Warning" in System → Provider Quotas, while other providers correctly showed exhausted/blocked. Per-limit statuses already reported `exhausted`, but the overall channel status was capped at warning, so the channel stayed routable and the UI never rendered the Blocked badge.

## Changes

- The NanoGPT quota checker now escalates the overall status to the worst per-limit status (available < warning < exhausted) rather than capping it at warning, so any fully-used window marks the channel `exhausted` and not-ready.
- State-driven statuses (inactive → exhausted, unrecognized → unknown) and responses with no limit windows are unaffected.

## Notes

- No frontend changes required: the UI's "Blocked" badge already derives from the persisted overall status.
- Updated the test that pinned the old warning-cap behavior and added a regression test for the exact reported scenario (weekly input tokens at 100%).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quota status reporting when individual limits are exhausted.
  - Preserved accurate overall states for exhausted and unknown quota conditions.
  - Corrected readiness indicators so exhausted quotas are marked unavailable.
  - Added more accurate weekly token usage and limit reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->