### PR TITLE
fix: render image-generation traces without GraphQL errors

### DIFF
--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -716,12 +716,22 @@ func requestToSegment(ctx context.Context, req *ent.Request) (*Segment, error) {
 				// skip it instead of failing the whole trace.
 				log.Warn(ctx, "No outbound transformer for format, skipping response spans", log.Cause(err), log.Int("request_id", req.ID))
 			} else {
+				httpReq := &httpclient.Request{
+					APIFormat: req.Format,
+				}
+				if isImageFormat(apiFormat) {
+					httpReq.TransformerMetadata = map[string]any{
+						"model": req.ModelID,
+					}
+				}
+
 				httpResp := &httpclient.Response{
 					Body:       req.ResponseBody,
 					StatusCode: http.StatusOK,
 					Headers: http.Header{
 						"Content-Type": {"application/json"},
 					},
+					Request: httpReq,
 				}
 
 				unifiedResp, err := outbound.TransformResponse(ctx, httpResp)
@@ -1522,7 +1532,10 @@ func getInboundTransformer(format llm.APIFormat) (transformer.Inbound, error) {
 func getOutboundTransformer(format llm.APIFormat) (transformer.Outbound, error) {
 	//nolint:exhaustive // Checked
 	switch format {
-	case llm.APIFormatOpenAIChatCompletion:
+	case llm.APIFormatOpenAIChatCompletion,
+		llm.APIFormatOpenAIImageGeneration,
+		llm.APIFormatOpenAIImageEdit,
+		llm.APIFormatOpenAIImageVariation:
 		config := &openai.Config{
 			PlatformType:   openai.PlatformOpenAI,
 			BaseURL:        "https://api.openai.com/v1",

--- a/internal/server/biz/trace_test.go
+++ b/internal/server/biz/trace_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/project"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/pkg/xfile"
+	"github.com/looplj/axonhub/llm"
 )
 
 func setupTestTraceService(t *testing.T, client *ent.Client) (*TraceService, *ent.Client) {
@@ -382,6 +383,95 @@ func TestTraceService_GetRequestTrace(t *testing.T) {
 	require.Equal(t, int64(10), *traceRoot.Metadata.InputTokens)
 	require.NotNil(t, traceRoot.Metadata.OutputTokens)
 	require.Equal(t, int64(20), *traceRoot.Metadata.OutputTokens)
+}
+
+func TestTraceService_ImageGenerationTrace(t *testing.T) {
+	traceService, client := setupTestTraceService(t, nil)
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	projectEntity, err := client.Project.Create().
+		SetName("image-generation-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	traceEntity, err := client.Trace.Create().
+		SetTraceID("trace-image-generation").
+		SetProjectID(projectEntity.ID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	requestBody := []byte(`{
+		"model": "gpt-image-1",
+		"prompt": "A watercolor fox in a moonlit forest"
+	}`)
+	responseBody := []byte(`{
+		"created": 1730000000,
+		"data": [{"b64_json": "image-data"}],
+		"usage": {
+			"input_tokens": 12,
+			"output_tokens": 34,
+			"total_tokens": 46
+		}
+	}`)
+
+	req, err := client.Request.Create().
+		SetProjectID(projectEntity.ID).
+		SetTraceID(traceEntity.ID).
+		SetModelID("gpt-image-1").
+		SetFormat(llm.APIFormatOpenAIImageGeneration.String()).
+		SetRequestBody(requestBody).
+		SetResponseBody(responseBody).
+		SetStatus("completed").
+		SetStream(false).
+		Save(ctx)
+	require.NoError(t, err)
+
+	firstUserQuery, err := traceService.FirstUserQuery(ctx, traceEntity.ID)
+	require.NoError(t, err)
+	require.NotNil(t, firstUserQuery)
+	require.Equal(t, "A watercolor fox in a moonlit forest", *firstUserQuery)
+
+	traceRoot, err := traceService.GetRootSegment(ctx, traceEntity.ID)
+	require.NoError(t, err)
+	require.NotNil(t, traceRoot)
+	require.Equal(t, req.ID, traceRoot.ID)
+
+	promptSpan := findSpanByType(traceRoot.RequestSpans, "user_query")
+	require.NotNil(t, promptSpan)
+	require.NotNil(t, promptSpan.Value)
+	require.NotNil(t, promptSpan.Value.UserQuery)
+	require.Equal(t, "A watercolor fox in a moonlit forest", promptSpan.Value.UserQuery.Text)
+	require.Empty(t, traceRoot.ResponseSpans)
+
+	require.NotNil(t, traceRoot.Metadata)
+	require.NotNil(t, traceRoot.Metadata.InputTokens)
+	require.Equal(t, int64(12), *traceRoot.Metadata.InputTokens)
+	require.NotNil(t, traceRoot.Metadata.OutputTokens)
+	require.Equal(t, int64(34), *traceRoot.Metadata.OutputTokens)
+	require.NotNil(t, traceRoot.Metadata.TotalTokens)
+	require.Equal(t, int64(46), *traceRoot.Metadata.TotalTokens)
+}
+
+func TestGetOutboundTransformer_ImageFormats(t *testing.T) {
+	for _, format := range []llm.APIFormat{
+		llm.APIFormatOpenAIImageGeneration,
+		llm.APIFormatOpenAIImageEdit,
+		llm.APIFormatOpenAIImageVariation,
+	} {
+		t.Run(format.String(), func(t *testing.T) {
+			outbound, err := getOutboundTransformer(format)
+			require.NoError(t, err)
+			require.NotNil(t, outbound)
+		})
+	}
+
+	_, err := getOutboundTransformer(llm.APIFormat("unsupported/format"))
+	require.EqualError(t, err, "unsupported format for outbound transformation: unsupported/format")
 }
 
 func TestTraceService_GetRequestTrace_WithToolCalls(t *testing.T) {


### PR DESCRIPTION
## Summary

Extend the trace response-transformer selection in `internal/server/biz/trace.go` so OpenAI image generation, edit, and variation records use the existing OpenAI outbound transformer rather than failing as unsupported formats. Populate the synthetic `httpclient.Response.Request` with the stored API format (and model metadata where appropriate) so `OutboundTransformer.TransformResponse` dispatches to its existing image-response decoder instead of the chat-completions decoder. Keep the existing request-span extraction and GraphQL schema unchanged: image prompts should continue to produce the `user_query` used by the list, while image response usage can populate segment metadata without inventing text spans.

## Verification

- A completed `openai/image_generation` request with a prompt and a valid image response returns that prompt from `TraceService.FirstUserQuery` without an unsupported-format error, allowing the traces list field to resolve.
- Building the root segment for the same request succeeds, retains the prompt span, and maps available image-response usage into segment metadata even though the response has no chat choices.
- The shared image response routing accepts the existing image edit and variation API formats as well as generation, while an unrelated unsupported format continues to return the existing factory error.

## Motivation

The traces page requests `Trace.firstUserQuery`, which loads the trace's first completed request and converts both its request and response bodies into a segment. `requestToSegment` already recognizes OpenAI image-generation request bodies, but its response path asks `getOutboundTransformer` for the stored `openai/image_generation` format, which the factory currently rejects. That error propagates through the GraphQL field resolver and makes the entire traces query surface as an internal server error whenever an affected image request is listed. The same mismatch applies to the image edit and variation formats already grouped by `isImageFormat`.

Fixes #2283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved image API response handling by preserving request format and image model metadata.
  - Added support for OpenAI image-generation, image-editing, and image-variation formats in outbound processing.

- **Bug Fixes**
  - Improved tracing for image-generation requests, including prompt extraction and token usage metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->