### PR TITLE
fix: use HTTP URL for WebSocket model discovery

### DIFF
--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -647,6 +647,8 @@ func (f *ModelFetcher) prepareModelsEndpoint(channelType channel.Type, baseURL s
 		useRawURL = true
 	}
 
+	baseURL = httpModelsBaseURL(baseURL)
+
 	switch {
 	case channelType.IsAnthropic() || channelType == channel.TypeClaudecode:
 		headers.Set("Anthropic-Version", "2023-06-01")
@@ -708,6 +710,24 @@ func (f *ModelFetcher) prepareModelsEndpoint(channelType channel.Type, baseURL s
 
 		return baseURL + "/v1/models", headers
 	}
+}
+
+// httpModelsBaseURL converts a channel's WebSocket endpoint to the matching
+// HTTP endpoint used by the provider's model listing API.
+func httpModelsBaseURL(baseURL string) string {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
+	}
+
+	switch parsed.Scheme {
+	case "ws":
+		parsed.Scheme = "http"
+	case "wss":
+		parsed.Scheme = "https"
+	}
+
+	return parsed.String()
 }
 
 type GeminiModelResponse struct {

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -335,6 +335,18 @@ func TestPrepareModelsEndpoint(t *testing.T) {
 			expectedURL: "https://custom.api.com/custom/path/models",
 		},
 		{
+			name:        "OpenAI secure WebSocket endpoint",
+			channelType: channel.TypeOpenai,
+			baseURL:     "wss://api.openai.com/v1#",
+			expectedURL: "https://api.openai.com/v1/models",
+		},
+		{
+			name:        "OpenAI WebSocket endpoint",
+			channelType: channel.TypeOpenai,
+			baseURL:     "ws://api.example.com/v1",
+			expectedURL: "http://api.example.com/v1/models",
+		},
+		{
 			name:        "Deepseek",
 			channelType: channel.TypeDeepseek,
 			baseURL:     "https://api.deepseek.com",


### PR DESCRIPTION
## 变更

渠道使用 `ws://`/`wss://` WebSocket 地址时，模型同步和手动获取模型会转换为对应的 `http://`/`https://` 地址，再请求 `/models`。

## 验证

- `go test ./internal/server/biz`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model endpoint handling for WebSocket-based connections.
  * Model requests now correctly use secure or standard HTTP endpoints when configured with `wss://` or `ws://` URLs.

* **Tests**
  * Added coverage for both secure and standard WebSocket URL conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->