### PR TITLE
fix(openai): synthesize terminal chunk for complete streams

### DIFF
--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -104,6 +104,8 @@ func (t *InboundTransformer) TransformStream(
 	ctx context.Context,
 	stream streams.Stream[*llm.Response],
 ) (streams.Stream[*httpclient.StreamEvent], error) {
+	stream = newOpenAIInboundStream(stream)
+
 	return streams.NoNil(streams.MapErr(stream, func(chunk *llm.Response) (*httpclient.StreamEvent, error) {
 		return t.TransformStreamChunk(ctx, chunk)
 	})), nil

--- a/llm/transformer/openai/inbound_stream.go
+++ b/llm/transformer/openai/inbound_stream.go
@@ -1,0 +1,233 @@
+package openai
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+// openAIInboundStream finalizes complete OpenAI Chat Completions responses when
+// an upstream provider closes a clean stream without finish_reason or [DONE].
+// Usage is used as the positive completion signal so truncated streams are not
+// silently converted into successful responses.
+type openAIInboundStream struct {
+	source     streams.Stream[*llm.Response]
+	queue      []*llm.Response
+	queueIndex int
+	current    *llm.Response
+	finalized  bool
+
+	responseID    string
+	responseModel string
+	responseTime  int64
+	usage         *llm.Usage
+	doneSeen      bool
+	choices       map[int]*openAIInboundChoice
+}
+
+type openAIInboundChoice struct {
+	index        int
+	hasOutput    bool
+	hasToolCalls bool
+	finished     bool
+}
+
+func newOpenAIInboundStream(source streams.Stream[*llm.Response]) streams.Stream[*llm.Response] {
+	return &openAIInboundStream{
+		source:  source,
+		choices: make(map[int]*openAIInboundChoice),
+	}
+}
+
+func (s *openAIInboundStream) Next() bool {
+	if s.nextQueued() {
+		return true
+	}
+
+	s.queue = nil
+	s.queueIndex = 0
+
+	if s.source.Next() {
+		response := s.source.Current()
+		if response == nil {
+			return s.Next()
+		}
+
+		s.observe(response)
+		s.current = response
+
+		return true
+	}
+
+	if s.source.Err() != nil {
+		return false
+	}
+
+	s.finalize()
+
+	return s.nextQueued()
+}
+
+func (s *openAIInboundStream) nextQueued() bool {
+	if s.queueIndex >= len(s.queue) {
+		return false
+	}
+
+	s.current = s.queue[s.queueIndex]
+	s.queueIndex++
+
+	return true
+}
+
+func (s *openAIInboundStream) Current() *llm.Response {
+	return s.current
+}
+
+func (s *openAIInboundStream) Err() error {
+	return s.source.Err()
+}
+
+func (s *openAIInboundStream) Close() error {
+	return s.source.Close()
+}
+
+func (s *openAIInboundStream) observe(response *llm.Response) {
+	if response == nil {
+		return
+	}
+
+	if response.Object == "[DONE]" {
+		s.doneSeen = true
+		return
+	}
+
+	if response.ID != "" {
+		s.responseID = response.ID
+	}
+	if response.Model != "" {
+		s.responseModel = response.Model
+	}
+	if response.Created != 0 {
+		s.responseTime = response.Created
+	}
+	if response.Usage != nil {
+		s.usage = response.Usage
+	}
+
+	for _, choice := range response.Choices {
+		state, ok := s.choices[choice.Index]
+		if !ok {
+			state = &openAIInboundChoice{index: choice.Index}
+			s.choices[choice.Index] = state
+		}
+
+		if choice.FinishReason != nil && strings.TrimSpace(*choice.FinishReason) != "" {
+			state.finished = true
+		}
+
+		for _, message := range []*llm.Message{choice.Delta, choice.Message} {
+			if message == nil {
+				continue
+			}
+
+			if len(message.ToolCalls) > 0 {
+				state.hasToolCalls = true
+			}
+			if hasOpenAIInboundOutput(message) {
+				state.hasOutput = true
+			}
+		}
+	}
+}
+
+func hasOpenAIInboundOutput(message *llm.Message) bool {
+	if message == nil {
+		return false
+	}
+
+	if message.Content.Content != nil && *message.Content.Content != "" {
+		return true
+	}
+	if len(message.Content.MultipleContent) > 0 {
+		return true
+	}
+	if len(message.ToolCalls) > 0 {
+		return true
+	}
+	if message.ReasoningContent != nil && *message.ReasoningContent != "" {
+		return true
+	}
+	if message.Reasoning != nil && *message.Reasoning != "" {
+		return true
+	}
+	if message.Refusal != "" || message.Audio != nil || len(message.InlineToolResults) > 0 {
+		return true
+	}
+
+	return false
+}
+
+func (s *openAIInboundStream) finalize() {
+	if s.finalized {
+		return
+	}
+	s.finalized = true
+
+	if s.doneSeen {
+		return
+	}
+
+	missingChoices := s.missingChoices()
+	if len(missingChoices) == 0 {
+		return
+	}
+
+	// A clean EOF without usage is still ambiguous: it may be a truncated
+	// response. Leave it to the existing incomplete-stream handling instead of
+	// fabricating a successful finish reason.
+	if s.usage == nil {
+		return
+	}
+
+	choices := make([]llm.Choice, 0, len(missingChoices))
+	for _, state := range missingChoices {
+		finishReason := "stop"
+		if state.hasToolCalls {
+			finishReason = "tool_calls"
+		}
+
+		choices = append(choices, llm.Choice{
+			Index:        state.index,
+			Delta:        &llm.Message{},
+			FinishReason: &finishReason,
+		})
+	}
+
+	s.queue = append(s.queue, &llm.Response{
+		ID:      s.responseID,
+		Object:  "chat.completion.chunk",
+		Created: s.responseTime,
+		Model:   s.responseModel,
+		Choices: choices,
+	})
+	s.queue = append(s.queue, llm.DoneResponse)
+}
+
+func (s *openAIInboundStream) missingChoices() []*openAIInboundChoice {
+	indexes := make([]int, 0, len(s.choices))
+	for index, state := range s.choices {
+		if state.hasOutput && !state.finished {
+			indexes = append(indexes, index)
+		}
+	}
+	sort.Ints(indexes)
+
+	missing := make([]*openAIInboundChoice, 0, len(indexes))
+	for _, index := range indexes {
+		missing = append(missing, s.choices[index])
+	}
+
+	return missing
+}

--- a/llm/transformer/openai/inbound_stream_test.go
+++ b/llm/transformer/openai/inbound_stream_test.go
@@ -1,0 +1,278 @@
+package openai
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+func TestInboundTransformer_SynthesizesMissingFinishReasonForText(t *testing.T) {
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		openAITextChunk("Hello"),
+		openAIUsageChunk(),
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 4)
+
+	var finish Response
+	require.NoError(t, json.Unmarshal(events[2].Data, &finish))
+	require.Len(t, finish.Choices, 1)
+	require.NotNil(t, finish.Choices[0].Delta)
+	require.NotNil(t, finish.Choices[0].FinishReason)
+	require.Equal(t, "stop", *finish.Choices[0].FinishReason)
+	require.JSONEq(t, `{}`, string(mustMarshalJSON(t, finish.Choices[0].Delta)))
+	require.Equal(t, "[DONE]", string(events[3].Data))
+}
+
+func TestInboundTransformer_SynthesizesToolCallFinishReason(t *testing.T) {
+	toolCall := llm.ToolCall{
+		ID:    "call_probe",
+		Type:  "function",
+		Index: 0,
+		Function: llm.FunctionCall{
+			Name:      "probe_tool",
+			Arguments: `{"value":"ping"}`,
+		},
+	}
+
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			ID:      "chatcmpl-tool",
+			Object:  "chat.completion.chunk",
+			Created: 123,
+			Model:   "muse-spark-1.2",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{ToolCalls: []llm.ToolCall{toolCall}},
+			}},
+		},
+		openAIUsageChunk(),
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 4)
+
+	var toolChunk Response
+	require.NoError(t, json.Unmarshal(events[0].Data, &toolChunk))
+	require.Len(t, toolChunk.Choices[0].Delta.ToolCalls, 1)
+	require.Equal(t, `{"value":"ping"}`, toolChunk.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	var finish Response
+	require.NoError(t, json.Unmarshal(events[2].Data, &finish))
+	require.Len(t, finish.Choices, 1)
+	require.Equal(t, "tool_calls", lo.FromPtr(finish.Choices[0].FinishReason))
+	require.Equal(t, "[DONE]", string(events[3].Data))
+}
+
+func TestInboundTransformer_SynthesizesFinishForReasoningOnlyOutput(t *testing.T) {
+	reasoning := "thinking"
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			ID:      "chatcmpl-reasoning",
+			Object:  "chat.completion.chunk",
+			Created: 123,
+			Model:   "muse-spark-1.2",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{ReasoningContent: &reasoning},
+			}},
+		},
+		openAIUsageChunk(),
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 4)
+
+	var finish Response
+	require.NoError(t, json.Unmarshal(events[2].Data, &finish))
+	require.Equal(t, "stop", lo.FromPtr(finish.Choices[0].FinishReason))
+	require.Equal(t, "[DONE]", string(events[3].Data))
+}
+
+func TestInboundTransformer_PreservesExistingFinishReason(t *testing.T) {
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		openAITextChunk("Hello"),
+		{
+			ID:      "chatcmpl-finished",
+			Object:  "chat.completion.chunk",
+			Created: 123,
+			Model:   "muse-spark-1.2",
+			Choices: []llm.Choice{{
+				Index:        0,
+				Delta:        &llm.Message{},
+				FinishReason: lo.ToPtr("length"),
+			}},
+		},
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 2)
+
+	var finish Response
+	require.NoError(t, json.Unmarshal(events[1].Data, &finish))
+	require.Equal(t, "length", lo.FromPtr(finish.Choices[0].FinishReason))
+	require.NotEqual(t, "[DONE]", string(events[1].Data))
+}
+
+func TestInboundTransformer_DoesNotDuplicateExistingDone(t *testing.T) {
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		openAITextChunk("Hello"),
+		{
+			Object: "[DONE]",
+		},
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 2)
+	require.Equal(t, "[DONE]", string(events[1].Data))
+}
+
+func TestInboundTransformer_PreservesUpstreamErrorWithoutSyntheticFinish(t *testing.T) {
+	upstreamErr := errors.New("upstream stream failed")
+	source := &openAIInboundErrorStream{
+		events: []*llm.Response{openAITextChunk("partial"), openAIUsageChunk()},
+		err:    upstreamErr,
+	}
+
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), source)
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.ErrorIs(t, stream.Err(), upstreamErr)
+	require.Len(t, events, 2)
+	for _, event := range events {
+		require.NotEqual(t, "[DONE]", string(event.Data))
+	}
+}
+
+func TestInboundTransformer_DoesNotSynthesizeWithoutUsage(t *testing.T) {
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		openAITextChunk("partial"),
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 1)
+	require.NotContains(t, string(events[0].Data), `"finish_reason":"stop"`)
+}
+
+func TestInboundTransformer_SynthesizesOnlyMissingChoices(t *testing.T) {
+	stream, err := NewInboundTransformer().TransformStream(t.Context(), streams.SliceStream([]*llm.Response{
+		{
+			ID:      "chatcmpl-multi",
+			Object:  "chat.completion.chunk",
+			Created: 123,
+			Model:   "muse-spark-1.2",
+			Choices: []llm.Choice{
+				{Index: 0, Delta: &llm.Message{Content: llm.MessageContent{Content: lo.ToPtr("done")}}, FinishReason: lo.ToPtr("stop")},
+				{Index: 1, Delta: &llm.Message{Content: llm.MessageContent{Content: lo.ToPtr("pending")}}},
+			},
+		},
+		openAIUsageChunk(),
+	}))
+	require.NoError(t, err)
+
+	events := collectOpenAIInboundEvents(t, stream)
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 4)
+
+	var finish Response
+	require.NoError(t, json.Unmarshal(events[2].Data, &finish))
+	require.Len(t, finish.Choices, 1)
+	require.Equal(t, 1, finish.Choices[0].Index)
+	require.Equal(t, "stop", lo.FromPtr(finish.Choices[0].FinishReason))
+	require.Equal(t, "[DONE]", string(events[3].Data))
+}
+
+func openAITextChunk(content string) *llm.Response {
+	return &llm.Response{
+		ID:      "chatcmpl-text",
+		Object:  "chat.completion.chunk",
+		Created: 123,
+		Model:   "muse-spark-1.2",
+		Choices: []llm.Choice{{
+			Index: 0,
+			Delta: &llm.Message{Content: llm.MessageContent{Content: &content}},
+		}},
+	}
+}
+
+func openAIUsageChunk() *llm.Response {
+	return &llm.Response{
+		ID:    "chatcmpl-usage",
+		Model: "muse-spark-1.2",
+		Usage: &llm.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+}
+
+func collectOpenAIInboundEvents(t *testing.T, stream streams.Stream[*httpclient.StreamEvent]) []*httpclient.StreamEvent {
+	t.Helper()
+
+	var events []*httpclient.StreamEvent
+	for stream.Next() {
+		events = append(events, stream.Current())
+	}
+
+	return events
+}
+
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return data
+}
+
+type openAIInboundErrorStream struct {
+	events []*llm.Response
+	index  int
+	err    error
+}
+
+func (s *openAIInboundErrorStream) Next() bool {
+	return s.index < len(s.events)
+}
+
+func (s *openAIInboundErrorStream) Current() *llm.Response {
+	response := s.events[s.index]
+	s.index++
+
+	return response
+}
+
+func (s *openAIInboundErrorStream) Err() error {
+	if s.index >= len(s.events) {
+		return s.err
+	}
+
+	return nil
+}
+
+func (s *openAIInboundErrorStream) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary

Some OpenAI-compatible upstreams emit the complete response content and a
usage chunk, then close the SSE stream without sending `finish_reason` or
`[DONE]`. Strict OpenAI-compatible clients interpret this as an incomplete
stream.

This affects coding-agent clients such as pi when the upstream response is
otherwise complete.

## Changes

- Add a stateful finalization layer to the OpenAI Chat Completions inbound
  transformer.
- When the source stream ends cleanly after producing output and usage, synthesize
  a final chunk with an empty `delta` and:
  - `finish_reason: "stop"` for text/reasoning output
  - `finish_reason: "tool_calls"` for tool-call output
- Emit `[DONE]` after a synthesized terminal chunk.
- Preserve existing `finish_reason` and `[DONE]` behavior.
- Do not synthesize success when the source has an error, usage is absent, or no
  meaningful output was produced, so genuinely truncated streams remain
  distinguishable.

## Reproduction

The affected upstream shape is:

1. One or more normal content/tool-call chunks.
2. A `choices: []` usage chunk.
3. Clean SSE EOF without `finish_reason` or `[DONE]`.

## Testing

Added coverage for:

- text streams missing `finish_reason`
- tool-call streams missing `finish_reason`
- reasoning-only output
- existing finish reasons
- existing `[DONE]`
- upstream errors
- missing usage
- partially finished multi-choice streams

Validation:

- `cd llm && go test ./transformer/openai/...`
- `cd llm && go vet ./transformer/openai/...`
- `go test ./internal/server/api/... ./internal/server/orchestrator/...`
- `go vet ./internal/server/api/... ./internal/server/orchestrator/...`

Follow-up to #1924; this complements #2185 by handling complete weak-provider
streams rather than merely reporting incomplete streams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI streaming reliability by ensuring completed responses include the appropriate finish status.
  * Correctly identifies whether responses finish with normal text output or tool calls.
  * Preserves existing finish information and prevents duplicate completion events.
  * Prevents incomplete or errored streams from being incorrectly marked as complete.
* **Tests**
  * Added coverage for text, tool-call, reasoning-only, incomplete, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->