### PR TITLE
fix(requests): expose personal key callers to project owners

### DIFF
--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { IconCalendar, IconX, IconFilter } from '@tabler/icons-react';
-import { cn } from '@/lib/utils';
+import { cn, formatUserName } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -178,7 +178,7 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
   const userOptions = useMemo(
     () =>
       (usersData?.edges || []).map((edge) => ({
-        label: `${edge.node.firstName || ''} ${edge.node.lastName || ''}`.trim() || edge.node.email,
+        label: formatUserName(edge.node.firstName, edge.node.lastName) || edge.node.email,
         value: String(edge.node.id),
       })),
     [usersData]

--- a/frontend/src/features/apikeys/components/apikeys-columns.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-columns.tsx
@@ -3,7 +3,7 @@ import { ColumnDef, Table, Row } from '@tanstack/react-table';
 import { Copy, Eye, Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { cn, extractNumberID } from '@/lib/utils';
+import { cn, extractNumberID, formatUserName } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { DataTableColumnHeader } from '@/components/data-table-column-header';
@@ -151,7 +151,7 @@ export const createColumns = (
           header: ({ column }) => <DataTableColumnHeader column={column} title={t('apikeys.columns.creator')} />,
           cell: ({ row }) => {
             const creator = row.original.user;
-            const displayName = creator ? `${creator.firstName} ${creator.lastName}` : t('apikeys.user.deleted');
+            const displayName = creator ? formatUserName(creator.firstName, creator.lastName) : t('apikeys.user.deleted');
             return <LongText className='text-muted-foreground max-w-24'>{displayName}</LongText>;
           },
           filterFn: (row, _id, value) => {

--- a/frontend/src/features/apikeys/components/data-table-toolbar.tsx
+++ b/frontend/src/features/apikeys/components/data-table-toolbar.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { DateRangePicker } from '@/components/date-range-picker';
 import type { DateTimeRangeValue } from '@/utils/date-range';
+import { formatUserName } from '@/lib/utils';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { useUsers } from '@/features/users/data/users';
 import { ApiKeyStatus } from '../data/schema';
@@ -44,7 +45,7 @@ export function DataTableToolbar<TData>({
 
     return usersData.edges.map((edge) => ({
       value: edge.node.id,
-      label: `${edge.node.firstName} ${edge.node.lastName} (${edge.node.email})`,
+      label: `${formatUserName(edge.node.firstName, edge.node.lastName)} (${edge.node.email})`,
     }));
   }, [canViewCreators, usersData]);
 

--- a/frontend/src/features/proejct-users/components/project-user-action-dialog.tsx
+++ b/frontend/src/features/proejct-users/components/project-user-action-dialog.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
 import { canEditUserPermissions } from '@/lib/permission-utils';
+import { formatUserName } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -235,7 +236,7 @@ export function ProjectUserActionDialog({ currentRow, open, onOpenChange }: Prop
                           ) : (
                             availableUsers.map((user) => (
                               <SelectItem key={user.id} value={user.id}>
-                                {user.firstName} {user.lastName} ({user.email})
+                                {formatUserName(user.firstName, user.lastName)} ({user.email})
                               </SelectItem>
                             ))
                           )}

--- a/frontend/src/features/proejct-users/components/users-delete-dialog.tsx
+++ b/frontend/src/features/proejct-users/components/users-delete-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { formatUserName } from '@/lib/utils';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -22,7 +23,7 @@ export function UsersDeleteDialog({ open, onOpenChange, currentRow }: Props) {
   const [confirmText, setConfirmText] = useState('');
   const removeUser = useRemoveUserFromProject();
 
-  const fullName = `${currentRow.firstName} ${currentRow.lastName}`;
+  const fullName = formatUserName(currentRow.firstName, currentRow.lastName);
 
   const handleRemove = async () => {
     if (confirmText.trim() !== fullName) return;

--- a/frontend/src/features/requests/components/requests-columns.tsx
+++ b/frontend/src/features/requests/components/requests-columns.tsx
@@ -7,7 +7,7 @@ import { Ban, FileText } from 'lucide-react';
 import { zhCN, enUS } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { extractNumberID } from '@/lib/utils';
+import { extractNumberID, formatUserName } from '@/lib/utils';
 import { formatDuration } from '@/utils/format-duration';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -556,7 +556,14 @@ export function useRequestsColumns(options?: UseRequestsColumnsOptions): ColumnD
           return <Badge variant='secondary'>{t(`requests.source.${request.source}`)}</Badge>;
         }
 
-        return <span className='font-mono text-xs'>{request.apiKey?.name || '-'}</span>;
+        const callerName = formatUserName(request.apiKey?.user?.firstName, request.apiKey?.user?.lastName);
+
+        return (
+          <div className='flex min-w-[120px] flex-col gap-0.5'>
+            <span className='font-mono text-xs'>{request.apiKey?.name || '-'}</span>
+            {callerName && <span className='text-muted-foreground text-xs'>{callerName}</span>}
+          </div>
+        );
       },
       filterFn: (row, _id, value) => value.length === 0 || value.includes(row.original.apiKey?.id ?? ''),
     },

--- a/frontend/src/features/requests/data/requests.ts
+++ b/frontend/src/features/requests/data/requests.ts
@@ -14,12 +14,16 @@ import {
 } from './schema';
 
 // Dynamic GraphQL query builder
-function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean }) {
+function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean; canViewCallerUser: boolean }) {
   const apiKeyFields = permissions.canViewApiKeys
     ? `
           apiKey {
             id
-            name
+            name${permissions.canViewCallerUser ? `
+            user {
+              firstName
+              lastName
+            }` : ''}
           }`
     : '';
 
@@ -113,12 +117,16 @@ function buildRequestsQuery(permissions: { canViewApiKeys: boolean; canViewChann
   `;
 }
 
-function buildRequestDetailQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean }) {
+function buildRequestDetailQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean; canViewCallerUser: boolean }) {
   const apiKeyFields = permissions.canViewApiKeys
     ? `
           apiKey {
             id
-            name
+            name${permissions.canViewCallerUser ? `
+            user {
+              firstName
+              lastName
+            }` : ''}
         }`
     : '';
 
@@ -172,12 +180,16 @@ function buildRequestDetailQuery(permissions: { canViewApiKeys: boolean; canView
   `;
 }
 
-function buildRequestDetailPollingQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean }) {
+function buildRequestDetailPollingQuery(permissions: { canViewApiKeys: boolean; canViewChannels: boolean; canViewCallerUser: boolean }) {
   const apiKeyFields = permissions.canViewApiKeys
     ? `
           apiKey {
             id
-            name
+            name${permissions.canViewCallerUser ? `
+            user {
+              firstName
+              lastName
+            }` : ''}
         }`
     : '';
 
@@ -413,7 +425,7 @@ export async function fetchAdjacentRequestPage(params: {
   direction: 'older' | 'newer';
   pageSize: number;
   where?: Record<string, any>;
-  permissions: { canViewApiKeys: boolean; canViewChannels: boolean };
+  permissions: { canViewApiKeys: boolean; canViewChannels: boolean; canViewCallerUser: boolean };
   projectId?: string | null;
 }): Promise<{ requests: Request[]; pageInfo: RequestConnection['pageInfo'] }> {
   const query = buildRequestsQuery(params.permissions);

--- a/frontend/src/features/users/components/users-change-password-dialog.tsx
+++ b/frontend/src/features/users/components/users-change-password-dialog.tsx
@@ -6,6 +6,7 @@ import { graphqlRequest } from '@/gql/graphql';
 import { UPDATE_USER_MUTATION } from '@/gql/users';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { formatUserName } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
@@ -67,7 +68,7 @@ export function UsersChangePasswordDialog({ currentRow, open, onOpenChange }: Pr
             {t('users.dialogs.changePassword.description', {
               firstName: currentRow?.firstName || '',
               lastName: currentRow?.lastName || '',
-              name: `${currentRow?.firstName} ${currentRow?.lastName}`,
+              name: formatUserName(currentRow?.firstName, currentRow?.lastName),
               email: currentRow?.email || '',
             })}
           </DialogDescription>

--- a/frontend/src/features/users/components/users-delete-dialog.tsx
+++ b/frontend/src/features/users/components/users-delete-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { formatUserName } from '@/lib/utils';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -22,7 +23,7 @@ export function UsersDeleteDialog({ open, onOpenChange, currentRow }: Props) {
   const [value, setValue] = useState('');
   const deleteUser = useDeleteUser();
 
-  const fullName = `${currentRow.firstName} ${currentRow.lastName}`;
+  const fullName = formatUserName(currentRow.firstName, currentRow.lastName);
 
   const handleDelete = async () => {
     if (value.trim() !== fullName) return;

--- a/frontend/src/features/users/components/users-status-dialog.tsx
+++ b/frontend/src/features/users/components/users-status-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { IconUserCheck, IconUserOff } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { formatUserName } from '@/lib/utils';
 import { ConfirmDialog } from '@/components/confirm-dialog';
 import { User } from '../data/schema';
 import { useUpdateUserStatus } from '../data/users';
@@ -54,7 +55,7 @@ export function UsersStatusDialog({ open, onOpenChange, currentRow }: Props) {
           <p>
             {t('users.dialogs.statusChange.confirmMessage', {
               action: actionText,
-              name: `${currentRow.firstName} ${currentRow.lastName}`,
+              name: formatUserName(currentRow.firstName, currentRow.lastName),
             })}
           </p>
           <p className='text-muted-foreground text-sm'>

--- a/frontend/src/hooks/useRequestPermissions.ts
+++ b/frontend/src/hooks/useRequestPermissions.ts
@@ -8,6 +8,7 @@ export interface RequestPermissions {
   canViewApiKeys: boolean;
   canViewChannels: boolean;
   canViewRoles: boolean;
+  canViewCallerUser: boolean;
 }
 
 export function useRequestPermissions(): RequestPermissions {
@@ -29,17 +30,23 @@ export function useRequestPermissions(): RequestPermissions {
     return project?.scopes || [];
   }, [selectedProjectId, user?.projects]);
 
+  const isProjectOwner = useMemo(() => {
+    if (isOwner) return true;
+    return user?.projects?.some((project) => project.projectID === selectedProjectId && project.isOwner) ?? false;
+  }, [isOwner, selectedProjectId, user?.projects]);
+
   const permissions = useMemo(() => {
     // 合并系统级和项目级权限
     const userScopes = [...systemScopes, ...projectScopes];
 
     // Owner用户拥有所有权限
-    if (isOwner || userScopes.includes('*')) {
+    if (isProjectOwner || userScopes.includes('*')) {
       return {
         canViewUsers: true,
         canViewApiKeys: true,
         canViewChannels: true,
         canViewRoles: true,
+        canViewCallerUser: isProjectOwner,
       };
     }
 
@@ -48,8 +55,9 @@ export function useRequestPermissions(): RequestPermissions {
       canViewApiKeys: userScopes.includes('read_api_keys'),
       canViewChannels: userScopes.includes('read_channels'),
       canViewRoles: userScopes.includes('read_roles'),
+      canViewCallerUser: false,
     };
-  }, [systemScopes, projectScopes, isOwner]);
+  }, [systemScopes, projectScopes, isProjectOwner]);
 
   return permissions;
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -20,10 +20,12 @@ export const buildGUID = (type: string, id: string) => {
 
 const cjkCharacterPattern = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
+// isCJKName reports whether any name contains a CJK script character.
 export function isCJKName(...names: Array<string | null | undefined>) {
   return names.some((name) => !!name && cjkCharacterPattern.test(name));
 }
 
+// formatUserName returns CJK names as surname followed by given name and other names in Western order.
 export function formatUserName(firstName?: string | null, lastName?: string | null) {
   const first = firstName?.trim() ?? '';
   const last = lastName?.trim() ?? '';

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -17,3 +17,20 @@ export const extractNumberIDAsNumber = (id: string) => {
 export const buildGUID = (type: string, id: string) => {
   return `gid://axonhub/${type}/${id}`;
 };
+
+const cjkCharacterPattern = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
+export function isCJKName(...names: Array<string | null | undefined>) {
+  return names.some((name) => !!name && cjkCharacterPattern.test(name));
+}
+
+export function formatUserName(firstName?: string | null, lastName?: string | null) {
+  const first = firstName?.trim() ?? '';
+  const last = lastName?.trim() ?? '';
+
+  if (first && last) {
+    return isCJKName(first, last) ? `${last}${first}` : `${first} ${last}`;
+  }
+
+  return first || last;
+}

--- a/frontend/src/sidebar.ts
+++ b/frontend/src/sidebar.ts
@@ -18,11 +18,12 @@ import { Command } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useRoutePermissions } from '@/hooks/useRoutePermissions';
+import { formatUserName, isCJKName } from '@/lib/utils';
 import { useMe } from '@/features/auth/data/auth';
 import { type SidebarData, type NavGroup, type NavLink } from './components/layout/types';
 
 export function useSidebarData(): SidebarData {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { user: authUser } = useAuthStore((state) => state.auth);
   const { data: meData } = useMe();
   const { filterNavGroups } = useRoutePermissions();
@@ -33,8 +34,7 @@ export function useSidebarData(): SidebarData {
   // Generate user initials for avatar
   const getInitials = (firstName?: string, lastName?: string, email?: string) => {
     if (firstName && lastName) {
-      const isZh = i18n.language?.startsWith('zh');
-      const [first, second] = isZh ? [lastName, firstName] : [firstName, lastName];
+      const [first, second] = isCJKName(firstName, lastName) ? [lastName, firstName] : [firstName, lastName];
       return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
     }
     if (firstName) {
@@ -49,8 +49,7 @@ export function useSidebarData(): SidebarData {
   // Generate user display name
   const getDisplayName = (firstName?: string, lastName?: string, email?: string) => {
     if (firstName && lastName) {
-      const isZh = i18n.language?.startsWith('zh');
-      return isZh ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
+      return formatUserName(firstName, lastName);
     }
     if (firstName) {
       return firstName;

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -101,6 +101,7 @@ func (User) Policy() ent.Policy {
 	return scopes.Policy{
 		Query: scopes.QueryPolicy{
 			scopes.OwnerRule(),
+			scopes.ProjectOwnerReadUsersRule(),
 			scopes.UserReadScopeRule(scopes.ScopeReadUsers),
 			scopes.UserOwnedQueryRule(),
 		},

--- a/internal/scopes/rule_personal_apikey.go
+++ b/internal/scopes/rule_personal_apikey.go
@@ -16,8 +16,8 @@ type PersonalKeyProjectFilter interface {
 	Where(entql.P)
 }
 
-// UserPersonalAPIKeyReadRule allows users to view API keys within their project,
-// with the additional restriction that personal keys are only visible to their creator.
+// UserPersonalAPIKeyReadRule allows users to view API keys within their project.
+// Personal keys are visible to their creator and project owners.
 // It replaces UserProjectScopeReadRule for the APIKey schema.
 func UserPersonalAPIKeyReadRule(requiredScope ScopeSlug) privacy.QueryRule {
 	return privacy.FilterFunc(func(ctx context.Context, q privacy.Filter) error {
@@ -43,11 +43,12 @@ func UserPersonalAPIKeyReadRule(requiredScope ScopeSlug) privacy.QueryRule {
 
 		pf.WhereProjectID(entql.IntEQ(projectID))
 
-		// Personal keys are only visible to their creator, regardless of the user's role
-		pf.Where(entql.Or(
-			entql.FieldNEQ("type", "personal"),
-			entql.FieldEQ("user_id", currentUser.ID),
-		))
+		if !userIsProjectOwner(currentUser, projectID) {
+			pf.Where(entql.Or(
+				entql.FieldNEQ("type", "personal"),
+				entql.FieldEQ("user_id", currentUser.ID),
+			))
+		}
 
 		return privacy.Allowf("User %d can query project %d with scope %s", currentUser.ID, projectID, requiredScope)
 	})

--- a/internal/scopes/rule_user_project_scope.go
+++ b/internal/scopes/rule_user_project_scope.go
@@ -10,6 +10,7 @@ import (
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/privacy"
+	"github.com/looplj/axonhub/internal/ent/userproject"
 )
 
 type ProjectOwnedFilter interface {
@@ -62,6 +63,33 @@ func userIsProjectOwner(user *ent.User, projectID int) bool {
 	}
 
 	return false
+}
+
+// ProjectOwnerReadUsersRule allows project owners to view users belonging to their current project.
+func ProjectOwnerReadUsersRule() privacy.QueryRule {
+	return privacy.FilterFunc(func(ctx context.Context, q privacy.Filter) error {
+		projectID, hasProjectID := contexts.GetProjectID(ctx)
+		if !hasProjectID {
+			return privacy.Skipf("Project ID not found in context")
+		}
+
+		currentUser, err := getUserFromContext(ctx)
+		if err != nil {
+			return privacy.Skipf("User not found in context")
+		}
+
+		if !userIsProjectOwner(currentUser, projectID) {
+			return privacy.Skipf("User %d is not an owner of project %d", currentUser.ID, projectID)
+		}
+
+		userFilter, ok := q.(*ent.UserFilter)
+		if !ok {
+			return privacy.Skipf("Not a user query")
+		}
+
+		userFilter.WhereHasProjectUsersWith(userproject.ProjectID(projectID))
+		return privacy.Allowf("Project owner %d can query users in project %d", currentUser.ID, projectID)
+	})
 }
 
 // UserProjectScopeReadRule allows users to query projects they are members of.

--- a/internal/scopes/rule_user_project_scope.go
+++ b/internal/scopes/rule_user_project_scope.go
@@ -50,6 +50,20 @@ func userHasProjectScope(user *ent.User, projectID int, requiredScope ScopeSlug)
 	return false
 }
 
+func userIsProjectOwner(user *ent.User, projectID int) bool {
+	if user.IsOwner {
+		return true
+	}
+
+	for _, membership := range user.Edges.ProjectUsers {
+		if membership.ProjectID == projectID && membership.IsOwner {
+			return true
+		}
+	}
+
+	return false
+}
+
 // UserProjectScopeReadRule allows users to query projects they are members of.
 // It checks:
 // 1. If user has global scope permission -> Allow all

--- a/internal/scopes/rule_user_project_scope.go
+++ b/internal/scopes/rule_user_project_scope.go
@@ -51,6 +51,7 @@ func userHasProjectScope(user *ent.User, projectID int, requiredScope ScopeSlug)
 	return false
 }
 
+// userIsProjectOwner reports whether a user owns the given project or the system.
 func userIsProjectOwner(user *ent.User, projectID int) bool {
 	if user.IsOwner {
 		return true

--- a/internal/scopes/rule_user_project_scope_requests.go
+++ b/internal/scopes/rule_user_project_scope_requests.go
@@ -16,9 +16,10 @@ import (
 
 // UserProjectScopeReadRequestsRule is a query rule that restricts users' access to Request and UsageLog records.
 // It ensures that project-level users can only see:
-// 1. Requests / UsageLogs that do not have an API key (e.g., playground requests).
-// 2. Requests / UsageLogs that were made using a non-personal API key.
-// 3. Requests / UsageLogs that were made using a personal API key created by the user themselves.
+//  1. Requests / UsageLogs that do not have an API key (e.g., playground requests).
+//  2. Requests / UsageLogs that were made using a non-personal API key.
+//  3. Requests / UsageLogs that were made using a personal API key created by the user themselves,
+//     unless the user is a project owner.
 func UserProjectScopeReadRequestsRule(requiredScope ScopeSlug) privacy.QueryRule {
 	return privacy.FilterFunc(func(ctx context.Context, q privacy.Filter) error {
 		// Check if project ID is in context
@@ -44,30 +45,33 @@ func UserProjectScopeReadRequestsRule(requiredScope ScopeSlug) privacy.QueryRule
 			return privacy.Skipf("Not a project-owned query")
 		}
 
-		// Apply personal API key log visibility filter
-		switch q := q.(type) {
-		case *ent.RequestFilter:
-			q.Where(entql.Or(
-				entql.FieldNil(request.FieldAPIKeyID),
-				entql.HasEdgeWith("api_key", sqlgraph.WrapFunc(func(s *sql.Selector) {
-					apikey.Or(
-						apikey.TypeNEQ(apikey.TypePersonal),
-						apikey.UserID(currentUser.ID),
-					)(s)
-				})),
-			))
-		case *ent.UsageLogFilter:
-			q.WhereHasRequestWith(
-				request.Or(
-					request.APIKeyIDIsNil(),
-					request.HasAPIKeyWith(
+		// Personal key requests are private to their creator for regular project
+		// members, while project owners can audit all requests in the project.
+		if !userIsProjectOwner(currentUser, projectID) {
+			switch q := q.(type) {
+			case *ent.RequestFilter:
+				q.Where(entql.Or(
+					entql.FieldNil(request.FieldAPIKeyID),
+					entql.HasEdgeWith("api_key", sqlgraph.WrapFunc(func(s *sql.Selector) {
 						apikey.Or(
 							apikey.TypeNEQ(apikey.TypePersonal),
 							apikey.UserID(currentUser.ID),
+						)(s)
+					})),
+				))
+			case *ent.UsageLogFilter:
+				q.WhereHasRequestWith(
+					request.Or(
+						request.APIKeyIDIsNil(),
+						request.HasAPIKeyWith(
+							apikey.Or(
+								apikey.TypeNEQ(apikey.TypePersonal),
+								apikey.UserID(currentUser.ID),
+							),
 						),
 					),
-				),
-			)
+				)
+			}
 		}
 
 		return privacy.Allowf("User %d can query requests in project %d with personal key filtering", currentUser.ID, projectID)

--- a/internal/scopes/rule_user_project_scope_requests_test.go
+++ b/internal/scopes/rule_user_project_scope_requests_test.go
@@ -1,0 +1,88 @@
+package scopes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/contexts"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/apikey"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/privacy"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/user"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/scopes"
+)
+
+func TestProjectOwnerCanReadMemberPersonalKeyRequests(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:project-owner-personal-key-requests?mode=memory&_fk=1")
+	defer client.Close()
+
+	setupCtx := privacy.DecisionContext(context.Background(), privacy.Allow)
+	project := client.Project.Create().SetName("project").SaveX(setupCtx)
+	owner := client.User.Create().SetEmail("owner@example.com").SetPassword("password").SaveX(setupCtx)
+	creator := client.User.Create().SetEmail("creator@example.com").SetPassword("password").SaveX(setupCtx)
+	member := client.User.Create().SetEmail("member@example.com").SetPassword("password").SaveX(setupCtx)
+
+	client.UserProject.Create().SetUserID(owner.ID).SetProjectID(project.ID).SetIsOwner(true).SaveX(setupCtx)
+	client.UserProject.Create().SetUserID(creator.ID).SetProjectID(project.ID).SetScopes([]string{string(scopes.ScopeReadRequests)}).SaveX(setupCtx)
+	client.UserProject.Create().SetUserID(member.ID).SetProjectID(project.ID).SetScopes([]string{string(scopes.ScopeReadRequests)}).SaveX(setupCtx)
+
+	personalKey := client.APIKey.Create().
+		SetName("creator personal key").
+		SetKey("personal-key").
+		SetType(apikey.TypePersonal).
+		SetUserID(creator.ID).
+		SetProjectID(project.ID).
+		SaveX(setupCtx)
+	personalRequest := client.Request.Create().
+		SetAPIKeyID(personalKey.ID).
+		SetProjectID(project.ID).
+		SetModelID("test-model").
+		SetStatus(request.StatusCompleted).
+		SetRequestBody(objects.JSONRawMessage([]byte(`{}`))).
+		SaveX(setupCtx)
+	client.UsageLog.Create().
+		SetRequestID(personalRequest.ID).
+		SetAPIKeyID(personalKey.ID).
+		SetProjectID(project.ID).
+		SetModelID("test-model").
+		SaveX(setupCtx)
+
+	loadUser := func(id int) *ent.User {
+		return client.User.Query().Where(user.IDEQ(id)).WithProjectUsers().OnlyX(setupCtx)
+	}
+	queryCount := func(user *ent.User) (int, int, error) {
+		ctx := ent.NewContext(context.Background(), client)
+		ctx = contexts.WithProjectID(contexts.WithUser(ctx, user), project.ID)
+		requestCount, err := client.Request.Query().Count(ctx)
+		if err != nil {
+			return 0, 0, err
+		}
+		usageLogCount, err := client.UsageLog.Query().Count(ctx)
+		return requestCount, usageLogCount, err
+	}
+
+	tests := []struct {
+		name              string
+		user              *ent.User
+		wantRequestCount  int
+		wantUsageLogCount int
+	}{
+		{name: "project owner", user: loadUser(owner.ID), wantRequestCount: 1, wantUsageLogCount: 1},
+		{name: "personal key creator", user: loadUser(creator.ID), wantRequestCount: 1, wantUsageLogCount: 1},
+		{name: "regular member", user: loadUser(member.ID), wantRequestCount: 0, wantUsageLogCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount, usageLogCount, err := queryCount(tt.user)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantRequestCount, requestCount)
+			require.Equal(t, tt.wantUsageLogCount, usageLogCount)
+		})
+	}
+}

--- a/internal/scopes/rule_user_project_scope_requests_test.go
+++ b/internal/scopes/rule_user_project_scope_requests_test.go
@@ -26,6 +26,7 @@ func TestProjectOwnerCanReadMemberPersonalKeyRequests(t *testing.T) {
 	owner := client.User.Create().SetEmail("owner@example.com").SetPassword("password").SaveX(setupCtx)
 	creator := client.User.Create().SetEmail("creator@example.com").SetPassword("password").SaveX(setupCtx)
 	member := client.User.Create().SetEmail("member@example.com").SetPassword("password").SaveX(setupCtx)
+	client.User.Create().SetEmail("outside@example.com").SetPassword("password").SaveX(setupCtx)
 
 	client.UserProject.Create().SetUserID(owner.ID).SetProjectID(project.ID).SetIsOwner(true).SaveX(setupCtx)
 	client.UserProject.Create().SetUserID(creator.ID).SetProjectID(project.ID).SetScopes([]string{string(scopes.ScopeReadRequests)}).SaveX(setupCtx)
@@ -65,6 +66,25 @@ func TestProjectOwnerCanReadMemberPersonalKeyRequests(t *testing.T) {
 		usageLogCount, err := client.UsageLog.Query().Count(ctx)
 		return requestCount, usageLogCount, err
 	}
+	projectOwner := loadUser(owner.ID)
+	ownerCtx := ent.NewContext(context.Background(), client)
+	ownerCtx = contexts.WithProjectID(contexts.WithUser(ownerCtx, projectOwner), project.ID)
+
+	memberCount, err := client.User.Query().Count(ownerCtx)
+	require.NoError(t, err)
+	require.Equal(t, 3, memberCount)
+
+	personalKeyCount, err := client.APIKey.Query().Count(ownerCtx)
+	require.NoError(t, err)
+	require.Equal(t, 1, personalKeyCount)
+	loadedCreator, err := personalKey.QueryUser().Only(ownerCtx)
+	require.NoError(t, err)
+	require.Equal(t, creator.ID, loadedCreator.ID)
+
+	memberCtx := ent.NewContext(context.Background(), client)
+	memberCtx = contexts.WithProjectID(contexts.WithUser(memberCtx, loadUser(member.ID)), project.ID)
+	_, err = client.User.Query().Count(memberCtx)
+	require.Error(t, err)
 
 	tests := []struct {
 		name              string
@@ -72,7 +92,7 @@ func TestProjectOwnerCanReadMemberPersonalKeyRequests(t *testing.T) {
 		wantRequestCount  int
 		wantUsageLogCount int
 	}{
-		{name: "project owner", user: loadUser(owner.ID), wantRequestCount: 1, wantUsageLogCount: 1},
+		{name: "project owner", user: projectOwner, wantRequestCount: 1, wantUsageLogCount: 1},
 		{name: "personal key creator", user: loadUser(creator.ID), wantRequestCount: 1, wantUsageLogCount: 1},
 		{name: "regular member", user: loadUser(member.ID), wantRequestCount: 0, wantUsageLogCount: 0},
 	}

--- a/internal/scopes/rule_user_project_scope_test.go
+++ b/internal/scopes/rule_user_project_scope_test.go
@@ -664,3 +664,45 @@ func TestUserHasProjectScope(t *testing.T) {
 		})
 	}
 }
+
+func TestUserIsProjectOwner(t *testing.T) {
+	tests := []struct {
+		name      string
+		user      *ent.User
+		projectID int
+		expected  bool
+	}{
+		{
+			name:      "system owner",
+			user:      &ent.User{IsOwner: true},
+			projectID: 100,
+			expected:  true,
+		},
+		{
+			name:      "project owner",
+			user:      &ent.User{Edges: ent.UserEdges{ProjectUsers: []*ent.UserProject{{ProjectID: 100, IsOwner: true}}}},
+			projectID: 100,
+			expected:  true,
+		},
+		{
+			name:      "owner of another project",
+			user:      &ent.User{Edges: ent.UserEdges{ProjectUsers: []*ent.UserProject{{ProjectID: 200, IsOwner: true}}}},
+			projectID: 100,
+			expected:  false,
+		},
+		{
+			name:      "regular project member",
+			user:      &ent.User{Edges: ent.UserEdges{ProjectUsers: []*ent.UserProject{{ProjectID: 100}}}},
+			projectID: 100,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := userIsProjectOwner(tt.user, tt.projectID); got != tt.expected {
+				t.Fatalf("userIsProjectOwner() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- allow project owners to audit requests and usage created by members' personal API keys
- scope owner access to members and API keys in the active project
- show the personal-key caller under the API key in request logs
- add shared CJK-aware user name formatting

## Verification

- `go test ./internal/scopes -count=1`

## Notes

- regular project members continue to see only their own personal-key request activity and do not receive caller names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user-name display across filters, dialogs, tables, the sidebar, and API key views, including CJK name support and email fallbacks.
  * Request listings can show the associated caller’s formatted name when permitted.
* **Permissions**
  * Project owners can view relevant project users, personal API keys, requests, and usage logs.
  * Caller identity visibility is restricted according to project ownership.
* **Bug Fixes**
  * Standardized name formatting throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->