### PR TITLE
fix: preserve conditional template overrides

### DIFF
--- a/frontend/src/features/channels-override-merge.test.mjs
+++ b/frontend/src/features/channels-override-merge.test.mjs
@@ -51,7 +51,7 @@ test('scalar body override replacement removes existing duplicates', () => {
   );
 });
 
-test('last template scalar body override at the same path wins', () => {
+test('template scalar body overrides at the same path remain ordered', () => {
   assert.deepEqual(
     mergeOverrideOperations(
       [{ op: 'set', path: 'temperature', value: '0.5' }],
@@ -62,9 +62,27 @@ test('last template scalar body override at the same path wins', () => {
     ),
     [
       { op: 'set', path: 'temperature', value: '0.5' },
+      { op: 'set_if_absent', path: 'max_output_tokens', value: '32000' },
       { op: 'set', path: 'max_output_tokens', value: '16000' },
     ]
   );
+});
+
+test('template preserves conditional scalar body overrides at the same path', () => {
+  const sessionFallback = {
+    op: 'set_if_absent',
+    path: 'client_metadata.x-codex-window-id',
+    value: '{{index .RequestHeader "X-Claude-Code-Session-Id"}}:0',
+    condition: '{{ne (index .RequestHeader "X-Claude-Code-Session-Id") ""}}',
+  };
+  const interactionFallback = {
+    op: 'set_if_absent',
+    path: 'client_metadata.x-codex-window-id',
+    value: '{{index .RequestHeader "X-Interaction-Id"}}:0',
+    condition: '{{ne (index .RequestHeader "X-Interaction-Id") ""}}',
+  };
+
+  assert.deepEqual(mergeOverrideOperations([], [sessionFallback, interactionFallback]), [sessionFallback, interactionFallback]);
 });
 
 test('set_if_absent is exposed as a localized body-only operation', () => {

--- a/frontend/src/features/channels/utils/merge.ts
+++ b/frontend/src/features/channels/utils/merge.ts
@@ -51,30 +51,43 @@ export function mergeOverrideHeaders(existing: OverrideOperation[], template: Ov
 
 /**
  * Merges override body operations with template body operations.
- * - For `set`, `set_if_absent`, and `delete` ops: match by `path`, template overrides existing
+ * - For `set`, `set_if_absent`, and `delete` ops: template paths replace matching existing ops
+ * - Template ops are preserved in order because multiple conditions at the same path are meaningful
  * - For `rename`, `copy`, and array ops: always appended from template
  * - Existing ops not matched by template are preserved
  */
 export function mergeOverrideOperations(existing: OverrideOperation[], template: OverrideOperation[]): OverrideOperation[] {
-  const result: OverrideOperation[] = [...existing];
+  const templateOpsByPath = new Map<string, OverrideOperation[]>();
+  for (const op of template) {
+    if (isReplacingBodyOverrideOperation(op)) {
+      const replacements = templateOpsByPath.get(op.path) || [];
+      replacements.push(op);
+      templateOpsByPath.set(op.path, replacements);
+    }
+  }
+
+  const result: OverrideOperation[] = [];
+  const emittedTemplatePaths = new Set<string>();
+
+  for (const existingOp of existing) {
+    if (isReplacingBodyOverrideOperation(existingOp)) {
+      const replacements = templateOpsByPath.get(existingOp.path);
+      if (replacements) {
+        if (!emittedTemplatePaths.has(existingOp.path)) {
+          result.push(...replacements);
+          emittedTemplatePaths.add(existingOp.path);
+        }
+        continue;
+      }
+    }
+    result.push(existingOp);
+  }
 
   for (const templateOp of template) {
-    if (!isReplacingBodyOverrideOperation(templateOp)) {
-      result.push(templateOp);
+    if (isReplacingBodyOverrideOperation(templateOp) && emittedTemplatePaths.has(templateOp.path)) {
       continue;
     }
-
-    const existingIndex = result.findIndex((op) => isReplacingBodyOverrideOperation(op) && op.path === templateOp.path);
-    if (existingIndex >= 0) {
-      result[existingIndex] = templateOp;
-      for (let i = result.length - 1; i > existingIndex; i--) {
-        if (isReplacingBodyOverrideOperation(result[i]) && result[i].path === templateOp.path) {
-          result.splice(i, 1);
-        }
-      }
-    } else {
-      result.push(templateOp);
-    }
+    result.push(templateOp);
   }
 
   return result;

--- a/internal/server/biz/channel_merge_test.go
+++ b/internal/server/biz/channel_merge_test.go
@@ -143,6 +143,11 @@ func TestMergeOverrideOperations(t *testing.T) {
 	setIfAbsentOp := func(path, value string) objects.OverrideOperation {
 		return objects.OverrideOperation{Op: objects.OverrideOpSetIfAbsent, Path: path, Value: value}
 	}
+	setIfAbsentConditionalOp := func(path, value, condition string) objects.OverrideOperation {
+		op := setIfAbsentOp(path, value)
+		op.Condition = condition
+		return op
+	}
 	deleteOp := func(path string) objects.OverrideOperation {
 		return objects.OverrideOperation{Op: objects.OverrideOpDelete, Path: path}
 	}
@@ -195,10 +200,42 @@ func TestMergeOverrideOperations(t *testing.T) {
 			},
 		},
 		{
-			name:     "last template scalar operation at the same path wins",
+			name:     "template scalar operations at the same path remain ordered",
 			existing: []objects.OverrideOperation{setOp("temperature", "0.5")},
 			template: []objects.OverrideOperation{setIfAbsentOp("max_output_tokens", "32000"), setOp("max_output_tokens", "16000")},
-			expected: []objects.OverrideOperation{setOp("temperature", "0.5"), setOp("max_output_tokens", "16000")},
+			expected: []objects.OverrideOperation{
+				setOp("temperature", "0.5"),
+				setIfAbsentOp("max_output_tokens", "32000"),
+				setOp("max_output_tokens", "16000"),
+			},
+		},
+		{
+			name:     "template preserves conditional scalar operations at the same path",
+			existing: nil,
+			template: []objects.OverrideOperation{
+				setIfAbsentConditionalOp(
+					"client_metadata.x-codex-window-id",
+					`{{index .RequestHeader "X-Claude-Code-Session-Id"}}:0`,
+					`{{ne (index .RequestHeader "X-Claude-Code-Session-Id") ""}}`,
+				),
+				setIfAbsentConditionalOp(
+					"client_metadata.x-codex-window-id",
+					`{{index .RequestHeader "X-Interaction-Id"}}:0`,
+					`{{ne (index .RequestHeader "X-Interaction-Id") ""}}`,
+				),
+			},
+			expected: []objects.OverrideOperation{
+				setIfAbsentConditionalOp(
+					"client_metadata.x-codex-window-id",
+					`{{index .RequestHeader "X-Claude-Code-Session-Id"}}:0`,
+					`{{ne (index .RequestHeader "X-Claude-Code-Session-Id") ""}}`,
+				),
+				setIfAbsentConditionalOp(
+					"client_metadata.x-codex-window-id",
+					`{{index .RequestHeader "X-Interaction-Id"}}:0`,
+					`{{ne (index .RequestHeader "X-Interaction-Id") ""}}`,
+				),
+			},
 		},
 	}
 

--- a/internal/server/biz/channel_override_template.go
+++ b/internal/server/biz/channel_override_template.go
@@ -330,47 +330,40 @@ func getBodyOverrideOperations(settings *objects.ChannelSettings) []objects.Over
 }
 
 // MergeOverrideOperations merges existing body operations with template operations.
-// - For set/set_if_absent/delete ops, matching is by Path. Template overrides existing.
+// - For set/set_if_absent/delete ops, template paths replace matching existing operations.
+// - Template operations remain ordered because multiple conditions at the same path are meaningful.
 // - For rename/copy and array_* ops, they are always appended (multiple of the same path are meaningful).
 // - Existing ops not mentioned in the template are preserved.
 func MergeOverrideOperations(existing, template []objects.OverrideOperation) []objects.OverrideOperation {
 	result := make([]objects.OverrideOperation, 0, len(existing)+len(template))
-	result = append(result, existing...)
+	templateOpsByPath := make(map[string][]objects.OverrideOperation, len(template))
+	for _, op := range template {
+		if isReplacingBodyOverrideOperation(op.Op) {
+			templateOpsByPath[op.Path] = append(templateOpsByPath[op.Path], op)
+		}
+	}
+
+	emittedTemplatePaths := make(map[string]struct{}, len(templateOpsByPath))
+	for _, op := range existing {
+		if isReplacingBodyOverrideOperation(op.Op) {
+			if replacements, ok := templateOpsByPath[op.Path]; ok {
+				if _, emitted := emittedTemplatePaths[op.Path]; !emitted {
+					result = append(result, replacements...)
+					emittedTemplatePaths[op.Path] = struct{}{}
+				}
+				continue
+			}
+		}
+		result = append(result, op)
+	}
 
 	for _, op := range template {
-		if !isReplacingBodyOverrideOperation(op.Op) {
-			result = append(result, op)
-			continue
-		}
-
-		result = replaceBodyOverrideOperation(result, op)
-	}
-
-	return result
-}
-
-func replaceBodyOverrideOperation(result []objects.OverrideOperation, replacement objects.OverrideOperation) []objects.OverrideOperation {
-	found := false
-	writeIndex := 0
-
-	for _, op := range result {
-		if isReplacingBodyOverrideOperation(op.Op) && op.Path == replacement.Path {
-			if !found {
-				result[writeIndex] = replacement
-				writeIndex++
-				found = true
+		if isReplacingBodyOverrideOperation(op.Op) {
+			if _, emitted := emittedTemplatePaths[op.Path]; emitted {
+				continue
 			}
-
-			continue
 		}
-
-		result[writeIndex] = op
-		writeIndex++
-	}
-
-	result = result[:writeIndex]
-	if !found {
-		result = append(result, replacement)
+		result = append(result, op)
 	}
 
 	return result


### PR DESCRIPTION
## Summary

- Fixes: Applying a channel template containing two conditional set_if_absent operations for the same body path keeps only the last operation, so one header-derived fallback silently disappears.
- Root cause: Both mergeOverrideOperations implementations merge template entries into the combined result one at a time and identify replacements by path alone. The second template entry therefore replaces the first template entry even though only pre-existing channel entries should be replaced. Grouping same-path template entries before replacing existing entries preserves the conditional sequence while retaining the established replacement position.

Closes #2168.

## Regression evidence

- Before: `go test ./internal/server/biz -run '^TestMergeOverrideOperations$' -count=1` exited `1`

- After: `go test ./internal/server/biz -run '^TestMergeOverrideOperations$' -count=1` exited `0`
- The matching frontend regression also failed before and passes after (5/5 focused tests).

## Verification

- `go test ./internal/server/biz -count=1`
- `pnpm test:unit`
- `make test-backend-all`
- `pnpm exec eslint src/features/channels/utils/merge.ts src/features/channels-override-merge.test.mjs && pnpm exec prettier --check src/features/channels/utils/merge.ts src/features/channels-override-merge.test.mjs && pnpm exec tsc --noEmit`
- `pnpm build`
- `go build CI matrix and production dependency verification`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run --timeout 10m --max-same-issues 50`
- `git diff --cached --check`

The full frontend `pnpm lint` currently reports 160 errors and 93 warnings in unchanged files. Neither changed frontend file appears in that failure set; focused ESLint, Prettier, and full TypeScript checks pass.

## Scope

- 4 files changed, +108 / -47 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected channel override merging so multiple operations targeting the same path are preserved in their original template order.
  * Fixed conditional “set if absent” operations to avoid unintentionally discarding earlier matching entries.
  * Improved consistency between existing and template override operations during merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->