### PR TITLE
fix: skip postgres monotonic updated_at cleanup

### DIFF
--- a/internal/ent/migrate/datamigrate/v1.0.0-beta9.go
+++ b/internal/ent/migrate/datamigrate/v1.0.0-beta9.go
@@ -86,13 +86,16 @@ func (v *V1_0_0_Beta9) purgeProviderQuota(ctx context.Context, client *ent.Clien
 func (v *V1_0_0_Beta9) stripMonotonicUpdatedAt(ctx context.Context, client *ent.Client, dialectName string) error {
 	var stmt string
 	switch dialectName {
-	case dialect.Postgres:
-		stmt = `UPDATE channels SET updated_at = split_part(updated_at, ' m=', 1) WHERE updated_at LIKE '% m=%'`
 	case dialect.SQLite:
 		stmt = `UPDATE channels SET updated_at = substr(updated_at, 1, instr(updated_at, ' m=') - 1) WHERE updated_at LIKE '% m=%'`
+	case dialect.Postgres:
+		// PostgreSQL stores updated_at as a typed timestamptz value, so the
+		// legacy SQLite-only " m=+..." string suffix can never exist there.
+		log.Info(ctx, "Skipping channel updated_at monotonic cleanup on PostgreSQL")
+		return nil
 	default:
-		// MySQL/MariaDB and other dialects are not in scope for this cleanup;
-		// the "m=" suffix only ever originates from the default driver format.
+		// SQLite is the only dialect known to have persisted the driver's
+		// time.Time.String() output with a monotonic suffix.
 		log.Info(ctx, "Unsupported dialect, skipping channel updated_at monotonic cleanup",
 			log.String("dialect", dialectName))
 		return nil

--- a/internal/ent/migrate/datamigrate/v1.0.0-beta9_test.go
+++ b/internal/ent/migrate/datamigrate/v1.0.0-beta9_test.go
@@ -3,12 +3,17 @@ package datamigrate_test
 import (
 	"context"
 	"database/sql"
+	sqldriver "database/sql/driver"
+	"errors"
+	"fmt"
 	"testing"
 
+	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/ent/migrate/datamigrate"
@@ -235,4 +240,43 @@ func TestV1_0_0_Beta9_StripsMonotonicSuffixIsIdempotent(t *testing.T) {
 	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
 	require.Equal(t, 1, updatedAtMatches(t, driver, ch.ID, cleanedUpdatedAt))
 	require.Equal(t, 0, updatedAtMatches(t, driver, ch.ID, dirtyUpdatedAt))
+}
+
+type recordingDriver struct {
+	dialect     string
+	execQueries []string
+}
+
+func (d *recordingDriver) Dialect() string { return d.dialect }
+
+func (d *recordingDriver) Close() error { return nil }
+
+func (d *recordingDriver) Tx(context.Context) (dialect.Tx, error) {
+	return nil, errors.New("unexpected tx")
+}
+
+func (d *recordingDriver) Query(context.Context, string, any, any) error {
+	return errors.New("unexpected query")
+}
+
+func (d *recordingDriver) Exec(_ context.Context, query string, _ any, v any) error {
+	d.execQueries = append(d.execQueries, query)
+	result, ok := v.(*sql.Result)
+	if !ok {
+		return fmt.Errorf("expected *sql.Result, got %T", v)
+	}
+	*result = sqldriver.RowsAffected(0)
+	return nil
+}
+
+func TestV1_0_0_Beta9_PostgresSkipsMonotonicUpdatedAtCleanup(t *testing.T) {
+	drv := &recordingDriver{dialect: dialect.Postgres}
+	client := ent.NewClient(ent.Driver(drv))
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+	require.NoError(t, datamigrate.NewV1_0_0_Beta9().Migrate(ctx, client))
+	require.Equal(t, []string{
+		`UPDATE channels SET settings = settings #- '{providerQuota}' WHERE settings ? 'providerQuota'`,
+	}, drv.execQueries)
 }


### PR DESCRIPTION
## Summary
AxonHub can fail to start on PostgreSQL after the `v1.0.0-beta9` migration because the monotonic `updated_at` cleanup was written for SQLite and then run against a typed `timestamptz` column. This PR limits that cleanup to SQLite and adds regression coverage for the PostgreSQL path.

## Motivation
The migration introduced by commit `86eac3a7` began applying a string-based `LIKE '% m=%'` rewrite to `channels.updated_at` for every supported dialect. On PostgreSQL, that column is `timestamptz`, so the statement fails with `operator does not exist: timestamp with time zone ~~ unknown` and the server panics before startup completes.

## Changes
- The `v1.0.0-beta9` migration now only rewrites `channels.updated_at` for SQLite.
- PostgreSQL keeps the original `settings.providerQuota` purge and skips the `updated_at` cleanup with a logged notice.
- Added a regression test proving the PostgreSQL migration executes only the JSONB purge and does not attempt the string-based `updated_at` cleanup.

## Notes
- This is the minimal fix for the production startup failure.
- The breaking commit is `86eac3a7` ("fix(channel): write UTC updated_at when saving model prices (#2257)").
- The new test exercises the migration through a fake driver rather than a live PostgreSQL instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration behavior for PostgreSQL by skipping an unnecessary timestamp cleanup.
  * Preserved timestamp cleanup for SQLite and existing behavior for unsupported database types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->