### PR TITLE
fix(codex): scope Responses Lite to explicit official clients

### DIFF
--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -17,9 +17,9 @@ import (
 	"github.com/looplj/axonhub/llm/transformer"
 )
 
-// codexResponsesPassThroughHeaders contains client metadata that Codex-compatible
-// Responses upstreams use to select protocol behavior. Keep this as an explicit
-// allowlist: inbound credentials and transport headers must never be copied.
+// codexResponsesPassThroughHeaders contains Codex identity metadata that can
+// accompany a pass-through body. Keep this as an explicit allowlist: inbound
+// credentials, transport headers, and protocol-selection headers are never copied.
 var codexResponsesPassThroughHeaders = []string{
 	"X-Codex-Turn-Metadata",
 	"X-Codex-Window-Id",
@@ -27,7 +27,6 @@ var codexResponsesPassThroughHeaders = []string{
 	"X-Codex-Beta-Features",
 	"Session-Id",
 	"Originator",
-	"X-OpenAI-Internal-Codex-Responses-Lite",
 	"Thread-Id",
 }
 
@@ -141,10 +140,9 @@ func (p *PersistentOutboundTransformer) allowPassThroughBody(ctx context.Context
 	return policy.AllowPassThroughBody(ctx, llmReq, providerReq)
 }
 
-// applyPassThroughRequestHeaders forwards the Codex Responses metadata paired with
-// a pass-through body. These headers are part of the client's protocol negotiation;
-// dropping them while replaying the original body can change how a compatible
-// upstream interprets the same request.
+// applyPassThroughRequestHeaders forwards Codex identity metadata paired with
+// a pass-through body. Protocol-selection headers such as Responses Lite are
+// deliberately excluded: the Codex transformer decides whether they apply.
 func applyPassThroughRequestHeaders(outbound *PersistentOutboundTransformer) pipeline.Middleware {
 	return pipeline.OnRawRequest("pass-through-request-headers", func(_ context.Context, request *httpclient.Request) (*httpclient.Request, error) {
 		if !outbound.state.PassThroughApplied || outbound.state.LlmRequest == nil ||

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1475,6 +1475,7 @@ func TestApplyPassThroughRequestHeaders(t *testing.T) {
 		require.Equal(t, inboundHeaders.Values(header), processed.Headers.Values(header), header)
 	}
 	require.Equal(t, "Bearer provider-secret", processed.Headers.Get("Authorization"))
+	require.Empty(t, processed.Headers.Get("X-OpenAI-Internal-Codex-Responses-Lite"))
 	require.Empty(t, processed.Headers.Get("Cookie"))
 	require.Empty(t, processed.Headers.Get("Host"))
 	require.Empty(t, processed.Headers.Get("Content-Length"))

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -34,12 +34,18 @@ const (
 
 // OutboundTransformer implements transformer.Outbound for Codex proxy.
 // It normally talks to the Codex Responses upstream over SSE and adapts requests accordingly.
-// Compatible relays that return a completed JSON response are also supported for non-stream callers.
+// The official backend always streams SSE; compatible relays that return a
+// completed JSON response are also supported for non-stream callers.
 //
 //nolint:containedctx // It is used as a transformer.
 type OutboundTransformer struct {
 	tokens    oauth.TokenGetter
 	transport string
+
+	// official reports whether the configured upstream is the official Codex
+	// backend (chatgpt.com). Official endpoints always stream SSE, so they keep
+	// the DoStream path; only compatible relays get the JSON passthrough path.
+	official bool
 
 	// reuse existing Responses outbound for payload building.
 	responsesOutbound *responses.OutboundTransformer
@@ -64,6 +70,18 @@ type Params struct {
 	TokenProvider oauth.TokenGetter
 	BaseURL       string
 	Transport     string
+}
+
+// isOfficialCodexBaseURL reports whether baseURL points at the official Codex
+// backend. Everything else is treated as a compatible relay that may return a
+// completed JSON response instead of SSE.
+func isOfficialCodexBaseURL(baseURL string) bool {
+	return strings.Contains(strings.ToLower(baseURL), "chatgpt.com")
+}
+
+// isOfficialCodex reports whether the transformer targets the official Codex backend.
+func (t *OutboundTransformer) isOfficialCodex() bool {
+	return t != nil && t.official
 }
 
 func NewOutboundTransformer(params Params) (*OutboundTransformer, error) {
@@ -91,6 +109,7 @@ func NewOutboundTransformer(params Params) (*OutboundTransformer, error) {
 	return &OutboundTransformer{
 		tokens:            params.TokenProvider,
 		transport:         params.Transport,
+		official:          isOfficialCodexBaseURL(baseURL),
 		responsesOutbound: ro,
 	}, nil
 }
@@ -430,10 +449,73 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 		return e.inner.Do(ctx, request)
 	}
 
-	// Execute the request once and inspect the completed body. Codex normally
-	// responds with SSE even for downstream non-stream requests, but compatible
-	// relays can return a completed Responses JSON document instead. Reissuing
-	// the request to change protocols could duplicate model execution.
+	// The official Codex backend always streams SSE, so keep the historical
+	// DoStream path for it. Compatible relays may instead return a completed
+	// Responses JSON document; for those, execute once and dispatch on the
+	// response Content-Type. The request is never reissued, which could
+	// duplicate model execution and billing.
+	if e.transformer != nil && e.transformer.isOfficialCodex() {
+		return e.doStreamAndAggregate(ctx, request)
+	}
+
+	return e.doOnceAndDispatch(ctx, request)
+}
+
+// doStreamAndAggregate preserves the original Codex behavior: consume the
+// upstream SSE stream and aggregate the events into a completed Responses
+// JSON body.
+func (e *codexExecutor) doStreamAndAggregate(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	stream, err := e.inner.DoStream(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	var chunks []*httpclient.StreamEvent
+	for stream.Next() {
+		ev := stream.Current()
+		if ev == nil {
+			continue
+		}
+
+		chunks = append(chunks, &httpclient.StreamEvent{
+			Type:        ev.Type,
+			LastEventID: ev.LastEventID,
+			Data:        append([]byte(nil), ev.Data...),
+		})
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+	if err := responses.TopLevelWebSocketError(chunks); err != nil {
+		return nil, err
+	}
+
+	body, _, err := e.transformer.AggregateStreamChunks(ctx, request, chunks)
+	if err != nil {
+		return nil, err
+	}
+
+	return &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body:    body,
+		Request: request,
+	}, nil
+}
+
+// doOnceAndDispatch sends a single upstream request and inspects the completed
+// body. Codex normally responds with SSE even for downstream non-stream
+// requests, but compatible relays can return a completed Responses JSON
+// document instead. JSON responses pass through unchanged; everything else is
+// decoded as SSE and aggregated into a completed JSON response.
+func (e *codexExecutor) doOnceAndDispatch(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
 	response, err := e.inner.Do(ctx, request)
 	if err != nil {
 		return nil, err

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -168,13 +168,12 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		rawUserAgent = llmReq.RawRequest.Headers.Get("User-Agent")
 		rawTurnMetadata = llmReq.RawRequest.Headers.Get(TurnMetadataHeader)
 
-		// Non-Codex inbound clients omit the Responses Lite signal. Fabricate it
-		// so the Codex upstream sees the same protocol shape as a real Codex
-		// client. This must be set on the raw request before the underlying
-		// Responses outbound runs: it reads this header to emit an explicit
-		// parallel_tool_calls=false body, matching what real Codex sends.
-		if strings.TrimSpace(rawHeaders.Get(ResponsesLiteHeader)) == "" {
-			rawHeaders.Set(ResponsesLiteHeader, "true")
+		// Responses Lite selects a private Codex protocol mode. It is not
+		// identity metadata: never fabricate it for OpenAI-compatible clients.
+		// A client-selected Lite request is retained only for the official Codex
+		// backend; relays are not assumed to implement the same private protocol.
+		if !t.isOfficialCodex() || !strings.EqualFold(strings.TrimSpace(rawHeaders.Get(ResponsesLiteHeader)), "true") {
+			rawHeaders.Del(ResponsesLiteHeader)
 		}
 	}
 
@@ -227,21 +226,6 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 			reqCopy.ReasoningSummary = lo.ToPtr("auto")
 		}
 
-		// Responses Lite (signaled on the raw request above) rejects requests
-		// whose reasoning context is not "all_turns"; clients that never sent a
-		// reasoning block would otherwise fail upstream with HTTP 400. Only fill
-		// in a missing context — never override what the client explicitly sent.
-		if providerExt := reqCopy.ProviderExtensions; providerExt == nil || providerExt.OpenAIResponses == nil ||
-			providerExt.OpenAIResponses.Request == nil || providerExt.OpenAIResponses.Request.ReasoningContext == "" {
-			oaiExt := llm.EnsureOpenAIResponsesProviderExtensions(&reqCopy)
-			if oaiExt != nil {
-				if oaiExt.Request == nil {
-					oaiExt.Request = &llm.OpenAIResponsesRequestExtensions{ReasoningContext: "all_turns"}
-				} else {
-					oaiExt.Request.ReasoningContext = "all_turns"
-				}
-			}
-		}
 	}
 
 	// Codex Responses rejects token limit fields, so strip them out.

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -1,10 +1,13 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
@@ -30,7 +33,8 @@ const (
 )
 
 // OutboundTransformer implements transformer.Outbound for Codex proxy.
-// It always talks to the Codex Responses upstream (SSE only) and adapts requests accordingly.
+// It normally talks to the Codex Responses upstream over SSE and adapts requests accordingly.
+// Compatible relays that return a completed JSON response are also supported for non-stream callers.
 //
 //nolint:containedctx // It is used as a transformer.
 type OutboundTransformer struct {
@@ -426,31 +430,23 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 		return e.inner.Do(ctx, request)
 	}
 
-	stream, err := e.inner.DoStream(ctx, request)
+	// Execute the request once and inspect the completed body. Codex normally
+	// responds with SSE even for downstream non-stream requests, but compatible
+	// relays can return a completed Responses JSON document instead. Reissuing
+	// the request to change protocols could duplicate model execution.
+	response, err := e.inner.Do(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-
-	defer func() {
-		_ = stream.Close()
-	}()
-
-	var chunks []*httpclient.StreamEvent
-
-	for stream.Next() {
-		ev := stream.Current()
-		if ev == nil {
-			continue
-		}
-
-		chunks = append(chunks, &httpclient.StreamEvent{
-			Type:        ev.Type,
-			LastEventID: ev.LastEventID,
-			Data:        append([]byte(nil), ev.Data...),
-		})
+	if response == nil {
+		return nil, errors.New("empty response")
+	}
+	if isJSONResponse(response) {
+		return response, nil
 	}
 
-	if err := stream.Err(); err != nil {
+	chunks, err := decodeSSEChunks(ctx, response.Body)
+	if err != nil {
 		return nil, err
 	}
 	if err := responses.TopLevelWebSocketError(chunks); err != nil {
@@ -470,6 +466,47 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 		Body:    body,
 		Request: request,
 	}, nil
+}
+
+func isJSONResponse(response *httpclient.Response) bool {
+	if response == nil {
+		return false
+	}
+
+	mediaType, _, err := mime.ParseMediaType(response.Headers.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+
+	mediaType = strings.ToLower(mediaType)
+
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func decodeSSEChunks(ctx context.Context, body []byte) ([]*httpclient.StreamEvent, error) {
+	stream := httpclient.NewDefaultSSEDecoder(ctx, io.NopCloser(bytes.NewReader(body)))
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	chunks := make([]*httpclient.StreamEvent, 0)
+	for stream.Next() {
+		ev := stream.Current()
+		if ev == nil {
+			continue
+		}
+
+		chunks = append(chunks, &httpclient.StreamEvent{
+			Type:        ev.Type,
+			LastEventID: ev.LastEventID,
+			Data:        append([]byte(nil), ev.Data...),
+		})
+	}
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+
+	return chunks, nil
 }
 
 func (e *codexExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -359,7 +359,7 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 			{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"msg_test_456","type":"message","status":"completed","role":"assistant"}}`)},
 			{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_test_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"completed","output":[]}}`)},
 		},
-	})
+	}
 	executor := outbound.CustomizeExecutor(mock)
 
 	response, err := executor.Do(ctx, request)

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -349,7 +349,7 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 	require.NoError(t, err)
 
 	request := buildCodexStreamRequest(t, ctx, outbound, false)
-	executor := outbound.CustomizeExecutor(&mockCodexExecutor{
+	mock := &mockCodexExecutor{
 		streamEvents: []*httpclient.StreamEvent{
 			{Type: "response.created", Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_test_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"in_progress","output":[]}}`)},
 			{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_test_456","type":"message","status":"in_progress","role":"assistant"}}`)},
@@ -360,9 +360,11 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 			{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_test_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"completed","output":[]}}`)},
 		},
 	})
+	executor := outbound.CustomizeExecutor(mock)
 
 	response, err := executor.Do(ctx, request)
 	require.NoError(t, err)
+	require.Zero(t, mock.doCalls.Load(), "official Codex must stream and never call Do()")
 	require.Equal(t, http.StatusOK, response.StatusCode)
 	require.Equal(t, "application/json", response.Headers.Get("Content-Type"))
 
@@ -469,6 +471,51 @@ func TestCodexOutbound_CustomizeExecutorPassesThroughJSONForNonStreamRequests(t 
 	}
 }
 
+func TestCodexOutbound_CustomizeExecutorAggregatesRelaySSEForNonStreamRequests(t *testing.T) {
+	ctx := context.Background()
+	accessToken := testAccessTokenWithAccountID(t)
+
+	// A compatible relay (non-official upstream) may still respond with SSE for
+	// the stream-enabled upstream request. It must be decoded and aggregated
+	// into a completed Responses JSON body with a single upstream execution.
+	outbound, err := NewOutboundTransformer(Params{
+		BaseURL: "https://relay.example.com/v1",
+		TokenProvider: staticTokenGetter{
+			creds: &oauth.OAuthCredentials{
+				AccessToken: accessToken,
+				ExpiresAt:   time.Now().Add(time.Hour),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	request := buildCodexStreamRequest(t, ctx, outbound, false)
+	mock := &mockCodexExecutor{
+		streamEvents: []*httpclient.StreamEvent{
+			{Type: "response.created", Data: []byte(`{"type":"response.created","sequence_number":0,"response":{"id":"resp_relay_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"in_progress","output":[]}}`)},
+			{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_relay_456","type":"message","status":"in_progress","role":"assistant"}}`)},
+			{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","sequence_number":2,"item_id":"msg_relay_456","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+			{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","sequence_number":3,"item_id":"msg_relay_456","output_index":0,"content_index":0,"delta":"Hello"}`)},
+			{Type: "response.output_text.done", Data: []byte(`{"type":"response.output_text.done","sequence_number":4,"item_id":"msg_relay_456","output_index":0,"content_index":0,"text":"Hello"}`)},
+			{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"msg_relay_456","type":"message","status":"completed","role":"assistant"}}`)},
+			{Type: "response.completed", Data: []byte(`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_relay_123","object":"response","created_at":1700000000,"model":"gpt-5-codex","status":"completed","output":[]}}`)},
+		},
+	}
+	executor := outbound.CustomizeExecutor(mock)
+
+	response, err := executor.Do(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), mock.doCalls.Load(), "relay SSE must be executed exactly once")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "application/json", response.Headers.Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(response.Body, &body))
+	assert.Equal(t, "resp_relay_123", body["id"])
+	assert.Equal(t, "completed", body["status"])
+	assert.Equal(t, "gpt-5-codex", body["model"])
+}
+
 func TestCodexOutbound_DoReturnsWebSocketErrorEvents(t *testing.T) {
 	ctx := context.Background()
 	accessToken := testAccessTokenWithAccountID(t)
@@ -500,9 +547,11 @@ var _ pipeline.ChannelCustomizedExecutor = (*OutboundTransformer)(nil)
 
 type mockCodexExecutor struct {
 	streamEvents []*httpclient.StreamEvent
+	doCalls      atomic.Int32
 }
 
 func (m *mockCodexExecutor) Do(_ context.Context, _ *httpclient.Request) (*httpclient.Response, error) {
+	m.doCalls.Add(1)
 	return newCodexSSEResponse(m.streamEvents), nil
 }
 

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -372,6 +373,102 @@ func TestCodexOutbound_CustomizeExecutorAggregatesNonStreamRequests(t *testing.T
 	assert.Equal(t, "gpt-5-codex", body["model"])
 }
 
+func TestCodexOutbound_CustomizeExecutorPassesThroughJSONForNonStreamRequests(t *testing.T) {
+	const upstreamBody = `{
+		"id":"resp_json_123",
+		"object":"response",
+		"created_at":1700000000,
+		"status":"completed",
+		"model":"gpt-5.6-luna",
+		"output":[{
+			"id":"msg_json_123",
+			"type":"message",
+			"status":"completed",
+			"role":"assistant",
+			"content":[{"type":"output_text","text":"OK"}]
+		}]
+	}`
+
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{name: "application JSON with charset", contentType: "application/json; charset=utf-8"},
+		{name: "vendor JSON with charset", contentType: "application/vnd.compat+json; charset=utf-8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			accessToken := testAccessTokenWithAccountID(t)
+
+			type capturedRequest struct {
+				accept string
+				stream bool
+			}
+
+			var requestCount atomic.Int32
+			capturedRequests := make(chan capturedRequest, 2)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount.Add(1)
+
+				var body struct {
+					Stream bool `json:"stream"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				select {
+				case capturedRequests <- capturedRequest{accept: r.Header.Get("Accept"), stream: body.Stream}:
+				default:
+				}
+
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = w.Write([]byte(upstreamBody))
+			}))
+			defer server.Close()
+
+			outbound, err := NewOutboundTransformer(Params{
+				BaseURL: server.URL,
+				TokenProvider: staticTokenGetter{
+					creds: &oauth.OAuthCredentials{
+						AccessToken: accessToken,
+						ExpiresAt:   time.Now().Add(time.Hour),
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			request, err := outbound.TransformRequest(ctx, &llm.Request{
+				Model:     "gpt-5.6-luna",
+				APIFormat: llm.APIFormatOpenAIResponse,
+				Stream:    lo.ToPtr(false),
+				Messages: []llm.Message{{
+					Role:    "user",
+					Content: llm.MessageContent{Content: lo.ToPtr("Only reply OK")},
+				}},
+			})
+			require.NoError(t, err)
+
+			executor := outbound.CustomizeExecutor(httpclient.NewHttpClientWithClient(server.Client()))
+			response, err := executor.Do(ctx, request)
+			require.NoError(t, err)
+			require.Equal(t, int32(1), requestCount.Load(), "JSON fallback must not reissue the model request")
+
+			captured := <-capturedRequests
+			assert.Equal(t, "text/event-stream", captured.accept)
+			assert.True(t, captured.stream, "Codex upstream requests remain stream-enabled")
+			assert.Equal(t, http.StatusOK, response.StatusCode)
+			assert.Equal(t, tt.contentType, response.Headers.Get("Content-Type"))
+			assert.JSONEq(t, upstreamBody, string(response.Body))
+
+			llmResponse, err := outbound.TransformResponse(ctx, response)
+			require.NoError(t, err)
+			require.Len(t, llmResponse.Choices, 1)
+			require.NotNil(t, llmResponse.Choices[0].Message.Content.Content)
+			assert.Equal(t, "OK", *llmResponse.Choices[0].Message.Content.Content)
+		})
+	}
+}
+
 func TestCodexOutbound_DoReturnsWebSocketErrorEvents(t *testing.T) {
 	ctx := context.Background()
 	accessToken := testAccessTokenWithAccountID(t)
@@ -406,11 +503,55 @@ type mockCodexExecutor struct {
 }
 
 func (m *mockCodexExecutor) Do(_ context.Context, _ *httpclient.Request) (*httpclient.Response, error) {
-	return nil, assert.AnError
+	return newCodexSSEResponse(m.streamEvents), nil
 }
 
 func (m *mockCodexExecutor) DoStream(_ context.Context, _ *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	return streams.SliceStream(m.streamEvents), nil
+}
+
+func newCodexSSEResponse(events []*httpclient.StreamEvent) *httpclient.Response {
+	var body strings.Builder
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		if event.Type != "" {
+			body.WriteString("event: ")
+			body.WriteString(event.Type)
+			body.WriteByte('\n')
+		}
+		if event.LastEventID != "" {
+			body.WriteString("id: ")
+			body.WriteString(event.LastEventID)
+			body.WriteByte('\n')
+		}
+		// SSE requires a separate data field for each logical payload line.
+		for _, line := range strings.Split(string(event.Data), "\n") {
+			body.WriteString("data: ")
+			body.WriteString(strings.TrimSuffix(line, "\r"))
+			body.WriteByte('\n')
+		}
+		body.WriteByte('\n')
+	}
+
+	return &httpclient.Response{
+		StatusCode: http.StatusOK,
+		Headers: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: []byte(body.String()),
+	}
+}
+
+func TestNewCodexSSEResponseEncodesMultilineData(t *testing.T) {
+	response := newCodexSSEResponse([]*httpclient.StreamEvent{{
+		Type:        "response.created",
+		LastEventID: "event_123",
+		Data:        []byte("{\r\n  \"type\": \"response.created\"\n}"),
+	}})
+
+	assert.Equal(t, "event: response.created\nid: event_123\ndata: {\ndata:   \"type\": \"response.created\"\ndata: }\n\n", string(response.Body))
 }
 
 func TestCodexOutbound_DoesNotInjectCLIInstructions(t *testing.T) {

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -709,15 +709,15 @@ func TestCodexOutbound_AppliesReasoningDefaultsWhenMissing(t *testing.T) {
 	assert.Equal(t, true, body["parallel_tool_calls"])
 	assert.Equal(t, []any{"reasoning.encrypted_content"}, body["include"])
 	assert.Equal(t, "auto", reasoning["summary"])
-	assert.Equal(t, "all_turns", reasoning["context"])
+	assert.Empty(t, reasoning["context"])
 	assert.NotContains(t, body, "metadata")
 }
 
-func TestCodexOutbound_FillsMissingReasoningContextForResponsesLite(t *testing.T) {
+func TestCodexOutbound_ResponsesLiteIsExplicitAndOfficialOnly(t *testing.T) {
 	ctx := context.Background()
-	outbound := newTestCodexOutbound(t)
 
-	t.Run("plain chat request gets all_turns context", func(t *testing.T) {
+	t.Run("plain request does not fabricate Lite or reasoning context", func(t *testing.T) {
+		outbound := newTestCodexOutbound(t)
 		hreq, err := outbound.TransformRequest(ctx, &llm.Request{
 			Model: "gpt-5-codex",
 			Messages: []llm.Message{{
@@ -728,23 +728,58 @@ func TestCodexOutbound_FillsMissingReasoningContextForResponsesLite(t *testing.T
 		})
 		require.NoError(t, err)
 
+		assert.Empty(t, hreq.Headers.Get(responses.ResponsesLiteHeader))
 		body := decodeCodexRequestBody(t, hreq)
 		reasoning, ok := body["reasoning"].(map[string]any)
-		require.True(t, ok, "reasoning block must be emitted for Responses Lite")
-		assert.Equal(t, "all_turns", reasoning["context"])
+		if ok {
+			assert.Empty(t, reasoning["context"])
+		}
 	})
 
-	t.Run("client-sent reasoning without context gets all_turns", func(t *testing.T) {
+	t.Run("official backend preserves client-selected Lite semantics", func(t *testing.T) {
+		outbound := newTestCodexOutbound(t)
 		headers := make(http.Header)
 		headers.Set("Content-Type", "application/json")
 		headers.Set(responses.ResponsesLiteHeader, "true")
 		inboundRequest := &httpclient.Request{
 			Headers: headers,
 			Body: []byte(`{
-				"model": "gpt-5.6-sol",
+				"model": "gpt-5.3-codex-spark",
 				"input": "Hello",
 				"stream": true,
-				"reasoning": {"effort": "xhigh"}
+				"parallel_tool_calls": false,
+				"reasoning": {"effort": "high", "context": "current_turn"}
+			}`),
+		}
+
+		llmRequest, err := responses.NewInboundTransformer().TransformRequest(ctx, inboundRequest)
+		require.NoError(t, err)
+		llmRequest.RawRequest = inboundRequest
+
+		outboundRequest, err := outbound.TransformRequest(ctx, llmRequest)
+		require.NoError(t, err)
+		outboundRequest = httpclient.MergeInboundRequest(outboundRequest, inboundRequest)
+
+		assert.Equal(t, "true", outboundRequest.Headers.Get(responses.ResponsesLiteHeader))
+		body := decodeCodexRequestBody(t, outboundRequest)
+		assert.Equal(t, false, body["parallel_tool_calls"])
+		reasoning, ok := body["reasoning"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "current_turn", reasoning["context"])
+	})
+
+	t.Run("relay removes Lite without rewriting client reasoning", func(t *testing.T) {
+		outbound := newTestCodexOutboundForBaseURL(t, "https://relay.example/v1")
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+		headers.Set(responses.ResponsesLiteHeader, "true")
+		inboundRequest := &httpclient.Request{
+			Headers: headers,
+			Body: []byte(`{
+				"model": "gpt-5.3-codex-spark",
+				"input": "Hello",
+				"stream": true,
+				"reasoning": {"context": "current_turn"}
 			}`),
 		}
 
@@ -755,24 +790,11 @@ func TestCodexOutbound_FillsMissingReasoningContextForResponsesLite(t *testing.T
 		outboundRequest, err := outbound.TransformRequest(ctx, llmRequest)
 		require.NoError(t, err)
 
+		assert.Empty(t, outboundRequest.Headers.Get(responses.ResponsesLiteHeader))
 		body := decodeCodexRequestBody(t, outboundRequest)
 		reasoning, ok := body["reasoning"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "all_turns", reasoning["context"])
-		assert.Equal(t, "xhigh", reasoning["effort"])
-	})
-
-	t.Run("image requests do not get a fabricated reasoning context", func(t *testing.T) {
-		req, err := outbound.TransformRequest(ctx, &llm.Request{
-			Model:       "gpt-image-2",
-			RequestType: llm.RequestTypeImage,
-			APIFormat:   llm.APIFormatOpenAIImageGeneration,
-			RawRequest:  &httpclient.Request{Headers: http.Header{}},
-			Image:       &llm.ImageRequest{Prompt: "a cat"},
-		})
-		require.NoError(t, err)
-
-		assert.NotContains(t, string(req.Body), `"context"`)
+		assert.Equal(t, "current_turn", reasoning["context"])
 	})
 }
 
@@ -848,10 +870,16 @@ func TestCodexOutbound_PreservesResponsesLiteRequirements(t *testing.T) {
 func newTestCodexOutbound(t *testing.T) *OutboundTransformer {
 	t.Helper()
 
+	return newTestCodexOutboundForBaseURL(t, "https://chatgpt.com/backend-api/codex#")
+}
+
+func newTestCodexOutboundForBaseURL(t *testing.T, baseURL string) *OutboundTransformer {
+	t.Helper()
+
 	accessToken := testAccessTokenWithAccountID(t)
 
 	outbound, err := NewOutboundTransformer(Params{
-		BaseURL: "https://chatgpt.com/backend-api/codex#",
+		BaseURL: baseURL,
 		TokenProvider: staticTokenGetter{
 			creds: &oauth.OAuthCredentials{
 				AccessToken: accessToken,


### PR DESCRIPTION
﻿## Summary

Fix Codex Responses handling for ordinary OpenAI-compatible clients and compatible relays.

- keep official Codex SSE aggregation while allowing compatible relays to return one completed Responses JSON document for non-stream callers;
- do not fabricate `X-OpenAI-Internal-Codex-Responses-Lite` for ordinary clients;
- do not inject `reasoning.context: all_turns` into client requests;
- preserve explicitly selected Responses Lite only for the official `chatgpt.com` Codex backend;
- exclude Responses Lite from pass-through header replay so it cannot override the transformer’s target-aware decision.

## Why

Responses Lite is a private protocol mode with model- and tool-specific constraints. Treating it as mandatory identity metadata caused ordinary requests to fail with unsupported `reasoning.context` or unsupported tool errors.

## Tests

- Added coverage for ordinary requests, explicit official Lite requests using `current_turn`, and relay requests.
- Ran `gofmt` and `git diff --check`.
- Local Go tests could not start because this environment cannot reach `proxy.golang.org` to download Go modules; GitHub Actions will run the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Codex compatibility across official backends and compatible relays.
  * Added support for handling both JSON and server-sent event responses from relay connections.
  * Preserved Responses Lite behavior for official backends while preventing unsupported forwarding to relays.

* **Bug Fixes**
  * Prevented internal protocol-selection headers from being forwarded incorrectly.
  * Removed automatic reasoning-context injection where it could conflict with request settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->