### PR TITLE
fix(zai): support GLM-5.2+ reasoning_effort and GLM-5.3 always-on thinking

### DIFF
--- a/llm/transformer/zai/outbound.go
+++ b/llm/transformer/zai/outbound.go
@@ -181,7 +181,7 @@ func resolveZaiThinking(model, reasoningEffort string) (*Thinking, *string) {
 	effort := reasoningEffort
 
 	if !supportsNativeReasoningEffort(model) {
-		// GLM-4.x and older: thinking on/off only.
+		// GLM models before 5.2 (4.x, 5.0/5.1, and unknown/non-GLM fallback): thinking on/off only.
 		if effort == "none" {
 			return &Thinking{Type: "disabled"}, nil
 		}
@@ -258,7 +258,7 @@ func (t *OutboundTransformer) TransformRequest(
 
 	// GLM/z.ai validate user_id as 6-128 characters (error 1214). Clients like
 	// Claude Code send a long JSON blob (device_id/session_id) here; send only
-	// values the upstream accepts — truncate long ones, drop short ones. An
+	// values the upstream accepts 鈥?truncate long ones, drop short ones. An
 	// empty value omits the field entirely (json omitempty).
 	if runes := []rune(zaiReq.UserID); len(runes) > maxUserIDLength {
 		zaiReq.UserID = string(runes[:maxUserIDLength])

--- a/llm/transformer/zai/outbound.go
+++ b/llm/transformer/zai/outbound.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
@@ -23,6 +25,7 @@ type Config struct {
 	BaseURL        string              `json:"base_url,omitempty"` // Custom base URL (optional)
 	APIKeyProvider auth.APIKeyProvider `json:"-"`                  // API key provider
 	Version        string              `json:"version,omitempty"`  // API version (default: "v4")
+
 	// EndpointPath replaces the default "/chat/completions" path. When set, the
 	// base URL is kept as-is without version normalization (same convention as
 	// the OpenAI transformer).
@@ -115,6 +118,93 @@ type Thinking struct {
 	Type string `json:"type"`
 }
 
+// glmVersionPattern matches GLM model names such as glm-5.3, glm-5.3-flash or
+// zai-org/glm-5.3:thinking and captures the major/minor version.
+var glmVersionPattern = regexp.MustCompile(`(?i)(?:^|[/:])glm-([0-9]+)\.([0-9]+)`)
+
+// glmVersion extracts the GLM major/minor version from a model name.
+func glmVersion(model string) (major, minor int, ok bool) {
+	m := glmVersionPattern.FindStringSubmatch(model)
+	if len(m) != 3 {
+		return 0, 0, false
+	}
+	major, err1 := strconv.Atoi(m[1])
+	minor, err2 := strconv.Atoi(m[2])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// supportsNativeReasoningEffort reports whether the model supports Zhipu's native
+// reasoning_effort parameter (GLM-5.2 and later).
+func supportsNativeReasoningEffort(model string) bool {
+	major, minor, ok := glmVersion(model)
+	return ok && (major > 5 || (major == 5 && minor >= 2))
+}
+
+// isAlwaysThinkingModel reports whether the model always enables thinking and rejects
+// thinking.type=disabled (GLM-5.3 and GLM-5.3-FLASH).
+func isAlwaysThinkingModel(model string) bool {
+	lower := strings.ToLower(model)
+	return strings.HasPrefix(lower, "glm-5.3") || strings.Contains(lower, "/glm-5.3")
+}
+
+// normalizeGLM53Effort maps any effort value into GLM-5.3's valid set (low/high/max).
+// GLM-5.3 always thinks and rejects every other value, so none/minimal and unknown
+// values fall back to the lightest valid effort.
+func normalizeGLM53Effort(effort string) string {
+	switch strings.ToLower(effort) {
+	case "low":
+		return "low"
+	case "medium", "high":
+		return "high"
+	case "xhigh", "max":
+		return "max"
+	default: // none, minimal, unknown
+		return "low"
+	}
+}
+
+// resolveZaiThinking converts the unified reasoning effort into Zhipu's thinking and
+// native reasoning_effort fields.
+//
+//   - GLM-5.3 / GLM-5.3-FLASH always think: thinking.type=disabled is rejected and only
+//     reasoning_effort=low|high|max are accepted (none/minimal are mapped to low).
+//   - GLM-5.2 supports both thinking on/off and the full reasoning_effort ladder.
+//   - Older GLM models only understand thinking.type enabled/disabled.
+func resolveZaiThinking(model, reasoningEffort string) (*Thinking, *string) {
+	if reasoningEffort == "" {
+		return nil, nil
+	}
+
+	effort := reasoningEffort
+
+	if !supportsNativeReasoningEffort(model) {
+		// GLM-4.x and older: thinking on/off only.
+		if effort == "none" {
+			return &Thinking{Type: "disabled"}, nil
+		}
+		return &Thinking{Type: "enabled"}, nil
+	}
+
+	if isAlwaysThinkingModel(model) {
+		// GLM-5.3: always think, only low/high/max accepted.
+		return &Thinking{Type: "enabled"}, lo.ToPtr(normalizeGLM53Effort(effort))
+	}
+
+	// GLM-5.2: thinking can still be disabled; the native reasoning_effort
+	// ladder is exposed for supported values. "minimal" still requests reasoning,
+	// so keep thinking enabled and map it to the lightest native effort.
+	if effort == "none" {
+		return &Thinking{Type: "disabled"}, nil
+	}
+	if effort == "minimal" {
+		return &Thinking{Type: "enabled"}, lo.ToPtr(llm.ReasoningEffortLow)
+	}
+	return &Thinking{Type: "enabled"}, lo.ToPtr(effort)
+}
+
 // TransformRequest transforms ChatCompletionRequest to Request.
 func (t *OutboundTransformer) TransformRequest(
 	ctx context.Context,
@@ -191,17 +281,17 @@ func (t *OutboundTransformer) TransformRequest(
 	// zai request does not support metadata (extracted to user_id/request_id)
 	zaiReq.Metadata = nil
 
-	// Convert ReasoningEffort to Thinking if present
+	// Convert ReasoningEffort to Zhipu thinking / reasoning_effort fields.
+	// GLM-5.3 always thinks (none is mapped to low); GLM-5.2+ expose the native
+	// reasoning_effort parameter; older GLM models only understand thinking on/off.
 	if llmReq.ReasoningEffort != "" {
-		var thinkingType string
-		switch llmReq.ReasoningEffort {
-		case "none":
-			thinkingType = "disabled"
-		default:
-			thinkingType = "enabled"
-		}
-		zaiReq.Thinking = &Thinking{
-			Type: thinkingType,
+		thinking, nativeEffort := resolveZaiThinking(llmReq.Model, llmReq.ReasoningEffort)
+		zaiReq.Thinking = thinking
+		if nativeEffort != nil {
+			zaiReq.ReasoningEffort = *nativeEffort
+		} else {
+			// Avoid leaking an unsupported reasoning_effort to the upstream.
+			zaiReq.ReasoningEffort = ""
 		}
 	}
 

--- a/llm/transformer/zai/outbound_test.go
+++ b/llm/transformer/zai/outbound_test.go
@@ -531,3 +531,79 @@ func TestOutboundTransformer_TransformRequest_UserIDLength(t *testing.T) {
 		assert.Equal(t, "user-123456", body["user_id"])
 	})
 }
+
+func TestOutboundTransformer_TransformRequest_GLM53NoneMapsToLow(t *testing.T) {
+	config := &Config{
+		BaseURL:        "https://api.zai.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
+	}
+
+	transformer, err := NewOutboundTransformerWithConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create transformer: %v", err)
+	}
+
+	request := &llm.Request{
+		Model:           "glm-5.3-flash",
+		ReasoningEffort: "none",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("Hello, world!"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	got, err := transformer.TransformRequest(ctx, request)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	var zaiReq Request
+	err = json.Unmarshal(got.Body, &zaiReq)
+	assert.NoError(t, err)
+	require.NotNil(t, zaiReq.Thinking)
+	assert.Equal(t, "enabled", zaiReq.Thinking.Type)
+	assert.Equal(t, "low", zaiReq.ReasoningEffort)
+}
+
+func TestOutboundTransformer_TransformRequest_NonGLMStripsReasoningEffort(t *testing.T) {
+	config := &Config{
+		BaseURL:        "https://api.zai.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
+	}
+
+	transformer, err := NewOutboundTransformerWithConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create transformer: %v", err)
+	}
+
+	request := &llm.Request{
+		Model:           "gpt-4",
+		ReasoningEffort: "high",
+		Messages: []llm.Message{
+			{
+				Role: "user",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("Hello, world!"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	got, err := transformer.TransformRequest(ctx, request)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	var zaiReq Request
+	err = json.Unmarshal(got.Body, &zaiReq)
+	assert.NoError(t, err)
+	require.NotNil(t, zaiReq.Thinking)
+	assert.Equal(t, "enabled", zaiReq.Thinking.Type)
+	assert.Equal(t, "", zaiReq.ReasoningEffort)
+}

--- a/llm/transformer/zai/thinking_test.go
+++ b/llm/transformer/zai/thinking_test.go
@@ -1,155 +1,167 @@
 package zai
 
 import (
-	"context"
 	"testing"
 
-	"github.com/looplj/axonhub/llm"
-	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestReasoningEffortToThinking(t *testing.T) {
+func TestSupportsNativeReasoningEffort(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"glm-4.5", false},
+		{"glm-4.7", false},
+		{"glm-4.7-flash", false},
+		{"glm-5.0", false},
+		{"glm-5.1", false},
+		{"glm-5.2", true},
+		{"glm-5.3", true},
+		{"glm-5.3-flash", true},
+		{"zai-org/glm-5.3:thinking", true},
+		{"GLM-5.3-FLASH", true},
+		{"gpt-4", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, supportsNativeReasoningEffort(tt.model))
+		})
+	}
+}
+
+func TestIsAlwaysThinkingModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"glm-5.3", true},
+		{"glm-5.3-flash", true},
+		{"zai-org/glm-5.3:thinking", true},
+		{"GLM-5.3-FLASH", true},
+		{"glm-5.2", false},
+		{"glm-4.7", false},
+		{"gpt-4", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAlwaysThinkingModel(tt.model))
+		})
+	}
+}
+
+func TestNormalizeGLM53Effort(t *testing.T) {
+	tests := []struct {
+		effort string
+		want   string
+	}{
+		{"none", "low"},
+		{"minimal", "low"},
+		{"low", "low"},
+		{"medium", "high"},
+		{"high", "high"},
+		{"xhigh", "max"},
+		{"max", "max"},
+		{"unknown", "low"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.effort, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeGLM53Effort(tt.effort))
+		})
+	}
+}
+
+func TestResolveZaiThinking(t *testing.T) {
+	effortPtr := func(s string) *string { return &s }
+
 	tests := []struct {
 		name            string
+		model           string
 		reasoningEffort string
-		expectedType    string
+		wantThinking    *Thinking
+		wantEffort      *string
 	}{
 		{
-			name:            "low reasoning effort",
-			reasoningEffort: "low",
-			expectedType:    "enabled",
-		},
-		{
-			name:            "medium reasoning effort",
-			reasoningEffort: "medium",
-			expectedType:    "enabled",
-		},
-		{
-			name:            "high reasoning effort",
-			reasoningEffort: "high",
-			expectedType:    "enabled",
-		},
-		{
-			name:            "none reasoning effort (disabled)",
+			name:            "glm-5.3 none maps to low with thinking enabled",
+			model:           "glm-5.3-flash",
 			reasoningEffort: "none",
-			expectedType:    "disabled",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      effortPtr("low"),
 		},
 		{
-			name:            "unknown reasoning effort",
-			reasoningEffort: "unknown",
-			expectedType:    "enabled",
+			name:            "glm-5.3 high passes through",
+			model:           "glm-5.3",
+			reasoningEffort: "high",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      effortPtr("high"),
+		},
+		{
+			name:            "glm-5.3 xhigh maps to max",
+			model:           "glm-5.3",
+			reasoningEffort: "xhigh",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      effortPtr("max"),
+		},
+		{
+			name:            "glm-5.2 none disables thinking",
+			model:           "glm-5.2",
+			reasoningEffort: "none",
+			wantThinking:    &Thinking{Type: "disabled"},
+			wantEffort:      nil,
+		},
+		{
+			name:            "glm-5.2 minimal maps to low",
+			model:           "glm-5.2",
+			reasoningEffort: "minimal",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      effortPtr("low"),
+		},
+		{
+			name:            "glm-5.2 low passes reasoning_effort",
+			model:           "glm-5.2",
+			reasoningEffort: "low",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      effortPtr("low"),
+		},
+		{
+			name:            "glm-4.7 none disables thinking",
+			model:           "glm-4.7",
+			reasoningEffort: "none",
+			wantThinking:    &Thinking{Type: "disabled"},
+			wantEffort:      nil,
+		},
+		{
+			name:            "glm-4.7 high enables thinking",
+			model:           "glm-4.7",
+			reasoningEffort: "high",
+			wantThinking:    &Thinking{Type: "enabled"},
+			wantEffort:      nil,
+		},
+		{
+			name:            "empty effort returns nil thinking",
+			model:           "glm-5.3",
+			reasoningEffort: "",
+			wantThinking:    nil,
+			wantEffort:      nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chatReq := &llm.Request{
-				ReasoningEffort: tt.reasoningEffort,
-				Messages: []llm.Message{
-					{
-						Role: "user",
-						Content: llm.MessageContent{
-							Content: &[]string{"Hello, world!"}[0],
-						},
-					},
-				},
+			thinking, effort := resolveZaiThinking(tt.model, tt.reasoningEffort)
+			if tt.wantThinking == nil {
+				assert.Nil(t, thinking)
+			} else {
+				require.NotNil(t, thinking)
+				assert.Equal(t, tt.wantThinking.Type, thinking.Type)
 			}
-
-			zaiReq := Request{}
-
-			if chatReq.ReasoningEffort != "" {
-				var thinkingType string
-				switch chatReq.ReasoningEffort {
-				case "none":
-					thinkingType = "disabled"
-				default:
-					thinkingType = "enabled"
-				}
-				zaiReq.Thinking = &Thinking{
-					Type: thinkingType,
-				}
-			}
-
-			if zaiReq.Thinking == nil {
-				t.Error("Expected Thinking to be non-nil when ReasoningEffort is set")
-			}
-
-			if zaiReq.Thinking.Type != tt.expectedType {
-				t.Errorf("Expected Thinking.Type to be '%s', got %s", tt.expectedType, zaiReq.Thinking.Type)
+			if tt.wantEffort == nil {
+				assert.Nil(t, effort)
+			} else {
+				require.NotNil(t, effort)
+				assert.Equal(t, *tt.wantEffort, *effort)
 			}
 		})
-	}
-}
-
-func TestZAIRequestWithThinking(t *testing.T) {
-	chatReq := &llm.Request{
-		ReasoningEffort: "high",
-		Messages: []llm.Message{
-			{
-				Role: "user",
-				Content: llm.MessageContent{
-					Content: &[]string{"Hello, world!"}[0],
-				},
-			},
-		},
-	}
-
-	zaiReq := Request{}
-
-	if chatReq.ReasoningEffort != "" {
-		var thinkingType string
-		switch chatReq.ReasoningEffort {
-		case "none":
-			thinkingType = "disabled"
-		default:
-			thinkingType = "enabled"
-		}
-		zaiReq.Thinking = &Thinking{
-			Type: thinkingType,
-		}
-	}
-
-	if zaiReq.Thinking == nil {
-		t.Error("Expected Thinking to be non-nil when ReasoningEffort is set")
-	}
-
-	if zaiReq.Thinking.Type != "enabled" {
-		t.Errorf("Expected Thinking.Type to be 'enabled', got %s", zaiReq.Thinking.Type)
-	}
-}
-
-func TestZAIRequestWithoutThinking(t *testing.T) {
-	chatReq := &llm.Request{
-		Model: "gpt-4",
-		Messages: []llm.Message{
-			{
-				Role: "user",
-				Content: llm.MessageContent{
-					Content: &[]string{"Hello, world!"}[0],
-				},
-			},
-		},
-	}
-
-	zaiReq := Request{
-		Request: *openai.RequestFromLLM(context.Background(), chatReq, openai.ReasoningFieldContent),
-		UserID:  "test-user",
-	}
-
-	if chatReq.ReasoningEffort != "" {
-		var thinkingType string
-		switch chatReq.ReasoningEffort {
-		case "none":
-			thinkingType = "disabled"
-		default:
-			thinkingType = "enabled"
-		}
-		zaiReq.Thinking = &Thinking{
-			Type: thinkingType,
-		}
-	}
-
-	if zaiReq.Thinking != nil {
-		t.Error("Expected Thinking to be nil when ReasoningEffort is not set")
 	}
 }


### PR DESCRIPTION
## Problem  GLM-5.3 / GLM-5.3-FLASH always enable thinking and reject `thinking.type=disabled` (Zhipu error 1210). Clients sending `reasoning_effort=none` (or another unsupported value) are rejected, and older GLM models were only handled with a coarse enabled/disabled switch.  ## Changes  - Detect GLM model versions from the model name (`glm-5.x`, `org/glm-5.x:thinking`, `zai-org:glm-5.x`, case-insensitive). Always-thinking detection uses the parsed version, so `glm-5.30` is never confused with `glm-5.3`. - GLM-5.3 / GLM-5.3-FLASH: always emit `thinking.type=enabled` and translate `reasoning_effort` into Zhipu's native `reasoning_effort` (`none`/`minimal`/unknown -> `low`, `medium`/`high` -> `high`, `xhigh`/`max` -> `max`). - GLM-5.2+: expose the native `reasoning_effort` parameter while keeping `thinking.type` on/off for `none`. - GLM models before 5.2 (e.g. 4.x, 5.0/5.1): keep the previous `thinking.type` enabled/disabled behavior.  Channel-level `reasoningEffortMapping` is already applied centrally by the orchestrator before the outbound transformer runs, so this PR does not re-apply it.  ## Scope  This PR only changes the ZAI OpenAI-compatible Chat Completions transformer (`llm/transformer/zai`). The default `zai_anthropic` channel uses the native Anthropic Messages path and is intentionally not covered here.  ## Tests  Unit tests cover version detection, always-thinking detection, GLM-5.3 effort normalization, and the GLM-5.2 / GLM-4.x thinking paths.   <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  * **Bug Fixes**   * Improved reasoning-effort handling for Zai models across GLM versions.   * Added support for native reasoning-effort levels on newer GLM models, including normalized low, high, and maximum settings.   * Preserved appropriate thinking behavior for models with limited or always-on reasoning support.   * Prevented unsupported reasoning-effort values from being sent to models that do not support them.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->