### PR TITLE
feat: add model-routed protocols for OpenCode Go

### DIFF
--- a/frontend/src/features/channels/data/channel-config.test.mjs
+++ b/frontend/src/features/channels/data/channel-config.test.mjs
@@ -93,6 +93,22 @@ test('xAI subscription is exposed as an OAuth Responses channel', () => {
   );
 });
 
+test('OpenCode Go exposes Chat Completions and Responses on one channel type', () => {
+  const channelsConfig = read('features/channels/data/config_channels.ts');
+  const providersConfig = read('features/channels/data/config_providers.ts');
+
+  assert.match(
+    channelsConfig,
+    /opencode_go:\s*{[\s\S]*apiFormat:\s*OPENAI_CHAT_COMPLETIONS[\s\S]*apiFormats:\s*\[OPENAI_CHAT_COMPLETIONS,\s*OPENAI_RESPONSES\]/,
+    'OpenCode Go should declare both OpenAI protocols as supported formats'
+  );
+  assert.match(
+    providersConfig,
+    /opencode_go:\s*{[\s\S]*channelTypes:\s*\[\s*'opencode_go',\s*'opencode_go_anthropic'\s*\]/,
+    'OpenCode Go should keep one provider with its Anthropic variant'
+  );
+});
+
 test('channel proxy connection reuse setting is submitted, echoed, and localized', () => {
   const schema = read('features/channels/data/schema.ts');
   const channelsData = read('features/channels/data/channels.ts');

--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -58,8 +58,11 @@ export interface ChannelConfig {
   /** Default models available for quick selection */
   defaultModels: string[];
 
-  /** API protocol format used when calling this channel */
+  /** Default API protocol format used when calling this channel */
   apiFormat: ApiFormat;
+
+  /** API protocol formats supported by this channel type, including apiFormat */
+  apiFormats?: ApiFormat[];
 
   /** Badge color classes for the channel type */
   color: string;
@@ -712,6 +715,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
     baseURL: 'https://opencode.ai/zen/go',
     defaultModels: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2.5', 'mimo-v2.5-pro'],
     apiFormat: OPENAI_CHAT_COMPLETIONS,
+    apiFormats: [OPENAI_CHAT_COMPLETIONS, OPENAI_RESPONSES],
     color: 'bg-indigo-100 text-indigo-800 border-indigo-200',
     icon: OpenCode,
   },

--- a/frontend/src/features/channels/data/config_providers.ts
+++ b/frontend/src/features/channels/data/config_providers.ts
@@ -316,7 +316,8 @@ export const getChannelTypeForApiFormat = (provider: string, apiFormat: ApiForma
 
   for (const channelType of providerConfig.channelTypes) {
     const channelConfig = CHANNEL_CONFIGS[channelType];
-    if (channelConfig?.apiFormat === apiFormat) {
+    const supportedFormats = channelConfig?.apiFormats ?? (channelConfig ? [channelConfig.apiFormat] : []);
+    if (supportedFormats.includes(apiFormat)) {
       return channelType;
     }
   }
@@ -333,8 +334,11 @@ export const getApiFormatsForProvider = (provider: string): ApiFormat[] => {
   const formats: ApiFormat[] = [];
   for (const channelType of providerConfig.channelTypes) {
     const channelConfig = CHANNEL_CONFIGS[channelType];
-    if (channelConfig?.apiFormat && !formats.includes(channelConfig.apiFormat)) {
-      formats.push(channelConfig.apiFormat);
+    const supportedFormats = channelConfig?.apiFormats ?? (channelConfig ? [channelConfig.apiFormat] : []);
+    for (const format of supportedFormats) {
+      if (!formats.includes(format)) {
+        formats.push(format);
+      }
     }
   }
   return formats;

--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -197,7 +197,10 @@ var defaultEndpointsForChannelType = map[channel.Type][]objects.ChannelEndpoint{
 	channel.TypeAntigravity:      {{APIFormat: llm.APIFormatGeminiContents.String()}},
 	channel.TypeNanogpt:          openAIFullDefaultEndpoints,
 	channel.TypeNanogptResponses: {{APIFormat: llm.APIFormatOpenAIResponse.String()}},
-	channel.TypeOpencodeGo:       openAIChatOnlyDefaultEndpoints,
+	channel.TypeOpencodeGo: {
+		{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
+		{APIFormat: llm.APIFormatOpenAIResponse.String()},
+	},
 	channel.TypeOllama:           {{APIFormat: llm.APIFormatOllamaChat.String()}},
 	channel.TypeOllamaAnthropic:  {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
 	channel.TypeEvolink:          openAICompatibleDefaultEndpoints,

--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -198,8 +198,8 @@ var defaultEndpointsForChannelType = map[channel.Type][]objects.ChannelEndpoint{
 	channel.TypeNanogpt:          openAIFullDefaultEndpoints,
 	channel.TypeNanogptResponses: {{APIFormat: llm.APIFormatOpenAIResponse.String()}},
 	channel.TypeOpencodeGo: {
-		{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
-		{APIFormat: llm.APIFormatOpenAIResponse.String()},
+		{APIFormat: llm.APIFormatOpenAIChatCompletion.String(), Path: "", BaseURL: "", Transport: ""},
+		{APIFormat: llm.APIFormatOpenAIResponse.String(), Path: "", BaseURL: "", Transport: ""},
 	},
 	channel.TypeOllama:           {{APIFormat: llm.APIFormatOllamaChat.String()}},
 	channel.TypeOllamaAnthropic:  {{APIFormat: llm.APIFormatAnthropicMessage.String()}},

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -107,6 +107,14 @@ func TestDefaultEndpointsForChannelType_UseLLMAPIFormatValues(t *testing.T) {
 			expected: []string{llm.APIFormatOpenAIResponse.String()},
 		},
 		{
+			name: "opencode_go exposes chat and responses",
+			typ:  channel.TypeOpencodeGo,
+			expected: []string{
+				llm.APIFormatOpenAIChatCompletion.String(),
+				llm.APIFormatOpenAIResponse.String(),
+			},
+		},
+		{
 			name: "xai api key exposes chat and responses",
 			typ:  channel.TypeXai,
 			expected: []string{

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
@@ -28,11 +27,13 @@ func TestOpenCodeChannel_ResponsesEndpointUsesModelRoutedOutbound(t *testing.T) 
 	defer client.Close()
 
 	ctx := authz.WithTestBypass(context.Background())
+	var credentials objects.ChannelCredentials
+	credentials.APIKey = "test-key"
 	entChannel := client.Channel.Create().
 		SetName("OpenCode Go Model Routed Channel").
 		SetType(channel.TypeOpencodeGo).
 		SetBaseURL("https://opencode.ai/zen/go").
-		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetCredentials(credentials).
 		SetSupportedModels([]string{
 			"glm-5.2",
 			"deepseek-v4-pro",
@@ -65,14 +66,18 @@ func TestOpenCodeChannel_ResponsesEndpointUsesModelRoutedOutbound(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			httpReq, err := responsesOutbound.TransformRequest(ctx, &llm.Request{
-				APIFormat: llm.APIFormatOpenAIResponse,
-				Model:     tt.model,
-				Messages: []llm.Message{{
-					Role:    "user",
-					Content: llm.MessageContent{Content: lo.ToPtr("Hello")},
-				}},
-			})
+			content := "Hello"
+			var messageContent llm.MessageContent
+			messageContent.Content = &content
+			var message llm.Message
+			message.Role = "user"
+			message.Content = messageContent
+			var request llm.Request
+			request.APIFormat = llm.APIFormatOpenAIResponse
+			request.Model = tt.model
+			request.Messages = []llm.Message{message}
+
+			httpReq, err := responsesOutbound.TransformRequest(ctx, &request)
 			require.NoError(t, err)
 			require.Contains(t, httpReq.URL, tt.path)
 		})

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
@@ -21,6 +22,62 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/openai/codex"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
+
+func TestOpenCodeChannel_ResponsesEndpointUsesModelRoutedOutbound(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+	entChannel := client.Channel.Create().
+		SetName("OpenCode Go Model Routed Channel").
+		SetType(channel.TypeOpencodeGo).
+		SetBaseURL("https://opencode.ai/zen/go").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{
+			"glm-5.2",
+			"deepseek-v4-pro",
+			"minimax-m3",
+			"grok-4.5",
+			"gpt-5.6-luna",
+			"muse-spark-1.2-contributor",
+		}).
+		SetDefaultTestModel("glm-5.2").
+		SaveX(ctx)
+
+	built, err := NewChannelServiceForTest(client).buildChannelWithOutbounds(entChannel)
+	require.NoError(t, err)
+
+	responsesOutbound, err := BuildOutboundByAPIFormat(built, llm.APIFormatOpenAIResponse.String())
+	require.NoError(t, err)
+	require.Same(t, built.Outbound, responsesOutbound, "OpenCode Responses endpoint must retain model-based routing")
+
+	tests := []struct {
+		model string
+		path  string
+	}{
+		{model: "glm-5.2", path: "/v1/chat/completions"},
+		{model: "deepseek-v4-pro", path: "/v1/chat/completions"},
+		{model: "minimax-m3", path: "/v1/messages"},
+		{model: "grok-4.5", path: "/v1/responses"},
+		{model: "gpt-5.6-luna", path: "/v1/responses"},
+		{model: "muse-spark-1.2-contributor", path: "/v1/responses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			httpReq, err := responsesOutbound.TransformRequest(ctx, &llm.Request{
+				APIFormat: llm.APIFormatOpenAIResponse,
+				Model:     tt.model,
+				Messages: []llm.Message{{
+					Role:    "user",
+					Content: llm.MessageContent{Content: lo.ToPtr("Hello")},
+				}},
+			})
+			require.NoError(t, err)
+			require.Contains(t, httpReq.URL, tt.path)
+		})
+	}
+}
 
 func TestOpenAICompatibleChannel_BuildChannelWithOutbounds(t *testing.T) {
 	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -371,6 +371,33 @@ func selectOutboundForCandidate(candidate *ChannelModelsCandidate) transformer.O
 	return candidate.Channel.Outbound
 }
 
+// requestAPIFormatResolver is implemented by composite outbounds whose
+// upstream protocol depends on the request, such as OpenCode Go. Candidate
+// APIFormat describes the endpoint accepted for the inbound request, while
+// this resolver describes the protocol actually used by the selected model.
+type requestAPIFormatResolver interface {
+	APIFormatForRequest(*llm.Request) llm.APIFormat
+}
+
+func resolveOutboundAPIFormat(outbound transformer.Outbound, candidateAPIFormat string, req *llm.Request) llm.APIFormat {
+	if outbound == nil {
+		return ""
+	}
+
+	format := outbound.APIFormat()
+	if candidateAPIFormat != "" {
+		format = llm.APIFormat(candidateAPIFormat)
+	}
+
+	if resolver, ok := outbound.(requestAPIFormatResolver); ok {
+		if resolved := resolver.APIFormatForRequest(req); resolved != "" {
+			format = resolved
+		}
+	}
+
+	return format
+}
+
 // APIFormat returns the API format of the transformer.
 func (p *PersistentOutboundTransformer) APIFormat() llm.APIFormat {
 	return p.wrapped.APIFormat()
@@ -408,13 +435,9 @@ func (p *PersistentOutboundTransformer) TransformRequest(ctx context.Context, ll
 
 	llmRequest.Model = entry.ActualModel
 
-	outboundFormat := p.wrapped.APIFormat()
-	if candidate.APIFormat != "" {
-		outboundFormat = llm.APIFormat(candidate.APIFormat)
-	}
-
 	// Apply channel transform options to create a new request
 	llmRequest = applyTransformOptions(llmRequest, candidate.Channel.Settings)
+	outboundFormat := resolveOutboundAPIFormat(p.wrapped, candidate.APIFormat, llmRequest)
 	for _, middleware := range p.outboundLlmRequestMiddlewares {
 		transformedRequest, err := middleware.OnOutboundLlmRequest(ctx, llmRequest, outboundFormat)
 		if err != nil {

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -37,6 +37,15 @@ type mockTransformer struct {
 	includeEffort      bool
 }
 
+type requestFormatMockTransformer struct {
+	mockTransformer
+	resolvedFormat llm.APIFormat
+}
+
+func (m *requestFormatMockTransformer) APIFormatForRequest(*llm.Request) llm.APIFormat {
+	return m.resolvedFormat
+}
+
 func (m *mockTransformer) TransformRequest(ctx context.Context, req *llm.Request) (*httpclient.Request, error) {
 	payload := map[string]any{
 		"model":       req.Model,
@@ -1166,6 +1175,63 @@ func TestFilterResponseCustomToolMessagesForNonResponsesOutbound(t *testing.T) {
 		got := filterResponseCustomToolMessagesForNonResponsesOutbound(&nonResponsesReq, llm.APIFormatOpenAIChatCompletion)
 		require.Same(t, &nonResponsesReq, got)
 	})
+}
+
+func TestResolveOutboundAPIFormat_PrefersRequestResolvedFormat(t *testing.T) {
+	outbound := &requestFormatMockTransformer{
+		mockTransformer: mockTransformer{apiFormat: llm.APIFormatOpenAIChatCompletion},
+		resolvedFormat:  llm.APIFormatOpenAIChatCompletion,
+	}
+
+	got := resolveOutboundAPIFormat(outbound, llm.APIFormatOpenAIResponse.String(), &llm.Request{Model: "glm-5.3"})
+	require.Equal(t, llm.APIFormatOpenAIChatCompletion, got)
+}
+
+func TestPersistentOutboundTransformer_FiltersResponsesCustomToolsForModelRoutedOpenCode(t *testing.T) {
+	outbound := &requestFormatMockTransformer{
+		mockTransformer: mockTransformer{apiFormat: llm.APIFormatOpenAIChatCompletion},
+		resolvedFormat:  llm.APIFormatOpenAIChatCompletion,
+	}
+	channel := &biz.Channel{
+		Channel:  &ent.Channel{ID: 1, Name: "opencode-go", Settings: nil},
+		Outbound: outbound,
+	}
+	processor := &PersistentOutboundTransformer{
+		wrapped: outbound,
+		state: &PersistenceState{
+			ChannelModelsCandidates: []*ChannelModelsCandidate{{
+				Channel:   channel,
+				Models:    []biz.ChannelModelEntry{{ActualModel: "glm-5.3"}},
+				APIFormat: llm.APIFormatOpenAIResponse.String(),
+			}},
+		},
+	}
+
+	customCallID := "custom-1"
+	request := &llm.Request{
+		APIFormat: llm.APIFormatOpenAIResponse,
+		Model:     "glm-5.3",
+		Messages: []llm.Message{
+			{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{{
+					ID:                     customCallID,
+					Type:                   llm.ToolTypeResponsesCustomTool,
+					ResponseCustomToolCall: &llm.ResponseCustomToolCall{CallID: customCallID, Name: "apply_patch", Input: "patch"},
+				}},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: &customCallID,
+				Content:    llm.MessageContent{Content: lo.ToPtr("result")},
+			},
+		},
+	}
+
+	httpRequest, err := processor.TransformRequest(context.Background(), request)
+	require.NoError(t, err)
+	require.NotContains(t, string(httpRequest.Body), "responses_custom_tool")
+	require.NotContains(t, string(httpRequest.Body), "apply_patch")
 }
 
 // ========== 429 Retry-After Tests ==========

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -39,6 +39,7 @@ type mockTransformer struct {
 
 type requestFormatMockTransformer struct {
 	mockTransformer
+
 	resolvedFormat llm.APIFormat
 }
 
@@ -1178,55 +1179,61 @@ func TestFilterResponseCustomToolMessagesForNonResponsesOutbound(t *testing.T) {
 }
 
 func TestResolveOutboundAPIFormat_PrefersRequestResolvedFormat(t *testing.T) {
-	outbound := &requestFormatMockTransformer{
-		mockTransformer: mockTransformer{apiFormat: llm.APIFormatOpenAIChatCompletion},
-		resolvedFormat:  llm.APIFormatOpenAIChatCompletion,
-	}
+	outbound := new(requestFormatMockTransformer)
+	outbound.mockTransformer.apiFormat = llm.APIFormatOpenAIChatCompletion
+	outbound.resolvedFormat = llm.APIFormatOpenAIChatCompletion
+	request := new(llm.Request)
+	request.Model = "glm-5.3"
 
-	got := resolveOutboundAPIFormat(outbound, llm.APIFormatOpenAIResponse.String(), &llm.Request{Model: "glm-5.3"})
+	got := resolveOutboundAPIFormat(outbound, llm.APIFormatOpenAIResponse.String(), request)
 	require.Equal(t, llm.APIFormatOpenAIChatCompletion, got)
 }
 
 func TestPersistentOutboundTransformer_FiltersResponsesCustomToolsForModelRoutedOpenCode(t *testing.T) {
-	outbound := &requestFormatMockTransformer{
-		mockTransformer: mockTransformer{apiFormat: llm.APIFormatOpenAIChatCompletion},
-		resolvedFormat:  llm.APIFormatOpenAIChatCompletion,
-	}
-	channel := &biz.Channel{
-		Channel:  &ent.Channel{ID: 1, Name: "opencode-go", Settings: nil},
-		Outbound: outbound,
-	}
-	processor := &PersistentOutboundTransformer{
-		wrapped: outbound,
-		state: &PersistenceState{
-			ChannelModelsCandidates: []*ChannelModelsCandidate{{
-				Channel:   channel,
-				Models:    []biz.ChannelModelEntry{{ActualModel: "glm-5.3"}},
-				APIFormat: llm.APIFormatOpenAIResponse.String(),
-			}},
-		},
-	}
+	outbound := new(requestFormatMockTransformer)
+	outbound.mockTransformer.apiFormat = llm.APIFormatOpenAIChatCompletion
+	outbound.resolvedFormat = llm.APIFormatOpenAIChatCompletion
+	channelEntity := new(ent.Channel)
+	channelEntity.ID = 1
+	channelEntity.Name = "opencode-go"
+	channel := new(biz.Channel)
+	channel.Channel = channelEntity
+	channel.Outbound = outbound
+	var model biz.ChannelModelEntry
+	model.ActualModel = "glm-5.3"
+	candidate := new(ChannelModelsCandidate)
+	candidate.Channel = channel
+	candidate.Models = []biz.ChannelModelEntry{model}
+	candidate.APIFormat = llm.APIFormatOpenAIResponse.String()
+	state := new(PersistenceState)
+	state.ChannelModelsCandidates = []*ChannelModelsCandidate{candidate}
+	processor := new(PersistentOutboundTransformer)
+	processor.wrapped = outbound
+	processor.state = state
 
 	customCallID := "custom-1"
-	request := &llm.Request{
-		APIFormat: llm.APIFormatOpenAIResponse,
-		Model:     "glm-5.3",
-		Messages: []llm.Message{
-			{
-				Role: "assistant",
-				ToolCalls: []llm.ToolCall{{
-					ID:                     customCallID,
-					Type:                   llm.ToolTypeResponsesCustomTool,
-					ResponseCustomToolCall: &llm.ResponseCustomToolCall{CallID: customCallID, Name: "apply_patch", Input: "patch"},
-				}},
-			},
-			{
-				Role:       "tool",
-				ToolCallID: &customCallID,
-				Content:    llm.MessageContent{Content: lo.ToPtr("result")},
-			},
-		},
-	}
+	customTool := new(llm.ResponseCustomToolCall)
+	customTool.CallID = customCallID
+	customTool.Name = "apply_patch"
+	customTool.Input = "patch"
+	var toolCall llm.ToolCall
+	toolCall.ID = customCallID
+	toolCall.Type = llm.ToolTypeResponsesCustomTool
+	toolCall.ResponseCustomToolCall = customTool
+	var assistantMessage llm.Message
+	assistantMessage.Role = "assistant"
+	assistantMessage.ToolCalls = []llm.ToolCall{toolCall}
+	toolContent := "result"
+	var toolMessageContent llm.MessageContent
+	toolMessageContent.Content = &toolContent
+	var toolMessage llm.Message
+	toolMessage.Role = "tool"
+	toolMessage.ToolCallID = &customCallID
+	toolMessage.Content = toolMessageContent
+	request := new(llm.Request)
+	request.APIFormat = llm.APIFormatOpenAIResponse
+	request.Model = "glm-5.3"
+	request.Messages = []llm.Message{assistantMessage, toolMessage}
 
 	httpRequest, err := processor.TransformRequest(context.Background(), request)
 	require.NoError(t, err)

--- a/llm/transformer/opencode/outbound.go
+++ b/llm/transformer/opencode/outbound.go
@@ -28,7 +28,7 @@ const (
 	// routeDeepseek routes DeepSeek models through the DeepSeek transformer,
 	// which handles its thinking/reasoning_content conventions.
 	routeDeepseek route = "deepseek"
-	// routeResponses routes Grok/GPT models through the OpenAI Responses API (/v1/responses).
+	// routeResponses routes Grok/GPT/Muse models through the OpenAI Responses API (/v1/responses).
 	routeResponses route = "responses"
 	// routeAnthropic routes MiniMax/Qwen models through the Anthropic messages endpoint (/v1/messages).
 	routeAnthropic route = "anthropic"
@@ -132,13 +132,28 @@ func routeForModel(model string) route {
 	switch {
 	case strings.HasPrefix(model, "deepseek"):
 		return routeDeepseek
-	case strings.HasPrefix(model, "grok"), strings.HasPrefix(model, "gpt"):
+	case strings.HasPrefix(model, "grok"),
+		strings.HasPrefix(model, "gpt"),
+		strings.HasPrefix(model, "muse"):
 		return routeResponses
-	case strings.HasPrefix(model, "minimax"), strings.HasPrefix(model, "qwen3"):
+	case strings.HasPrefix(model, "minimax"),
+		strings.HasPrefix(model, "qwen3"):
 		return routeAnthropic
 	default:
 		return routeChat
 	}
+}
+
+// APIFormatForRequest returns the protocol used by OpenCode Go for the
+// request's actual model. The channel exposes both Chat Completions and
+// Responses endpoints, but OpenCode selects the upstream protocol by model
+// family rather than by the inbound request format.
+func (t *OutboundTransformer) APIFormatForRequest(req *llm.Request) llm.APIFormat {
+	if req == nil {
+		return t.APIFormat()
+	}
+
+	return t.sub(routeForModel(req.Model)).APIFormat()
 }
 
 func (t *OutboundTransformer) sub(r route) transformer.Outbound {

--- a/llm/transformer/opencode/outbound.go
+++ b/llm/transformer/opencode/outbound.go
@@ -130,17 +130,30 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 // routeForModel returns the sub-transformer route for an OpenCode Go model ID.
 func routeForModel(model string) route {
 	switch {
-	case strings.HasPrefix(model, "deepseek"):
+	case hasModelFamilyPrefix(model, "deepseek"):
 		return routeDeepseek
-	case strings.HasPrefix(model, "grok"),
-		strings.HasPrefix(model, "gpt"),
-		strings.HasPrefix(model, "muse"):
+	case hasModelFamilyPrefix(model, "grok"),
+		hasModelFamilyPrefix(model, "gpt"),
+		hasModelFamilyPrefix(model, "muse"):
 		return routeResponses
-	case strings.HasPrefix(model, "minimax"),
-		strings.HasPrefix(model, "qwen3"):
+	case hasModelFamilyPrefix(model, "minimax"),
+		hasModelFamilyPrefix(model, "qwen3"):
 		return routeAnthropic
 	default:
 		return routeChat
+	}
+}
+
+func hasModelFamilyPrefix(model, family string) bool {
+	if !strings.HasPrefix(model, family) || len(model) == len(family) {
+		return false
+	}
+
+	switch model[len(family)] {
+	case '-', '.':
+		return true
+	default:
+		return false
 	}
 }
 

--- a/llm/transformer/opencode/outbound_test.go
+++ b/llm/transformer/opencode/outbound_test.go
@@ -70,6 +70,13 @@ func TestRouteForModel(t *testing.T) {
 		{"gpt-unknown", routeResponses},
 		{"muse-unknown", routeResponses},
 		{"qwen3-unknown", routeAnthropic},
+		// The model family must end at a delimiter; similar names stay on Chat.
+		{"deepseekfoo-v1", routeChat},
+		{"grokfoo-v1", routeChat},
+		{"gptfoo-v1", routeChat},
+		{"museum-v1", routeChat},
+		{"minimaxfoo-v1", routeChat},
+		{"qwen3foo-v1", routeChat},
 		// Model IDs are matched exactly; do not normalize case or whitespace.
 		{"GPT-5", routeChat},
 		{" gpt-5", routeChat},

--- a/llm/transformer/opencode/outbound_test.go
+++ b/llm/transformer/opencode/outbound_test.go
@@ -40,25 +40,65 @@ func TestRouteForModel(t *testing.T) {
 		// DeepSeek family → DeepSeek transformer
 		{"deepseek-v4-pro", routeDeepseek},
 		{"deepseek-v4-flash", routeDeepseek},
-		// Grok/GPT family → OpenAI Responses API
+		// Grok/GPT/Muse family → OpenAI Responses API
 		{"grok-4.5", routeResponses},
 		{"gpt-5.6-luna", routeResponses},
+		{"gpt-6-preview", routeResponses},
+		{"muse-spark-1.2-contributor", routeResponses},
+		{"muse-spark-2.0", routeResponses},
+		// OpenCode Go models using the OpenAI-compatible chat endpoint
+		{"glm-5.3", routeChat},
+		{"glm-5.1", routeChat},
+		{"kimi-k2.7-code", routeChat},
+		{"kimi-k2.6", routeChat},
+		{"mimo-v2.5-pro", routeChat},
+		{"hy3", routeChat},
 		// MiniMax/Qwen family → Anthropic messages
 		{"minimax-m3", routeAnthropic},
 		{"minimax-m2.7", routeAnthropic},
+		{"minimax-m2.5", routeAnthropic},
 		{"qwen3.8-max", routeAnthropic},
+		{"qwen3.7-max", routeAnthropic},
 		{"qwen3.7-plus", routeAnthropic},
+		{"qwen3.6-plus", routeAnthropic},
+		{"qwen3.9-max", routeAnthropic},
 		// Everything else → OpenAI chat completions
 		{"glm-5.2", routeChat},
 		{"kimi-k3", routeChat},
 		{"mimo-v2.5", routeChat},
-		{"hy3", routeChat},
 		{"unknown-model", routeChat},
+		{"gpt-unknown", routeResponses},
+		{"muse-unknown", routeResponses},
+		{"qwen3-unknown", routeAnthropic},
+		// Model IDs are matched exactly; do not normalize case or whitespace.
+		{"GPT-5", routeChat},
+		{" gpt-5", routeChat},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
 			assert.Equal(t, tt.want, routeForModel(tt.model))
+		})
+	}
+}
+
+func TestOutboundTransformer_APIFormatForRequest(t *testing.T) {
+	tr := newTestTransformer(t)
+
+	tests := []struct {
+		model  string
+		format llm.APIFormat
+	}{
+		{model: "glm-5.3", format: llm.APIFormatOpenAIChatCompletion},
+		{model: "deepseek-v4-pro", format: llm.APIFormatOpenAIChatCompletion},
+		{model: "minimax-m3", format: llm.APIFormatAnthropicMessage},
+		{model: "gpt-5.6-luna", format: llm.APIFormatOpenAIResponse},
+		{model: "muse-spark-1.2-contributor", format: llm.APIFormatOpenAIResponse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.format, tr.APIFormatForRequest(&llm.Request{Model: tt.model}))
 		})
 	}
 }
@@ -87,6 +127,11 @@ func TestOutboundTransformer_TransformRequest_RoutesByModel(t *testing.T) {
 			expectedURL: "https://opencode.ai/zen/go/v1/responses",
 		},
 		{
+			name:        "future gpt model routes to Responses API",
+			model:       "gpt-6-preview",
+			expectedURL: "https://opencode.ai/zen/go/v1/responses",
+		},
+		{
 			name:        "minimax routes to Anthropic messages",
 			model:       "minimax-m3",
 			expectedURL: "https://opencode.ai/zen/go/v1/messages",
@@ -95,6 +140,16 @@ func TestOutboundTransformer_TransformRequest_RoutesByModel(t *testing.T) {
 			name:        "qwen routes to Anthropic messages",
 			model:       "qwen3.8-max",
 			expectedURL: "https://opencode.ai/zen/go/v1/messages",
+		},
+		{
+			name:        "muse-spark routes to Responses API",
+			model:       "muse-spark-1.2-contributor",
+			expectedURL: "https://opencode.ai/zen/go/v1/responses",
+		},
+		{
+			name:        "future muse model routes to Responses API",
+			model:       "muse-spark-2.0",
+			expectedURL: "https://opencode.ai/zen/go/v1/responses",
 		},
 		{
 			name:        "glm routes to OpenAI chat completions",


### PR DESCRIPTION
## 关联

Related to #2240，作为 OpenCode Go Responses 支持合并后的后续问题。

#2105 仅作为背景说明：它描述了 Responses → Chat 的特殊工具语义转换缺失。本 PR 不实现完整的 custom/tool_search/namespace 转换，只处理本次 OpenCode 动态路由引入的协议判断错位。

## 本次工作

- OpenCode Go 渠道默认暴露 OpenAI Chat Completions 和 OpenAI Responses 两个 endpoint。
- 前端 API Format 下拉支持在同一个 OpenCode Go 渠道中选择 Chat、Responses 和 Anthropic Messages。
- OpenCode transformer 按模型前缀选择实际上游协议：
  - `gpt-*`、`grok-*`、`muse-*` → Responses
  - `minimax-*`、`qwen3-*` → Anthropic Messages
  - `deepseek-*` 和其他模型 → Chat Completions
  
   <img width="1286" height="1100" alt="image" src="https://github.com/user-attachments/assets/c5cb2029-d83e-49d4-b82d-fa46f40092c1" />

- 保持模型 ID 原样进行前缀匹配，不自动转小写或去除空格。

## 审核意见修复

审查指出：当客户端发送 Responses 请求并使用 `glm-*`、`deepseek-*` 或 `minimax-*` 时，候选 endpoint 会报告 `openai/responses`，但 OpenCode 实际会路由到 Chat 或 Anthropic。这样中间件会错误保留 Responses 专用 custom tool 续接消息。

现在编排层在中间件执行前读取 transformer 根据实际模型解析出的上游协议：

- `glm-*` → 按 Chat 协议过滤 Responses 专用 custom tool 消息；
- `minimax-*`、`qwen3-*` → 按 Anthropic 协议处理；
- `gpt-*`、`grok-*`、`muse-*` → 保留 Responses 专用消息。

## 验证

- `cd llm && go test ./transformer/opencode`
- `go test ./internal/server/orchestrator -run 'TestResolveOutboundAPIFormat|TestPersistentOutboundTransformer_FiltersResponsesCustomToolsForModelRoutedOpenCode|TestFilterResponseCustomToolMessagesForNonResponsesOutbound' -count=1`
- `go test ./internal/server/biz -run 'TestOpenCodeChannel_ResponsesEndpointUsesModelRoutedOutbound|TestDefaultEndpointsForChannelType_UseLLMAPIFormatValues' -count=1`
- `cd frontend && pnpm test:unit -- src/features/channels/data/channel-config.test.mjs`

## 后续优化项

当前思考强度设置和转换仍然依赖渠道级配置，无法根据模型分别设置或转换。例如同一 OpenCode Go 渠道中的不同模型可能需要不同的 reasoning effort 映射。后续可以增加模型级或其他粒度思考强度配置和转换能力。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode Go channels now support both Chat Completions and Responses API formats.
  * Requests are automatically routed to the appropriate API based on the selected model, including Muse, GPT, Grok, Anthropic, and other supported models.
  * Provider and channel selection now recognize multiple supported API formats.

* **Bug Fixes**
  * Improved model-based routing and handling of protocol-specific tools across OpenCode requests.
  * Improved model matching to prevent incorrect routing for similarly named models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->