### PR TITLE
fix(requests): honor effective API key scopes

### DIFF
--- a/frontend/src/hooks/useRequestPermissions.ts
+++ b/frontend/src/hooks/useRequestPermissions.ts
@@ -27,7 +27,7 @@ export function useRequestPermissions(): RequestPermissions {
       return [];
     }
     const project = user.projects.find((p) => p.projectID === selectedProjectId);
-    return project?.scopes || [];
+    return project?.effectiveScopes || project?.scopes || [];
   }, [selectedProjectId, user?.projects]);
 
   const isProjectOwner = useMemo(() => {

--- a/frontend/src/hooks/useRequestPermissions.ts
+++ b/frontend/src/hooks/useRequestPermissions.ts
@@ -11,6 +11,7 @@ export interface RequestPermissions {
   canViewCallerUser: boolean;
 }
 
+/** Returns request-view permissions for the selected project's effective scopes. */
 export function useRequestPermissions(): RequestPermissions {
   const { user: authUser } = useAuthStore((state) => state.auth);
   const { data: meData } = useMe();


### PR DESCRIPTION
## Summary

Project roles grant permissions through `effectiveScopes`, but the requests-specific permission hook only read direct project scopes. Developers with `read_api_keys` through a project role therefore did not request `apiKey.name`, leaving the request caller column empty.

- Read project `effectiveScopes` with a direct-scope fallback
- Restore API key names in the request caller column for authorized developers

## Verification

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project permission checks now use the most accurate effective permission scopes, with a fallback for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->