### PR TITLE
fix(channels): map ollama_anthropic to the ollama provider

### DIFF
--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -928,6 +928,7 @@ export const CHANNEL_TYPE_TO_PROVIDER: Record<ChannelType, Provider> = {
   opencode_go: 'opencode_go',
   opencode_go_anthropic: 'opencode_go',
   ollama: 'ollama',
+  ollama_anthropic: 'ollama',
   evolink: 'evolink',
   evolink_anthropic: 'evolink',
   groq: 'groq',


### PR DESCRIPTION
## Summary

`CHANNEL_TYPE_TO_PROVIDER` 缺少 `ollama_anthropic` 条目。UI 的 provider 徽标通过 `getProvider(type)` 后渲染 `t('channels.providers.' + provider)`，因此 Ollama (Anthropic) 渠道会显示未定义/缺失的标签，而不是 "Ollama"。

本次补充 `ollama_anthropic: 'ollama'`，与以下内容保持一致：

- `PROVIDER_CONFIGS.ollama.channelTypes: ['ollama', 'ollama_anthropic']`
- 其他 Anthropic 变体的映射方式（如 `qiniu_anthropic` → `qiniu`、`evolink_anthropic` → `evolink`）

## Changes

- 在 `CHANNEL_TYPE_TO_PROVIDER` 中补充 `ollama_anthropic` 映射（1 行）

Related: #2058
PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for recognizing Ollama Anthropic channels and routing them to the Ollama provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->