### PR TITLE
fix: restore meta muse lineup in model catalog

### DIFF
--- a/frontend/src/features/models/data/providers.json
+++ b/frontend/src/features/models/data/providers.json
@@ -3982,11 +3982,224 @@
     },
     "meta": {
       "id": "meta",
-      "api": "https://api.llama.com/compat/v1/",
+      "api": "https://api.meta.ai/v1",
       "name": "Meta",
-      "doc": "https://llama.developer.meta.com/docs/models",
+      "doc": "https://dev.meta.ai/docs",
       "display_name": "Meta",
       "models": [
+        {
+          "id": "muse-glimmer-30b",
+          "name": "Muse Glimmer 30B",
+          "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
+          "family": "muse",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "knowledge": "2026-01",
+          "release_date": "2026-08-10",
+          "last_updated": "2026-08-10",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": true,
+          "limit": {
+            "context": 131072,
+            "output": 131072
+          },
+          "cost": {
+            "input": 0,
+            "output": 0
+          },
+          "display_name": "Muse Glimmer 30B",
+          "type": "chat"
+        },
+        {
+          "id": "muse-spark-1.2",
+          "name": "Muse Spark 1.2",
+          "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+          "family": "muse",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2026-08-05",
+          "last_updated": "2026-08-05",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1048576,
+            "output": 131072
+          },
+          "cost": {
+            "input": 1.25,
+            "output": 4.25,
+            "cache_read": 0.15
+          },
+          "display_name": "Muse Spark 1.2",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          }
+        },
+        {
+          "id": "muse-spark-1.2-contributor",
+          "name": "Muse Spark 1.2 Contributor",
+          "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+          "family": "muse",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2026-08-05",
+          "last_updated": "2026-08-05",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1048576,
+            "output": 131072
+          },
+          "cost": {
+            "input": 0.1,
+            "output": 0.2,
+            "cache_read": 0.002
+          },
+          "display_name": "Muse Spark 1.2 Contributor",
+          "type": "chat"
+        },
+        {
+          "id": "muse-spark-1.1",
+          "name": "Muse Spark 1.1",
+          "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+          "family": "muse",
+          "attachment": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "temperature": true,
+          "release_date": "2026-04-08",
+          "last_updated": "2026-07-09",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 1000000,
+            "output": 32000
+          },
+          "cost": {
+            "input": 1.25,
+            "output": 4.25,
+            "cache_read": 0.15
+          },
+          "display_name": "Muse Spark 1.1",
+          "type": "chat",
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          }
+        },
         {
           "id": "llama-4-scout-17b-16e-instruct-fp8",
           "name": "Llama-4-Scout-17B-16E-Instruct-FP8",

--- a/scripts/sync/models.json
+++ b/scripts/sync/models.json
@@ -1011,6 +1011,56 @@
       "vision": true
     }
   ],
+  "meta": [
+    {
+      "id": "muse-glimmer-30b",
+      "name": "Muse Glimmer 30B",
+      "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
+      "family": "muse",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ]
+        }
+      ],
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "knowledge": "2026-01",
+      "release_date": "2026-08-10",
+      "last_updated": "2026-08-10",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "open_weights": true,
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "display_name": "Muse Glimmer 30B",
+      "type": "chat"
+    }
+  ],
   "thinkingmachines": {
     "id": "thinkingmachines",
     "name": "Thinking Machines",

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -285,22 +285,37 @@ function filterProviders(data, allowedIds) {
 		}
 	}
 
-	// Map llama channel's llama models to meta developer
-	if (allowedIds.includes("meta") && data.providers.llama) {
-		const llamaProvider = data.providers.llama;
-		const llamaModels = (llamaProvider.models || []).filter((m) =>
-			m.id?.toLowerCase().startsWith("llama"),
-		);
-		if (llamaModels.length > 0) {
+	// Build meta developer from upstream meta provider (Meta Model API,
+	// carries the Muse lineup) plus llama channel's llama models
+	if (allowedIds.includes("meta")) {
+		const metaModels = new Map();
+		const upstreamMeta = data.providers.meta || null;
+
+		if (upstreamMeta) {
+			for (const model of upstreamMeta.models || []) {
+				metaModels.set(model.id, deepClone(model));
+			}
+		}
+
+		if (data.providers.llama) {
+			for (const model of data.providers.llama.models || []) {
+				if (!model.id?.toLowerCase().startsWith("llama")) continue;
+				if (!metaModels.has(model.id)) {
+					metaModels.set(model.id, deepClone(model));
+				}
+			}
+		}
+
+		if (metaModels.size > 0) {
 			filtered.meta = {
-				...llamaProvider,
+				...(upstreamMeta || data.providers.llama || {}),
 				id: "meta",
 				name: "Meta",
 				display_name: "Meta",
-				models: llamaModels,
+				models: Array.from(metaModels.values()),
 			};
 			console.log(
-				`Mapped ${llamaModels.length} llama models to meta developer`,
+				`Merged ${metaModels.size} models (muse + llama) into meta developer`,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

Restores Meta's Muse lineup (muse-glimmer-30b and the Muse Spark releases) to the Meta developer entry in the model catalog, and fixes the sync pipeline so it no longer drops the upstream Muse models on every run. The Meta provider entry also points at the current Meta API base (api.meta.ai/v1) instead of the legacy llama compatibility endpoints.

## Motivation

The sync script built the meta developer from the llama channel only, which overwrote the upstream meta provider and dropped the entire Muse lineup on every sync. The provider endpoint had likewise been left on the old llama API. muse-glimmer-30b is a recent open-weight release not yet present in the upstream feed, so it needed manual curation into the sync list as well.

## Changes

- The model catalog now lists the full Muse lineup under the Meta developer: muse-glimmer-30b plus the Muse Spark 1.1 and 1.2 releases, each with reasoning effort options, context/output limits, input modalities, and pricing.
- The sync pipeline merges the upstream meta provider models with the llama channel models instead of mapping llama only, so the Muse lineup survives future sync runs.
- The Meta provider entry uses the current Meta API base URL and its new documentation page.

## Notes

- The catalog change is scoped to the meta provider block only, avoiding a full 16k-line feed re-sync; the diff is small and reviewable.
- muse-glimmer-30b is listed with zero input/output cost because it is open-weight and Meta does not publish a native API price for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Meta’s Muse model family, including Muse Glimmer 30B and Muse Spark variants.
  * Added multimodal, reasoning, tool-use, structured-output, and open-weights capability details.
  * Updated Meta provider links and API configuration.
  * Added model pricing, usage limits, and release metadata.
  * Improved synchronization of Meta and Llama model listings while preventing duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->