### PR TITLE
fix: forward image parameter in /v1/images/generations

### DIFF
--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -51,21 +51,24 @@ var allowedImageTypes = []string{
 }
 
 // ImageGenerationRequest represents the request structure for image generation API.
+// The Image field accepts a data URL string or an array of data URL strings for
+// image-to-image generation (supported by gpt-image-1).
 type ImageGenerationRequest struct {
-	Prompt            string `json:"prompt"`
-	Model             string `json:"model"`
-	N                 *int64 `json:"n,omitempty"`
-	Quality           string `json:"quality,omitempty"`
-	ResponseFormat    string `json:"response_format,omitempty"`
-	Size              string `json:"size,omitempty"`
-	Style             string `json:"style,omitempty"`
-	User              string `json:"user,omitempty"`
-	Background        string `json:"background,omitempty"`
-	OutputFormat      string `json:"output_format,omitempty"`
-	OutputCompression *int64 `json:"output_compression,omitempty"`
-	Moderation        string `json:"moderation,omitempty"`
-	PartialImages     *int64 `json:"partial_images,omitempty"`
-	Stream            bool   `json:"stream,omitempty"`
+	Prompt            string          `json:"prompt"`
+	Model             string          `json:"model"`
+	N                 *int64          `json:"n,omitempty"`
+	Quality           string          `json:"quality,omitempty"`
+	ResponseFormat    string          `json:"response_format,omitempty"`
+	Size              string          `json:"size,omitempty"`
+	Style             string          `json:"style,omitempty"`
+	User              string          `json:"user,omitempty"`
+	Background        string          `json:"background,omitempty"`
+	OutputFormat      string          `json:"output_format,omitempty"`
+	OutputCompression *int64          `json:"output_compression,omitempty"`
+	Moderation        string          `json:"moderation,omitempty"`
+	PartialImages     *int64          `json:"partial_images,omitempty"`
+	Stream            bool            `json:"stream,omitempty"`
+	Image             json.RawMessage `json:"image,omitempty"`
 }
 
 type ImageInboundTransformer struct {
@@ -221,8 +224,14 @@ func (t *ImageInboundTransformer) transformGenerationRequest(httpReq *httpclient
 		return nil, fmt.Errorf("%w: prompt is required", transformer.ErrInvalidRequest)
 	}
 
+	images, err := parseGenerationImageField(genReq.Image)
+	if err != nil {
+		return nil, err
+	}
+
 	imageReq := &llm.ImageRequest{
 		Prompt:            genReq.Prompt,
+		Images:            images,
 		N:                 genReq.N,
 		Size:              genReq.Size,
 		Quality:           genReq.Quality,
@@ -545,4 +554,63 @@ func parseOptionalInt64(s string) *int64 {
 	}
 
 	return &v
+}
+
+// parseGenerationImageField parses the "image" field from a JSON image generation
+// request body. The field can be a single data URL string or an array of data URL
+// strings. The returned [][]byte contains the decoded raw image bytes.
+func parseGenerationImageField(raw json.RawMessage) ([][]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		data, err := decodeDataURLToBytes(single)
+		if err != nil {
+			return nil, err
+		}
+
+		return [][]byte{data}, nil
+	}
+
+	var many []string
+	if err := json.Unmarshal(raw, &many); err != nil {
+		return nil, fmt.Errorf("%w: image field must be a string or array of strings", transformer.ErrInvalidRequest)
+	}
+
+	images := make([][]byte, 0, len(many))
+	for _, url := range many {
+		data, err := decodeDataURLToBytes(url)
+		if err != nil {
+			return nil, err
+		}
+
+		images = append(images, data)
+	}
+
+	return images, nil
+}
+
+// decodeDataURLToBytes decodes a data URL (data:image/png;base64,...) to raw bytes.
+func decodeDataURLToBytes(dataURL string) ([]byte, error) {
+	if !xurl.IsDataURL(dataURL) {
+		return nil, fmt.Errorf("%w: image must be a data URL", transformer.ErrInvalidRequest)
+	}
+
+	parsed := xurl.ParseDataURL(dataURL)
+	if parsed == nil {
+		return nil, fmt.Errorf("%w: invalid data URL format", transformer.ErrInvalidRequest)
+	}
+
+	if !parsed.IsBase64 {
+		return nil, fmt.Errorf("%w: image data URL must be base64-encoded", transformer.ErrInvalidRequest)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(parsed.Data)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to decode base64 image data", transformer.ErrInvalidRequest)
+	}
+
+	return data, nil
 }

--- a/llm/transformer/openai/image_inbound_test.go
+++ b/llm/transformer/openai/image_inbound_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"mime/multipart"
 	"net/http"
@@ -62,6 +63,170 @@ func TestImageInboundTransformer_TransformRequest_Generation_JSON(t *testing.T) 
 	assert.Equal(t, "https://api.openai.com/v1/images/generations", outReq.URL)
 	assert.Contains(t, string(outReq.Body), `"response_format":"url"`)
 	assert.Contains(t, string(outReq.Body), `"n":2`)
+}
+
+func TestImageInboundTransformer_TransformRequest_Generation_WithSingleImage(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	// 1x1 red pixel PNG
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "make this image brighter",
+		"model":  "gpt-image-1",
+		"image":  dataURL,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	require.NotNil(t, llmReq.Image)
+	require.Len(t, llmReq.Image.Images, 1)
+	assert.Equal(t, pngBytes, llmReq.Image.Images[0])
+}
+
+func TestImageInboundTransformer_TransformRequest_Generation_WithMultipleImages(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	pngBytes1 := []byte{0x89, 0x50, 0x4E, 0x47}
+	pngBytes2 := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D}
+	dataURL1 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes1)
+	dataURL2 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes2)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "combine these images",
+		"model":  "gpt-image-1",
+		"image":  []string{dataURL1, dataURL2},
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	require.NotNil(t, llmReq.Image)
+	require.Len(t, llmReq.Image.Images, 2)
+	assert.Equal(t, pngBytes1, llmReq.Image.Images[0])
+	assert.Equal(t, pngBytes2, llmReq.Image.Images[1])
+}
+
+func TestImageInboundTransformer_TransformRequest_Generation_WithInvalidImageField(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	reqBody := []byte(`{
+		"prompt":"a cat",
+		"model":"gpt-image-1",
+		"image":123
+	}`)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image field must be a string or array of strings")
+}
+
+func TestImageInboundTransformer_TransformRequest_Generation_WithNonDataURLImage(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	reqBody := []byte(`{
+		"prompt":"a cat",
+		"model":"gpt-image-1",
+		"image":"https://example.com/image.png"
+	}`)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image must be a data URL")
+}
+
+func TestImageInboundTransformer_TransformRequest_Generation_WithNonBase64DataURL(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	reqBody := []byte(`{
+		"prompt":"a cat",
+		"model":"gpt-image-1",
+		"image":"data:image/png,raw-not-base64"
+	}`)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be base64-encoded")
+}
+
+func TestImageInboundTransformer_Generation_RoundTrip_WithImage(t *testing.T) {
+	inbound := NewImageGenerationInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "make this brighter",
+		"model":  "gpt-image-1",
+		"image":  dataURL,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/generations",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+
+	outReq, err := ot.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://api.openai.com/v1/images/generations", outReq.URL)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(outReq.Body, &body))
+
+	imageField, ok := body["image"].(string)
+	require.True(t, ok, "image should be forwarded as a string in the outbound request")
+	assert.Contains(t, imageField, "data:image/png;base64,")
 }
 
 func TestImageInboundTransformer_TransformRequest_Edit_Multipart_WithMask(t *testing.T) {

--- a/llm/transformer/openai/image_outbound.go
+++ b/llm/transformer/openai/image_outbound.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/internal/pkg/xurl"
 	"github.com/looplj/axonhub/llm/transformer"
 )
 
@@ -95,6 +96,21 @@ func (t *OutboundTransformer) buildImageGenerateRequest(chatReq *llm.Request, ap
 
 	// Extract image generation parameters from Image field
 	img := chatReq.Image
+
+	// Forward input images for image-to-image generation (gpt-image-1)
+	if len(img.Images) > 0 {
+		dataURLs := make([]string, len(img.Images))
+		for i, data := range img.Images {
+			dataURLs[i] = encodeImageBytesToDataURL(data)
+		}
+
+		if len(dataURLs) == 1 {
+			reqBody["image"] = dataURLs[0]
+		} else {
+			reqBody["image"] = dataURLs
+		}
+	}
+
 	if img.N != nil {
 		reqBody["n"] = *img.N
 	}
@@ -700,4 +716,15 @@ func extractFile(url string) (FormFile, error) {
 	}
 
 	return FormFile{}, fmt.Errorf("%w: only data URLs are supported for image editing", transformer.ErrInvalidRequest)
+}
+
+// encodeImageBytesToDataURL encodes raw image bytes to a base64 data URL
+// suitable for JSON API request bodies (e.g. the image field in images/generations).
+func encodeImageBytesToDataURL(data []byte) string {
+	contentType := http.DetectContentType(data)
+	if !strings.HasPrefix(contentType, "image/") {
+		contentType = "image/png"
+	}
+
+	return xurl.BuildDataURL(contentType, base64.StdEncoding.EncodeToString(data), true)
 }

--- a/llm/transformer/openai/image_outbound_test.go
+++ b/llm/transformer/openai/image_outbound_test.go
@@ -154,6 +154,103 @@ func TestBuildImageGenerateRequest_WithParameters(t *testing.T) {
 	assert.Equal(t, "transparent", body["background"])
 }
 
+func TestBuildImageGenerateRequest_WithSingleImage(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+
+	// 1x1 red pixel PNG
+	imageData, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==")
+	require.NoError(t, err)
+
+	req := &llm.Request{
+		Model: "gpt-image-1",
+		Image: &llm.ImageRequest{
+			Prompt: "Make this image brighter",
+			Images: [][]byte{imageData},
+		},
+	}
+
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
+	require.NoError(t, err)
+
+	var body map[string]any
+	err = json.Unmarshal(httpReq.Body, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Make this image brighter", body["prompt"])
+	assert.Equal(t, "gpt-image-1", body["model"])
+
+	// image should be a single data URL string
+	imageField, ok := body["image"].(string)
+	require.True(t, ok, "image field should be a string for single image")
+	assert.Contains(t, imageField, "data:image/png;base64,")
+}
+
+func TestBuildImageGenerateRequest_WithMultipleImages(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+
+	imageData1, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==")
+	require.NoError(t, err)
+
+	imageData2 := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	req := &llm.Request{
+		Model: "gpt-image-1",
+		Image: &llm.ImageRequest{
+			Prompt: "Combine these images",
+			Images: [][]byte{imageData1, imageData2},
+		},
+	}
+
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
+	require.NoError(t, err)
+
+	var body map[string]any
+	err = json.Unmarshal(httpReq.Body, &body)
+	require.NoError(t, err)
+
+	// image should be an array for multiple images
+	imageField, ok := body["image"].([]any)
+	require.True(t, ok, "image field should be an array for multiple images")
+	assert.Len(t, imageField, 2)
+
+	for _, img := range imageField {
+		str, ok := img.(string)
+		require.True(t, ok)
+		assert.Contains(t, str, "data:image/")
+	}
+}
+
+func TestBuildImageGenerateRequest_WithoutImage(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+
+	req := &llm.Request{
+		Model: "dall-e-3",
+		Image: &llm.ImageRequest{
+			Prompt: "A beautiful sunset",
+		},
+	}
+
+	httpReq, err := ot.buildImageGenerateRequest(req, "test-key")
+	require.NoError(t, err)
+
+	var body map[string]any
+	err = json.Unmarshal(httpReq.Body, &body)
+	require.NoError(t, err)
+
+	// image field should not be present when no input images
+	_, hasImage := body["image"]
+	assert.False(t, hasImage, "image field should not be present when no input images")
+}
+
 func TestBuildImageGenerateRequest_GPTImageModelOmitsResponseFormat(t *testing.T) {
 	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

The `/v1/images/generations` endpoint silently dropped the `image` parameter when forwarding to upstream channels. This affected `gpt-image-1` image-to-image generation where input images are sent as data URLs in the JSON request body.

## Root Cause

Two issues in the OpenAI image transformer:

1. **Inbound** (`image_inbound.go`): `ImageGenerationRequest` struct had no `Image` field, so the `image` parameter in the JSON body was silently discarded during parsing.

2. **Outbound** (`image_outbound.go`): `buildImageGenerateRequest` only handled text-generation parameters (prompt, size, quality, etc.) and completely ignored `chatReq.Image.Images`, not forwarding input images to the upstream channel.

## Fix

### Inbound
- Added `Image json.RawMessage` field to `ImageGenerationRequest`
- Added `parseGenerationImageField` to parse the `image` field (supports a single data URL string or an array of data URLs)
- Added `decodeDataURLToBytes` helper to decode data URLs to raw bytes
- Parsed images are stored in `llm.ImageRequest.Images`

### Outbound
- `buildImageGenerateRequest` now encodes `img.Images` back to data URLs and includes them in the request body as the `image` field
- Single image → string, multiple images → array (matching OpenAI API format)
- Added `encodeImageBytesToDataURL` helper

## Tests

Added 8 test cases:
- Inbound: single image, multiple images, invalid type, non-data-URL, round-trip
- Outbound: single image, multiple images, no image (backward compatibility)

All existing tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation requests can now include one or multiple input images.
  * Input images are accepted as base64 data URLs and forwarded in the request.
  * Generated image requests preserve image data using a single value or an array, as applicable.
* **Bug Fixes**
  * Invalid image formats, data URLs, and base64 content now return clear invalid-request errors.
* **Tests**
  * Added coverage for single-image, multiple-image, missing-image, invalid-input, and round-trip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->