### PR TITLE
fix(frontend): correct conversation sidebar height

### DIFF
--- a/frontend/src/features/requests/components/request-conversation-viewer.tsx
+++ b/frontend/src/features/requests/components/request-conversation-viewer.tsx
@@ -592,7 +592,7 @@ export function RequestConversationViewer({ body, format, className }: RequestCo
       <div className='grid grid-cols-1 gap-4 lg:grid-cols-[260px_1fr]'>
         {/* Sidebar jump */}
         <div className='hidden lg:block'>
-          <div className='border-border bg-muted/20 sticky top-[72px] max-h-[calc(100vh-100px)] overflow-y-auto rounded-lg border p-2.5'>
+          <div className='border-border bg-muted/20 sticky top-[72px] max-h-[calc(100vh-72px-120px-16px)] overflow-y-auto rounded-lg border p-2.5'>
             {sidebarGroups.map((g) => (
               <div key={g.role} className='mb-1.5'>
                 <div className='text-muted-foreground px-1.5 py-0.5 font-mono text-[10.5px] tracking-wider uppercase'>


### PR DESCRIPTION
## Summary

Fix the sticky conversation sidebar height so its bottom remains visible and scrollable.

## Before

<img width="2560" height="1528" alt="Request detail page with the conversation outline clipped at the bottom" src="https://github.com/user-attachments/assets/f9c55f53-beda-4e58-b8c2-9cb7c19a905b" />

## After

<img width="2560" height="1528" alt="Request detail page with the full conversation outline visible and scrollable" src="https://github.com/user-attachments/assets/3b4e7f38-726f-4914-ac94-fc8314f8cb37" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the conversation sidebar’s maximum height to better fit within the available screen space.
  - Reduced unnecessary scrolling and layout overflow in the conversation view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->