### PR TITLE
fix(responses): synthesize terminal events for SSE streams that end without response.completed

### DIFF
--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -199,7 +199,7 @@ func (ts *InboundPersistentStream) Close() error {
 
 	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted {
 		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.responseChunks)
-		if aggErr == nil && meta.ID != "" && len(responseBody) > 0 && isCompletedAggregated(meta) {
+		if aggErr == nil && meta.ID != "" && len(responseBody) > 0 && isCompletedAggregated(meta) && ctxErr == nil && streamErr == nil {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
 			ts.state.StreamCompleted = true
 		}

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -145,7 +145,7 @@ func (ts *OutboundPersistentStream) Close() error {
 
 	if len(ts.responseChunks) > 0 {
 		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.state.RawProviderRequest, ts.responseChunks)
-		aggregatedCompleted = aggErr == nil && isCompletedAggregated(meta)
+		aggregatedCompleted = aggErr == nil && isCompletedAggregated(meta) && ctxErr == nil && streamErr == nil
 		ts.logFinalizationDecision(ctx, "aggregated_outbound_chunks", streamErr, ctxErr, aggregatedCompleted, aggErr)
 		if aggregatedCompleted {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -1037,7 +1037,7 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 		require.True(t, state.StreamCompleted)
 	})
 
-	t.Run("canceled client with aggregated completed response is still completed", func(t *testing.T) {
+	t.Run("canceled client with only aggregated inference is not completed", func(t *testing.T) {
 		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
 		defer client.Close()
 
@@ -1097,10 +1097,8 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 
 		dbExec, err := client.RequestExecution.Get(baseCtx, exec.ID)
 		require.NoError(t, err)
-		require.Equal(t, requestexecution.StatusCompleted, dbExec.Status)
-		require.JSONEq(t, string(aggregated), string(dbExec.ResponseBody))
-		require.Equal(t, "resp_codex_like", dbExec.ExternalID)
-		require.True(t, state.StreamCompleted)
+		require.NotEqual(t, requestexecution.StatusCompleted, dbExec.Status)
+		require.False(t, state.StreamCompleted)
 	})
 
 	t.Run("canceled client after finish reason is still completed without done or usage", func(t *testing.T) {

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/looplj/axonhub/llm/pipeline/cc"
 	"github.com/looplj/axonhub/llm/streams"
 	"github.com/looplj/axonhub/llm/transformer"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
 // mockTransformer is a simple mock transformer for testing.

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -1543,3 +1543,59 @@ func TestOutboundPersistentStream_Close_TransportErrorKeepsMetricsAndClassifiesE
 	require.NotNil(t, dbExec.MetricsLatencyMs)
 	require.GreaterOrEqual(t, *dbExec.MetricsLatencyMs, int64(1500))
 }
+
+func TestOutboundPersistentStream_ResponsesCleanEOFWithOutputIsCompleted(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+	ctx = ent.NewContext(ctx, client)
+	project := createTestProject(t, ctx, client)
+	ch := createTestChannel(t, ctx, client)
+	_, requestService, _, usageLogService := setupTestServices(t, client)
+
+	req, err := client.Request.Create().
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("qwen3.8-max").
+		SetStatus(request.StatusPending).
+		SetRequestBody([]byte(`{"stream":true}`)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	exec, err := client.RequestExecution.Create().
+		SetRequestID(req.ID).
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("qwen3.8-max").
+		SetRequestBody([]byte(`{"stream":true}`)).
+		SetFormat("openai/responses").
+		SetStatus(requestexecution.StatusPending).
+		SetStream(true).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Bailian/DashScope compatible-mode closes cleanly after deltas: no
+	// response.completed, no [DONE], no usage.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_clean_eof","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
+		{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"你好"}`)},
+	}
+	transformer, err := responses.NewOutboundTransformer("https://api.example.com/v1", "test-api-key")
+	require.NoError(t, err)
+
+	state := &PersistenceState{}
+	persistentStream := NewOutboundPersistentStream(ctx, streams.SliceStream(chunks), req, exec, requestService, usageLogService, transformer, nil, state)
+	for persistentStream.Next() {
+		_ = persistentStream.Current()
+	}
+	require.NoError(t, persistentStream.Close())
+
+	dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+	require.NoError(t, err)
+	require.Equal(t, requestexecution.StatusCompleted, dbExec.Status)
+	require.Empty(t, dbExec.ErrorMessage)
+	require.True(t, state.StreamCompleted)
+}

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -1578,15 +1578,46 @@ func TestOutboundPersistentStream_ResponsesCleanEOFWithOutputIsCompleted(t *test
 	// Bailian/DashScope compatible-mode closes cleanly after deltas: no
 	// response.completed, no [DONE], no usage.
 	chunks := []*httpclient.StreamEvent{
-		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_clean_eof","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
-		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
-		{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
-		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"你好"}`)},
+		{Type: "response.created", LastEventID: "", Size: 0, Data: []byte(`{"type":"response.created","response":{"id":"resp_clean_eof","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", LastEventID: "", Size: 0, Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
+		{Type: "response.content_part.added", LastEventID: "", Size: 0, Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+		{Type: "response.output_text.delta", LastEventID: "", Size: 0, Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"你好"}`)},
 	}
 	transformer, err := responses.NewOutboundTransformer("https://api.example.com/v1", "test-api-key")
 	require.NoError(t, err)
 
-	state := &PersistenceState{}
+	state := &PersistenceState{
+		APIKey:                  nil,
+		RequestService:          nil,
+		UsageLogService:         nil,
+		ChannelService:          nil,
+		PromptProvider:          nil,
+		PromptProtecter:         nil,
+		RetryPolicyProvider:     nil,
+		CandidateSelector:       nil,
+		LoadBalancers:           nil,
+		RoutingPolicy:           EffectiveRoutingPolicy{LoadBalancerStrategy: "", TraceStickyMode: ""},
+		ModelMapper:             nil,
+		Proxy:                   nil,
+		OriginalModel:           "",
+		RawRequest:              nil,
+		LlmRequest:              nil,
+		OriginalRequestStream:   nil,
+		Request:                 nil,
+		RequestExec:             nil,
+		ChannelModelsCandidates: nil,
+		CurrentCandidateIndex:   0,
+		CurrentCandidate:        nil,
+		CurrentModelIndex:       0,
+		Perf:                    nil,
+		StreamCompleted:         false,
+		RawProviderResponse:     nil,
+		RawProviderRequest:      nil,
+		RawStreamCh:             nil,
+		RawStreamErrRef:         nil,
+		RawStreamCancel:         nil,
+		PassThroughApplied:      false,
+	}
 	persistentStream := NewOutboundPersistentStream(ctx, streams.SliceStream(chunks), req, exec, requestService, usageLogService, transformer, nil, state)
 	for persistentStream.Next() {
 		_ = persistentStream.Current()

--- a/llm/transformer/openai/fake.go
+++ b/llm/transformer/openai/fake.go
@@ -7,7 +7,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -48,7 +47,7 @@ type fakeExecutor struct{}
 // Do returns a fixed HTTP response from testdata/openai-stop.response.json.
 func (e *fakeExecutor) Do(ctx context.Context, req *httpclient.Request) (*httpclient.Response, error) {
 	// Read the fixed response from testdata
-	testDataPath := filepath.Join("testdata", "openai-stop.response.json")
+	testDataPath := "testdata/openai-stop.response.json"
 
 	responseData, err := testdataFS.ReadFile(testDataPath)
 	if err != nil {
@@ -68,7 +67,7 @@ func (e *fakeExecutor) Do(ctx context.Context, req *httpclient.Request) (*httpcl
 // DoStream returns a fixed stream response from testdata/openai-stop.stream.jsonl.
 func (e *fakeExecutor) DoStream(ctx context.Context, req *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
 	// Read the fixed stream response from testdata
-	testDataPath := filepath.Join("testdata", "openai-stop.stream.jsonl")
+	testDataPath := "testdata/openai-stop.stream.jsonl"
 
 	streamData, err := testdataFS.ReadFile(testDataPath)
 	if err != nil {

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -279,11 +279,11 @@ func responseHasOutput(resp *Response) bool {
 				}
 			}
 		case "function_call":
-			if item.Arguments != "" {
+			if item.Arguments != "" && item.Status != nil && *item.Status == "completed" {
 				return true
 			}
 		case "custom_tool_call":
-			if item.Input != nil && *item.Input != "" {
+			if item.Input != nil && item.Status != nil && *item.Status == "completed" {
 				return true
 			}
 		case "reasoning":
@@ -420,6 +420,7 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 					item.Arguments.Reset()
 					item.Arguments.WriteString(ev.Arguments)
 				}
+				item.Status = "completed"
 			}
 		}
 
@@ -438,7 +439,10 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 			if item := a.getItemForEvent(ev.OutputIndex, ev.ItemID); item != nil {
 				if ev.Input != "" {
 					item.Input = lo.ToPtr(ev.Input)
+				} else if item.Input == nil {
+					item.Input = lo.ToPtr("")
 				}
+				item.Status = "completed"
 			}
 		}
 

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -235,7 +235,78 @@ func AggregateStreamChunks(_ context.Context, chunks []*httpclient.StreamEvent) 
 		meta.Usage = agg.usage.ToUsage()
 	}
 
+	// A Responses stream that delivered real output and did not end in an
+	// explicit abnormal terminal state (failed/cancelled/incomplete) is a
+	// complete generation even when the upstream closes cleanly without
+	// emitting response.completed (e.g. Bailian/DashScope compatible-mode
+	// relays). Mark it Completed so the orchestrator's aggregation fallback
+	// treats the stream as finished instead of reporting ErrStreamIncomplete.
+	// Empty streams and explicit abnormal terminations stay incomplete.
+	if !agg.hasAbnormalTerminalStatus() && responseHasOutput(resp) {
+		meta.Completed = true
+	}
+
 	return body, meta, nil
+}
+
+// hasAbnormalTerminalStatus reports whether the aggregated response ended in an
+// explicit abnormal terminal state rather than a normal (or unstated)
+// completion.
+func (a *streamAggregator) hasAbnormalTerminalStatus() bool {
+	switch a.status {
+	case "failed", "cancelled", "canceled", "incomplete":
+		return true
+	default:
+		return false
+	}
+}
+
+// responseHasOutput reports whether the built response carries substantive
+// output (text, reasoning, tool-call arguments, generated image result, etc.).
+func responseHasOutput(resp *Response) bool {
+	if resp == nil {
+		return false
+	}
+
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			if item.Content != nil {
+				for _, part := range item.Content.Items {
+					if part.Text != nil && *part.Text != "" {
+						return true
+					}
+				}
+			}
+		case "function_call":
+			if item.Arguments != "" {
+				return true
+			}
+		case "custom_tool_call":
+			if item.Input != nil && *item.Input != "" {
+				return true
+			}
+		case "reasoning":
+			if item.Content != nil {
+				for _, part := range item.Content.Items {
+					if part.Text != nil && *part.Text != "" {
+						return true
+					}
+				}
+			}
+			for _, s := range item.Summary {
+				if s.Text != "" {
+					return true
+				}
+			}
+		case "image_generation_call":
+			if item.Result != nil && *item.Result != "" {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 //nolint:gocognit,maintidx // Event processing is inherently complex.

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -955,3 +955,52 @@ func TestAggregateStreamChunks_ImageGenerationCall(t *testing.T) {
 	require.NotNil(t, resp.Output[0].Result)
 	require.Equal(t, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", *resp.Output[0].Result)
 }
+
+func TestAggregateStreamChunks_CompletedMetaOnCleanEOFWithOutput(t *testing.T) {
+	// Bailian/DashScope compatible-mode relays close cleanly after delivering
+	// content without emitting response.completed (and often without [DONE]).
+	// The aggregated stream must be reported as Completed so the orchestrator
+	// does not treat a complete generation as truncated.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_clean_eof","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
+		{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"你好"}`)},
+	}
+
+	resultBytes, meta, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+	require.NotNil(t, resultBytes)
+	require.Equal(t, "resp_clean_eof", meta.ID)
+	require.True(t, meta.Completed)
+}
+
+func TestAggregateStreamChunks_NotCompletedWhenNoOutput(t *testing.T) {
+	// A stream with only response.created (no output, no terminal event) is a
+	// genuinely truncated/empty stream and must stay incomplete.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_empty","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+	}
+
+	resultBytes, meta, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+	require.NotNil(t, resultBytes)
+	require.False(t, meta.Completed)
+}
+
+func TestAggregateStreamChunks_NotCompletedOnAbnormalTerminalStatus(t *testing.T) {
+	// An explicit abnormal terminal status (failed) must never be promoted to
+	// Completed, even when partial output was delivered.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_failed","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
+		{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"partial"}`)},
+		{Type: "response.failed", Data: []byte(`{"type":"response.failed","response":{"id":"resp_failed","status":"failed"}}`)},
+	}
+
+	resultBytes, meta, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+	require.NotNil(t, resultBytes)
+	require.False(t, meta.Completed)
+}

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -1004,3 +1004,35 @@ func TestAggregateStreamChunks_NotCompletedOnAbnormalTerminalStatus(t *testing.T
 	require.NotNil(t, resultBytes)
 	require.False(t, meta.Completed)
 }
+
+func TestAggregateStreamChunks_PartialToolCallWithoutDoneNotCompleted(t *testing.T) {
+	// A function call with partial delta arguments but no arguments-done event
+	// is not a confirmed tool-call output, so the clean-EOF aggregate must not
+	// be marked Completed.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_partial_tool","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_partial","type":"function_call","call_id":"call_partial","name":"get_weather","arguments":""}}`)},
+		{Type: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_partial","output_index":0,"delta":"{\"city\":\"bei"}`)},
+	}
+
+	resultBytes, meta, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+	require.NotNil(t, resultBytes)
+	require.False(t, meta.Completed)
+}
+
+func TestAggregateStreamChunks_CompletedToolCallWithDoneMarkedCompleted(t *testing.T) {
+	// Once the arguments-done event confirms the tool call, the clean-EOF
+	// aggregate is a real output and may be marked Completed.
+	chunks := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_complete_tool","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_complete","type":"function_call","call_id":"call_complete","name":"get_weather","arguments":""}}`)},
+		{Type: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_complete","output_index":0,"delta":"{\"city\":\"beijing\"}"}`)},
+		{Type: "response.function_call_arguments.done", Data: []byte(`{"type":"response.function_call_arguments.done","item_id":"fc_complete","output_index":0,"arguments":"{\"city\":\"beijing\"}"}`)},
+	}
+
+	resultBytes, meta, err := AggregateStreamChunks(t.Context(), chunks)
+	require.NoError(t, err)
+	require.NotNil(t, resultBytes)
+	require.True(t, meta.Completed)
+}

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -838,6 +838,19 @@ func (s *responsesOutboundStream) Close() error {
 	return s.stream.Close()
 }
 
+// hasToolCallOutput reports whether any tracked tool call carries actual
+// arguments/input. A stream that closes after only creating a tool call item
+// (with no arguments delivered) has no meaningful output yet and must stay
+// incomplete.
+func (s *responsesOutboundStream) hasToolCallOutput() bool {
+	for _, tc := range s.state.toolCalls {
+		if tc.Function.Arguments != "" || (tc.ResponseCustomToolCall != nil && tc.ResponseCustomToolCall.Input != "") {
+			return true
+		}
+	}
+	return false
+}
+
 // canSynthesizeCompletion reports whether a clean EOF without a semantic
 // terminal event should still be treated as a successful completion. This is
 // true when the source ended without a transport error and the upstream
@@ -860,7 +873,7 @@ func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
 	// "completed" response, which would hide the truncation from the client.
 	return s.state.textContent.Len() > 0 ||
 		s.state.reasoningContent.Len() > 0 ||
-		len(s.state.toolCalls) > 0
+		s.hasToolCallOutput()
 }
 
 // synthesizeCompletion emits the terminal finish chunk and usage (if any) the
@@ -871,7 +884,7 @@ func (s *responsesOutboundStream) synthesizeCompletion() {
 	s.responseCompleted = true
 
 	finishReason := "stop"
-	if len(s.state.toolCalls) > 0 {
+	if s.hasToolCallOutput() {
 		finishReason = "tool_calls"
 	}
 

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -854,10 +854,13 @@ func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
 		return false
 	}
 
+	// A bare usage blob is not evidence of a complete generation. A stream
+	// truncated before any content (e.g. only a response.id + usage) must be
+	// surfaced as ErrStreamIncomplete rather than promoted to an empty
+	// "completed" response, which would hide the truncation from the client.
 	return s.state.textContent.Len() > 0 ||
 		s.state.reasoningContent.Len() > 0 ||
-		len(s.state.toolCalls) > 0 ||
-		s.state.usage != nil
+		len(s.state.toolCalls) > 0
 }
 
 // synthesizeCompletion emits the terminal finish chunk and usage (if any) the

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -48,6 +48,14 @@ type responsesOutboundStream struct {
 	// provider `[DONE]` marker is valid only after this becomes true.
 	responseCompleted bool
 	doneEmitted       bool
+
+	// sawProviderDone records that the upstream emitted a bare `[DONE]`
+	// transport marker. Some OpenAI-compatible Responses implementations (e.g.
+	// Bailian/DashScope compatible-mode) close the SSE stream with `[DONE]`
+	// after delivering content and usage, without a semantic
+	// response.completed event; treat that as a normal completion when output
+	// was produced.
+	sawProviderDone bool
 }
 
 // outboundStreamState holds the state for a streaming session.
@@ -106,6 +114,18 @@ func (s *responsesOutboundStream) Next() bool {
 	if !s.stream.Next() {
 		if s.err == nil && s.stream.Err() == nil {
 			if !s.responseCompleted {
+				// Some OpenAI-compatible Responses upstreams (e.g.
+				// Bailian/DashScope compatible-mode) close the SSE stream with
+				// a bare `[DONE]` marker after delivering content and usage,
+				// without emitting response.completed. When output was produced
+				// and the source ended cleanly, synthesize the terminal event
+				// instead of reporting an incomplete stream so strict clients do
+				// not treat a complete generation as truncated.
+				if s.canSynthesizeCompletion() {
+					s.synthesizeCompletion()
+
+					return true
+				}
 				s.err = ErrStreamIncomplete
 			} else if !s.doneEmitted {
 				s.doneEmitted = true
@@ -142,6 +162,8 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 	// error may only become visible when the source is advanced to exhaustion.
 	// Clean EOF without a semantic terminal is classified by Next().
 	if string(event.Data) == "[DONE]" {
+		s.sawProviderDone = true
+
 		return nil
 	}
 
@@ -824,6 +846,71 @@ func (s *responsesOutboundStream) Err() error {
 
 func (s *responsesOutboundStream) Close() error {
 	return s.stream.Close()
+}
+
+// canSynthesizeCompletion reports whether a clean EOF without a semantic
+// terminal event should still be treated as a successful completion. This is
+// true only when the upstream explicitly signaled the end of the stream with a
+// bare [DONE] marker and produced meaningful output (text, reasoning, or tool
+// calls). Genuinely truncated streams that end without either a terminal event
+// or meaningful output still surface ErrStreamIncomplete.
+func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
+	if !s.sawProviderDone {
+		return false
+	}
+
+	return s.state.textContent.Len() > 0 ||
+		s.state.reasoningContent.Len() > 0 ||
+		len(s.state.toolCalls) > 0 ||
+		s.state.usage != nil
+}
+
+// synthesizeCompletion emits the terminal finish chunk and usage (if any) the
+// way response.completed would, then marks the stream done. Callers invoke it
+// only after canSynthesizeCompletion returned true, i.e. the upstream already
+// delivered content and closed cleanly with a [DONE] marker.
+func (s *responsesOutboundStream) synthesizeCompletion() {
+	s.responseCompleted = true
+
+	finishReason := "stop"
+	if len(s.state.toolCalls) > 0 {
+		finishReason = "tool_calls"
+	}
+
+	finishChunk := &llm.Response{
+		Object:             "chat.completion.chunk",
+		ID:                 s.state.responseID,
+		Model:              s.state.responseModel,
+		Created:            s.state.created,
+		PreviousResponseID: s.state.previousResponseID,
+		Choices: []llm.Choice{
+			{
+				Index:        0,
+				Delta:        &llm.Message{},
+				FinishReason: &finishReason,
+			},
+		},
+	}
+	if len(s.state.transformerMetadata) > 0 && !s.state.transformerMetadataEmitted {
+		finishChunk.TransformerMetadata = s.state.transformerMetadata
+		s.state.transformerMetadataEmitted = true
+	}
+	s.enqueue(finishChunk)
+
+	if s.state.usage != nil {
+		s.enqueue(&llm.Response{
+			Object:             "chat.completion.chunk",
+			ID:                 s.state.responseID,
+			Model:              s.state.responseModel,
+			Created:            s.state.created,
+			PreviousResponseID: s.state.previousResponseID,
+			Choices:            []llm.Choice{},
+			Usage:              s.state.usage,
+		})
+	}
+
+	s.doneEmitted = true
+	s.enqueue(llm.DoneResponse)
 }
 
 // AggregateStreamChunks aggregates OpenAI Responses API streaming chunks into a complete response.

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -841,8 +841,8 @@ func (s *responsesOutboundStream) Close() error {
 // canSynthesizeCompletion reports whether a clean EOF without a semantic
 // terminal event should still be treated as a successful completion. This is
 // true when the source ended without a transport error and the upstream
-// produced meaningful output (text, reasoning, tool calls, or usage) under a
-// known response ID. Some OpenAI-compatible Responses upstreams (e.g.
+// produced meaningful output (text, reasoning, or tool calls) under a known
+// response ID. Some OpenAI-compatible Responses upstreams (e.g.
 // Bailian/DashScope compatible-mode) close the SSE stream cleanly without a
 // semantic terminal event or even a bare [DONE] marker; treating that as a
 // completed generation avoids surfacing a spurious truncation error to strict
@@ -866,7 +866,7 @@ func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
 // synthesizeCompletion emits the terminal finish chunk and usage (if any) the
 // way response.completed would, then marks the stream done. Callers invoke it
 // only after canSynthesizeCompletion returned true, i.e. the upstream already
-// delivered content and closed cleanly with a [DONE] marker.
+// delivered content and closed cleanly (with or without a [DONE] marker).
 func (s *responsesOutboundStream) synthesizeCompletion() {
 	s.responseCompleted = true
 

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -48,14 +48,6 @@ type responsesOutboundStream struct {
 	// provider `[DONE]` marker is valid only after this becomes true.
 	responseCompleted bool
 	doneEmitted       bool
-
-	// sawProviderDone records that the upstream emitted a bare `[DONE]`
-	// transport marker. Some OpenAI-compatible Responses implementations (e.g.
-	// Bailian/DashScope compatible-mode) close the SSE stream with `[DONE]`
-	// after delivering content and usage, without a semantic
-	// response.completed event; treat that as a normal completion when output
-	// was produced.
-	sawProviderDone bool
 }
 
 // outboundStreamState holds the state for a streaming session.
@@ -115,12 +107,12 @@ func (s *responsesOutboundStream) Next() bool {
 		if s.err == nil && s.stream.Err() == nil {
 			if !s.responseCompleted {
 				// Some OpenAI-compatible Responses upstreams (e.g.
-				// Bailian/DashScope compatible-mode) close the SSE stream with
-				// a bare `[DONE]` marker after delivering content and usage,
-				// without emitting response.completed. When output was produced
-				// and the source ended cleanly, synthesize the terminal event
-				// instead of reporting an incomplete stream so strict clients do
-				// not treat a complete generation as truncated.
+				// Bailian/DashScope compatible-mode) close the SSE stream
+				// cleanly after delivering content and usage, without emitting
+				// response.completed. When output was produced and the source
+				// ended cleanly (no transport error), synthesize the terminal
+				// event instead of reporting an incomplete stream so strict
+				// clients do not treat a complete generation as truncated.
 				if s.canSynthesizeCompletion() {
 					s.synthesizeCompletion()
 
@@ -162,8 +154,6 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 	// error may only become visible when the source is advanced to exhaustion.
 	// Clean EOF without a semantic terminal is classified by Next().
 	if string(event.Data) == "[DONE]" {
-		s.sawProviderDone = true
-
 		return nil
 	}
 
@@ -850,12 +840,17 @@ func (s *responsesOutboundStream) Close() error {
 
 // canSynthesizeCompletion reports whether a clean EOF without a semantic
 // terminal event should still be treated as a successful completion. This is
-// true only when the upstream explicitly signaled the end of the stream with a
-// bare [DONE] marker and produced meaningful output (text, reasoning, or tool
-// calls). Genuinely truncated streams that end without either a terminal event
-// or meaningful output still surface ErrStreamIncomplete.
+// true when the source ended without a transport error and the upstream
+// produced meaningful output (text, reasoning, tool calls, or usage) under a
+// known response ID. Some OpenAI-compatible Responses upstreams (e.g.
+// Bailian/DashScope compatible-mode) close the SSE stream cleanly without a
+// semantic terminal event or even a bare [DONE] marker; treating that as a
+// completed generation avoids surfacing a spurious truncation error to strict
+// clients. Genuinely truncated streams that end without meaningful output, or
+// without a response identity to attach the output to, still surface
+// ErrStreamIncomplete.
 func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
-	if !s.sawProviderDone {
+	if s.state.responseID == "" {
 		return false
 	}
 

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -64,6 +64,7 @@ type outboundStreamState struct {
 
 	// Tool call tracking
 	toolCalls     map[string]*llm.ToolCall // callID -> tool call
+	toolCallsDone map[string]bool          // callID -> arguments/input confirmed finished
 	itemToCallID  map[string]string        // item.id -> call_id mapping
 	toolCallIndex map[string]int           // callID -> index in the output
 
@@ -80,6 +81,7 @@ func newResponsesOutboundStream(stream streams.Stream[*httpclient.StreamEvent]) 
 		stream: stream,
 		state: &outboundStreamState{
 			toolCalls:                        make(map[string]*llm.ToolCall),
+			toolCallsDone:                    make(map[string]bool),
 			itemToCallID:                     make(map[string]string),
 			toolCallIndex:                    make(map[string]int),
 			pendingReasoningEncryptedContent: make(map[string]*string),
@@ -361,6 +363,7 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		if !ok {
 			return nil // Intentionally skip an unknown tool call.
 		}
+		s.state.toolCallsDone[callID] = true
 
 		identityChanged := false
 		if streamEvent.Name != "" && streamEvent.Name != tc.Function.Name {
@@ -466,6 +469,7 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 
 			if tc, ok := s.state.toolCalls[callID]; ok {
 				tc.ResponseCustomToolCall.Input = streamEvent.Input
+				s.state.toolCallsDone[callID] = true
 			}
 		}
 
@@ -565,6 +569,17 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 				},
 			}
 			break
+		}
+		if streamEvent.Item.Type == "function_call" || streamEvent.Item.Type == "custom_tool_call" {
+			callID := s.state.itemToCallID[streamEvent.Item.ID]
+			if callID == "" {
+				callID = streamEvent.Item.CallID
+			}
+			status := lo.FromPtr(streamEvent.Item.Status)
+			if callID != "" && (status == "" || status == "completed") {
+				s.state.toolCallsDone[callID] = true
+			}
+			return nil // Intentionally skip this event; tool content was already streamed via deltas.
 		}
 		if streamEvent.Item.Type != "message" {
 			return nil // Intentionally skip this event
@@ -838,17 +853,17 @@ func (s *responsesOutboundStream) Close() error {
 	return s.stream.Close()
 }
 
-// hasToolCallOutput reports whether any tracked tool call carries actual
-// arguments/input. A stream that closes after only creating a tool call item
-// (with no arguments delivered) has no meaningful output yet and must stay
-// incomplete.
-func (s *responsesOutboundStream) hasToolCallOutput() bool {
-	for _, tc := range s.state.toolCalls {
-		if tc.Function.Arguments != "" || (tc.ResponseCustomToolCall != nil && tc.ResponseCustomToolCall.Input != "") {
-			return true
+// allToolCallsDone reports whether every tracked tool call received a matching
+// arguments/input completion event. A stream that closes after only creating a
+// tool call item, or after a partial delta without its done event, has no
+// confirmed tool-call output yet and must stay incomplete.
+func (s *responsesOutboundStream) allToolCallsDone() bool {
+	for callID := range s.state.toolCalls {
+		if !s.state.toolCallsDone[callID] {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // canSynthesizeCompletion reports whether a clean EOF without a semantic
@@ -871,9 +886,9 @@ func (s *responsesOutboundStream) canSynthesizeCompletion() bool {
 	// truncated before any content (e.g. only a response.id + usage) must be
 	// surfaced as ErrStreamIncomplete rather than promoted to an empty
 	// "completed" response, which would hide the truncation from the client.
-	return s.state.textContent.Len() > 0 ||
+	return (s.state.textContent.Len() > 0 ||
 		s.state.reasoningContent.Len() > 0 ||
-		s.hasToolCallOutput()
+		len(s.state.toolCalls) > 0) && s.allToolCallsDone()
 }
 
 // synthesizeCompletion emits the terminal finish chunk and usage (if any) the
@@ -884,7 +899,7 @@ func (s *responsesOutboundStream) synthesizeCompletion() {
 	s.responseCompleted = true
 
 	finishReason := "stop"
-	if s.hasToolCallOutput() {
+	if len(s.state.toolCalls) > 0 {
 		finishReason = "tool_calls"
 	}
 

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1475,3 +1475,31 @@ func TestOutboundTransformer_TransformStream_CleanEOFWithOutputSynthesizesComple
 	}
 	require.Equal(t, 1, finishResponses)
 }
+
+func TestOutboundTransformer_TransformStream_UsageWithoutContentStillIncomplete(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// A clean EOF with only a response.id + usage (no content, no terminal
+	// event) must not be promoted to an empty "completed" response. A bare
+	// usage blob hides truncation; only actual output proves a complete
+	// generation.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_usage_only","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`)},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.ErrorIs(t, err, ErrStreamIncomplete)
+	require.Equal(t, 0, countDoneResponses(responses))
+
+	// No finish chunk must be synthesized for an empty (usage-only) stream.
+	for _, response := range responses {
+		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			t.Fatalf("unexpected synthesized finish_reason for usage-only stream")
+		}
+	}
+}
+
+

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1330,5 +1330,117 @@ func TestOutboundTransformer_TransformStream_PreservesOfficialWebSocketError(t *
 			require.Equal(t, "invalid websocket request", responseErr.Detail.Message)
 			require.Equal(t, "input", responseErr.Detail.Param)
 		})
+	}func TestOutboundTransformer_TransformStream_DoneWithoutSemanticTerminalSynthesizesCompletion(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// Bailian/DashScope compatible-mode closes the SSE stream with a bare
+	// [DONE] marker after delivering content and usage, without emitting
+	// response.completed. The stream must be treated as a normal completion.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_done_synth","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"hello"}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":" world"}`)},
+		{Data: []byte("[DONE]")},
 	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Equal(t, 1, countDoneResponses(responses))
+
+	// A finish chunk with stop must be synthesized.
+	finishResponses := 0
+	for _, response := range responses {
+		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			finishResponses++
+			require.Equal(t, "stop", lo.FromPtr(response.Choices[0].FinishReason))
+		}
+	}
+	require.Equal(t, 1, finishResponses)
+}
+
+func TestOutboundTransformer_TransformStream_DoneWithUsageWithoutSemanticTerminalSynthesizesCompletion(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// Some weak providers also deliver a usage chunk before the [DONE] marker;
+	// the synthesized completion must carry that usage.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_done_usage","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"hello"}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_done_usage","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"completed","output":[],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`)},
+		{Data: []byte("[DONE]")},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Equal(t, 1, countDoneResponses(responses))
+
+	// Both finish_reason and usage chunks must be present.
+	finishResponses := 0
+	usageSeen := false
+	for _, response := range responses {
+		if response == nil {
+			continue
+		}
+		if len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			finishResponses++
+		}
+		if response.Usage != nil && response.Usage.TotalTokens == 3 {
+			usageSeen = true
+		}
+	}
+	require.Equal(t, 1, finishResponses)
+	require.True(t, usageSeen)
+}
+
+func TestOutboundTransformer_TransformStream_DoneWithoutOutputStillIncomplete(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// A bare [DONE] with no meaningful output must not be promoted to a
+	// successful completion - it remains an incomplete stream.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_empty","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Data: []byte("[DONE]")},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.ErrorIs(t, err, ErrStreamIncomplete)
+	require.Equal(t, 0, countDoneResponses(responses))
+}
+
+func TestOutboundTransformer_TransformStream_ToolCallsDoneWithoutSemanticTerminalSynthesizesToolCalls(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// Tool-call streams closed by a bare [DONE] must synthesize
+	// finish_reason=tool_calls rather than failing the request.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_tool_done","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"get_weather","arguments":""}}`)},
+		{Type: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"city\":\"beijing\"}"}`)},
+		{Data: []byte("[DONE]")},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Equal(t, 1, countDoneResponses(responses))
+
+	finishResponses := 0
+	for _, response := range responses {
+		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			finishResponses++
+			require.Equal(t, "tool_calls", lo.FromPtr(response.Choices[0].FinishReason))
+		}
+	}
+	require.Equal(t, 1, finishResponses)
 }

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1330,7 +1330,9 @@ func TestOutboundTransformer_TransformStream_PreservesOfficialWebSocketError(t *
 			require.Equal(t, "invalid websocket request", responseErr.Detail.Message)
 			require.Equal(t, "input", responseErr.Detail.Param)
 		})
-	}func TestOutboundTransformer_TransformStream_DoneWithoutSemanticTerminalSynthesizesCompletion(t *testing.T) {
+	}
+}
+func TestOutboundTransformer_TransformStream_DoneWithoutSemanticTerminalSynthesizesCompletion(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)
 

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1332,6 +1332,7 @@ func TestOutboundTransformer_TransformStream_PreservesOfficialWebSocketError(t *
 		})
 	}
 }
+
 func TestOutboundTransformer_TransformStream_DoneWithoutSemanticTerminalSynthesizesCompletion(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)
@@ -1503,5 +1504,3 @@ func TestOutboundTransformer_TransformStream_UsageWithoutContentStillIncomplete(
 		}
 	}
 }
-
-

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1504,3 +1504,29 @@ func TestOutboundTransformer_TransformStream_UsageWithoutContentStillIncomplete(
 		}
 	}
 }
+
+func TestOutboundTransformer_TransformStream_ToolCallWithoutArgumentsStillIncomplete(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// A stream that only creates a tool call item but never delivers any
+	// arguments/input has no meaningful output. It must stay incomplete instead
+	// of being promoted to a tool_calls completion with empty arguments.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_empty_tool","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_empty","type":"function_call","call_id":"call_empty","name":"get_weather","arguments":""}}`)},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.ErrorIs(t, err, ErrStreamIncomplete)
+	require.Equal(t, 0, countDoneResponses(responses))
+
+	// No finish chunk must be synthesized for an empty tool-call stream.
+	for _, response := range responses {
+		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			t.Fatalf("unexpected synthesized finish_reason for empty tool-call stream")
+		}
+	}
+}

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1444,3 +1444,34 @@ func TestOutboundTransformer_TransformStream_ToolCallsDoneWithoutSemanticTermina
 	}
 	require.Equal(t, 1, finishResponses)
 }
+
+func TestOutboundTransformer_TransformStream_CleanEOFWithOutputSynthesizesCompletion(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	// Bailian/DashScope compatible-mode relays close the SSE stream cleanly
+	// after delivering content, without response.completed and without a bare
+	// [DONE] marker. The outbound stream must synthesize the terminal finish
+	// chunk so downstream clients do not see the generation as truncated.
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_clean_eof","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant"}}`)},
+		{Type: "response.content_part.added", Data: []byte(`{"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"你好"}`)},
+	}
+	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
+	require.NoError(t, err)
+
+	responses, err := streams.All(stream)
+	require.NoError(t, err)
+	require.Equal(t, 1, countDoneResponses(responses))
+
+	finishResponses := 0
+	for _, response := range responses {
+		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
+			finishResponses++
+			require.Equal(t, "stop", lo.FromPtr(response.Choices[0].FinishReason))
+		}
+	}
+	require.Equal(t, 1, finishResponses)
+}

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1373,7 +1373,7 @@ func TestOutboundTransformer_TransformStream_DoneWithUsageWithoutSemanticTermina
 	events := []*httpclient.StreamEvent{
 		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_done_usage","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
 		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"hello"}`)},
-		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_done_usage","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"completed","output":[],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`)},
+		{Type: "response.in_progress", Data: []byte(`{"type":"response.in_progress","response":{"id":"resp_done_usage","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`)},
 		{Data: []byte("[DONE]")},
 	}
 	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
@@ -1429,6 +1429,7 @@ func TestOutboundTransformer_TransformStream_ToolCallsDoneWithoutSemanticTermina
 		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_tool_done","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
 		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"get_weather","arguments":""}}`)},
 		{Type: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"city\":\"beijing\"}"}`)},
+		{Type: "response.function_call_arguments.done", Data: []byte(`{"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\"city\":\"beijing\"}"}`)},
 		{Data: []byte("[DONE]")},
 	}
 	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
@@ -1505,16 +1506,17 @@ func TestOutboundTransformer_TransformStream_UsageWithoutContentStillIncomplete(
 	}
 }
 
-func TestOutboundTransformer_TransformStream_ToolCallWithoutArgumentsStillIncomplete(t *testing.T) {
+func TestOutboundTransformer_TransformStream_ToolCallWithoutDoneStillIncomplete(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)
 
-	// A stream that only creates a tool call item but never delivers any
-	// arguments/input has no meaningful output. It must stay incomplete instead
-	// of being promoted to a tool_calls completion with empty arguments.
+	// A tool call with only partial delta arguments and no arguments-done event
+	// has not been confirmed as complete. It must stay incomplete instead of
+	// being promoted to a tool_calls completion.
 	events := []*httpclient.StreamEvent{
-		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_empty_tool","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
-		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_empty","type":"function_call","call_id":"call_empty","name":"get_weather","arguments":""}}`)},
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_partial_tool","object":"response","created_at":1700000000,"model":"qwen3.8-max","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_partial","type":"function_call","call_id":"call_partial","name":"get_weather","arguments":""}}`)},
+		{Type: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_partial","output_index":0,"delta":"{\"city\":\"bei"}`)},
 	}
 	stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream(events))
 	require.NoError(t, err)
@@ -1523,10 +1525,10 @@ func TestOutboundTransformer_TransformStream_ToolCallWithoutArgumentsStillIncomp
 	require.ErrorIs(t, err, ErrStreamIncomplete)
 	require.Equal(t, 0, countDoneResponses(responses))
 
-	// No finish chunk must be synthesized for an empty tool-call stream.
+	// No finish chunk must be synthesized for an unfinished tool-call stream.
 	for _, response := range responses {
 		if response != nil && len(response.Choices) > 0 && response.Choices[0].FinishReason != nil {
-			t.Fatalf("unexpected synthesized finish_reason for empty tool-call stream")
+			t.Fatalf("unexpected synthesized finish_reason for unfinished tool-call stream")
 		}
 	}
 }

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1084,17 +1084,23 @@ type webSocketStream struct {
 	terminal bool
 }
 
-// isWebSocketTransportClosed reports whether err indicates the peer closed the
-// connection, either via a WebSocket close frame or an abrupt transport close
-// (TCP reset / abort). The OS error strings differ between platforms: Linux
-// reports "connection reset by peer", while Windows reports "an established
-// connection was aborted by the software in your host machine".
-func isWebSocketTransportClosed(err error) bool {
+// isWebSocketCleanClose reports whether err is a normal WebSocket close frame.
+// Only a normal close is considered a clean end of the stream.
+func isWebSocketCleanClose(err error) bool {
 	if err == nil {
 		return false
 	}
-	if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-		return true
+	return websocket.IsCloseError(err, websocket.CloseNormalClosure)
+}
+
+// isWebSocketTransportClose reports whether err indicates an abrupt transport
+// close (TCP reset / abort / EOF) rather than a WebSocket close frame. The OS
+// error strings differ between platforms: Linux reports "connection reset by
+// peer", while Windows reports "an established connection was aborted by the
+// software in your host machine".
+func isWebSocketTransportClose(err error) bool {
+	if err == nil {
+		return false
 	}
 	msg := strings.ToLower(err.Error())
 	for _, s := range []string{
@@ -1121,11 +1127,25 @@ func (s *webSocketStream) Next() bool {
 
 	_, msg, err := s.lease.conn.ReadMessage()
 	if err != nil {
-		if isWebSocketTransportClosed(err) {
-			if ctxErr := s.ctx.Err(); ctxErr != nil {
+		ctxErr := s.ctx.Err()
+		if isWebSocketCleanClose(err) {
+			if ctxErr != nil {
 				s.setErr(ctxErr)
 			} else if !s.hasSeenEvent() {
 				s.setErr(fmt.Errorf("websocket closed before response event"))
+			}
+			s.finish(true)
+			return false
+		}
+		if isWebSocketTransportClose(err) {
+			if ctxErr != nil {
+				s.setErr(ctxErr)
+			} else if !s.hasSeenEvent() {
+				s.setErr(fmt.Errorf("websocket closed before response event"))
+			} else {
+				// An abrupt transport close after output is an upstream
+				// interruption, not a clean completion.
+				s.setErr(err)
 			}
 			s.finish(true)
 			return false

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1084,6 +1084,33 @@ type webSocketStream struct {
 	terminal bool
 }
 
+// isWebSocketTransportClosed reports whether err indicates the peer closed the
+// connection, either via a WebSocket close frame or an abrupt transport close
+// (TCP reset / abort). The OS error strings differ between platforms: Linux
+// reports "connection reset by peer", while Windows reports "an established
+// connection was aborted by the software in your host machine".
+func isWebSocketTransportClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"use of closed network connection",
+		"connection reset by peer",
+		"established connection was aborted",
+		"broken pipe",
+		"eof",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *webSocketStream) Next() bool {
 	if s.contextCancelled() {
 		return false
@@ -1094,7 +1121,7 @@ func (s *webSocketStream) Next() bool {
 
 	_, msg, err := s.lease.conn.ReadMessage()
 	if err != nil {
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure) || strings.Contains(err.Error(), "use of closed network connection") {
+		if isWebSocketTransportClosed(err) {
 			if ctxErr := s.ctx.Err(); ctxErr != nil {
 				s.setErr(ctxErr)
 			} else if !s.hasSeenEvent() {

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -1448,3 +1448,44 @@ func TestToWebSocketURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "ws://localhost:8080/v1/responses", got)
 }
+
+func TestWebSocketStreamReturnsErrorWhenConnectionAbortsAfterEvent(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var payload map[string]any
+		require.NoError(t, conn.ReadJSON(&payload))
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"type": "response.created",
+			"response": map[string]any{
+				"id":         "resp_aborted",
+				"object":     "response",
+				"created_at": 1700000000,
+				"model":      "gpt-5",
+				"status":     "in_progress",
+				"output":     []any{},
+			},
+		}))
+		// Close the TCP connection without a WebSocket close frame so the
+		// peer sees an abrupt transport close after it already received output.
+		_ = conn.UnderlyingConn().Close()
+	}))
+	defer server.Close()
+
+	executor := NewWebSocketExecutor(nil)
+	stream, err := executor.DoStream(webSocketTestContext(), &httpclient.Request{
+		Method: http.MethodPost,
+		URL:    "http" + strings.TrimPrefix(server.URL, "http") + "/v1/responses",
+		Auth:   &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:   []byte(`{"model":"gpt-5"}`),
+	})
+	require.NoError(t, err)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.created", stream.Current().Type)
+	require.False(t, stream.Next())
+	require.Error(t, stream.Err())
+	require.NoError(t, stream.Close())
+}


### PR DESCRIPTION
## 背景

部分 OpenAI 兼容的 Responses 上游（例如 Bailian / DashScope 兼容模式，以及部分中转服务）在内容已经完整返回后直接关闭 SSE 流，没有发送 `response.completed`；有时只发一个 `[DONE]`，有时连 `[DONE]` 都没有。

之前 AxonHub 会把这类流判成 `ErrStreamIncomplete`（流不完整），导致 Codex 这类对 OpenAI 协议要求较严格的下游客户端认为生成被截断，把已经收到的内容也丢掉了。

## 修改内容

1. **干净收尾且已有有效输出时，补发结束事件**

   `outbound_stream.go`：当流在没有传输错误的情况下干净结束，并且已经产生真实输出（文本、思考、工具调用）且能关联到 response id 时，自动补发终止 chunk（`stop` / `tool_calls`）和使用量，不再误报 `ErrStreamIncomplete`。

2. **没有有效输出时，仍然按不完整处理**

   只有 response id + usage、没有任何正文的流，仍然返回 `ErrStreamIncomplete`，避免把真实截断包装成“成功”。

3. **工具调用必须确认完成**

   只有收到 `response.function_call_arguments.done`、`response.custom_tool_call_input.done`，或 completed 的 output item，才认为工具调用完成；只创建了工具调用、参数还没发完的流，不能补成 `tool_calls` 完成。

   `outbound_stream.go` 和 `aggregator.go` 使用一致的完成条件。

4. **错误和取消不能被当作成功**

   `internal/server/orchestrator/outbound.go`、`inbound.go`：只要出现取消或终止错误，就不能只凭“聚合结果看起来完整”就把请求记为 completed；只有已经明确收到结束事件、随后客户端才断开的情况，才保留原来的例外处理。

5. **WebSocket 异常断开不再当作干净结束**

   只有正常的 WebSocket close frame 才算干净收尾；reset / abort / broken pipe / EOF 这类传输层中断：
   - 在收到任何事件前发生：上报 “closed before response event”；
   - 已经开始输出后发生：按上游中断上报，而不是补成完成。

6. **其他修复**

   `fake.go`：测试数据改用正斜杠路径，兼容 Windows（`embed.FS` 只认正斜杠路径）。

## 测试覆盖

- 收到 `[DONE]` 后关闭，但有内容 → 正常补完成
- 干净 EOF 且有文本输出 → 正常补完成
- 只有 usage、没有任何内容 → 仍判不完整
- 工具调用参数未发完 / 没有 done 事件 → 不完整
- 工具调用带 done 事件 → 正常完成
- 聚合器对工具调用完成条件的判断
- WebSocket 在输出过程中异常断开 → 报错，不再补完成
- orchestrator 层面：请求被取消时，不能被聚合结果升级为 completed

## 验证

- `llm` 模块 `go test ./...` 通过
- `internal/server/orchestrator` 测试通过
- `zai`、`openai`、`openai/responses` 相关测试通过