### PR TITLE
fix(providers): accept boolean experimental flag

### DIFF
--- a/frontend/src/features/models/data/providers.schema.ts
+++ b/frontend/src/features/models/data/providers.schema.ts
@@ -82,7 +82,7 @@ export const providerModelSchema = z.object({
   open_weights: z.boolean().optional(),
   cost: modelCostSchema.optional(),
   limit: modelLimitSchema.optional().nullable(),
-  experimental: modelExperimentalSchema.optional(),
+  experimental: z.union([z.boolean(), modelExperimentalSchema]).optional(),
   display_name: z.string().optional(),
   extra_capabilities: z.record(z.string(), z.unknown()).optional(),
   vision: z.boolean().optional(),


### PR DESCRIPTION
## Summary

The frontend loads a bundled provider/model catalog and validates it against a Zod schema; one DeepSeek model entry uses a plain `true` for its `experimental` field while the schema only accepted an object, so the entire provider catalog failed to load in the UI.

## Motivation

Schema validation is a hard gate at load time (parse, not validate-with-warnings), so one out-of-shape field in the shared provider data source broke model data for every provider, not just DeepSeek. The provider data is maintained upstream (PublicProviderConf) and mixes both shapes, so the local schema must stay permissive here.

## Notes

No frontend code reads `model.experimental` — it is pass-through display data, so widening the type is safe. Alternative rejected: tightening the upstream data, which is outside this repo's control and would not have guarded against the next shape drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider model configurations can now mark experimental status with either a simple true/false value or the existing detailed configuration.

* **Compatibility**
  * Existing experimental configuration objects remain supported, and the setting remains optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->