### PR TITLE
fix: image outbound & override

### DIFF
--- a/internal/server/orchestrator/override.go
+++ b/internal/server/orchestrator/override.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"strings"
 	"text/template"
@@ -155,6 +156,22 @@ func applyOverrideRequestBody(outbound *PersistentOutboundTransformer) pipeline.
 			return request, nil
 		}
 
+		// Body override operations are implemented with sjson, which silently discards a
+		// non-JSON document and rebuilds it as a fresh JSON object. Applying them to a
+		// multipart body (image edit/variation, transcription, ...) would replace the whole
+		// payload with a tiny JSON object while the Content-Type still advertises the
+		// multipart boundary, so the upstream sees a truncated form.
+		if !bodyOverrideSupported(request) {
+			log.Warn(ctx, "skipping body override operations for non-JSON request body",
+				log.String("channel", channel.Name),
+				log.Int("channel_id", channel.ID),
+				log.String("content_type", requestContentType(request)),
+				log.String("api_format", request.APIFormat),
+			)
+
+			return request, nil
+		}
+
 		llmReq := outbound.state.LlmRequest
 		renderCtx := buildRenderContext(llmReq, outbound.state.OriginalModel)
 		body := request.Body
@@ -196,6 +213,48 @@ func applyOverrideRequestBody(outbound *PersistentOutboundTransformer) pipeline.
 
 		return request, nil
 	})
+}
+
+// requestContentType returns the effective outbound Content-Type, preferring the
+// explicit field and falling back to the header.
+func requestContentType(request *httpclient.Request) string {
+	if request == nil {
+		return ""
+	}
+
+	if request.ContentType != "" {
+		return request.ContentType
+	}
+
+	return request.Headers.Get("Content-Type")
+}
+
+// bodyOverrideSupported reports whether channel body override operations can safely be
+// applied to the outbound request body. Only JSON bodies are patchable: sjson treats any
+// non-JSON input as an empty document and returns a freshly built object, which would
+// destroy multipart and binary payloads.
+func bodyOverrideSupported(request *httpclient.Request) bool {
+	if request == nil || len(request.Body) == 0 {
+		return false
+	}
+
+	contentType := requestContentType(request)
+	if contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err == nil && !isJSONMediaType(mediaType) {
+			return false
+		}
+	}
+
+	return gjson.ValidBytes(request.Body)
+}
+
+func isJSONMediaType(mediaType string) bool {
+	mediaType = strings.ToLower(mediaType)
+
+	return mediaType == "application/json" ||
+		mediaType == "text/json" ||
+		strings.HasSuffix(mediaType, "+json")
 }
 
 func applyBodyOperation(

--- a/internal/server/orchestrator/override_test.go
+++ b/internal/server/orchestrator/override_test.go
@@ -2390,3 +2390,93 @@ func TestOverrideOperationsArrayOps(t *testing.T) {
 		require.Equal(t, "calculate", gjson.Get(got, "tools.0.function.name").String())
 	})
 }
+
+// TestOverrideBodySkipsNonJSONBody guards the image edit regression: sjson rebuilds a
+// non-JSON document from scratch, so applying body overrides to a multipart payload used
+// to replace the whole form with a tiny JSON object while Content-Type still advertised
+// the multipart boundary, producing a truncated upstream request.
+func TestOverrideBodySkipsNonJSONBody(t *testing.T) {
+	ctx := context.Background()
+
+	multipartBody := []byte("--boundary123\r\n" +
+		"Content-Disposition: form-data; name=\"image\"; filename=\"image_1.png\"\r\n" +
+		"Content-Type: image/png\r\n\r\n" +
+		"\x89PNG\r\n\x1a\nbinary-image-bytes\r\n" +
+		"--boundary123\r\n" +
+		"Content-Disposition: form-data; name=\"prompt\"\r\n\r\n" +
+		"make it blue\r\n" +
+		"--boundary123--\r\n")
+
+	newOutbound := func() *PersistentOutboundTransformer {
+		channel := &biz.Channel{
+			Channel: &ent.Channel{
+				ID:              1,
+				Name:            "test-channel",
+				SupportedModels: []string{"gpt-image-1"},
+				Settings: &objects.ChannelSettings{
+					BodyOverrideOperations: []objects.OverrideOperation{
+						{Op: objects.OverrideOpSet, Path: "response_format", Value: "b64_json"},
+					},
+				},
+			},
+			Outbound: &mockTransformer{},
+		}
+
+		return &PersistentOutboundTransformer{
+			wrapped: &mockTransformer{},
+			state: &PersistenceState{
+				CurrentCandidate:      &ChannelModelsCandidate{Channel: channel},
+				CurrentCandidateIndex: 0,
+				CurrentModelIndex:     0,
+				LlmRequest:            &llm.Request{Model: "gpt-image-1"},
+			},
+		}
+	}
+
+	t.Run("multipart body is left untouched", func(t *testing.T) {
+		headers := make(http.Header)
+		headers.Set("Content-Type", "multipart/form-data; boundary=boundary123")
+
+		request := &httpclient.Request{
+			Method:      "POST",
+			URL:         "https://api.example.com/v1/images/edits",
+			Headers:     headers,
+			ContentType: "multipart/form-data; boundary=boundary123",
+			Body:        multipartBody,
+		}
+
+		modified, err := applyOverrideRequestBody(newOutbound()).OnOutboundRawRequest(ctx, request)
+		require.NoError(t, err)
+		require.Equal(t, multipartBody, modified.Body)
+	})
+
+	t.Run("multipart body without explicit content type is left untouched", func(t *testing.T) {
+		request := &httpclient.Request{
+			Method: "POST",
+			URL:    "https://api.example.com/v1/images/edits",
+			Body:   multipartBody,
+		}
+
+		modified, err := applyOverrideRequestBody(newOutbound()).OnOutboundRawRequest(ctx, request)
+		require.NoError(t, err)
+		require.Equal(t, multipartBody, modified.Body)
+	})
+
+	t.Run("json body still gets overridden", func(t *testing.T) {
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+
+		request := &httpclient.Request{
+			Method:      "POST",
+			URL:         "https://api.example.com/v1/images/generations",
+			Headers:     headers,
+			ContentType: "application/json",
+			Body:        []byte(`{"model":"gpt-image-1","prompt":"a cat"}`),
+		}
+
+		modified, err := applyOverrideRequestBody(newOutbound()).OnOutboundRawRequest(ctx, request)
+		require.NoError(t, err)
+		require.Equal(t, "b64_json", gjson.GetBytes(modified.Body, "response_format").String())
+		require.Equal(t, "a cat", gjson.GetBytes(modified.Body, "prompt").String())
+	})
+}

--- a/llm/transformer/openai/image_edit_outbound_test.go
+++ b/llm/transformer/openai/image_edit_outbound_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -43,4 +44,49 @@ func TestImageEditRequestWritesModelBeforeImageFiles(t *testing.T) {
 	// Then
 	require.Equal(t, "model", part.FormName())
 	require.Equal(t, "gpt-image-2", string(value))
+}
+
+func TestImageEditRequestKeepsJPEGMetadataConsistent(t *testing.T) {
+	outbound, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	request := &llm.Request{
+		Model:       "gpt-image-2",
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageEdit,
+		Image: &llm.ImageRequest{
+			Prompt: "Make this image brighter",
+			Images: [][]byte{{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F'}},
+		},
+	}
+
+	httpRequest, err := outbound.TransformRequest(t.Context(), request)
+	require.NoError(t, err)
+
+	var logged struct {
+		FormFiles []struct {
+			Filename    string `json:"filename"`
+			ContentType string `json:"content_type"`
+			Format      string `json:"format"`
+		} `json:"formFiles"`
+	}
+	require.NoError(t, json.Unmarshal(httpRequest.JSONBody, &logged))
+	require.Len(t, logged.FormFiles, 1)
+	require.Equal(t, "image_1.jpg", logged.FormFiles[0].Filename)
+	require.Equal(t, "image/jpeg", logged.FormFiles[0].ContentType)
+	require.Equal(t, "jpg", logged.FormFiles[0].Format)
+
+	_, params, err := mime.ParseMediaType(httpRequest.Headers.Get("Content-Type"))
+	require.NoError(t, err)
+	reader := multipart.NewReader(bytes.NewReader(httpRequest.Body), params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		require.NoError(t, err)
+		if part.FileName() == "" {
+			continue
+		}
+		require.Equal(t, "image_1.jpg", part.FileName())
+		require.Equal(t, "image/jpeg", part.Header.Get("Content-Type"))
+		break
+	}
 }

--- a/llm/transformer/openai/image_outbound.go
+++ b/llm/transformer/openai/image_outbound.go
@@ -191,21 +191,12 @@ func (t *OutboundTransformer) buildImageEditRequest(chatReq *llm.Request, apiKey
 	// Convert raw image bytes to FormFiles
 
 	for i, data := range chatReq.Image.Images {
-		formFiles = append(formFiles, FormFile{
-			Filename:    fmt.Sprintf("image_%d.png", i+1),
-			ContentType: "image/png",
-			Data:        data,
-			Format:      "png",
-		})
+		formFiles = append(formFiles, newImageFormFile(fmt.Sprintf("image_%d", i+1), data))
 	}
 
 	if len(chatReq.Image.Mask) > 0 {
-		maskFile = &FormFile{
-			Filename:    "mask.png",
-			ContentType: "image/png",
-			Data:        chatReq.Image.Mask,
-			Format:      "png",
-		}
+		file := newImageFormFile("mask", chatReq.Image.Mask)
+		maskFile = &file
 	}
 
 	if len(formFiles) == 0 {
@@ -410,12 +401,7 @@ func (t *OutboundTransformer) buildImageVariationRequest(chatReq *llm.Request, a
 
 	// Convert raw image bytes to FormFiles
 	for i, data := range chatReq.Image.Images {
-		formFiles = append(formFiles, FormFile{
-			Filename:    fmt.Sprintf("image_%d.png", i+1),
-			ContentType: "image/png",
-			Data:        data,
-			Format:      "png",
-		})
+		formFiles = append(formFiles, newImageFormFile(fmt.Sprintf("image_%d", i+1), data))
 	}
 
 	if len(formFiles) == 0 {
@@ -530,6 +516,34 @@ type FormFile struct {
 	ContentType string `json:"content_type"`
 	Data        []byte `json:"data"`
 	Format      string `json:"format"` // image format like "png", "jpeg", etc.
+}
+
+func newImageFormFile(name string, data []byte) FormFile {
+	contentType := http.DetectContentType(data)
+	extension := "png"
+	format := "png"
+
+	switch contentType {
+	case "image/jpeg":
+		extension = "jpg"
+		format = "jpg"
+	case "image/gif":
+		extension = "gif"
+		format = "gif"
+	case "image/webp":
+		extension = "webp"
+		format = "webp"
+	case "image/png":
+	default:
+		contentType = "image/png"
+	}
+
+	return FormFile{
+		Filename:    fmt.Sprintf("%s.%s", name, extension),
+		ContentType: contentType,
+		Data:        data,
+		Format:      format,
+	}
 }
 
 // transformImageGenerationResponse transforms the OpenAI Image Generation/Edit API response

--- a/llm/transformer/openrouter/image_test.go
+++ b/llm/transformer/openrouter/image_test.go
@@ -85,23 +85,22 @@ func TestOutboundTransformer_ImageGenerationRequest(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, req)
 
-			// Verify it's a POST request to /chat/completions
+			// Verify it's a POST request to the OpenRouter image router.
 			require.Equal(t, http.MethodPost, req.Method)
-			require.Contains(t, req.URL, "/chat/completions")
+			require.Contains(t, req.URL, "/images")
 
 			// Verify request type is set
 			require.Equal(t, llm.RequestTypeImage.String(), req.RequestType)
+			require.Equal(t, llm.APIFormatOpenAIImageGeneration.String(), req.APIFormat)
 
-			// Parse body and verify modalities
+			// Parse body and verify the image-generation request shape.
 			var body map[string]any
 
 			err = json.Unmarshal(req.Body, &body)
 			require.NoError(t, err)
 
-			modalities, ok := body["modalities"].([]any)
-			require.True(t, ok, "modalities should be present")
-			require.Contains(t, modalities, "image")
-			require.Contains(t, modalities, "text")
+			require.Equal(t, tt.request.Model, body["model"])
+			require.Equal(t, tt.request.Image.Prompt, body["prompt"])
 
 			// Verify stream is not set (must be false for image generation)
 			_, hasStream := body["stream"]
@@ -121,10 +120,10 @@ func TestOutboundTransformer_ImageGenerationResponse(t *testing.T) {
 		want     *llm.Response
 	}{
 		{
-			name:     "response with images array",
-			response: `{"id":"gen-1759393520-lxwGJP80UyDdG9VmVTQj","model":"google/gemini-2.5-flash-image-preview","object":"chat.completion","created":1759393520,"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"","images":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo"},"index":0}]}}],"usage":{"prompt_tokens":7,"completion_tokens":1290,"total_tokens":1297}}`,
+			name:     "response with data array",
+			response: `{"created":1759393520,"data":[{"b64_json":"iVBORw0KGgo","media_type":"image/png"}],"usage":{"prompt_tokens":7,"completion_tokens":1290,"total_tokens":1297}}`,
 			want: &llm.Response{
-				ID:          "gen-1759393520-lxwGJP80UyDdG9VmVTQj",
+				ID:          "img-1759393520",
 				Object:      "chat.completion",
 				Created:     1759393520,
 				Model:       "test-model",
@@ -146,10 +145,10 @@ func TestOutboundTransformer_ImageGenerationResponse(t *testing.T) {
 			},
 		},
 		{
-			name:     "response with content array",
-			response: `{"id":"gen-test","model":"test-model","object":"chat.completion","created":1759393520,"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":[{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/4AAQ"}}]}}],"usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}}`,
+			name:     "response with multiple data images",
+			response: `{"created":1759393520,"data":[{"b64_json":"/9j/4AAQ","media_type":"image/jpeg"},{"b64_json":"R0lGODlh","media_type":"image/gif"}],"usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}}`,
 			want: &llm.Response{
-				ID:          "gen-test",
+				ID:          "img-1759393520",
 				Object:      "chat.completion",
 				Created:     1759393520,
 				Model:       "test-model",
@@ -160,6 +159,10 @@ func TestOutboundTransformer_ImageGenerationResponse(t *testing.T) {
 						{
 							B64JSON: "/9j/4AAQ",
 							URL:     "data:image/jpeg;base64,/9j/4AAQ",
+						},
+						{
+							B64JSON: "R0lGODlh",
+							URL:     "data:image/gif;base64,R0lGODlh",
 						},
 					},
 				},
@@ -284,9 +287,9 @@ func TestOutboundTransformer_ImageEditRequest(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, req)
 
-			// Verify it's a POST request to /chat/completions
+			// Verify it's a POST request to the OpenRouter image router.
 			require.Equal(t, http.MethodPost, req.Method)
-			require.Contains(t, req.URL, "/chat/completions")
+			require.Contains(t, req.URL, "/images")
 
 			// Parse body and verify structure
 			var body map[string]any
@@ -294,53 +297,22 @@ func TestOutboundTransformer_ImageEditRequest(t *testing.T) {
 			err = json.Unmarshal(req.Body, &body)
 			require.NoError(t, err)
 
-			// Verify messages contain content parts
-			messages, ok := body["messages"].([]any)
-			require.True(t, ok, "messages should be present")
-			require.Len(t, messages, 1)
+			require.Equal(t, tt.request.Model, body["model"])
+			require.Equal(t, tt.request.Image.Prompt, body["prompt"])
 
-			firstMsg, ok := messages[0].(map[string]any)
-			require.True(t, ok)
-
-			content, ok := firstMsg["content"].([]any)
-			require.True(t, ok, "content should be an array of parts")
-
-			// Count image_url parts and text parts
-			imageCount := 0
-			textCount := 0
-
-			for _, part := range content {
-				partMap, ok := part.(map[string]any)
+			inputReferences, ok := body["input_references"].([]any)
+			require.True(t, ok, "input_references should be present")
+			require.Len(t, inputReferences, tt.expectedImgCount)
+			for _, reference := range inputReferences {
+				referenceMap, ok := reference.(map[string]any)
 				require.True(t, ok)
-
-				partType, ok := partMap["type"].(string)
+				require.Equal(t, "image_url", referenceMap["type"])
+				imageURL, ok := referenceMap["image_url"].(map[string]any)
 				require.True(t, ok)
-
-				switch partType {
-				case "image_url":
-					imageCount++
-					// Verify image_url structure
-					imageURL, ok := partMap["image_url"].(map[string]any)
-					require.True(t, ok)
-					url, ok := imageURL["url"].(string)
-					require.True(t, ok)
-					require.True(t, strings.HasPrefix(url, "data:image/"), "image URL should be a data URL")
-				case "text":
-					textCount++
-					text, ok := partMap["text"].(string)
-					require.True(t, ok)
-					require.Equal(t, tt.request.Image.Prompt, text)
-				}
+				url, ok := imageURL["url"].(string)
+				require.True(t, ok)
+				require.True(t, strings.HasPrefix(url, "data:image/"), "image URL should be a data URL")
 			}
-
-			require.Equal(t, tt.expectedImgCount, imageCount, "expected %d image parts", tt.expectedImgCount)
-			require.Equal(t, 1, textCount, "expected 1 text part")
-
-			// Verify modalities
-			modalities, ok := body["modalities"].([]any)
-			require.True(t, ok, "modalities should be present")
-			require.Contains(t, modalities, "image")
-			require.Contains(t, modalities, "text")
 		})
 	}
 }

--- a/llm/transformer/openrouter/model.go
+++ b/llm/transformer/openrouter/model.go
@@ -6,6 +6,55 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
 
+// ImageGenerationRequest is the request body for OpenRouter's image router.
+// InputReferences intentionally use OpenAI's image_url content-part shape,
+// which is the shape required by OpenRouter's API.
+//
+// OpenRouter's image router does not accept OpenAI's moderation, response_format
+// or user fields, so those are intentionally dropped instead of forwarded.
+type ImageGenerationRequest struct {
+	Model             string                      `json:"model"`
+	Prompt            string                      `json:"prompt"`
+	N                 *int64                      `json:"n,omitempty"`
+	Size              string                      `json:"size,omitempty"`
+	Quality           string                      `json:"quality,omitempty"`
+	Background        string                      `json:"background,omitempty"`
+	OutputFormat      string                      `json:"output_format,omitempty"`
+	OutputCompression *int64                      `json:"output_compression,omitempty"`
+	Seed              *int64                      `json:"seed,omitempty"`
+	InputReferences   []openai.MessageContentPart `json:"input_references,omitempty"`
+}
+
+// ImageGenerationResponse is the non-streaming response from OpenRouter's
+// image router.
+type ImageGenerationResponse struct {
+	Created int64                 `json:"created"`
+	Data    []ImageGenerationData `json:"data"`
+	Usage   *ImageGenerationUsage `json:"usage,omitempty"`
+}
+
+type ImageGenerationData struct {
+	B64JSON   string `json:"b64_json"`
+	MediaType string `json:"media_type,omitempty"`
+}
+
+type ImageGenerationUsage struct {
+	PromptTokens            int64                         `json:"prompt_tokens"`
+	CompletionTokens        int64                         `json:"completion_tokens"`
+	TotalTokens             int64                         `json:"total_tokens"`
+	PromptTokensDetails     *ImagePromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *ImageCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+type ImagePromptTokensDetails struct {
+	ImageTokens  int64 `json:"image_tokens,omitempty"`
+	CachedTokens int64 `json:"cached_tokens,omitempty"`
+}
+
+type ImageCompletionTokensDetails struct {
+	ReasoningTokens int64 `json:"reasoning_tokens,omitempty"`
+}
+
 type Response struct {
 	openai.Response
 

--- a/llm/transformer/openrouter/outbound.go
+++ b/llm/transformer/openrouter/outbound.go
@@ -89,7 +89,7 @@ func (t *OutboundTransformer) TransformRequest(
 	case llm.RequestTypeChat, "":
 		// continue
 	case llm.RequestTypeImage:
-		return t.buildImageGenerationRequest(llmReq)
+		return t.buildImageGenerationRequest(ctx, llmReq)
 	case llm.RequestTypeEmbedding,
 		llm.RequestTypeSpeech,
 		llm.RequestTypeTranscription,
@@ -136,10 +136,11 @@ func (t *OutboundTransformer) TransformRequest(
 	}, nil
 }
 
-// buildImageGenerationRequest builds the request for OpenRouter image generation.
-// OpenRouter uses the chat completions endpoint with modalities: ["image", "text"].
-// Supports image editing when llmReq.Image.Images is provided.
-func (t *OutboundTransformer) buildImageGenerationRequest(llmReq *llm.Request) (*httpclient.Request, error) {
+// buildImageGenerationRequest builds the request for OpenRouter's image router.
+// OpenRouter exposes image generation at /images rather than through chat
+// completions. Input images are sent as input_references, which supports the
+// same image_url content-part shape as the OpenAI-compatible APIs.
+func (t *OutboundTransformer) buildImageGenerationRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
 	if llmReq.Model == "" {
 		return nil, fmt.Errorf("%w: model is required", transformer.ErrInvalidRequest)
 	}
@@ -152,43 +153,35 @@ func (t *OutboundTransformer) buildImageGenerationRequest(llmReq *llm.Request) (
 		return nil, fmt.Errorf("%w: prompt is required for image generation", transformer.ErrInvalidRequest)
 	}
 
-	prompt := llmReq.Image.Prompt
+	if len(llmReq.Image.Images) > 16 {
+		return nil, fmt.Errorf("%w: at most 16 input references are supported", transformer.ErrInvalidRequest)
+	}
 
-	// Build message content parts
-	var contentParts []openai.MessageContentPart
+	if len(llmReq.Image.Mask) > 0 {
+		return nil, fmt.Errorf("%w: masks are not supported by OpenRouter image generation", transformer.ErrInvalidRequest)
+	}
 
-	// Add input images if provided (for image editing)
+	inputReferences := make([]openai.MessageContentPart, 0, len(llmReq.Image.Images))
 	for _, imgData := range llmReq.Image.Images {
-		base64Image := encodeImageToBase64(imgData)
-		contentParts = append(contentParts, openai.MessageContentPart{
+		inputReferences = append(inputReferences, openai.MessageContentPart{
 			Type: "image_url",
 			ImageURL: &openai.ImageURL{
-				URL: base64Image,
+				URL: encodeImageToBase64(imgData),
 			},
 		})
 	}
 
-	// Add the text prompt
-	contentParts = append(contentParts, openai.MessageContentPart{
-		Type: "text",
-		Text: &prompt,
-	})
-
-	// Build messages with the content parts
-	messages := []openai.Message{
-		{
-			Role: "user",
-			Content: openai.MessageContent{
-				MultipleContent: contentParts,
-			},
-		},
-	}
-
-	// Build the OpenAI request
-	req := &openai.Request{
-		Model:      llmReq.Model,
-		Messages:   messages,
-		Modalities: []string{"image", "text"},
+	req := &ImageGenerationRequest{
+		Model:             llmReq.Model,
+		Prompt:            llmReq.Image.Prompt,
+		N:                 llmReq.Image.N,
+		Size:              llmReq.Image.Size,
+		Quality:           llmReq.Image.Quality,
+		Background:        llmReq.Image.Background,
+		OutputFormat:      llmReq.Image.OutputFormat,
+		OutputCompression: llmReq.Image.OutputCompression,
+		Seed:              llmReq.Seed,
+		InputReferences:   inputReferences,
 	}
 
 	body, err := json.Marshal(req)
@@ -202,14 +195,14 @@ func (t *OutboundTransformer) buildImageGenerationRequest(llmReq *llm.Request) (
 	headers.Set("Accept", "application/json")
 
 	// Get API key from provider
-	apiKey := t.APIKeyProvider.Get(context.Background())
+	apiKey := t.APIKeyProvider.Get(ctx)
 
 	auth := &httpclient.AuthConfig{
 		Type:   httpclient.AuthTypeBearer,
 		APIKey: apiKey,
 	}
 
-	url := t.BaseURL + "/chat/completions"
+	url := t.BaseURL + "/images"
 
 	rawReq := &httpclient.Request{
 		Method:      http.MethodPost,
@@ -219,6 +212,7 @@ func (t *OutboundTransformer) buildImageGenerationRequest(llmReq *llm.Request) (
 		Auth:        auth,
 		ContentType: "application/json",
 		RequestType: llm.RequestTypeImage.String(),
+		APIFormat:   llm.APIFormatOpenAIImageGeneration.String(),
 	}
 
 	// Save model to TransformerMetadata for response transformation
@@ -313,8 +307,8 @@ func (t *OutboundTransformer) TransformResponse(
 	return chatResp.ToOpenAIResponse().ToLLMResponse(), nil
 }
 
-// transformImageGenerationResponse transforms OpenRouter image generation response to llm.Response.
-// OpenRouter returns images in message.images array with base64 data URLs.
+// transformImageGenerationResponse transforms the OpenRouter image-router
+// response to the unified image response model.
 func (t *OutboundTransformer) transformImageGenerationResponse(httpResp *httpclient.Response) (*llm.Response, error) {
 	// Check for HTTP error status codes
 	if httpResp.StatusCode >= 400 {
@@ -326,13 +320,6 @@ func (t *OutboundTransformer) transformImageGenerationResponse(httpResp *httpcli
 		return nil, fmt.Errorf("response body is empty")
 	}
 
-	var chatResp Response
-
-	err := json.Unmarshal(httpResp.Body, &chatResp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal image generation response: %w", err)
-	}
-
 	// Read model from request TransformerMetadata
 	model := "image-generation"
 
@@ -342,54 +329,43 @@ func (t *OutboundTransformer) transformImageGenerationResponse(httpResp *httpcli
 		}
 	}
 
-	// Build the base response
+	var imageResp ImageGenerationResponse
+	if err := json.Unmarshal(httpResp.Body, &imageResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal image generation response: %w", err)
+	}
+
 	resp := &llm.Response{
-		ID:          chatResp.ID,
+		ID:          fmt.Sprintf("img-%d", imageResp.Created),
 		Object:      "chat.completion",
-		Created:     chatResp.Created,
+		Created:     imageResp.Created,
 		Model:       model,
 		RequestType: llm.RequestTypeImage,
+		APIFormat:   llm.APIFormatOpenAIImageGeneration,
 	}
 
-	// Convert usage information
-	if chatResp.Usage != nil {
-		resp.Usage = chatResp.Usage.ToLLMUsage()
+	if imageResp.Usage != nil {
+		resp.Usage = imageResp.Usage.ToLLMUsage()
 	}
 
-	// Build ImageResponse from the message images
 	imageResponse := &llm.ImageResponse{
-		Created: chatResp.Created,
-		Data:    make([]llm.ImageData, 0),
+		Created: imageResp.Created,
+		Data:    make([]llm.ImageData, 0, len(imageResp.Data)),
 	}
 
-	// Extract images from the response
-	for _, choice := range chatResp.Choices {
-		if choice.Message != nil && len(choice.Message.Images) > 0 {
-			for _, img := range choice.Message.Images {
-				if img.ImageURL != nil && img.ImageURL.URL != "" {
-					imageResponse.Data = append(imageResponse.Data, llm.ImageData{
-						B64JSON: extractBase64FromDataURL(img.ImageURL.URL),
-						URL:     img.ImageURL.URL,
-					})
-				}
-			}
-		}
-	}
+	// OpenRouter reports the encoding per image rather than once per response,
+	// while ImageResponse.OutputFormat is response-scoped. Take the first image
+	// that carries a usable media type instead of letting the last one win.
+	for _, image := range imageResp.Data {
+		data := llm.ImageData{B64JSON: image.B64JSON}
+		if image.B64JSON != "" {
+			data.URL = buildImageDataURL(image.MediaType, image.B64JSON)
 
-	// If no images found in Images field, check Content.MultipleContent
-	if len(imageResponse.Data) == 0 {
-		for _, choice := range chatResp.Choices {
-			if choice.Message != nil && len(choice.Message.Content.MultipleContent) > 0 {
-				for _, part := range choice.Message.Content.MultipleContent {
-					if part.Type == "image_url" && part.ImageURL != nil && part.ImageURL.URL != "" {
-						imageResponse.Data = append(imageResponse.Data, llm.ImageData{
-							B64JSON: extractBase64FromDataURL(part.ImageURL.URL),
-							URL:     part.ImageURL.URL,
-						})
-					}
-				}
+			if imageResponse.OutputFormat == "" {
+				imageResponse.OutputFormat = imageFormatFromMediaType(image.MediaType)
 			}
 		}
+
+		imageResponse.Data = append(imageResponse.Data, data)
 	}
 
 	resp.Image = imageResponse
@@ -397,17 +373,56 @@ func (t *OutboundTransformer) transformImageGenerationResponse(httpResp *httpcli
 	return resp, nil
 }
 
-// extractBase64FromDataURL extracts base64 data from a data URL.
-// e.g., "data:image/png;base64,iVBORw0KGgo..." -> "iVBORw0KGgo...".
-func extractBase64FromDataURL(dataURL string) string {
-	const prefix = "base64,"
-
-	_, after, ok := strings.Cut(dataURL, prefix)
-	if !ok {
-		return ""
+func (u *ImageGenerationUsage) ToLLMUsage() *llm.Usage {
+	if u == nil {
+		return nil
 	}
 
-	return after
+	usage := &llm.Usage{
+		PromptTokens:     u.PromptTokens,
+		CompletionTokens: u.CompletionTokens,
+		TotalTokens:      u.TotalTokens,
+	}
+
+	if u.PromptTokensDetails != nil {
+		usage.PromptTokensDetails = &llm.PromptTokensDetails{
+			ImageTokens:  u.PromptTokensDetails.ImageTokens,
+			CachedTokens: u.PromptTokensDetails.CachedTokens,
+		}
+	}
+
+	if u.CompletionTokensDetails != nil {
+		usage.CompletionTokensDetails = &llm.CompletionTokensDetails{
+			ReasoningTokens: u.CompletionTokensDetails.ReasoningTokens,
+		}
+	}
+
+	return usage
+}
+
+func buildImageDataURL(mediaType, b64JSON string) string {
+	if strings.HasPrefix(b64JSON, "data:") {
+		return b64JSON
+	}
+
+	if mediaType == "" {
+		mediaType = "image/png"
+	}
+
+	return xurl.BuildDataURL(mediaType, b64JSON, true)
+}
+
+func imageFormatFromMediaType(mediaType string) string {
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
+	if mediaType == "image/svg+xml" {
+		return "svg"
+	}
+
+	if format, ok := strings.CutPrefix(mediaType, "image/"); ok {
+		return format
+	}
+
+	return ""
 }
 
 func (t *OutboundTransformer) AggregateStreamChunks(ctx context.Context, req *httpclient.Request, chunks []*httpclient.StreamEvent) ([]byte, llm.ResponseMeta, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenRouter image generation with support for multiple input images, image metadata, usage details, and generated image identifiers.
  * Image uploads now preserve the correct format and filename for JPEG, GIF, WebP, and PNG files.
* **Bug Fixes**
  * Request body overrides no longer replace multipart, binary, invalid, or non-JSON payloads.
  * Fixed consistency between uploaded image data and its reported media type and filename.
* **Tests**
  * Added coverage for image generation, image editing, and safe request-body handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->