### PR TITLE
fix: should reload channels after txn commited, close  #2256

### DIFF
--- a/internal/server/biz/channel.go
+++ b/internal/server/biz/channel.go
@@ -985,7 +985,7 @@ func (svc *ChannelService) UpdateChannelStatus(ctx context.Context, id int, stat
 		return nil, fmt.Errorf("failed to update channel status: %w", err)
 	}
 
-	svc.asyncReloadChannels()
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return channel, nil
 }
@@ -1034,7 +1034,7 @@ func (svc *ChannelService) SaveChannelEndpoints(ctx context.Context, input SaveC
 		return nil, fmt.Errorf("failed to update channel endpoints: %w", err)
 	}
 
-	svc.asyncReloadChannels()
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return ch, nil
 }
@@ -1046,7 +1046,7 @@ func (svc *ChannelService) DeleteChannel(ctx context.Context, id int) error {
 	}
 
 	svc.forgetLimiter(id)
-	svc.asyncReloadChannels()
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return nil
 }

--- a/internal/server/biz/channel_bulk.go
+++ b/internal/server/biz/channel_bulk.go
@@ -35,7 +35,10 @@ func (svc *ChannelService) BulkUpdateChannelOrdering(ctx context.Context, items 
 		updatedChannels = append(updatedChannels, channel)
 	}
 
-	svc.asyncReloadChannels()
+	// The GraphQL Transactioner wraps this mutation in an Ent transaction, so the
+	// refresh must wait for commit: reloading before commit would read a stale
+	// ordering_weight snapshot and keep failover chains on the old ordering.
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return updatedChannels, nil
 }
@@ -189,7 +192,9 @@ func (svc *ChannelService) bulkUpdateChannelStatus(ctx context.Context, ids []in
 		return fmt.Errorf("failed to %s channels: %w", action, err)
 	}
 
-	svc.asyncReloadChannels()
+	// Refresh only after the surrounding transaction commits, otherwise a reload
+	// could observe the pre-commit snapshot (see BulkUpdateChannelOrdering).
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return nil
 }
@@ -230,7 +235,7 @@ func (svc *ChannelService) BulkDeleteChannels(ctx context.Context, ids []int) er
 	}
 
 	log.Info(ctx, "bulk deleted channels", log.Int("count", deleted))
-	svc.asyncReloadChannels()
+	svc.reloadChannelsAfterCommit(ctx)
 
 	return nil
 }
@@ -326,7 +331,7 @@ func (svc *ChannelService) BulkImportChannels(ctx context.Context, items []*Bulk
 	}
 
 	if created > 0 {
-		svc.asyncReloadChannels()
+		svc.reloadChannelsAfterCommit(ctx)
 	}
 
 	success := failed == 0

--- a/internal/server/biz/channel_bulk_test.go
+++ b/internal/server/biz/channel_bulk_test.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/pkg/xcache/live"
 )
 
 func TestChannelService_BulkEnableChannels(t *testing.T) {
@@ -348,4 +350,199 @@ func TestChannelService_BulkArchiveChannels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createBulkOrderingTestChannel(t *testing.T, ctx context.Context, client *ent.Client, name string, weight int) *ent.Channel {
+	t.Helper()
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName(name).
+		SetBaseURL("https://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "key-" + name}).
+		SetSupportedModels([]string{"gpt-4"}).
+		SetDefaultTestModel("gpt-4").
+		SetStatus(channel.StatusEnabled).
+		SetOrderingWeight(weight).
+		Save(ctx)
+	require.NoError(t, err)
+
+	return ch
+}
+
+// The GraphQL Transactioner wraps bulkUpdateChannelOrdering in a caller-owned
+// transaction. The cache refresh must be published only after that transaction
+// commits, otherwise the asynchronous reload can read a stale ordering_weight
+// snapshot and keep failover chains on the old ordering (issue #2256).
+func TestChannelService_BulkUpdateChannelOrdering_DefersReloadUntilCommit(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+
+	ch1 := createBulkOrderingTestChannel(t, ctx, client, "Ordering Commit 1", 10)
+	ch2 := createBulkOrderingTestChannel(t, ctx, client, "Ordering Commit 2", 20)
+
+	notifier := &channelSyncNotifierSpy{}
+	svc.channelNotifier = notifier
+	previousAsyncReloadDisabled := asyncReloadDisabled
+	asyncReloadDisabled = false
+	t.Cleanup(func() {
+		asyncReloadDisabled = previousAsyncReloadDisabled
+	})
+
+	tx, err := client.Tx(ctx)
+	require.NoError(t, err)
+	txCtx := ent.NewTxContext(ctx, tx)
+	txCtx = ent.NewContext(txCtx, tx.Client())
+
+	updated, err := svc.BulkUpdateChannelOrdering(txCtx, []*ChannelOrderingItem{
+		{ID: ch1.ID, OrderingWeight: 100},
+		{ID: ch2.ID, OrderingWeight: 50},
+	})
+	require.NoError(t, err)
+	require.Len(t, updated, 2)
+
+	// Before commit no refresh may be published: an asynchronous reload at this
+	// point could read the uncommitted transaction or the stale ordering
+	// snapshot and keep failover chains on the old ordering.
+	require.Zero(t, notifier.notifyCount, "cache refresh must not be published before the transaction commits")
+
+	require.NoError(t, tx.Commit())
+
+	// After commit exactly one force refresh is delivered.
+	require.Equal(t, 1, notifier.notifyCount)
+
+	committed1, err := client.Channel.Get(ctx, ch1.ID)
+	require.NoError(t, err)
+	require.Equal(t, 100, committed1.OrderingWeight)
+	committed2, err := client.Channel.Get(ctx, ch2.ID)
+	require.NoError(t, err)
+	require.Equal(t, 50, committed2.OrderingWeight)
+}
+
+func TestChannelService_BulkUpdateChannelOrdering_NoReloadOnRollback(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+
+	ch1 := createBulkOrderingTestChannel(t, ctx, client, "Ordering Rollback 1", 10)
+
+	notifier := &channelSyncNotifierSpy{}
+	svc.channelNotifier = notifier
+	previousAsyncReloadDisabled := asyncReloadDisabled
+	asyncReloadDisabled = false
+	t.Cleanup(func() {
+		asyncReloadDisabled = previousAsyncReloadDisabled
+	})
+
+	tx, err := client.Tx(ctx)
+	require.NoError(t, err)
+	txCtx := ent.NewTxContext(ctx, tx)
+	txCtx = ent.NewContext(txCtx, tx.Client())
+
+	_, err = svc.BulkUpdateChannelOrdering(txCtx, []*ChannelOrderingItem{
+		{ID: ch1.ID, OrderingWeight: 100},
+	})
+	require.NoError(t, err)
+	require.Zero(t, notifier.notifyCount)
+
+	require.NoError(t, tx.Rollback())
+
+	// A rolled-back ordering change must not trigger any cache refresh, and
+	// the database keeps the old weight.
+	require.Zero(t, notifier.notifyCount)
+	unchanged, err := client.Channel.Get(ctx, ch1.ID)
+	require.NoError(t, err)
+	require.Equal(t, 10, unchanged.OrderingWeight)
+}
+
+func TestChannelService_BulkStatusAndDelete_DefersReloadUntilCommit(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+
+	ch1 := createBulkOrderingTestChannel(t, ctx, client, "Status Commit 1", 10)
+	ch2 := createBulkOrderingTestChannel(t, ctx, client, "Status Commit 2", 20)
+
+	notifier := &channelSyncNotifierSpy{}
+	svc.channelNotifier = notifier
+	previousAsyncReloadDisabled := asyncReloadDisabled
+	asyncReloadDisabled = false
+	t.Cleanup(func() {
+		asyncReloadDisabled = previousAsyncReloadDisabled
+	})
+
+	// Bulk status change inside a caller-owned transaction.
+	tx, err := client.Tx(ctx)
+	require.NoError(t, err)
+	txCtx := ent.NewTxContext(ctx, tx)
+	txCtx = ent.NewContext(txCtx, tx.Client())
+
+	require.NoError(t, svc.BulkDisableChannels(txCtx, []int{ch1.ID}))
+	require.Zero(t, notifier.notifyCount, "bulk status change must not refresh before commit")
+
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, notifier.notifyCount)
+
+	// Bulk delete inside a caller-owned transaction.
+	tx2, err := client.Tx(ctx)
+	require.NoError(t, err)
+	txCtx2 := ent.NewTxContext(ctx, tx2)
+	txCtx2 = ent.NewContext(txCtx2, tx2.Client())
+
+	require.NoError(t, svc.BulkDeleteChannels(txCtx2, []int{ch2.ID}))
+	require.Equal(t, 1, notifier.notifyCount, "bulk delete must not refresh before commit")
+
+	require.NoError(t, tx2.Commit())
+	require.Equal(t, 2, notifier.notifyCount)
+}
+
+// After the ordering transaction commits, a cache reload must produce a
+// snapshot ordered by the newly committed ordering_weight values.
+func TestChannelService_BulkUpdateChannelOrdering_CacheSnapshotUsesCommittedWeights(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+
+	ch1 := createBulkOrderingTestChannel(t, ctx, client, "Ordering Snapshot 1", 10)
+	ch2 := createBulkOrderingTestChannel(t, ctx, client, "Ordering Snapshot 2", 20)
+
+	// Install a real cache backed by reloadEnabledChannels so the snapshot is
+	// rebuilt from the database on Load.
+	svc.enabledChannelsCache.Stop()
+	svc.enabledChannelsCache = live.NewCache(live.Options[[]*Channel]{
+		Name:            "test_enabled_channels_ordering",
+		InitialValue:    []*Channel{},
+		RefreshInterval: time.Hour,
+		RefreshFunc:     svc.reloadEnabledChannels,
+		OnSwap:          svc.onEnabledChannelsSwap,
+	})
+
+	require.NoError(t, svc.enabledChannelsCache.Load(ctx, true))
+	before := svc.GetEnabledChannels()
+	require.Len(t, before, 2)
+	require.Equal(t, ch2.ID, before[0].ID) // weight 20 ranks first
+	require.Equal(t, ch1.ID, before[1].ID) // weight 10 ranks second
+
+	tx, err := client.Tx(ctx)
+	require.NoError(t, err)
+	txCtx := ent.NewTxContext(ctx, tx)
+	txCtx = ent.NewContext(txCtx, tx.Client())
+
+	_, err = svc.BulkUpdateChannelOrdering(txCtx, []*ChannelOrderingItem{
+		{ID: ch1.ID, OrderingWeight: 100},
+		{ID: ch2.ID, OrderingWeight: 50},
+	})
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, svc.enabledChannelsCache.Load(ctx, true))
+	after := svc.GetEnabledChannels()
+	require.Len(t, after, 2)
+	require.Equal(t, ch1.ID, after[0].ID) // weight 100 now ranks first
+	require.Equal(t, ch2.ID, after[1].ID) // weight 50 now ranks second
 }

--- a/internal/server/biz/channel_override_template.go
+++ b/internal/server/biz/channel_override_template.go
@@ -233,7 +233,7 @@ func (svc *ChannelOverrideTemplateService) ApplyTemplate(
 	}
 
 	if svc.channelService != nil {
-		svc.channelService.asyncReloadChannels()
+		svc.channelService.reloadChannelsAfterCommit(ctx)
 	}
 
 	return updated, nil
@@ -290,7 +290,7 @@ func (svc *ChannelOverrideTemplateService) ClearTemplates(
 	}
 
 	if svc.channelService != nil {
-		svc.channelService.asyncReloadChannels()
+		svc.channelService.reloadChannelsAfterCommit(ctx)
 	}
 
 	return updated, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel changes now refresh availability and ordering data only after successful saves, updates, imports, and deletions.
  * Rolled-back channel changes no longer trigger stale cache refreshes.
  * Channel override template updates now apply cache changes after the transaction completes.
  * Improved consistency between committed channel settings and displayed channel data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->