### PR TITLE
fix(channel): write UTC updated_at when saving model prices

### DIFF
--- a/internal/ent/migrate/datamigrate/v1.0.0-beta9.go
+++ b/internal/ent/migrate/datamigrate/v1.0.0-beta9.go
@@ -25,13 +25,27 @@ func (v *V1_0_0_Beta9) Version() string {
 	return "v1.0.0-beta9"
 }
 
-// Migrate purges the stale settings.providerQuota key from channels.
+// Migrate performs the v1.0.0-beta9 data cleanup:
 //
-// The old OpenCode Go quota checker stored workspaceId and a live auth cookie
-// under settings.providerQuota.opencodeGo. Quota now uses the official usage
-// API keyed by the channel's own API key, so the key is never read again and
-// must not linger in the database (it may hold a live session credential).
-func (v *V1_0_0_Beta9) Migrate(ctx context.Context, client *ent.Client) (err error) {
+//  1. Purges the stale settings.providerQuota key from channels.
+//     The old OpenCode Go quota checker stored workspaceId and a live auth cookie
+//     under settings.providerQuota.opencodeGo. Quota now uses the official usage
+//     API keyed by the channel's own API key, so the key is never read again and
+//     must not linger in the database (it may hold a live session credential).
+//
+//  2. Strips the monotonic-clock suffix from channel updated_at values.
+//     Setting a model price used to write time.Now() (with its "m=" monotonic
+//     reading and local timezone) into channels.updated_at. The SQLite driver
+//     serializes such values with time.Time.String(), persisting e.g.
+//     "2026-08-18 00:13:11.396794292 +0800 CST m=+0.000011483" instead of the
+//     canonical UTC format produced by the updated_at mixin (xtime.UTCNow).
+//     When UpdateChannel later edits type/baseURL it snapshots updated_at and
+//     appends WHERE updated_at = <snapshot>; the driver drops the "m=+..."
+//     suffix on scan, so the re-serialized value never matches the stored
+//     string and every update fails with "channel was updated concurrently".
+//     This rewrites affected rows to the same string the driver produces after
+//     a round-trip, making the optimistic-lock comparison consistent again.
+func (v *V1_0_0_Beta9) Migrate(ctx context.Context, client *ent.Client) (retErr error) {
 	ctx = authz.WithSystemBypass(ctx, "database-migrate")
 
 	// Use the dialect.Driver.Exec interface rather than asserting a concrete
@@ -40,6 +54,14 @@ func (v *V1_0_0_Beta9) Migrate(ctx context.Context, client *ent.Client) (err err
 	// dialect.Driver.Exec (routing writes to the master).
 	dialectName := client.Driver().Dialect()
 
+	if retErr = v.purgeProviderQuota(ctx, client, dialectName); retErr != nil {
+		return retErr
+	}
+	return v.stripMonotonicUpdatedAt(ctx, client, dialectName)
+}
+
+// purgeProviderQuota removes the obsolete settings.providerQuota key.
+func (v *V1_0_0_Beta9) purgeProviderQuota(ctx context.Context, client *ent.Client, dialectName string) error {
 	var stmt string
 	switch dialectName {
 	case dialect.Postgres:
@@ -54,17 +76,45 @@ func (v *V1_0_0_Beta9) Migrate(ctx context.Context, client *ent.Client) (err err
 		return nil
 	}
 
+	return v.execWithAffectedLog(ctx, client, stmt,
+		"failed to purge settings.providerQuota",
+		"Purged stale settings.providerQuota from channels")
+}
+
+// stripMonotonicUpdatedAt removes the " m=+..." monotonic suffix from
+// channels.updated_at values written by the old channel_price.go time.Now().
+func (v *V1_0_0_Beta9) stripMonotonicUpdatedAt(ctx context.Context, client *ent.Client, dialectName string) error {
+	var stmt string
+	switch dialectName {
+	case dialect.Postgres:
+		stmt = `UPDATE channels SET updated_at = split_part(updated_at, ' m=', 1) WHERE updated_at LIKE '% m=%'`
+	case dialect.SQLite:
+		stmt = `UPDATE channels SET updated_at = substr(updated_at, 1, instr(updated_at, ' m=') - 1) WHERE updated_at LIKE '% m=%'`
+	default:
+		// MySQL/MariaDB and other dialects are not in scope for this cleanup;
+		// the "m=" suffix only ever originates from the default driver format.
+		log.Info(ctx, "Unsupported dialect, skipping channel updated_at monotonic cleanup",
+			log.String("dialect", dialectName))
+		return nil
+	}
+
+	return v.execWithAffectedLog(ctx, client, stmt,
+		"failed to strip monotonic suffix from channels.updated_at",
+		"Stripped monotonic suffix from channels.updated_at")
+}
+
+// execWithAffectedLog runs a raw UPDATE and logs the number of affected rows.
+func (v *V1_0_0_Beta9) execWithAffectedLog(ctx context.Context, client *ent.Client, stmt, errMsg, logMsg string) error {
 	var result sql.Result
 	if err := client.Driver().Exec(ctx, stmt, []any{}, &result); err != nil {
-		return fmt.Errorf("failed to purge settings.providerQuota: %w", err)
+		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
 	affected, err := result.RowsAffected()
 	if err != nil {
-		log.Warn(ctx, "failed to read affected rows after providerQuota purge", log.Cause(err))
+		log.Warn(ctx, "failed to read affected rows", log.Cause(err))
 	} else {
-		log.Info(ctx, "Purged stale settings.providerQuota from channels",
-			log.Int64("affected", affected))
+		log.Info(ctx, logMsg, log.Int64("affected", affected))
 	}
 
 	return nil

--- a/internal/ent/migrate/datamigrate/v1.0.0-beta9_test.go
+++ b/internal/ent/migrate/datamigrate/v1.0.0-beta9_test.go
@@ -131,3 +131,108 @@ func TestV1_0_0_Beta9_LeavesUntouchedChannelsAlone(t *testing.T) {
 }
 
 func int64Ptr(v int64) *int64 { return &v }
+
+// dirtyUpdatedAt mimics the corrupted value channel_price.go used to persist:
+// time.Now() (monotonic suffix "m=+..." plus local timezone) serialized by the
+// SQLite driver via time.Time.String().
+const dirtyUpdatedAt = "2026-08-18 00:13:11.396794292 +0800 CST m=+0.000011483"
+
+// cleanedUpdatedAt is dirtyUpdatedAt with the monotonic suffix stripped, i.e.
+// the exact string the driver produces after a scan round-trip. The optimistic
+// lock in UpdateChannel compares against this value via updated_at = ?.
+const cleanedUpdatedAt = "2026-08-18 00:13:11.396794292 +0800 CST"
+
+// updatedAtMatches simulates the optimistic-lock comparison UpdateChannel
+// performs: WHERE updated_at = <snapshot>. Returns how many rows match.
+func updatedAtMatches(t *testing.T, driver *entsql.Driver, id int, updatedAt string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, driver.DB().QueryRowContext(context.Background(),
+		"SELECT count(*) FROM channels WHERE id = ? AND updated_at = ?", id, updatedAt).Scan(&n))
+	return n
+}
+
+func TestV1_0_0_Beta9_StripsMonotonicSuffixFromUpdatedAt(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:beta9-updated-at?mode=memory&_fk=1")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+
+	ch := client.Channel.Create().
+		SetName("dirty-updated-at").
+		SetType(channel.TypeOpenai).
+		SetCredentials(objects.ChannelCredentials{APIKey: "sk-test"}).
+		SetSupportedModels([]string{"test-model"}).
+		SetDefaultTestModel("test-model").
+		SaveX(ctx)
+
+	driver := client.Driver().(*entsql.Driver)
+	_, err := driver.ExecContext(ctx,
+		"UPDATE channels SET updated_at = ? WHERE id = ?", dirtyUpdatedAt, ch.ID)
+	require.NoError(t, err)
+
+	// Before migration the optimistic lock can never match: the stored value
+	// still carries the "m=+..." suffix.
+	require.Equal(t, 0, updatedAtMatches(t, driver, ch.ID, cleanedUpdatedAt))
+
+	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
+
+	// After migration the cleaned snapshot matches, so UpdateChannel recovers.
+	require.Equal(t, 1, updatedAtMatches(t, driver, ch.ID, cleanedUpdatedAt))
+	// The raw dirty value is gone.
+	require.Equal(t, 0, updatedAtMatches(t, driver, ch.ID, dirtyUpdatedAt))
+}
+
+func TestV1_0_0_Beta9_PreservesCleanUpdatedAt(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:beta9-clean-updated-at?mode=memory&_fk=1")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+
+	ch := client.Channel.Create().
+		SetName("clean-updated-at").
+		SetType(channel.TypeOpenai).
+		SetCredentials(objects.ChannelCredentials{APIKey: "sk-test"}).
+		SetSupportedModels([]string{"test-model"}).
+		SetDefaultTestModel("test-model").
+		SaveX(ctx)
+
+	clean := "2026-08-18 00:13:11.396794292 +0000 UTC"
+	driver := client.Driver().(*entsql.Driver)
+	_, err := driver.ExecContext(ctx,
+		"UPDATE channels SET updated_at = ? WHERE id = ?", clean, ch.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
+
+	// Unaffected rows still satisfy the optimistic lock.
+	require.Equal(t, 1, updatedAtMatches(t, driver, ch.ID, clean))
+}
+
+func TestV1_0_0_Beta9_StripsMonotonicSuffixIsIdempotent(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:beta9-updated-at-idem?mode=memory&_fk=1")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+
+	ch := client.Channel.Create().
+		SetName("dirty-updated-at-idem").
+		SetType(channel.TypeOpenai).
+		SetCredentials(objects.ChannelCredentials{APIKey: "sk-test"}).
+		SetSupportedModels([]string{"test-model"}).
+		SetDefaultTestModel("test-model").
+		SaveX(ctx)
+
+	driver := client.Driver().(*entsql.Driver)
+	_, err := driver.ExecContext(ctx,
+		"UPDATE channels SET updated_at = ? WHERE id = ?", dirtyUpdatedAt, ch.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
+	require.Equal(t, 1, updatedAtMatches(t, driver, ch.ID, cleanedUpdatedAt))
+
+	// Running again must not corrupt anything further.
+	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
+	require.Equal(t, 1, updatedAtMatches(t, driver, ch.ID, cleanedUpdatedAt))
+	require.Equal(t, 0, updatedAtMatches(t, driver, ch.ID, dirtyUpdatedAt))
+}

--- a/internal/server/biz/channel_price.go
+++ b/internal/server/biz/channel_price.go
@@ -17,6 +17,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/model"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/pkg/xtime"
 	"github.com/looplj/axonhub/internal/scopes"
 )
 
@@ -197,7 +198,7 @@ func (svc *ChannelService) applyChannelModelPriceTemplates(
 	templates []channelModelPriceTemplate,
 ) (bool, error) {
 	changed := false
-	now := time.Now()
+	now := xtime.UTCNow()
 	for _, template := range templates {
 		created, err := svc.createChannelModelPriceIfMissing(ctx, channelID, template, now)
 		if err != nil {
@@ -401,7 +402,7 @@ func (svc *ChannelService) SaveChannelModelPrices(
 
 	var (
 		results []*ent.ChannelModelPrice
-		now     = time.Now()
+		now     = xtime.UTCNow()
 	)
 
 	err = svc.RunInTransaction(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
# 修复渠道修改模型价格后 type/baseURL 永久无法更新的问题

## 摘要

修复 #2248。设置模型价格时，`channel_price.go` 用 `time.Now()`（携带 monotonic
计数 `m=+...` 和本地时区）并通过 `SetUpdatedAt` 显式写入 `channels.updated_at`，
覆盖了 `updated_at` mixin 的默认值（`xtime.UTCNow`）。SQLite 驱动用
`time.Time.String()` 序列化，持久化出类似这样的脏值：

```
2026-08-18 00:13:11.396794292 +0800 CST m=+0.000011483
```

`UpdateChannel` 在修改 `type`/`baseURL` 时会先快照 `updated_at`，再附加
`WHERE updated_at = ?` 作为乐观锁。驱动在扫描时丢弃 `m=+...` 后缀，导致重绑定的
序列化字符串永远不等于库中存储的字符串，于是每次编辑都永久失败，报错：

```
channel was updated concurrently; retry the operation
```

该问题由 v1.0.0-beta7 引入的乐观锁触发；v1.0.0-beta6 已有脏写入但没有乐观锁，
所以当时修改其他信息仍能成功。

## 改动内容

- **`channel_price.go`**：模型价格保存时间戳改用 `xtime.UTCNow()`
  （涉及 `updated_at`、`effective_start_at`、`effective_end_at`），与 `updated_at`
  mixin 默认值保持一致，保证序列化往返稳定。
- **`datamigrate v1.0.0-beta9` 迁移**：自动剥离历史污染的 `channels.updated_at`
  中残留的 ` m=+...` 单调后缀（SQLite 与 Postgres），启动时自动执行。幂等，
  不触碰干净数据。

## 验证

- `datamigrate` 全量测试通过（含 3 个新用例：剥离脏后缀、保留干净值、幂等性）。
- `biz` 包编译通过，渠道模型价格相关测试通过。

## 升级说明

存量部署下次启动时自动修复，无需手工 SQL。迁移只处理携带损坏后缀的行。

fix #2248 