### PR TITLE
fix(llm): preserve top-level reasoning tokens

### DIFF
--- a/llm/transformer/openai/aggregator_test.go
+++ b/llm/transformer/openai/aggregator_test.go
@@ -420,6 +420,41 @@ func TestAggregateStreamChunks_PreservesEmptyReasoningContent(t *testing.T) {
 	require.Equal(t, "", *got.Choices[0].Message.ReasoningContent)
 }
 
+// TestAggregateStreamChunks_TopLevelReasoningTokens verifies that a provider
+// emitting reasoning tokens as a top-level `reasoning_tokens` field (SGLang
+// shape, with no nested completion_tokens_details) has the value merged into
+// the aggregated usage's CompletionTokensDetails.
+func TestAggregateStreamChunks_TopLevelReasoningTokens(t *testing.T) {
+	chunks := []*httpclient.StreamEvent{
+		{
+			Data: []byte(`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"qwen38-27b","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"qwen38-27b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`),
+		},
+		{
+			Data: []byte(`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"qwen38-27b","choices":[],"usage":{"prompt_tokens":17680,"completion_tokens":266,"total_tokens":17946,"prompt_tokens_details":{"cached_tokens":2304},"reasoning_tokens":97}}`),
+		},
+	}
+
+	gotBytes, meta, err := AggregateStreamChunks(context.Background(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+
+	var got llm.Response
+	err = json.Unmarshal(gotBytes, &got)
+	require.NoError(t, err)
+
+	require.NotNil(t, meta.Usage)
+	require.NotNil(t, meta.Usage.CompletionTokensDetails)
+	require.Equal(t, int64(97), meta.Usage.CompletionTokensDetails.ReasoningTokens)
+
+	require.NotNil(t, got.Usage)
+	require.NotNil(t, got.Usage.CompletionTokensDetails)
+	require.Equal(t, int64(97), got.Usage.CompletionTokensDetails.ReasoningTokens)
+	require.NotNil(t, got.Usage.PromptTokensDetails)
+	require.Equal(t, int64(2304), got.Usage.PromptTokensDetails.CachedTokens)
+}
+
 // TestAggregateStreamChunks_OmitsReasoningContentWhenAbsent verifies that when no
 // delta carries the reasoning_content field at all, the aggregated message does
 // not have ReasoningContent set (nil pointer).

--- a/llm/transformer/openai/usage.go
+++ b/llm/transformer/openai/usage.go
@@ -27,6 +27,13 @@ type Usage struct {
 	PromptTokensDetails     PromptTokensDetails     `json:"prompt_tokens_details"`
 	CompletionTokensDetails CompletionTokensDetails `json:"completion_tokens_details"`
 
+	// ReasoningTokens is a top-level reasoning token count emitted by some
+	// OpenAI-compatible providers (e.g. SGLang) that do not populate the nested
+	// completion_tokens_details. Merged into llm.Usage.CompletionTokensDetails by
+	// ToLLMUsage; omitempty ensures it is never emitted back to clients (UsageFromLLM
+	// does not set it).
+	ReasoningTokens int64 `json:"reasoning_tokens,omitempty"`
+
 	// CachedTokens is the number of tokens that were cached for Moonshot.
 	CachedTokens int64 `json:"cached_tokens,omitempty"`
 }
@@ -50,10 +57,20 @@ func (u *Usage) ToLLMUsage() *llm.Usage {
 		}
 	}
 
-	if u.CompletionTokensDetails != (CompletionTokensDetails{}) {
+	// Some OpenAI-compatible providers (e.g. SGLang) report reasoning tokens as a
+	// top-level `reasoning_tokens` field instead of the nested
+	// completion_tokens_details. Prefer the nested value (the OpenAI standard used by
+	// OpenAI/DeepSeek/Gemini), falling back to the top-level value only when the nested
+	// value is absent (zero).
+	reasoningTokens := u.CompletionTokensDetails.ReasoningTokens
+	if reasoningTokens == 0 {
+		reasoningTokens = u.ReasoningTokens
+	}
+
+	if u.CompletionTokensDetails != (CompletionTokensDetails{}) || reasoningTokens != 0 {
 		usage.CompletionTokensDetails = &llm.CompletionTokensDetails{
 			AudioTokens:              u.CompletionTokensDetails.AudioTokens,
-			ReasoningTokens:          u.CompletionTokensDetails.ReasoningTokens,
+			ReasoningTokens:          reasoningTokens,
 			AcceptedPredictionTokens: u.CompletionTokensDetails.AcceptedPredictionTokens,
 			RejectedPredictionTokens: u.CompletionTokensDetails.RejectedPredictionTokens,
 		}

--- a/llm/transformer/openai/usage_test.go
+++ b/llm/transformer/openai/usage_test.go
@@ -205,6 +205,80 @@ func TestUsage_ToLLMUsage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "top-level reasoning tokens (sglang shape)",
+			usage: &Usage{
+				PromptTokens:     17680,
+				CompletionTokens: 266,
+				TotalTokens:      17946,
+				ReasoningTokens:  97,
+			},
+			expected: &llm.Usage{
+				PromptTokens:     17680,
+				CompletionTokens: 266,
+				TotalTokens:      17946,
+				CompletionTokensDetails: &llm.CompletionTokensDetails{
+					ReasoningTokens: 97,
+				},
+			},
+		},
+		{
+			name: "top-level reasoning tokens with cached prompt details (full sglang shape)",
+			usage: &Usage{
+				PromptTokens:     40607,
+				CompletionTokens: 237,
+				TotalTokens:      40844,
+				PromptTokensDetails: PromptTokensDetails{
+					CachedTokens: 38723,
+				},
+				ReasoningTokens: 97,
+			},
+			expected: &llm.Usage{
+				PromptTokens:     40607,
+				CompletionTokens: 237,
+				TotalTokens:      40844,
+				PromptTokensDetails: &llm.PromptTokensDetails{
+					CachedTokens: 38723,
+				},
+				CompletionTokensDetails: &llm.CompletionTokensDetails{
+					ReasoningTokens: 97,
+				},
+			},
+		},
+		{
+			name: "nested reasoning tokens take precedence over top-level",
+			usage: &Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+				CompletionTokensDetails: CompletionTokensDetails{
+					ReasoningTokens: 10,
+				},
+				ReasoningTokens: 5,
+			},
+			expected: &llm.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+				CompletionTokensDetails: &llm.CompletionTokensDetails{
+					ReasoningTokens: 10,
+				},
+			},
+		},
+		{
+			name: "top-level zero reasoning tokens produces no details",
+			usage: &Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+				ReasoningTokens:  0,
+			},
+			expected: &llm.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Client-visible `completion_tokens_details.reasoning_tokens` and persisted usage logs no longer come back zero when the upstream provider reports reasoning tokens as a top-level usage field (SGLang shape). A top-level `ReasoningTokens` field is added to the OpenAI-compatible `Usage` struct, and `ToLLMUsage` merges it into `CompletionTokensDetails.ReasoningTokens` when the nested value is absent.

## Motivation

The OpenAI-compatible parser only knew the nested `completion_tokens_details.reasoning_tokens` field (the OpenAI/DeepSeek/Gemini standard), so SGLang-backed channels lost the count in both the client response and the usage log: the response carried `completion_tokens_details: null` and `completion_reasoning_tokens` persisted as 0.

## Notes

- Nested value wins when both are present, so OpenAI/DeepSeek/Gemini behavior is byte-identical.
- `omitempty` on the new parse-side field keeps it out of client-facing output.
- Covered by four new `TestUsage_ToLLMUsage` cases (sglang shape, cached-prompt shape, nested-precedence, zero) and a streaming aggregation test driving SGLang-shaped chunks through the aggregator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage reporting for reasoning tokens returned in top-level response data.
  * Preserved cached prompt-token details when usage information is aggregated.
  * Prioritized detailed reasoning-token values when multiple usage sources are available.

* **Tests**
  * Added coverage for token aggregation, fallback handling, precedence, and zero-value omission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->