### PR TITLE
fix: stabilize auto-refresh list transitions

### DIFF
--- a/frontend/src/components/auto-refresh-control.tsx
+++ b/frontend/src/components/auto-refresh-control.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { ChevronDown, RefreshCw } from 'lucide-react';
+import { ChevronDown, RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { AUTO_REFRESH_INTERVALS, type AutoRefreshInterval, type EnabledAutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
@@ -62,21 +62,48 @@ export function AutoRefreshControl({ interval, onIntervalChange, onRefresh, disa
     onIntervalChange(nextInterval);
   };
 
+  const handlePrimaryAction = () => {
+    if (interval !== null) {
+      onIntervalChange(null);
+      return;
+    }
+
+    void handleRefresh();
+  };
+
   return (
     <div className={cn('inline-flex shrink-0', className)}>
       <Button
         type='button'
         variant='outline'
         size='sm'
-        onClick={handleRefresh}
+        onClick={handlePrimaryAction}
         disabled={disabled || isRefreshing}
         aria-busy={isRefreshing}
-        aria-label={t('common.refresh')}
+        aria-label={interval === null ? t('common.refresh') : t('common.closeAutoRefresh')}
         data-testid='manual-refresh-button'
-        className='active:bg-accent active:text-accent-foreground dark:active:bg-accent h-8 rounded-r-none border-r-0'
+        className={cn(
+          'active:bg-accent active:text-accent-foreground dark:active:bg-accent group h-8 rounded-r-none border-r-0',
+          interval !== null && 'w-[4.75rem]'
+        )}
       >
-        <RefreshCw className={cn('mr-2 h-4 w-4', (interval !== null || isRefreshing) && 'animate-spin')} />
-        <span className='pointer-events-none select-none'>{interval === null ? t('common.refresh') : formatInterval(interval)}</span>
+        {interval === null ? (
+          <>
+            <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
+            <span className='pointer-events-none select-none'>{t('common.refresh')}</span>
+          </>
+        ) : (
+          <>
+            <RefreshCw className='h-4 w-4 animate-spin group-hover:hidden group-focus-visible:hidden' />
+            <X className='hidden h-4 w-4 group-hover:block group-focus-visible:block' />
+            <span className='pointer-events-none select-none group-hover:hidden group-focus-visible:hidden'>
+              {formatInterval(interval)}
+            </span>
+            <span className='pointer-events-none hidden select-none group-hover:inline group-focus-visible:inline'>
+              {t('common.close')}
+            </span>
+          </>
+        )}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/frontend/src/features/requests/components/requests-table.tsx
+++ b/frontend/src/features/requests/components/requests-table.tsx
@@ -246,7 +246,7 @@ export function RequestsTable({
     () => JSON.stringify({ queryWhere: queryWhere ?? null, autoRefreshResumeKey }),
     [queryWhere, autoRefreshResumeKey]
   );
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
+  const displayedData = useAnimatedList(data, showRefresh && autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = [];

--- a/frontend/src/features/threads/components/threads-table.tsx
+++ b/frontend/src/features/threads/components/threads-table.tsx
@@ -87,7 +87,7 @@ export function ThreadsTable({
     () => JSON.stringify({ dateRange, threadIdFilter, statusFilter, autoRefreshResumeKey }),
     [dateRange, threadIdFilter, statusFilter, autoRefreshResumeKey]
   );
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
+  const displayedData = useAnimatedList(data, showRefresh && autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/features/traces/components/traces-table.tsx
+++ b/frontend/src/features/traces/components/traces-table.tsx
@@ -88,7 +88,7 @@ export function TracesTable({
     () => JSON.stringify({ dateRange, traceIdFilter, statusFilter, autoRefreshResumeKey }),
     [dateRange, traceIdFilter, statusFilter, autoRefreshResumeKey]
   );
-  const displayedData = useAnimatedList(data, autoRefreshInterval !== null, pageSize, animationResetKey);
+  const displayedData = useAnimatedList(data, showRefresh && autoRefreshInterval !== null, pageSize, animationResetKey);
 
   const table = useReactTable({
     data: displayedData,

--- a/frontend/src/hooks/animated-list.test.mjs
+++ b/frontend/src/hooks/animated-list.test.mjs
@@ -56,6 +56,11 @@ test('replaces growing or changing snapshots that do not fill the page', () => {
   assert.equal(planAnimatedListUpdate(['a', 'b', 'c'], ['new', 'a', 'b'], [], 10).shouldReplace, true);
 });
 
+test('replaces an oversized stale snapshot after the page size changes', () => {
+  assert.equal(planAnimatedListUpdate(['a', 'b', 'c'], ['new', 'a', 'b'], [], 2).shouldReplace, true);
+  assert.equal(planAnimatedListUpdate(['new', 'a', 'b'], ['new', 'a', 'b'], ['new'], 2).shouldReplace, true);
+});
+
 test('keeps only queued items that still exist in an unchanged snapshot', () => {
   assert.deepEqual(planAnimatedListUpdate(['new', 'current'], ['new', 'current'], ['stale', 'new', 'new']), {
     shouldReplace: false,

--- a/frontend/src/hooks/animated-list.test.mjs
+++ b/frontend/src/hooks/animated-list.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MAX_SEQUENTIAL_ANIMATED_ITEMS, getMaxSequentialAnimatedItems, planAnimatedListUpdate } from './animated-list.ts';
+
+test('derives the animation limit from the duration budget and hard cap', () => {
+  assert.equal(getMaxSequentialAnimatedItems(500), 3);
+  assert.equal(getMaxSequentialAnimatedItems(300), 5);
+  assert.equal(getMaxSequentialAnimatedItems(200), MAX_SEQUENTIAL_ANIMATED_ITEMS);
+  assert.equal(getMaxSequentialAnimatedItems(1000), 1);
+  assert.equal(getMaxSequentialAnimatedItems(2000), 0);
+  assert.equal(getMaxSequentialAnimatedItems(0), 0);
+});
+
+test('queues top insertions within the animation budget from oldest to newest', () => {
+  const previousIds = ['current-1', 'current-2', 'current-3', 'current-4', 'current-5'];
+  const incomingIds = ['new-3', 'new-2', 'new-1', 'current-1', 'current-2'];
+
+  assert.deepEqual(planAnimatedListUpdate(previousIds, incomingIds, [], incomingIds.length, 3), {
+    shouldReplace: false,
+    queuedIds: ['new-1', 'new-2', 'new-3'],
+  });
+});
+
+test('replaces a snapshot when one update exceeds the animation budget', () => {
+  const previousIds = ['current-1', 'current-2', 'current-3', 'current-4', 'current-5'];
+  const incomingIds = ['new-4', 'new-3', 'new-2', 'new-1', 'current-1'];
+
+  assert.deepEqual(planAnimatedListUpdate(previousIds, incomingIds, [], incomingIds.length, 3), {
+    shouldReplace: true,
+    queuedIds: [],
+  });
+});
+
+test('replaces a snapshot when queued and newly added items exceed the limit', () => {
+  assert.deepEqual(
+    planAnimatedListUpdate(
+      ['queued-2', 'queued-1', 'current-1', 'current-2', 'current-3'],
+      ['new-2', 'new-1', 'queued-2', 'queued-1', 'current-1'],
+      ['queued-1', 'queued-2'],
+      5,
+      3
+    ),
+    { shouldReplace: true, queuedIds: [] }
+  );
+});
+
+test('replaces unrelated and structurally changed snapshots', () => {
+  assert.equal(planAnimatedListUpdate(['page-2-a', 'page-2-b'], ['page-1-a', 'page-1-b'], []).shouldReplace, true);
+  assert.equal(planAnimatedListUpdate(['a', 'b', 'c'], ['a', 'c'], []).shouldReplace, true);
+  assert.equal(planAnimatedListUpdate(['a', 'b', 'c'], ['b', 'a', 'c'], []).shouldReplace, true);
+  assert.equal(planAnimatedListUpdate(['a', 'b', 'c', 'd'], ['new', 'a', 'b'], []).shouldReplace, true);
+});
+
+test('replaces growing or changing snapshots that do not fill the page', () => {
+  assert.equal(planAnimatedListUpdate(['a', 'b'], ['new', 'a', 'b'], [], 10).shouldReplace, true);
+  assert.equal(planAnimatedListUpdate(['a', 'b', 'c'], ['new', 'a', 'b'], [], 10).shouldReplace, true);
+});
+
+test('keeps only queued items that still exist in an unchanged snapshot', () => {
+  assert.deepEqual(planAnimatedListUpdate(['new', 'current'], ['new', 'current'], ['stale', 'new', 'new']), {
+    shouldReplace: false,
+    queuedIds: ['new'],
+  });
+});
+
+test('replaces queued updates when the page size grows beyond the current snapshot', () => {
+  assert.deepEqual(planAnimatedListUpdate(['new', 'current'], ['new', 'current'], ['new'], 20), {
+    shouldReplace: true,
+    queuedIds: [],
+  });
+});

--- a/frontend/src/hooks/animated-list.ts
+++ b/frontend/src/hooks/animated-list.ts
@@ -1,0 +1,69 @@
+export const MAX_SEQUENTIAL_ANIMATED_ITEMS = 5;
+export const MAX_SEQUENTIAL_ANIMATION_DURATION_MS = 1500;
+
+export function getMaxSequentialAnimatedItems(animationIntervalMs: number): number {
+  if (!Number.isFinite(animationIntervalMs) || animationIntervalMs <= 0) {
+    return 0;
+  }
+
+  return Math.min(MAX_SEQUENTIAL_ANIMATED_ITEMS, Math.floor(MAX_SEQUENTIAL_ANIMATION_DURATION_MS / animationIntervalMs));
+}
+
+export interface AnimatedListUpdatePlan {
+  shouldReplace: boolean;
+  queuedIds: string[];
+}
+
+export function planAnimatedListUpdate(
+  previousIds: string[],
+  incomingIds: string[],
+  queuedIds: string[],
+  pageSize: number = incomingIds.length,
+  maxSequentialAnimatedItems: number = MAX_SEQUENTIAL_ANIMATED_ITEMS
+): AnimatedListUpdatePlan {
+  const incomingIdSet = new Set(incomingIds);
+  const nextQueue = queuedIds.filter((id, index) => incomingIdSet.has(id) && queuedIds.indexOf(id) === index);
+  const snapshotsMatch = previousIds.length === incomingIds.length && previousIds.every((id, index) => id === incomingIds[index]);
+
+  if (snapshotsMatch) {
+    const shouldReplace = nextQueue.length > maxSequentialAnimatedItems || (nextQueue.length > 0 && incomingIds.length < pageSize);
+    return {
+      shouldReplace,
+      queuedIds: shouldReplace ? [] : nextQueue,
+    };
+  }
+
+  if (previousIds.length === 0 || incomingIds.length === 0 || previousIds.length !== incomingIds.length) {
+    return { shouldReplace: true, queuedIds: [] };
+  }
+
+  const previousIdSet = new Set(previousIds);
+  const overlapIndex = incomingIds.findIndex((id) => previousIdSet.has(id));
+
+  // Only a small prefix inserted ahead of the previous snapshot is a live update.
+  // Pagination, deletion, reordering, and unrelated result sets replace the snapshot.
+  if (overlapIndex <= 0 || incomingIds.length < pageSize) {
+    return { shouldReplace: true, queuedIds: [] };
+  }
+
+  const retainedIds = incomingIds.slice(overlapIndex);
+  const retainsPreviousPrefix = retainedIds.every((id, index) => id === previousIds[index]);
+  if (!retainsPreviousPrefix) {
+    return { shouldReplace: true, queuedIds: [] };
+  }
+
+  const queuedIdSet = new Set(nextQueue);
+  const newIdsOldestFirst = incomingIds.slice(0, overlapIndex).reverse();
+  for (const id of newIdsOldestFirst) {
+    if (!queuedIdSet.has(id)) {
+      queuedIdSet.add(id);
+      nextQueue.push(id);
+    }
+  }
+
+  if (nextQueue.length > maxSequentialAnimatedItems) {
+    return { shouldReplace: true, queuedIds: [] };
+  }
+
+  return { shouldReplace: false, queuedIds: nextQueue };
+}

--- a/frontend/src/hooks/animated-list.ts
+++ b/frontend/src/hooks/animated-list.ts
@@ -26,7 +26,7 @@ export function planAnimatedListUpdate(
   const snapshotsMatch = previousIds.length === incomingIds.length && previousIds.every((id, index) => id === incomingIds[index]);
 
   if (snapshotsMatch) {
-    const shouldReplace = nextQueue.length > maxSequentialAnimatedItems || (nextQueue.length > 0 && incomingIds.length < pageSize);
+    const shouldReplace = nextQueue.length > maxSequentialAnimatedItems || (nextQueue.length > 0 && incomingIds.length !== pageSize);
     return {
       shouldReplace,
       queuedIds: shouldReplace ? [] : nextQueue,
@@ -42,7 +42,7 @@ export function planAnimatedListUpdate(
 
   // Only a small prefix inserted ahead of the previous snapshot is a live update.
   // Pagination, deletion, reordering, and unrelated result sets replace the snapshot.
-  if (overlapIndex <= 0 || incomingIds.length < pageSize) {
+  if (overlapIndex <= 0 || incomingIds.length !== pageSize) {
     return { shouldReplace: true, queuedIds: [] };
   }
 

--- a/frontend/src/hooks/useAnimatedList.ts
+++ b/frontend/src/hooks/useAnimatedList.ts
@@ -1,13 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
+import { getMaxSequentialAnimatedItems, planAnimatedListUpdate } from './animated-list';
 import useInterval from './useInterval';
 
 const MAX_ITEMS = 50;
 const parsedInterval = parseInt(import.meta.env.VITE_REQUESTS_ANIMATION_INTERVAL, 10);
 const ANIMATION_INTERVAL = !isNaN(parsedInterval) && parsedInterval > 0 ? parsedInterval : 500;
+const MAX_ANIMATED_ITEMS = getMaxSequentialAnimatedItems(ANIMATION_INTERVAL);
 
 export function useAnimatedList<T extends { id: string; createdAt: Date | string }>(
   data: T[],
-  autoRefresh: boolean,
+  animateUpdates: boolean,
   pageSize: number = MAX_ITEMS,
   resetKey?: string
 ) {
@@ -18,9 +20,9 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
 
   const [displayedData, setDisplayedData] = useState<T[]>(data);
   const queueRef = useRef<T[]>([]);
-  const prevDataLengthRef = useRef<number>(data.length);
   const prevResetKeyRef = useRef(resetKey);
   const prevDataSignatureRef = useRef(dataSignature);
+  const prevDataIdsRef = useRef(data.map((item) => item.id));
   const pendingResetDataSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -37,68 +39,48 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
       }
       setDisplayedData(data);
       queueRef.current = [];
-      prevDataLengthRef.current = data.length;
       prevDataSignatureRef.current = dataSignature;
+      prevDataIdsRef.current = data.map((item) => item.id);
       return;
     }
 
-    if (!autoRefresh) {
+    if (!animateUpdates) {
       setDisplayedData(data);
       queueRef.current = [];
-      prevDataLengthRef.current = data.length;
       prevDataSignatureRef.current = dataSignature;
+      prevDataIdsRef.current = data.map((item) => item.id);
       return;
     }
 
-    setDisplayedData((currentDisplayed) => {
-      const currentIds = new Set(currentDisplayed.map((r) => r.id));
-      const newDataMap = new Map(data.map((r) => [r.id, r]));
+    const incomingIds = data.map((item) => item.id);
+    const newDataMap = new Map(data.map((item) => [item.id, item]));
+    const updatePlan = planAnimatedListUpdate(
+      prevDataIdsRef.current,
+      incomingIds,
+      queueRef.current.map((item) => item.id),
+      pageSize,
+      MAX_ANIMATED_ITEMS
+    );
 
-      // Compute the minimum timestamp from incoming data to establish the time window
-      const minTimestampOfNewData = data.length > 0 ? Math.min(...data.map((item) => getTimestamp(item.createdAt))) : 0;
-
-      // Only flag removals when the removed item is still within the new data's time window
-      // Items pushed off by pagination (older than minTimestampOfNewData) should not trigger a reset
-      const hasRemovedItems = currentDisplayed.some((item) => {
-        const isMissingFromNewData = !newDataMap.has(item.id);
-        const itemTimestamp = getTimestamp(item.createdAt);
-        return isMissingFromNewData && itemTimestamp >= minTimestampOfNewData;
+    prevDataIdsRef.current = incomingIds;
+    if (updatePlan.shouldReplace) {
+      queueRef.current = [];
+      setDisplayedData(data);
+    } else {
+      queueRef.current = updatePlan.queuedIds.flatMap((id) => {
+        const item = newDataMap.get(id);
+        return item ? [item] : [];
       });
-
-      const shouldResetToNewData = hasRemovedItems || data.length !== prevDataLengthRef.current;
-
-      if (shouldResetToNewData) {
-        prevDataLengthRef.current = data.length;
-        queueRef.current = [];
-        return data;
-      }
-
-      const updatedDisplayed = currentDisplayed.map((item) => {
-        const newItem = newDataMap.get(item.id);
-        return newItem ? newItem : item;
+      setDisplayedData((currentDisplayed) => {
+        const updatedDisplayed = currentDisplayed.map((item) => {
+          const newItem = newDataMap.get(item.id);
+          return newItem ? newItem : item;
+        });
+        return updatedDisplayed;
       });
-
-      const newestCurrentTime = currentDisplayed.length > 0 ? getTimestamp(currentDisplayed[0].createdAt) : 0;
-
-      const newItems = data.filter((item) => {
-        const isNew = !currentIds.has(item.id);
-        const isNewer = getTimestamp(item.createdAt) > newestCurrentTime;
-        return isNew && isNewer;
-      });
-
-      const sortedNewItems = newItems.sort((a, b) => getTimestamp(a.createdAt) - getTimestamp(b.createdAt));
-
-      sortedNewItems.forEach((item) => {
-        if (!queueRef.current.some((q) => q.id === item.id)) {
-          queueRef.current.push(item);
-        }
-      });
-
-      prevDataLengthRef.current = data.length;
-      return updatedDisplayed;
-    });
+    }
     prevDataSignatureRef.current = dataSignature;
-  }, [data, autoRefresh, resetKey]);
+  }, [data, animateUpdates, pageSize, resetKey]);
 
   useInterval(
     () => {
@@ -112,7 +94,7 @@ export function useAnimatedList<T extends { id: string; createdAt: Date | string
         }
       }
     },
-    autoRefresh ? ANIMATION_INTERVAL : null
+    animateUpdates ? ANIMATION_INTERVAL : null
   );
 
   return displayedData;

--- a/frontend/src/locales/en/base.json
+++ b/frontend/src/locales/en/base.json
@@ -77,6 +77,7 @@
   "common.exitFullscreen": "Exit Fullscreen",
   "common.refresh": "Refresh",
   "common.autoRefresh": "Auto Refresh",
+  "common.closeAutoRefresh": "Turn off auto refresh",
   "common.showArchived": "Show archived",
   "common.selected": "selected",
   "common.select.placeholder": "Select an option",

--- a/frontend/src/locales/zh-CN/base.json
+++ b/frontend/src/locales/zh-CN/base.json
@@ -142,6 +142,7 @@
   "common.exitFullscreen": "退出全屏",
   "common.refresh": "刷新",
   "common.autoRefresh": "自动刷新",
+  "common.closeAutoRefresh": "关闭自动刷新",
   "common.showArchived": "显示已归档",
   "common.selected": "已选择",
   "common.select.placeholder": "选择一个选项",


### PR DESCRIPTION
## Problem

Follow-up to #2198. Auto-refreshed request lists still treated every unseen row as a live insertion. This caused several related problems:

- returning from a later page could replay the first page row by row instead of replacing it immediately
- bursts of new logs accumulated in the 500 ms animation queue and left the visible list behind the latest server snapshot
- pagination, deletion, reordering, and partial-page changes could be mistaken for incremental updates
- selecting an auto-refresh interval kept list animation enabled on later pages even though polling itself was paused
- stopping auto refresh required opening the interval dropdown; the active interval button did not expose a direct stop action

## Solution

### Stable list updates

- classify updates by comparing consecutive server snapshot ID order
- animate only small top insertions into a full first-page snapshot
- replace the complete snapshot for pagination, unrelated result sets, deletions, reordering, partial-page changes, oversized stale responses, and large batches
- cap sequential animation by both a 1.5 second budget and a five-item hard limit; the default 500 ms interval therefore animates at most three queued rows
- count pending and newly received rows together so repeated polling cannot build a stale animation backlog
- enable list animation only while first-page polling is active across requests, traces, and threads

### Direct auto-refresh stop action

- when auto refresh is active, hovering the left side of the control changes the spinning refresh indicator and interval label to `X + Close`
- clicking that left-side button immediately turns off auto refresh without opening the interval dropdown
- keyboard focus exposes the same close state and action
- when auto refresh is already off, the left-side button keeps its existing manual refresh behavior
- add localized accessible text for the close action

## Validation

- `cd frontend && pnpm test:unit` (20/20 passed)
- Prettier checks for touched files passed
- `git diff --check` passed

Lint and build were not run because repository instructions prohibit them unless explicitly requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The refresh control now clearly indicates whether auto-refresh is active and lets you turn it off directly.
  - Refresh controls dynamically show the active interval and provide an accessible close action.
- **Bug Fixes**
  - List animations now run only when refresh animations are enabled, preventing unexpected movement.
  - Animated updates better handle new items, pagination changes, duplicate entries, and large refreshes.
- **Localization**
  - Added auto-refresh controls in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->