### PR TITLE
opt: gemini channel compatible

### DIFF
--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -825,6 +825,26 @@ func TestWriteSSEStream_IncompleteStreamReportsErrorWithHeartbeat(t *testing.T) 
 	require.Contains(t, body, orchestrator.ErrStreamIncomplete.Error())
 }
 
+// Gemini generateContent streams terminate with candidates[].finishReason and
+// never send [DONE]. Treating that as incomplete appends a trailing error that
+// Gemini SDKs surface as StreamException.
+func TestWriteSSEStream_GeminiFinishReasonIsNotIncomplete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"hello"}]}}]}`)},
+		{Data: []byte(`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"world!"}]},"finishReason":"STOP"}]}`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	body := w.Body.String()
+	require.NotContains(t, body, "event:error")
+	require.NotContains(t, body, orchestrator.ErrStreamIncomplete.Error())
+}
+
 // A stream that carries finish_reason but no [DONE] is already complete; clients
 // commonly close right after that chunk, so it must not be flagged as incomplete.
 func TestWriteSSEStream_FinishReasonWithoutDoneIsNotIncomplete(t *testing.T) {

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -119,15 +119,26 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 		return true
 	}
 
-	choices := gjson.GetBytes(event.Data, "choices")
-	if !choices.IsArray() {
+	// OpenAI chat completions: choices[].finish_reason
+	if hasNonEmptyJSONStringField(event.Data, "choices", "finish_reason") {
+		return true
+	}
+
+	// Gemini generateContent streams have no [DONE] sentinel. Completion is
+	// signaled by candidates[].finishReason (e.g. STOP, MAX_TOKENS, SAFETY).
+	return hasNonEmptyJSONStringField(event.Data, "candidates", "finishReason")
+}
+
+func hasNonEmptyJSONStringField(data []byte, arrayPath, field string) bool {
+	arr := gjson.GetBytes(data, arrayPath)
+	if !arr.IsArray() {
 		return false
 	}
 
 	completed := false
-	choices.ForEach(func(_, choice gjson.Result) bool {
-		finishReason := choice.Get("finish_reason")
-		completed = finishReason.Type == gjson.String && finishReason.String() != ""
+	arr.ForEach(func(_, item gjson.Result) bool {
+		value := item.Get(field)
+		completed = value.Type == gjson.String && value.String() != ""
 
 		return !completed
 	})

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -365,6 +365,26 @@ func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "gemini finish reason stop",
+			event: &httpclient.StreamEvent{Data: []byte(`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"world!"}]},"finishReason":"STOP"}]}`)},
+			want:  true,
+		},
+		{
+			name:  "gemini finish reason max tokens",
+			event: &httpclient.StreamEvent{Data: []byte(`{"candidates":[{"index":0,"finishReason":"MAX_TOKENS"}]}`)},
+			want:  true,
+		},
+		{
+			name:  "gemini chunk without finish reason",
+			event: &httpclient.StreamEvent{Data: []byte(`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"hello"}]}}]}`)},
+			want:  false,
+		},
+		{
+			name:  "gemini empty finish reason",
+			event: &httpclient.StreamEvent{Data: []byte(`{"candidates":[{"index":0,"finishReason":""}]}`)},
+			want:  false,
+		},
+		{
 			name:  "non-terminal responses event",
 			event: &httpclient.StreamEvent{Data: []byte(`{"type":"response.output_text.delta","delta":"done"}`)},
 			want:  false,

--- a/llm/transformer/gemini/outbound_stream.go
+++ b/llm/transformer/gemini/outbound_stream.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
-	"github.com/looplj/axonhub/llm/transformer"
 )
 
 // streamState tracks state across streaming events.
 type streamState struct {
 	toolCallIndex int
+	responseID    string
 }
 
 // TransformStream transforms the HTTP stream response to the unified response format.
@@ -63,11 +64,15 @@ func (t *OutboundTransformer) transformStreamChunkWithState(
 		return nil, err
 	}
 
-	// Check if the response is valid.
-	// Gemini response empty event for some time, we should return error instead of continue to process.
-	if resp.ResponseID == "" {
-		return nil, transformer.ErrInvalidResponse
+	// Gemini does not guarantee responseId in every streaming chunk. Keep one
+	// stable ID for the whole stream so downstream clients can correlate chunks.
+	if state.responseID == "" {
+		state.responseID = resp.ResponseID
+		if state.responseID == "" {
+			state.responseID = "chatcmpl-" + uuid.NewString()
+		}
 	}
+	resp.ResponseID = state.responseID
 
 	// Convert to unified response format (streaming) with tool call index tracking
 	llmResp, nextIndex := convertGeminiToLLMResponseWithState(&resp, true, state.toolCallIndex)

--- a/llm/transformer/gemini/outbound_stream_test.go
+++ b/llm/transformer/gemini/outbound_stream_test.go
@@ -264,6 +264,58 @@ func TestOutboundTransformer_TransformStream(t *testing.T) {
 	require.Equal(t, ", world!", *results[1].Choices[0].Delta.Content.Content)
 }
 
+func TestOutboundTransformer_TransformStream_AllowsMissingResponseID(t *testing.T) {
+	transformer := &OutboundTransformer{
+		config: Config{
+			BaseURL:    DefaultBaseURL,
+			APIVersion: DefaultAPIVersion,
+		},
+	}
+
+	events := []*httpclient.StreamEvent{
+		{
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.5-flash",
+				Candidates: []*Candidate{{
+					Index: 0,
+					Content: &Content{
+						Role:  "model",
+						Parts: []*Part{{Text: "第一段"}},
+					},
+				}},
+			}),
+		},
+		{
+			Data: mustMarshal(&GenerateContentResponse{
+				ModelVersion: "gemini-2.5-flash",
+				Candidates: []*Candidate{{
+					Index: 0,
+					Content: &Content{
+						Role:  "model",
+						Parts: []*Part{{Text: "第二段"}},
+					},
+					FinishReason: "STOP",
+				}},
+			}),
+		},
+	}
+
+	stream, err := transformer.TransformStream(context.Background(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	var responses []*llm.Response
+	for stream.Next() {
+		if response := stream.Current(); response != nil && response.Object != "[DONE]" {
+			responses = append(responses, response)
+		}
+	}
+
+	require.NoError(t, stream.Err())
+	require.Len(t, responses, 2)
+	require.NotEmpty(t, responses[0].ID)
+	require.Equal(t, responses[0].ID, responses[1].ID)
+}
+
 func TestOutboundTransformer_TransformStream_ToolCallIndexAccumulation(t *testing.T) {
 	transformer := &OutboundTransformer{
 		config: Config{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gemini streaming responses now complete correctly when a finish reason is provided, even without a `[DONE]` marker.
  - Gemini streams without a response ID no longer fail and now receive a consistent generated ID across chunks.
  - Improved detection of terminal events for OpenAI and Gemini streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->