### PR TITLE
fix(frontend): grant system-level route access to owner users

### DIFF
--- a/frontend/src/hooks/useRoutePermissions.ts
+++ b/frontend/src/hooks/useRoutePermissions.ts
@@ -50,6 +50,10 @@ export function useRoutePermissions() {
     const scopeLevel = routeConfig.scopeLevel || groupScopeLevel || 'any';
 
     // Owner 拥有所有权限
+    if (isOwner) {
+      return true;
+    }
+
     if (isProjectOwner && scopeLevel !== 'system') {
       return true;
     }


### PR DESCRIPTION
Fixes #2252

System owners (`user.isOwner === true`) are currently hidden from every system-level route — the whole
Admin nav group — whenever `users.scopes` is empty, because the owner shortcut in `hasRouteAccess()` is
explicitly skipped for `scopeLevel === 'system'`.

This contradicts the backend, where `OwnerRule` (`internal/scopes/rule_owner.go`) allows every operation for
`user.IsOwner`, and `HasSystemScope()` (`internal/scopes/rule.go`) short-circuits on owner before checking
scopes. It is also inconsistent with the other consumers of the same permission model: `RouteGuard` and
`usePermissions().hasSystemScope()` both short-circuit on `isOwner`. The result is an owner who can query
`/admin/graphql` fine and can still reach the pages by URL, but cannot see them in the navigation.

Fresh installs mask the problem because initialization stores `["*"]` for the owner
(`internal/server/biz/system.go`), but installs upgraded from older versions end up with an owner locked out
of the admin navigation.

This restores the owner shortcut for system-level routes; project-owner behaviour is unchanged.

The repository's frontend unit tests run through `node --test src/**/*.test.mjs` with no React renderer
available, so this change is not covered by a unit test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Owners now receive immediate access to routes when they have the required permissions.
  * Route access checks remain enforced for project ownership and scope-level permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->