### PR TITLE
fix: classify upstream stream interruptions and keep latency metrics on failed executions

### DIFF
--- a/frontend/src/features/requests/components/request-detail-content.tsx
+++ b/frontend/src/features/requests/components/request-detail-content.tsx
@@ -824,7 +824,7 @@ export function RequestDetailContent({ requestId, projectId, previewRequest, isP
                                 {t('requests.columns.firstTokenLatency')}
                               </span>
                               <p className='text-muted-foreground font-mono text-sm'>
-                                {execution.status === 'completed' && execution.metricsFirstTokenLatencyMs != null ? formatLatency(execution.metricsFirstTokenLatencyMs) : '-'}
+                                {(execution.status === 'completed' || execution.status === 'failed') && execution.metricsFirstTokenLatencyMs != null ? formatLatency(execution.metricsFirstTokenLatencyMs) : '-'}
                               </p>
                             </div>
                           </div>

--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/orchestrator"
 	"github.com/looplj/axonhub/llm"
@@ -347,14 +348,14 @@ func writeSSEStreamEnd(
 			}
 		} else {
 			log.Error(ctx, "Error in stream", log.Cause(streamErr))
-			c.SSEvent("error", formatErr(ctx, streamErr))
+			c.SSEvent("error", formatErr(ctx, orchestrator.ClassifyUpstreamTransportError(streamErr)))
 		}
 	case errors.Is(ctx.Err(), context.Canceled):
 		*clientDisconnected = true
 	case !terminalSeen:
 		log.Error(ctx, "Stream ended without terminal event, reporting incomplete stream to client",
 			log.Cause(orchestrator.ErrStreamIncomplete))
-		c.SSEvent("error", formatErr(ctx, orchestrator.ErrStreamIncomplete))
+		c.SSEvent("error", formatErr(ctx, orchestrator.ClassifyUpstreamTransportError(orchestrator.ErrStreamIncomplete)))
 	}
 
 	c.Writer.Flush()
@@ -440,7 +441,9 @@ func WriteBinaryStream(c *gin.Context, stream streams.Stream[*httpclient.StreamE
 				} else {
 					log.Error(ctx, "Error in binary stream", log.Cause(err))
 					if !headersWritten {
-						c.JSON(streamErrorStatus(err), FormatStreamError(ctx, err))
+						failure := orchestrator.ClassifyUpstreamTransportError(err)
+						c.JSON(streamErrorStatus(failure), FormatStreamError(ctx, failure))
+
 						return
 					}
 				}
@@ -517,7 +520,9 @@ func streamErrorStatus(err error) int {
 }
 
 // FormatStreamError formats a stream error into an OpenAI-compatible JSON error object.
-func FormatStreamError(_ context.Context, err error) any {
+// When the error carries no upstream request id, the gateway's own request id from ctx
+// is used so clients can always correlate an error event with the request log.
+func FormatStreamError(ctx context.Context, err error) any {
 	errType := "server_error"
 	errCode := ""
 	requestID := ""
@@ -548,7 +553,7 @@ func FormatStreamError(_ context.Context, err error) any {
 				"type":    errType,
 				"code":    errCode,
 			},
-			"request_id": requestID,
+			"request_id": streamErrorRequestID(ctx, requestID),
 		}
 	}
 
@@ -573,8 +578,22 @@ func FormatStreamError(_ context.Context, err error) any {
 			"type":    errType,
 			"code":    errCode,
 		},
-		"request_id": requestID,
+		"request_id": streamErrorRequestID(ctx, requestID),
 	}
+}
+
+// streamErrorRequestID returns the upstream request id when present, otherwise the
+// gateway request id stored in ctx (the value echoed in the AH-Request-Id header).
+func streamErrorRequestID(ctx context.Context, requestID string) string {
+	if requestID != "" || ctx == nil {
+		return requestID
+	}
+
+	if id, ok := contexts.GetRequestID(ctx); ok {
+		return id
+	}
+
+	return ""
 }
 
 func wrapQuotaExhaustedAsResponseError(err error) error {

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/server/biz"
@@ -896,4 +899,141 @@ func TestWriteSSEStream_MessageStopIsNotIncomplete(t *testing.T) {
 
 	body := w.Body.String()
 	require.NotContains(t, body, "event:error")
+}
+
+// parseSSEErrorEvent extracts the JSON payload of the first "error" SSE event.
+func parseSSEErrorEvent(t *testing.T, body string) map[string]any {
+	t.Helper()
+
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "event:error") {
+			continue
+		}
+
+		require.Less(t, i+1, len(lines), "error event should have a data line")
+
+		var parsed map[string]any
+
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(lines[i+1], "data:")), &parsed))
+
+		return parsed
+	}
+
+	require.FailNow(t, "no error event found", body)
+
+	return nil
+}
+
+func TestFormatStreamError_FallsBackToContextRequestID(t *testing.T) {
+	ctx := contexts.WithRequestID(context.Background(), "req_gateway_1")
+
+	data, err := json.Marshal(FormatStreamError(ctx, errors.New("boom")))
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "req_gateway_1", parsed["request_id"])
+
+	// An upstream request id still wins over the gateway one.
+	respErr := &llm.ResponseError{Detail: llm.ErrorDetail{Message: "m", RequestID: "req_upstream"}}
+
+	data, err = json.Marshal(FormatStreamError(ctx, respErr))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "req_upstream", parsed["request_id"])
+
+	// No id anywhere keeps the field empty instead of failing.
+	data, err = json.Marshal(FormatStreamError(context.Background(), errors.New("boom")))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "", parsed["request_id"])
+}
+
+// An upstream that drops the connection after content was delivered must surface as a
+// classified upstream error (stable code, 502 semantics), not as a bare "unexpected EOF".
+func TestWriteSSEStream_TransportErrorIsClassified(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).
+		WithContext(contexts.WithRequestID(context.Background(), "req_gateway_2"))
+
+	stream := &errorAfterStream{
+		items: []*httpclient.StreamEvent{
+			{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"He"}}]}`)},
+		},
+		err: fmt.Errorf("read body: %w", io.ErrUnexpectedEOF),
+	}
+
+	WriteSSEStream(c, stream)
+
+	parsed := parseSSEErrorEvent(t, w.Body.String())
+	errorField := parsed["error"].(map[string]any)
+	assert.Equal(t, orchestrator.ErrTypeUpstreamError, errorField["type"])
+	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, errorField["code"])
+	assert.Contains(t, errorField["message"], "unexpected EOF")
+	assert.Equal(t, "req_gateway_2", parsed["request_id"])
+}
+
+func TestWriteSSEStream_IncompleteStreamErrorIsClassified(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	events := []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)},
+	}
+
+	WriteSSEStream(c, streams.SliceStream(events))
+
+	parsed := parseSSEErrorEvent(t, w.Body.String())
+	errorField := parsed["error"].(map[string]any)
+	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, errorField["code"])
+	assert.Contains(t, errorField["message"], orchestrator.ErrStreamIncomplete.Error())
+}
+
+// Hidden/custom policies rewrite the message but must keep the classification so
+// clients can still tell an interrupted stream from other upstream failures.
+func TestUpstreamErrorStream_HiddenModeKeepsTransportErrorCode(t *testing.T) {
+	ctx, systemService := setupUpstreamErrorPolicyTest(t, biz.UpstreamErrorPolicy{
+		Mode: biz.UpstreamErrorModeHidden,
+	})
+
+	inner := &errorAfterStream{err: io.ErrUnexpectedEOF}
+	stream := newUpstreamErrorStream(ctx, inner, systemService)
+	require.False(t, stream.Next())
+
+	err := stream.Err()
+
+	respErr := &llm.ResponseError{}
+	require.True(t, errors.As(err, &respErr))
+	assert.Equal(t, http.StatusBadGateway, respErr.StatusCode)
+	assert.Equal(t, orchestrator.ErrTypeUpstreamError, respErr.Detail.Type)
+	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, respErr.Detail.Code)
+	assert.Equal(t, biz.DefaultUpstreamErrorMessage, respErr.Detail.Message)
+	assert.NotContains(t, respErr.Detail.Message, "unexpected EOF")
+}
+
+func TestUpstreamErrorStream_PassthroughClassifiesTransportError(t *testing.T) {
+	ctx, systemService := setupUpstreamErrorPolicyTest(t, biz.UpstreamErrorPolicy{
+		Mode: biz.UpstreamErrorModePassthrough,
+	})
+
+	inner := &errorAfterStream{err: llm.ErrStreamIncomplete}
+	stream := newUpstreamErrorStream(ctx, inner, systemService)
+	require.False(t, stream.Next())
+
+	err := stream.Err()
+	require.True(t, errors.Is(err, llm.ErrStreamIncomplete))
+
+	respErr := &llm.ResponseError{}
+	require.True(t, errors.As(err, &respErr))
+	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, respErr.Detail.Code)
+	assert.Contains(t, respErr.Detail.Message, llm.ErrStreamIncomplete.Error())
+
+	// Non-transport errors are passed through untouched.
+	plain := errors.New("boom")
+	stream = newUpstreamErrorStream(ctx, &errorAfterStream{err: plain}, systemService)
+	require.False(t, stream.Next())
+	assert.Equal(t, plain, stream.Err())
 }

--- a/internal/server/api/upstream_error_policy.go
+++ b/internal/server/api/upstream_error_policy.go
@@ -18,6 +18,8 @@ import (
 
 func transformOrchestratorError(ctx context.Context, err error, orch *orchestrator.ChatCompletionOrchestrator) *httpclient.Error {
 	err = wrapQuotaExhaustedAsResponseError(err)
+	err = orchestrator.ClassifyUpstreamTransportError(err)
+
 	if orch != nil {
 		err = applyUpstreamErrorPolicy(ctx, err, orch.SystemService)
 		return orch.Inbound.TransformError(ctx, err)
@@ -126,6 +128,12 @@ func (s *upstreamErrorStream) Err() error {
 	err := s.stream.Err()
 	if err == nil {
 		return nil
+	}
+
+	// Classify transport-level interruptions before the policy runs so the stable
+	// code and 502 semantics survive a hidden/custom message rewrite.
+	if orchestrator.IsUpstreamTransportError(err) {
+		err = orchestrator.ClassifyUpstreamTransportError(pipeline.WrapUpstreamError(err))
 	}
 
 	policy := s.systemService.RetryPolicyOrDefault(s.ctx).UpstreamErrorPolicy

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -865,6 +865,20 @@ func (s *RequestService) UpdateRequestExecutionStatus(
 	errorMsg string,
 	errorInfo *ExecutionErrorInfo,
 ) error {
+	return s.UpdateRequestExecutionStatusWithMetrics(ctx, executionID, status, errorMsg, errorInfo, nil)
+}
+
+// UpdateRequestExecutionStatusWithMetrics is UpdateRequestExecutionStatus plus the latency
+// metrics collected before the execution ended, so a failed execution keeps its
+// time-to-first-token and total latency instead of losing them with the error.
+func (s *RequestService) UpdateRequestExecutionStatusWithMetrics(
+	ctx context.Context,
+	executionID int,
+	status requestexecution.Status,
+	errorMsg string,
+	errorInfo *ExecutionErrorInfo,
+	metrics *LatencyMetrics,
+) error {
 	client := s.entFromContext(ctx)
 
 	upd := client.RequestExecution.UpdateOneID(executionID).
@@ -875,6 +889,20 @@ func (s *RequestService) UpdateRequestExecutionStatus(
 
 	if errorInfo != nil && errorInfo.StatusCode != nil {
 		upd = upd.SetResponseStatusCode(*errorInfo.StatusCode)
+	}
+
+	if metrics != nil {
+		if metrics.LatencyMs != nil {
+			upd = upd.SetMetricsLatencyMs(*metrics.LatencyMs)
+		}
+
+		if metrics.FirstTokenLatencyMs != nil {
+			upd = upd.SetMetricsFirstTokenLatencyMs(*metrics.FirstTokenLatencyMs)
+		}
+
+		if metrics.ReasoningDurationMs != nil {
+			upd = upd.SetMetricsReasoningDurationMs(*metrics.ReasoningDurationMs)
+		}
 	}
 
 	_, err := upd.Save(ctx)

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -312,10 +312,12 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 		// Update the last request execution status based on error if it exists
 		// This ensures that when retry fails completely, the last execution is properly marked
 		if requestExec := outbound.GetRequestExecution(); requestExec != nil {
-			if updateErr := processor.RequestService.UpdateRequestExecutionStatusFromError(
+			if updateErr := persistRequestExecutionFailure(
 				persistCtx,
+				processor.RequestService,
 				requestExec.ID,
 				err,
+				nil,
 			); updateErr != nil {
 				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(updateErr))
 			}

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -133,11 +133,7 @@ func (ts *OutboundPersistentStream) Close() error {
 
 		ts.persistFailureChunks(persistCtx)
 
-		if ts.requestExec != nil {
-			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, streamErr); err != nil {
-				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
-			}
-		}
+		ts.persistExecutionFailure(persistCtx, streamErr)
 
 		return ts.stream.Close()
 	}
@@ -176,11 +172,7 @@ func (ts *OutboundPersistentStream) Close() error {
 			errToReport = ErrStreamIncomplete
 		}
 
-		if ts.requestExec != nil {
-			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport); err != nil {
-				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
-			}
-		}
+		ts.persistExecutionFailure(persistCtx, errToReport)
 
 		return ts.stream.Close()
 	}
@@ -195,11 +187,7 @@ func (ts *OutboundPersistentStream) Close() error {
 		ts.persistFailureChunks(persistCtx)
 
 		errToReport := ErrStreamIncomplete
-		if ts.requestExec != nil {
-			if err := ts.RequestService.UpdateRequestExecutionStatusFromError(persistCtx, ts.requestExec.ID, errToReport); err != nil {
-				log.Warn(persistCtx, "Failed to update request execution status from error", log.Cause(err))
-			}
-		}
+		ts.persistExecutionFailure(persistCtx, errToReport)
 
 		return ts.stream.Close()
 	}
@@ -276,6 +264,42 @@ func (ts *OutboundPersistentStream) persistFailureChunks(ctx context.Context) {
 
 	if err := ts.RequestService.SaveRequestExecutionChunks(ctx, ts.requestExec.ID, ts.responseChunks); err != nil {
 		log.Warn(ctx, "Failed to save request execution chunks after stream failure", log.Cause(err))
+	}
+}
+
+// failureLatencyMetrics captures the latency metrics collected before the stream failed,
+// so a failed execution still records its time-to-first-token and total latency.
+func (ts *OutboundPersistentStream) failureLatencyMetrics() *biz.LatencyMetrics {
+	if ts.perf == nil || ts.perf.StartTime.IsZero() {
+		return nil
+	}
+
+	endTime := ts.perf.EndTime
+	if endTime.IsZero() {
+		endTime = time.Now()
+	}
+
+	latencyMs := biz.ClampLatency(endTime.Sub(ts.perf.StartTime).Milliseconds())
+	metrics := &biz.LatencyMetrics{LatencyMs: &latencyMs}
+
+	if ts.perf.Stream && ts.perf.FirstTokenTime != nil {
+		firstTokenLatencyMs := biz.ClampLatency(ts.perf.FirstTokenTime.Sub(ts.perf.StartTime).Milliseconds())
+		metrics.FirstTokenLatencyMs = &firstTokenLatencyMs
+	}
+
+	return metrics
+}
+
+// persistExecutionFailure marks the execution failed (or canceled) with a classified
+// error and the latency metrics captured before the failure.
+func (ts *OutboundPersistentStream) persistExecutionFailure(ctx context.Context, rawErr error) {
+	if ts.requestExec == nil {
+		return
+	}
+
+	err := persistRequestExecutionFailure(ctx, ts.RequestService, ts.requestExec.ID, rawErr, ts.failureLatencyMetrics())
+	if err != nil {
+		log.Warn(ctx, "Failed to update request execution status from error", log.Cause(err))
 	}
 }
 

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -1361,4 +1363,70 @@ func TestPersistentOutboundTransformer_CanRetry_429_WithMultipleModels(t *testin
 		// Should skip retry even though there are more models
 		require.False(t, outbound.CanRetry(httpErr))
 	})
+}
+
+// A transport failure after content was delivered must keep the latency metrics that
+// were already captured and persist a classified error, so operators can tell "stalled
+// before the first byte" from "cut after N tokens" and the status code is not lost.
+func TestOutboundPersistentStream_Close_TransportErrorKeepsMetricsAndClassifiesError(t *testing.T) {
+	ctx := authz.WithTestBypass(context.Background())
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx = ent.NewContext(ctx, client)
+	project := createTestProject(t, ctx, client)
+	ch := createTestChannel(t, ctx, client)
+	_, requestService, _, usageLogService := setupTestServices(t, client)
+
+	req, err := client.Request.Create().
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("gpt-4.1").
+		SetStatus(request.StatusPending).
+		SetRequestBody([]byte(`{"stream":true}`)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	exec, err := client.RequestExecution.Create().
+		SetRequestID(req.ID).
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("gpt-4.1").
+		SetRequestBody([]byte(`{"stream":true}`)).
+		SetFormat("openai/chat_completions").
+		SetStatus(requestexecution.StatusPending).
+		SetStream(true).
+		Save(ctx)
+	require.NoError(t, err)
+
+	stream := &sliceEventStream{
+		events: []*httpclient.StreamEvent{
+			{Data: []byte(`{"id":"1","choices":[{"delta":{"content":"He"}}]}`)},
+		},
+		err: fmt.Errorf("read body: %w", io.ErrUnexpectedEOF),
+	}
+
+	start := time.Now().Add(-1500 * time.Millisecond)
+	firstToken := start.Add(400 * time.Millisecond)
+	perf := &biz.PerformanceRecord{StartTime: start, FirstTokenTime: &firstToken, Stream: true}
+	transformer := &mockTransformer{apiFormat: llm.APIFormatOpenAIResponse}
+
+	persistentStream := NewOutboundPersistentStream(ctx, stream, req, exec, requestService, usageLogService, transformer, perf, &PersistenceState{})
+	for persistentStream.Next() {
+		_ = persistentStream.Current()
+	}
+	require.NoError(t, persistentStream.Close())
+
+	dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+	require.NoError(t, err)
+	require.Equal(t, requestexecution.StatusFailed, dbExec.Status)
+	require.Contains(t, dbExec.ErrorMessage, "Upstream provider closed the connection before the response completed")
+	require.Contains(t, dbExec.ErrorMessage, "unexpected EOF")
+	require.NotNil(t, dbExec.ResponseStatusCode)
+	require.Equal(t, http.StatusBadGateway, *dbExec.ResponseStatusCode)
+	require.NotNil(t, dbExec.MetricsFirstTokenLatencyMs)
+	require.Equal(t, int64(400), *dbExec.MetricsFirstTokenLatencyMs)
+	require.NotNil(t, dbExec.MetricsLatencyMs)
+	require.GreaterOrEqual(t, *dbExec.MetricsLatencyMs, int64(1500))
 }

--- a/internal/server/orchestrator/request_execution.go
+++ b/internal/server/orchestrator/request_execution.go
@@ -217,11 +217,13 @@ func (m *persistRequestExecutionMiddleware) OnOutboundRawError(ctx context.Conte
 	persistCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	failure := ClassifyUpstreamTransportError(err)
+
 	updateErr := state.RequestService.UpdateRequestExecutionFailed(
 		persistCtx,
 		state.RequestExec.ID,
-		ExtractErrorMessage(err),
-		ExtractErrorInfo(err),
+		ExtractErrorMessage(failure),
+		ExtractErrorInfo(failure),
 	)
 	if updateErr != nil {
 		log.Warn(persistCtx, "Failed to update request execution status to failed", log.Cause(updateErr))
@@ -232,6 +234,13 @@ func (m *persistRequestExecutionMiddleware) OnOutboundRawError(ctx context.Conte
 func ExtractErrorInfo(err error) *biz.ExecutionErrorInfo {
 	httpErr, ok := xerrors.As[*httpclient.Error](err)
 	if !ok {
+		// Classified errors (e.g. upstream transport failures) carry their own status code.
+		if respErr, ok := xerrors.As[*llm.ResponseError](err); ok && respErr.StatusCode != 0 {
+			statusCode := respErr.StatusCode
+
+			return &biz.ExecutionErrorInfo{StatusCode: &statusCode}
+		}
+
 		return nil
 	}
 
@@ -244,6 +253,12 @@ func ExtractErrorInfo(err error) *biz.ExecutionErrorInfo {
 func ExtractErrorMessage(err error) string {
 	httpErr, ok := xerrors.As[*httpclient.Error](err)
 	if !ok {
+		// Prefer the structured message over ResponseError.Error(), which also
+		// concatenates the status text, code and type.
+		if respErr, ok := xerrors.As[*llm.ResponseError](err); ok && respErr.Detail.Message != "" {
+			return respErr.Detail.Message
+		}
+
 		return err.Error()
 	}
 

--- a/internal/server/orchestrator/upstream_transport_error.go
+++ b/internal/server/orchestrator/upstream_transport_error.go
@@ -1,0 +1,105 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+const (
+	// ErrTypeUpstreamError is the error type reported when the upstream connection breaks.
+	ErrTypeUpstreamError = "upstream_error"
+	// ErrCodeUpstreamStreamInterrupted is the stable code for an upstream connection that
+	// ended before the response completed: EOF, reset, timeout or a missing terminal event.
+	ErrCodeUpstreamStreamInterrupted = "upstream_stream_interrupted"
+)
+
+// IsUpstreamTransportError reports whether err is a transport-level failure of the
+// upstream connection rather than an HTTP error body or a local cancellation: the
+// connection ended early (io.EOF / io.ErrUnexpectedEOF), the stream never delivered a
+// terminal event, or the network reported a reset or timeout.
+func IsUpstreamTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Already carries a status code or structured detail: nothing to classify.
+	if _, ok := errors.AsType[*httpclient.Error](err); ok {
+		return false
+	}
+
+	if _, ok := errors.AsType[*llm.ResponseError](err); ok {
+		return false
+	}
+
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, llm.ErrStreamIncomplete) ||
+		errors.Is(err, ErrStreamIncomplete) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+
+	var netErr net.Error
+
+	return errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary())
+}
+
+// ClassifyUpstreamTransportError converts a transport-level upstream failure into a
+// *llm.ResponseError with 502 semantics, a stable code and the original cause, so
+// clients and the request log see a classifiable error instead of a bare
+// "unexpected EOF". Any other error is returned unchanged.
+func ClassifyUpstreamTransportError(err error) error {
+	if !IsUpstreamTransportError(err) {
+		return err
+	}
+
+	return &llm.ResponseError{
+		StatusCode: http.StatusBadGateway,
+		Detail: llm.ErrorDetail{
+			Message: "Upstream provider closed the connection before the response completed: " + err.Error(),
+			Type:    ErrTypeUpstreamError,
+			Code:    ErrCodeUpstreamStreamInterrupted,
+		},
+		Cause: err,
+	}
+}
+
+// persistRequestExecutionFailure marks an execution failed (or canceled) with a classified
+// error message and status code, keeping any latency metrics captured before the failure.
+func persistRequestExecutionFailure(
+	ctx context.Context,
+	requestService *biz.RequestService,
+	executionID int,
+	rawErr error,
+	metrics *biz.LatencyMetrics,
+) error {
+	status := requestexecution.StatusFailed
+	if errors.Is(rawErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		status = requestexecution.StatusCanceled
+	}
+
+	failure := ClassifyUpstreamTransportError(rawErr)
+
+	return requestService.UpdateRequestExecutionStatusWithMetrics(
+		ctx,
+		executionID,
+		status,
+		ExtractErrorMessage(failure),
+		ExtractErrorInfo(failure),
+		metrics,
+	)
+}

--- a/internal/server/orchestrator/upstream_transport_error_test.go
+++ b/internal/server/orchestrator/upstream_transport_error_test.go
@@ -1,0 +1,79 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestIsUpstreamTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
+		{name: "wrapped unexpected EOF", err: fmt.Errorf("HTTP stream request failed: %w", io.ErrUnexpectedEOF), want: true},
+		{name: "EOF", err: io.EOF, want: true},
+		{name: "llm stream incomplete", err: llm.ErrStreamIncomplete, want: true},
+		{name: "orchestrator stream incomplete", err: ErrStreamIncomplete, want: true},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "http error", err: &httpclient.Error{StatusCode: http.StatusBadGateway, Body: []byte(`{}`)}, want: false},
+		{name: "response error", err: &llm.ResponseError{StatusCode: http.StatusTooManyRequests}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsUpstreamTransportError(tt.err))
+		})
+	}
+}
+
+func TestClassifyUpstreamTransportError(t *testing.T) {
+	cause := fmt.Errorf("read body: %w", io.ErrUnexpectedEOF)
+
+	err := ClassifyUpstreamTransportError(cause)
+
+	respErr := &llm.ResponseError{}
+	require.True(t, errors.As(err, &respErr))
+	require.Equal(t, http.StatusBadGateway, respErr.StatusCode)
+	require.Equal(t, ErrTypeUpstreamError, respErr.Detail.Type)
+	require.Equal(t, ErrCodeUpstreamStreamInterrupted, respErr.Detail.Code)
+	require.Contains(t, respErr.Detail.Message, "unexpected EOF")
+	require.True(t, errors.Is(err, io.ErrUnexpectedEOF), "the cause must stay matchable through the classified error")
+
+	// Idempotent for already classified errors, transparent for everything else.
+	require.Same(t, err, ClassifyUpstreamTransportError(err))
+
+	plain := errors.New("boom")
+	require.Equal(t, plain, ClassifyUpstreamTransportError(plain))
+	require.Equal(t, context.Canceled, ClassifyUpstreamTransportError(context.Canceled))
+}
+
+func TestExtractErrorMessageAndInfo_ClassifiedTransportError(t *testing.T) {
+	err := ClassifyUpstreamTransportError(io.ErrUnexpectedEOF)
+
+	require.Equal(t,
+		"Upstream provider closed the connection before the response completed: unexpected EOF",
+		ExtractErrorMessage(err))
+
+	info := ExtractErrorInfo(err)
+	require.NotNil(t, info)
+	require.NotNil(t, info.StatusCode)
+	require.Equal(t, http.StatusBadGateway, *info.StatusCode)
+
+	// Plain errors keep the previous behavior.
+	require.Equal(t, "boom", ExtractErrorMessage(errors.New("boom")))
+	require.Nil(t, ExtractErrorInfo(errors.New("boom")))
+}

--- a/llm/model.go
+++ b/llm/model.go
@@ -877,6 +877,15 @@ type PromptTokensDetails struct {
 type ResponseError struct {
 	StatusCode int         `json:"-"`
 	Detail     ErrorDetail `json:"error"`
+
+	// Cause keeps the underlying error (for example a transport failure) so callers
+	// can still match it with errors.Is / errors.As after classification.
+	Cause error `json:"-"`
+}
+
+// Unwrap exposes the underlying cause, if any.
+func (e ResponseError) Unwrap() error {
+	return e.Cause
 }
 
 func (e ResponseError) Error() string {


### PR DESCRIPTION
## Summary

修复 #2316：`stream=true` 的 Chat Completions 在上游已下发内容后断开连接时，客户端只收到裸 `unexpected EOF`、请求日志丢失首字耗时的问题。

**修复前**，客户端收到的流内错误和请求日志分别是：

```
event: error
data: {"error":{"message":"unexpected EOF","type":"server_error","code":""},"request_id":""}
```

```
执行 #1  失败  错误信息: unexpected EOF  状态码: (无)  首字耗时: -
```

**修复后**：

```
event: error
data: {"error":{"message":"Upstream provider closed the connection before the response completed: unexpected EOF","type":"upstream_error","code":"upstream_stream_interrupted"},"request_id":"<AH-Request-Id>"}
```

```
执行 #1  失败  错误信息: Upstream provider closed the connection before the response completed: unexpected EOF  状态码: 502  首字耗时: 412ms
```

重试语义不变：`preReadLlmStream` 在首个有效内容后提交尝试、之后不再重试的逻辑没有改动，本 PR 只处理错误形态与可观测性。

## Changes

- `internal/server/orchestrator/upstream_transport_error.go`（新增）：`IsUpstreamTransportError` / `ClassifyUpstreamTransportError`，把 `io.EOF`、`io.ErrUnexpectedEOF`、`ErrStreamIncomplete`、连接重置/超时类 `net.Error` 映射为 `llm.ResponseError{StatusCode: 502, Type: "upstream_error", Code: "upstream_stream_interrupted"}`；`context.Canceled`、`*httpclient.Error`、已是 `ResponseError` 的错误原样返回。`persistRequestExecutionFailure` 统一失败执行的落库（分类后的消息 + 状态码 + 指标）。
- `llm/model.go`：`ResponseError` 增加 `Cause` 字段与 `Unwrap()`，分类后 `errors.Is(err, io.ErrUnexpectedEOF)` 仍成立，`pipeline.IsUpstreamError` 也能穿透识别，因此 hidden/custom 的 `UpstreamErrorPolicy` 仍会改写消息，但保留 type/code。
- `internal/server/api/upstream_error_policy.go`：`transformOrchestratorError` 与 `upstreamErrorStream.Err()` 在策略生效前先分类。
- `internal/server/api/chat.go`：`writeSSEStreamEnd`（含 `ErrStreamIncomplete` 兜底）和 `WriteBinaryStream` 输出分类后的错误；`FormatStreamError` 在错误没有上游 request id 时回填 `contexts.GetRequestID(ctx)`（即 `AH-Request-Id`）。
- `internal/server/orchestrator/outbound.go`：三个失败分支改走 `persistExecutionFailure`，把 perf 里已有的 `FirstTokenTime`/总耗时一并落库；`request_execution.go` 的 `OnOutboundRawError` 同样分类，`ExtractErrorMessage` / `ExtractErrorInfo` 识别 `ResponseError` 的结构化消息与状态码。
- `internal/server/biz/request.go`：新增 `UpdateRequestExecutionStatusWithMetrics`，原 `UpdateRequestExecutionStatus` 委托过去，签名不变。
- `frontend/.../request-detail-content.tsx`：失败执行也显示首字耗时（仅放开 `status === 'failed'` 的条件）。

## Tests

- 新增 `upstream_transport_error_test.go`（分类规则、cause 可穿透、幂等）、`outbound_test.go` 中流中断后指标与 502 落库的用例、`chat_test.go` 中 SSE 错误事件分类、request_id 回填、hidden 模式保留 code 的用例。
- `go test ./internal/server/api/ ./internal/server/orchestrator/ ./internal/server/biz/` 与 `cd llm && go test .` 通过。

## Notes

- #2316 第 3 点（首个事件之后的空闲超时）属于可选增强，不在本 PR 范围。
- 错误文案里保留原始错误串（`unexpected EOF` 等），便于和上游日志对照；hidden/custom 模式下文案仍按策略替换。

Fixes #2316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-token latency is now shown for failed executions as well as completed ones.
  * Failed streaming executions retain captured total and first-token latency metrics.

* **Bug Fixes**
  * Interrupted upstream streams now receive clearer error classification and Bad Gateway responses.
  * Gateway request IDs appear in streaming error details when upstream IDs are unavailable.
  * Structured upstream error details and status information are better preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->