### PR TITLE
fix: use ping for Responses WebSocket channel tests

### DIFF
--- a/internal/server/orchestrator/tester.go
+++ b/internal/server/orchestrator/tester.go
@@ -83,8 +83,7 @@ func buildChannelTestRequest(model string, useStream bool, systemPrompt string, 
 				Content: llm.MessageContent{Content: lo.ToPtr(userPrompt)},
 			},
 		},
-		MaxCompletionTokens: lo.ToPtr(int64(256)),
-		Stream:              lo.ToPtr(useStream),
+		Stream: lo.ToPtr(useStream),
 	}
 }
 

--- a/internal/server/orchestrator/tester.go
+++ b/internal/server/orchestrator/tester.go
@@ -97,6 +97,7 @@ func buildChannelTestRequest(model string, useStream bool, systemPrompt string, 
 			Content: llm.MessageContent{Content: lo.ToPtr(responsesWebSocketTestPrompt)},
 		}}
 		req.MaxCompletionTokens = nil
+		req.Stream = lo.ToPtr(true)
 	}
 
 	return req

--- a/internal/server/orchestrator/tester.go
+++ b/internal/server/orchestrator/tester.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,8 @@ import (
 )
 
 const testChannelAPIKeysMaxConcurrency = 8
+
+const responsesWebSocketTestPrompt = "ping"
 
 // TestChannelOrchestrator handles channel testing functionality.
 // It is stateless and can be reused across multiple test requests.
@@ -70,9 +73,9 @@ type TestChannelRequest struct {
 	ModelID   *string
 }
 
-// buildChannelTestRequest creates the minimal request used by channel tests.
-func buildChannelTestRequest(model string, useStream bool, systemPrompt string, userPrompt string) *llm.Request {
-	return &llm.Request{
+// buildChannelTestRequest creates the request used by channel tests.
+func buildChannelTestRequest(model string, useStream bool, systemPrompt string, userPrompt string, responsesWebSocket bool) *llm.Request {
+	req := &llm.Request{
 		Model: model,
 		Messages: []llm.Message{
 			{
@@ -84,8 +87,51 @@ func buildChannelTestRequest(model string, useStream bool, systemPrompt string, 
 				Content: llm.MessageContent{Content: lo.ToPtr(userPrompt)},
 			},
 		},
-		Stream: lo.ToPtr(useStream),
+		MaxCompletionTokens: lo.ToPtr(int64(256)),
+		Stream:              lo.ToPtr(useStream),
 	}
+
+	if responsesWebSocket {
+		req.Messages = []llm.Message{{
+			Role:    "user",
+			Content: llm.MessageContent{Content: lo.ToPtr(responsesWebSocketTestPrompt)},
+		}}
+		req.MaxCompletionTokens = nil
+	}
+
+	return req
+}
+
+// usesResponsesWebSocket reports whether a channel routes Responses requests over WebSocket.
+func usesResponsesWebSocket(channel *biz.Channel) bool {
+	if channel == nil {
+		return false
+	}
+
+	for _, endpoint := range channel.ResolveEndpoints() {
+		if endpoint.APIFormat != llm.APIFormatOpenAIResponse.String() && endpoint.APIFormat != llm.APIFormatOpenAIResponseCompact.String() {
+			continue
+		}
+
+		transport := strings.ToLower(strings.TrimSpace(endpoint.Transport))
+		if transport == objects.ChannelEndpointTransportWebSocket {
+			return true
+		}
+		if transport != "" {
+			continue
+		}
+
+		baseURL := endpoint.BaseURL
+		if baseURL == "" {
+			baseURL = channel.BaseURL
+		}
+		baseURL = strings.ToLower(strings.TrimSpace(baseURL))
+		if strings.HasPrefix(baseURL, "ws://") || strings.HasPrefix(baseURL, "wss://") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // TestChannelResult represents the result of a channel test.
@@ -144,7 +190,7 @@ func (processor *TestChannelOrchestrator) TestChannel(
 	// Check if the channel requires streaming
 	useStream := channel != nil && channel.Policies.Stream == objects.CapabilityPolicyRequire
 
-	llmRequest := buildChannelTestRequest(testModel, useStream, systemPrompt, userPrompt)
+	llmRequest := buildChannelTestRequest(testModel, useStream, systemPrompt, userPrompt, usesResponsesWebSocket(channel))
 
 	body, err := json.Marshal(llmRequest)
 	if err != nil {
@@ -340,6 +386,7 @@ func (processor *TestChannelOrchestrator) TestChannelAPIKeys(
 	}
 
 	useStream := ch.Policies.Stream == objects.CapabilityPolicyRequire
+	responsesWebSocket := usesResponsesWebSocket(ch)
 	systemPrompt, userPrompt, err := processor.systemService.ChannelTestPrompts(ctx)
 	if err != nil {
 		return nil, err
@@ -375,7 +422,7 @@ func (processor *TestChannelOrchestrator) TestChannelAPIKeys(
 			default:
 			}
 
-			result := processor.testSingleKey(groupCtx, channelID, apiKey, testModel, useStream, proxy, systemPrompt, userPrompt)
+			result := processor.testSingleKey(groupCtx, channelID, apiKey, testModel, useStream, responsesWebSocket, proxy, systemPrompt, userPrompt)
 			_, isDisabled := disabledSet[apiKey]
 			result.Disabled = isDisabled
 			results[index] = result
@@ -435,6 +482,7 @@ func (processor *TestChannelOrchestrator) TestSingleAPIKey(
 	}
 
 	useStream := ch.Policies.Stream == objects.CapabilityPolicyRequire
+	responsesWebSocket := usesResponsesWebSocket(ch)
 	systemPrompt, userPrompt, err := processor.systemService.ChannelTestPrompts(ctx)
 	if err != nil {
 		return nil, err
@@ -445,7 +493,7 @@ func (processor *TestChannelOrchestrator) TestSingleAPIKey(
 		disabledSet[dk.Key] = struct{}{}
 	}
 
-	result := processor.testSingleKey(ctx, channelID, key, testModel, useStream, proxy, systemPrompt, userPrompt)
+	result := processor.testSingleKey(ctx, channelID, key, testModel, useStream, responsesWebSocket, proxy, systemPrompt, userPrompt)
 	_, isDisabled := disabledSet[key]
 	result.Disabled = isDisabled
 
@@ -459,6 +507,7 @@ func (processor *TestChannelOrchestrator) testSingleKey(
 	key string,
 	testModel string,
 	useStream bool,
+	responsesWebSocket bool,
 	proxy *httpclient.ProxyConfig,
 	systemPrompt string,
 	userPrompt string,
@@ -493,7 +542,7 @@ func (processor *TestChannelOrchestrator) testSingleKey(
 		modelCircuitBreaker:        processor.modelCircuitBreaker,
 	}
 
-	llmRequest := buildChannelTestRequest(testModel, useStream, systemPrompt, userPrompt)
+	llmRequest := buildChannelTestRequest(testModel, useStream, systemPrompt, userPrompt, responsesWebSocket)
 
 	body, err := json.Marshal(llmRequest)
 	if err != nil {

--- a/internal/server/orchestrator/tester.go
+++ b/internal/server/orchestrator/tester.go
@@ -70,6 +70,7 @@ type TestChannelRequest struct {
 	ModelID   *string
 }
 
+// buildChannelTestRequest creates the minimal request used by channel tests.
 func buildChannelTestRequest(model string, useStream bool, systemPrompt string, userPrompt string) *llm.Request {
 	return &llm.Request{
 		Model: model,

--- a/internal/server/orchestrator/tester_test.go
+++ b/internal/server/orchestrator/tester_test.go
@@ -15,6 +15,6 @@ func TestBuildTestRequestUsesConfiguredPrompts(t *testing.T) {
 	require.Equal(t, "system prompt", *req.Messages[0].Content.Content)
 	require.Equal(t, "user", req.Messages[1].Role)
 	require.Equal(t, "user prompt", *req.Messages[1].Content.Content)
-	require.Equal(t, int64(256), *req.MaxCompletionTokens)
+	require.Nil(t, req.MaxCompletionTokens)
 	require.True(t, *req.Stream)
 }

--- a/internal/server/orchestrator/tester_test.go
+++ b/internal/server/orchestrator/tester_test.go
@@ -28,7 +28,7 @@ func TestBuildTestRequestUsesConfiguredPrompts(t *testing.T) {
 
 // TestBuildTestRequestUsesPingForResponsesWebSocket verifies WebSocket tests use a minimal compatible payload.
 func TestBuildTestRequestUsesPingForResponsesWebSocket(t *testing.T) {
-	req := buildChannelTestRequest("test-model", true, "system prompt", "user prompt", true)
+	req := buildChannelTestRequest("test-model", false, "system prompt", "user prompt", true)
 
 	require.Equal(t, "test-model", req.Model)
 	require.Len(t, req.Messages, 1)

--- a/internal/server/orchestrator/tester_test.go
+++ b/internal/server/orchestrator/tester_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBuildTestRequestUsesConfiguredPrompts verifies the channel test request remains minimal.
 func TestBuildTestRequestUsesConfiguredPrompts(t *testing.T) {
 	req := buildChannelTestRequest("test-model", true, "system prompt", "user prompt")
 

--- a/internal/server/orchestrator/tester_test.go
+++ b/internal/server/orchestrator/tester_test.go
@@ -4,11 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
 )
 
-// TestBuildTestRequestUsesConfiguredPrompts verifies the channel test request remains minimal.
+// TestBuildTestRequestUsesConfiguredPrompts verifies ordinary channel tests retain their configured prompts.
 func TestBuildTestRequestUsesConfiguredPrompts(t *testing.T) {
-	req := buildChannelTestRequest("test-model", true, "system prompt", "user prompt")
+	req := buildChannelTestRequest("test-model", true, "system prompt", "user prompt", false)
 
 	require.Equal(t, "test-model", req.Model)
 	require.Len(t, req.Messages, 2)
@@ -16,6 +22,52 @@ func TestBuildTestRequestUsesConfiguredPrompts(t *testing.T) {
 	require.Equal(t, "system prompt", *req.Messages[0].Content.Content)
 	require.Equal(t, "user", req.Messages[1].Role)
 	require.Equal(t, "user prompt", *req.Messages[1].Content.Content)
+	require.Equal(t, int64(256), *req.MaxCompletionTokens)
+	require.True(t, *req.Stream)
+}
+
+// TestBuildTestRequestUsesPingForResponsesWebSocket verifies WebSocket tests use a minimal compatible payload.
+func TestBuildTestRequestUsesPingForResponsesWebSocket(t *testing.T) {
+	req := buildChannelTestRequest("test-model", true, "system prompt", "user prompt", true)
+
+	require.Equal(t, "test-model", req.Model)
+	require.Len(t, req.Messages, 1)
+	require.Equal(t, "user", req.Messages[0].Role)
+	require.Equal(t, responsesWebSocketTestPrompt, *req.Messages[0].Content.Content)
 	require.Nil(t, req.MaxCompletionTokens)
 	require.True(t, *req.Stream)
+}
+
+// TestUsesResponsesWebSocket verifies explicit and URL-inferred WebSocket transports.
+func TestUsesResponsesWebSocket(t *testing.T) {
+	t.Run("inferred from channel base URL", func(t *testing.T) {
+		ch := &biz.Channel{Channel: &ent.Channel{
+			Type:    channel.TypeOpenaiResponses,
+			BaseURL: "wss://api.openai.com/v1",
+		}}
+
+		require.True(t, usesResponsesWebSocket(ch))
+	})
+
+	t.Run("explicit transport", func(t *testing.T) {
+		ch := &biz.Channel{Channel: &ent.Channel{
+			Type:    channel.TypeOpenai,
+			BaseURL: "https://api.example.com/v1",
+			Endpoints: []objects.ChannelEndpoint{{
+				APIFormat: llm.APIFormatOpenAIResponse.String(),
+				Transport: objects.ChannelEndpointTransportWebSocket,
+			}},
+		}}
+
+		require.True(t, usesResponsesWebSocket(ch))
+	})
+
+	t.Run("HTTP transport", func(t *testing.T) {
+		ch := &biz.Channel{Channel: &ent.Channel{
+			Type:    channel.TypeOpenaiResponses,
+			BaseURL: "https://api.openai.com/v1",
+		}}
+
+		require.False(t, usesResponsesWebSocket(ch))
+	})
 }


### PR DESCRIPTION
## 变更

- Responses WebSocket 渠道测试改用单条 `user` 消息，内容固定为 `ping`
- 该测试请求不再设置 `max_completion_tokens`
- 普通 HTTP 渠道继续使用已配置的 system/user prompts 和原有 token 上限
- 单渠道、全 API Key、单 API Key 三条测试路径统一生效

## 验证

- `go test ./internal/server/orchestrator`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connectivity checks for Responses API WebSocket endpoints.
  * WebSocket checks now use a lightweight ping request without unnecessary completion limits.
  * Improved endpoint and transport detection across supported testing flows.
  * Existing request settings, including the selected model, messages, and streaming configuration, remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->