### PR TITLE
fix(copilot): send Grok models through Responses API

### DIFF
--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -632,9 +632,14 @@ func (t *OutboundTransformer) transformResponsesRequest(ctx context.Context, llm
 }
 
 // usesResponsesAPI checks if the model uses the responses API.
-// GPT-5+ (except gpt-5-mini) uses /responses, everything else uses /chat/completions.
+// GPT-5+ (except gpt-5-mini) and Grok models use /responses; everything else uses /chat/completions.
 func usesResponsesAPI(model string) bool {
 	normalizedModel := strings.ToLower(model)
+
+	// Copilot Grok models do not support /chat/completions.
+	if strings.HasPrefix(normalizedModel, "grok-") {
+		return true
+	}
 
 	// Use package-level compiled regex
 	match := modelVersionRegex.FindStringSubmatch(normalizedModel)

--- a/llm/transformer/openai/copilot/outbound_test.go
+++ b/llm/transformer/openai/copilot/outbound_test.go
@@ -157,6 +157,26 @@ func TestUsesResponsesAPI(t *testing.T) {
 			model:    "claude-3-5-sonnet",
 			expected: false,
 		},
+		{
+			name:     "grok-4.6 uses responses API",
+			model:    "grok-4.6",
+			expected: true,
+		},
+		{
+			name:     "grok-4.5 uses responses API",
+			model:    "grok-4.5",
+			expected: true,
+		},
+		{
+			name:     "Grok-4.6 uses responses API",
+			model:    "Grok-4.6",
+			expected: true,
+		},
+		{
+			name:     "non-grok non-gpt-5 model does not use responses API",
+			model:    "o4-mini",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -309,6 +329,25 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 			},
 			request: &llm.Request{
 				Model: "gpt-5.2-codex",
+				Messages: []llm.Message{
+					{
+						Role:    "user",
+						Content: llm.MessageContent{Content: lo.ToPtr("Hello, Copilot!")},
+					},
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, req *httpclient.Request) {
+				assert.Equal(t, DefaultCopilotBaseURL+"/v1/responses", req.URL)
+			},
+		},
+		{
+			name: "grok-4.6 uses responses API endpoint",
+			params: OutboundTransformerParams{
+				TokenProvider: &mockTokenProvider{token: mockToken},
+			},
+			request: &llm.Request{
+				Model: "grok-4.6",
 				Messages: []llm.Message{
 					{
 						Role:    "user",


### PR DESCRIPTION
## Summary
Copilot Grok models (for example `grok-4.6`) do not support `/chat/completions`. AxonHub already converts GPT-5+ Copilot traffic through the Responses API; this change uses that same outbound path for any Copilot model whose name starts with `grok-` (case-insensitive).

## Changes
- `usesResponsesAPI` now returns true for `grok-*` while keeping existing GPT-5+ / `gpt-5-mini` behavior.
- Tests cover `grok-4.6`, `grok-4.5`, `Grok-4.6`, plus the existing gpt/claude cases.

## Test plan
- [x] Added `TestUsesResponsesAPI` cases for Grok models
- [x] Added `TransformRequest` case asserting `grok-4.6` hits `/v1/responses`
- [ ] Targeted package tests were not run locally: Go is not available in this environment and local Go install was skipped

## Related
Fixes #2249
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Grok models by routing them through the Responses API.
  * Added support for case variations in Grok model names.
  * Preserved existing behavior for models that should not use the Responses API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->