### PR TITLE
fix: double count reasoning token for throughput

### DIFF
--- a/frontend/src/features/requests/utils/tokens-per-second.ts
+++ b/frontend/src/features/requests/utils/tokens-per-second.ts
@@ -24,11 +24,8 @@ export function getTokensPerSecondValue(request: Request): number | null {
     return null;
   }
 
-  // Sum all completion token types (matching fastest performers logic)
-  const completionTokens =
-    (usageLog.completionTokens || 0) +
-    (usageLog.completionReasoningTokens || 0) +
-    (usageLog.completionAudioTokens || 0);
+  // Use completion tokens only (reasoning tokens are not included in throughput calculation)
+  const completionTokens = usageLog.completionTokens || 0;
 
   if (completionTokens === 0) {
     return null;

--- a/internal/server/biz/channel_probe_test.go
+++ b/internal/server/biz/channel_probe_test.go
@@ -132,13 +132,13 @@ func TestTPSCalculation_RetryScenario(t *testing.T) {
 		Only(ctx)
 	require.NoError(t, err)
 
-	totalTokens := ul.CompletionTokens + ul.CompletionReasoningTokens + ul.CompletionAudioTokens
-	assert.Equal(t, int64(100), totalTokens)
+	totalTokens := ul.CompletionTokens
+	assert.Equal(t, int64(50), totalTokens)
 
-	// TPS calculation: 100 tokens / ((3000 - 500) / 1000) = 100 / 2.5 = 40 tokens/s
+	// TPS calculation: 50 tokens / ((3000 - 500) / 1000) = 50 / 2.5 = 20 tokens/s
 	effectiveLatency := *execs[0].MetricsLatencyMs - *execs[0].MetricsFirstTokenLatencyMs
 	tps := float64(totalTokens) / (float64(effectiveLatency) / 1000.0)
-	assert.InDelta(t, 40.0, tps, 0.01)
+	assert.InDelta(t, 20.0, tps, 0.01)
 }
 
 // TestTPSCalculation_AllTokenTypes tests that all token types are included
@@ -210,13 +210,13 @@ func TestTPSCalculation_AllTokenTypes(t *testing.T) {
 		Only(ctx)
 	require.NoError(t, err)
 
-	totalTokens := ul.CompletionTokens + ul.CompletionReasoningTokens + ul.CompletionAudioTokens
-	assert.Equal(t, int64(175), totalTokens)
+	totalTokens := ul.CompletionTokens
+	assert.Equal(t, int64(100), totalTokens)
 
-	// TPS: 175 tokens / ((2000 - 400) / 1000) = 175 / 1.6 = 109.375 tokens/s
+	// TPS: 100 tokens / ((2000 - 400) / 1000) = 100 / 1.6 = 62.5 tokens/s
 	effectiveLatency := int64(2000) - int64(400)
 	tps := float64(totalTokens) / (float64(effectiveLatency) / 1000.0)
-	assert.InDelta(t, 109.375, tps, 0.01)
+	assert.InDelta(t, 62.5, tps, 0.01)
 }
 
 // TestTPSCalculation_StreamingVsNonStreaming tests streaming vs non-streaming formulas
@@ -519,9 +519,9 @@ func TestComputeAllChannelProbeStats_Integration(t *testing.T) {
 	assert.Equal(t, 1, channelStats.total)
 	assert.Equal(t, 1, channelStats.success)
 
-	// Verify TPS calculation: 175 tokens / ((3000 - 500) / 1000) = 175 / 2.5 = 70 tokens/s
+	// Verify TPS calculation: 100 tokens (completion only) / ((3000 - 500) / 1000) = 100 / 2.5 = 40 tokens/s
 	require.NotNil(t, channelStats.avgTokensPerSecond, "avgTokensPerSecond should not be nil")
-	assert.InDelta(t, 70.0, *channelStats.avgTokensPerSecond, 0.01)
+	assert.InDelta(t, 40.0, *channelStats.avgTokensPerSecond, 0.01)
 
 	// Verify TTFT calculation: 500ms / 1 request = 500ms
 	require.NotNil(t, channelStats.avgTimeToFirstTokenMs, "avgTimeToFirstTokenMs should not be nil")
@@ -622,11 +622,11 @@ func TestComputeAllChannelProbeStats_MultipleRequests(t *testing.T) {
 	assert.Equal(t, 3, channelStats.total)
 	assert.Equal(t, 3, channelStats.success)
 
-	// Total tokens: 175 + 100 + 200 = 475
+	// Total completion tokens: 100 + 80 + 200 = 380 (reasoning tokens excluded)
 	// Effective latency: (3000-500) + (2000-400) + 4000 = 2500 + 1600 + 4000 = 8100
-	// TPS: 475 / 8.1 = 58.64 tokens/s
+	// TPS: 380 / 8.1 = 46.91 tokens/s
 	require.NotNil(t, channelStats.avgTokensPerSecond)
-	assert.InDelta(t, 58.64, *channelStats.avgTokensPerSecond, 0.1)
+	assert.InDelta(t, 46.91, *channelStats.avgTokensPerSecond, 0.1)
 
 	// TTFT: (500 + 400 + 0) / 2 = 450ms (only streaming requests count: 2 out of 3 requests are streaming)
 	require.NotNil(t, channelStats.avgTimeToFirstTokenMs)

--- a/internal/server/gql/qb/throughput.go
+++ b/internal/server/gql/qb/throughput.go
@@ -119,7 +119,7 @@ WITH successful_execs AS (
 )
 SELECT
     ` + config.SelectColumns + `
-    SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,
+    SUM(ul.completion_tokens) as tokens_count,
     SUM(se.metrics_latency_ms) as latency_ms,
     COUNT(DISTINCT se.request_id) as request_count,
     CASE
@@ -128,7 +128,7 @@ SELECT
                       THEN 0
                       ELSE se.metrics_latency_ms - se.metrics_first_token_latency_ms END
                  ELSE se.metrics_latency_ms END) > 0
-        THEN SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) * 1000.0
+        THEN SUM(ul.completion_tokens) * 1000.0
              / SUM(CASE WHEN se.stream AND se.metrics_first_token_latency_ms IS NOT NULL
                    THEN CASE WHEN se.metrics_first_token_latency_ms >= se.metrics_latency_ms
                         THEN 0
@@ -154,7 +154,7 @@ func buildMaxIDQuery(placeholder string, config QueryFragmentConfig, limit int) 
 	return `
 SELECT
     ` + config.SelectColumns + `
-    SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,
+    SUM(ul.completion_tokens) as tokens_count,
     SUM(se.metrics_latency_ms) as latency_ms,
     COUNT(DISTINCT se.request_id) as request_count,
     CASE
@@ -163,7 +163,7 @@ SELECT
                       THEN 0
                       ELSE se.metrics_latency_ms - se.metrics_first_token_latency_ms END
                  ELSE se.metrics_latency_ms END) > 0
-        THEN SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) * 1000.0
+        THEN SUM(ul.completion_tokens) * 1000.0
              / SUM(CASE WHEN se.stream AND se.metrics_first_token_latency_ms IS NOT NULL
                    THEN CASE WHEN se.metrics_first_token_latency_ms >= se.metrics_latency_ms
                         THEN 0
@@ -281,7 +281,7 @@ LEFT JOIN (
     SELECT
         request_id,
         channel_id,
-        SUM(COALESCE(completion_tokens, 0) + COALESCE(completion_reasoning_tokens, 0) + COALESCE(completion_audio_tokens, 0)) as total_completion_tokens
+        SUM(COALESCE(completion_tokens, 0)) as total_completion_tokens
     FROM usage_logs
     WHERE created_at >= %s
     GROUP BY request_id, channel_id

--- a/internal/server/gql/qb/throughput_daily.go
+++ b/internal/server/gql/qb/throughput_daily.go
@@ -145,7 +145,7 @@ func throughputCalculationSQL(seTable string) string {
 	core := throughputCoreSQL(seTable)
 	return fmt.Sprintf(`CASE
         WHEN SUM(%s) > 0
-        THEN SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) * 1000.0
+        THEN SUM(ul.completion_tokens) * 1000.0
              / SUM(%s)
         ELSE 0
     END`, core, core)
@@ -172,7 +172,7 @@ func buildDailyRowNumberQuery(dateExpr string, config DailyQueryFragmentConfig, 
 		"        " + dateExpr + " as date,\n" +
 		"        " + config.IDColumn + " as id,\n" +
 		"        " + config.NameColumn + ",\n" +
-		"        SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,\n" +
+		"        SUM(ul.completion_tokens) as tokens_count,\n" +
 		"        COUNT(DISTINCT se.request_id) as request_count,\n" +
 		"        " + throughputSQL + " as throughput,\n" +
 		"        ROW_NUMBER() OVER (PARTITION BY " + dateExpr + " ORDER BY " + throughputSQL + " DESC) as daily_rn\n" +
@@ -197,7 +197,7 @@ func buildDailyMaxIDQuery(dateExpr string, config DailyQueryFragmentConfig, limi
 		"        " + dateExpr + " as date,\n" +
 		"        " + config.IDColumn + " as id,\n" +
 		"        " + config.NameColumn + ",\n" +
-		"        SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,\n" +
+		"        SUM(ul.completion_tokens) as tokens_count,\n" +
 		"        COUNT(DISTINCT se.request_id) as request_count,\n" +
 		"        " + throughputSQL + " as throughput,\n" +
 		"        ROW_NUMBER() OVER (PARTITION BY " + dateExpr + " ORDER BY " + throughputSQL + " DESC) as daily_rn\n" +
@@ -278,7 +278,7 @@ func buildDailyPerformanceStatsRowNumberQuery(dateExpr string, config DailyQuery
 		"    SELECT\n" +
 		"        exec_date as date,\n" +
 		"        se." + getIDColumnName(queryType) + " as id,\n" +
-		"        SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,\n" +
+		"        SUM(ul.completion_tokens) as tokens_count,\n" +
 		"        SUM(se.metrics_latency_ms) as latency_ms,\n" +
 		"        SUM(CASE\n" +
 		"            WHEN se.metrics_first_token_latency_ms IS NOT NULL AND se.metrics_first_token_latency_ms > 0\n" +
@@ -330,7 +330,7 @@ func buildDailyPerformanceStatsMaxIDQuery(dateExpr string, config DailyQueryFrag
 		"    SELECT\n" +
 		"        exec_date as date,\n" +
 		"        se." + getIDColumnName(queryType) + " as id,\n" +
-		"        SUM(ul.completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)) as tokens_count,\n" +
+		"        SUM(ul.completion_tokens) as tokens_count,\n" +
 		"        SUM(se.metrics_latency_ms) as latency_ms,\n" +
 		"        SUM(CASE\n" +
 		"            WHEN se.metrics_first_token_latency_ms IS NOT NULL AND se.metrics_first_token_latency_ms > 0\n" +

--- a/internal/server/gql/qb/throughput_daily_test.go
+++ b/internal/server/gql/qb/throughput_daily_test.go
@@ -303,7 +303,7 @@ func TestBuildDailyThroughputQuery_TokPerSecondCalculation(t *testing.T) {
 			name: "ROW_NUMBER mode has correct tok/s calculation",
 			mode: ThroughputModeRowNumber,
 			wantContains: []string{
-				"completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)",
+				"completion_tokens",
 				"* 1000.0",
 				"metrics_first_token_latency_ms",
 				"metrics_latency_ms - se.metrics_first_token_latency_ms",
@@ -313,7 +313,7 @@ func TestBuildDailyThroughputQuery_TokPerSecondCalculation(t *testing.T) {
 			name: "MAX_ID mode has correct tok/s calculation",
 			mode: ThroughputModeMaxID,
 			wantContains: []string{
-				"completion_tokens + COALESCE(ul.completion_reasoning_tokens, 0) + COALESCE(ul.completion_audio_tokens, 0)",
+				"completion_tokens",
 				"* 1000.0",
 				"metrics_first_token_latency_ms",
 			},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tokens-per-second metrics to count completion tokens only.
  * Excluded reasoning and audio completion tokens from throughput and performance statistics.
  * Aligned retry, integration, daily, and multi-request calculations for consistent results.

* **Tests**
  * Updated throughput tests to reflect completion-token-only calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->