### PR TITLE
ci: validate bundled providers.json against its schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,35 @@ jobs:
 
       - name: Test
         run: make test-backend-all
+
+  test-frontend-unit:
+    name: Test Frontend Unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+
+      # The *.test.mjs suites import .ts modules directly, which needs native
+      # TypeScript type stripping (enabled by default since Node 22.18).
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        working-directory: frontend
+        run: pnpm test:unit

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "prepare": "husky",
     "knip": "knip",
-    "test:unit": "node --test src/**/*.test.mjs",
+    "test:unit": "node --test \"src/**/*.test.mjs\"",
     "test:e2e": "../scripts/e2e/e2e-test.sh",
     "test:e2e:headed": "../scripts/e2e/e2e-test.sh --headed",
     "test:e2e:ui": "../scripts/e2e/e2e-test.sh --ui",

--- a/frontend/src/features/models/data/providers.schema.test.mjs
+++ b/frontend/src/features/models/data/providers.schema.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { providersDataSchema } from './providers.schema.ts';
+
+const providersJsonPath = join(import.meta.dirname, 'providers.json');
+
+function formatIssue(issue) {
+  const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+  return `  ${path}: ${issue.message}`;
+}
+
+test('bundled providers.json matches providersDataSchema', () => {
+  const raw = JSON.parse(readFileSync(providersJsonPath, 'utf8'));
+  const result = providersDataSchema.safeParse(raw);
+
+  if (!result.success) {
+    const issues = result.error.issues;
+    const shown = issues.slice(0, 10).map(formatIssue).join('\n');
+    const rest = issues.length > 10 ? `\n  ... and ${issues.length - 10} more` : '';
+    assert.fail(
+      `providers.json (synced by scripts/sync/sync-model-developers.js) no longer matches the schema that providers.ts parses at import time.\nUpdate providers.schema.ts to accept the new shape:\n${shown}${rest}`
+    );
+  }
+
+  assert.ok(Object.keys(result.data.providers).length > 0, 'bundled providers.json must contain at least one provider');
+});


### PR DESCRIPTION
## Why

`6f729f7c` shipped because nothing validated the bundled catalog snapshot against the schema that consumes it:

- `scripts/sync/sync-model-developers.js` rewrites `frontend/src/features/models/data/providers.json` from upstream data every week and opens a PR.
- `frontend/src/features/models/data/providers.ts:8` parses that file **at import time**. So when upstream started shipping `experimental` as a bare boolean, the schema rejected it, the module threw on import, and even the fallback path was unavailable — the models/developers page crashed instead of degrading.

The upstream-data PR merged without any check noticing the shape mismatch.

## What

1. **New check** — `frontend/src/features/models/data/providers.schema.test.mjs` imports the real `providersDataSchema` and `safeParse`s the real `providers.json`, failing with the offending JSON path. It also asserts the snapshot is not empty, so a silently-empty sync cannot pass.
2. **Fix the `test:unit` script** — it was `node --test src/**/*.test.mjs` unquoted. npm scripts run through `sh`, where `**` degrades to `*`, so the suite only reached 21 of the 35 existing tests and any nested test was skipped silently. Quoting the glob lets the node test runner expand it.
3. **Run it in CI** — a `test-frontend-unit` job in the existing Test workflow, reusing the pnpm setup from `build.yml`. Node 24 because the `*.test.mjs` suites import `.ts` modules directly and rely on native type stripping.

## Evidence

Against a schema reverted to its pre-`6f729f7c` form, the new test fails exactly where the bug was:

```
✖ bundled providers.json matches providersDataSchema
  AssertionError: providers.json (synced by scripts/sync/sync-model-developers.js) no longer
  matches the schema that providers.ts parses at import time.
  Update providers.schema.ts to accept the new shape:
    providers.deepseek.models.0.experimental: Invalid input: expected object, received boolean
```

On current `unstable`: `pnpm test:unit` → 36/36 pass (35 pre-existing + this one; the glob fix activated the 14 previously-skipped nested tests and none of them fail).

## Notes

- Out of scope here: `internal/server/biz/catalogdata/providers.json` is the backend mirror of the same snapshot, and `CatalogService.fallbackCache()` swallows the unmarshal error and serves an empty catalog. Go models are `[]map[string]any`, so this class of model-field drift does not affect it — provider-level typed fields (`vision`, `name`) still could, silently.
- `providers.ts:8` still uses `parse`, so a bad snapshot remains a hard crash rather than a degraded page; the check just blocks it before merge.
