### PR TITLE
docs(i18n): clarify where store-chunks persists stream chunks

### DIFF
--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -59,7 +59,7 @@
   "system.storage.policy.title": "Storage Policy",
   "system.storage.policy.description": "Choose what request and response content is saved to storage, and how long it is kept",
   "system.storage.policy.storeChunks.label": "Store Response Chunks",
-  "system.storage.policy.storeChunks.description": "Persist every raw event of a streaming response so you can replay it frame by frame later. Highest storage cost — a single streamed reply can produce hundreds of events. Keep off unless you need to debug streaming behavior.",
+  "system.storage.policy.storeChunks.description": "When enabled, raw stream chunks are saved to the default data storage (or the database when none is configured) after the stream ends, so you can replay them frame by frame in request details. A single streamed reply can produce hundreds of events — the highest storage cost. Keep off unless you need to debug streaming behavior.",
   "system.storage.policy.livePreview.label": "Live Preview",
   "system.storage.policy.livePreview.description": "Show streaming output in real time on the request detail page while the request is still running. Memory only — nothing is saved, and it disappears when the request finishes or the server restarts.",
   "system.storage.policy.storeRequestBody.label": "Store Request Body",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -59,7 +59,7 @@
   "system.storage.policy.title": "存储策略",
   "system.storage.policy.description": "选择哪些请求和响应内容会被保存，以及保留多久",
   "system.storage.policy.storeChunks.label": "存储流式响应块",
-  "system.storage.policy.storeChunks.description": "持久保存流式响应的每一个原始事件，事后可逐帧回放。存储开销最大——一次流式回复可能产生成百上千个事件。除非需要调试流式行为，建议保持关闭。",
+  "system.storage.policy.storeChunks.description": "开启后，流式响应的原始事件块会在流结束后保存到默认数据存储（未配置时为数据库），可在请求详情中逐帧回放。一次流式回复可能产生成百上千个事件，存储开销最大，除非需要调试流式行为，建议保持关闭。",
   "system.storage.policy.livePreview.label": "实时预览",
   "system.storage.policy.livePreview.description": "请求进行中时，在请求详情页实时观看打字机式的流式输出。仅存于内存，不做任何持久化，请求结束或服务重启后即消失。",
   "system.storage.policy.storeRequestBody.label": "存储请求体",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified English and Chinese descriptions for response chunk storage.
  * Explained storage behavior, post-stream persistence, frame-by-frame replay, and storage cost considerations.
  * Retained the recommendation to keep this option disabled due to its higher storage usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->