### PR TITLE
fix: suppress trailing SSE errors after terminal response

### DIFF
--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -345,6 +345,16 @@ func writeSSEStreamEnd(
 			if !errors.Is(streamErr, context.Canceled) {
 				log.Warn(ctx, "Stream error after client disconnected", log.Cause(streamErr))
 			}
+		} else if terminalSeen {
+			// A terminal event (response.completed / response.failed / message_stop /
+			// [DONE]) was already delivered to the client. Appending a bare `error`
+			// event after it breaks OpenAI SDK clients: the SDK treats any data frame
+			// with an `error` field as fatal and throws mid-iteration, even though the
+			// response already reached a terminal state (observed as "unexpected EOF"
+			// with pi over /v1/responses). Log for observability; the terminal event
+			// already told the client how the response ended.
+			log.Warn(ctx, "Stream error after terminal event was delivered, suppressing trailing error event",
+				log.Cause(streamErr))
 		} else {
 			log.Error(ctx, "Error in stream", log.Cause(streamErr))
 			c.SSEvent("error", formatErr(ctx, streamErr))

--- a/internal/server/api/sse_terminal_error_test.go
+++ b/internal/server/api/sse_terminal_error_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// TestWriteSSEStream_ResponsesTerminalEventThenError reproduces the production
+// incident (pi client "unexpected EOF"): the upstream delivers a full Responses
+// event sequence including response.completed, then the upstream connection
+// breaks. The inbound transformer enqueues a trailing response.failed event and
+// ends the stream with Err() == nil (the error was already converted to a
+// terminal event), but if the stream ALSO surfaces a non-nil error the SSE
+// writer appends `event: error` after the terminal event — the openai SDK
+// treats that error frame as fatal and throws mid-iteration, even though the
+// response already reached a terminal state.
+func TestWriteSSEStream_ResponsesTerminalEventThenError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Upstream: deltas → response.completed → (disconnect). The inbound
+	// transformer converts the disconnect into response.failed, then the
+	// stream ends. Error is consumed by the terminal event.
+	stream := &errorAfterStream{
+		items: []*httpclient.StreamEvent{
+			{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"r1"}}`)},
+			{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"r1","status":"completed"}}`)},
+			{Type: "response.failed", Data: []byte(`{"type":"response.failed","response":{"id":"r1","status":"failed","error":{"type":"server_error","code":"stream_error","message":"unexpected EOF"}}}`)},
+		},
+		err: nil,
+	}
+
+	WriteSSEStream(c, stream)
+
+	body := w.Body.String()
+	t.Logf("body:\n%s", body)
+
+	// The terminal response.failed must reach the client intact.
+	assert.Contains(t, body, "event:response.failed")
+	assert.Contains(t, body, `"code":"stream_error"`)
+
+	// A trailing bare `error` event after a terminal event breaks openai SDK
+	// clients (the SDK throws APIError mid-iteration on data.error frames).
+	// When the stream already delivered a terminal event, the writer must not
+	// append another error frame.
+	assert.NotContains(t, body, "event:error")
+}
+
+// TestWriteSSEStream_ResponsesErrorAfterTerminalWithStreamErr asserts the
+// incident shape: response.completed delivered, stream then errors. The writer
+// must not append `event: error` after a terminal event was already written.
+func TestWriteSSEStream_ResponsesErrorAfterTerminalWithStreamErr(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	stream := &errorAfterStream{
+		items: []*httpclient.StreamEvent{
+			{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"r1"}}`)},
+			{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"r1","status":"completed"}}`)},
+		},
+		err: errors.New("unexpected EOF"),
+	}
+
+	WriteSSEStream(c, stream)
+
+	body := w.Body.String()
+	t.Logf("body:\n%s", body)
+
+	assert.Contains(t, body, "event:response.completed")
+
+	// terminalSeen=true here: the writer already wrote response.completed.
+	// Appending `event: error` makes openai SDK clients throw even though the
+	// response completed — the exact production incident.
+	assert.NotContains(t, body, "event:error")
+}

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -27,16 +27,17 @@ var ErrStreamIncomplete = errors.New("stream ended without terminal event or com
 //
 //nolint:containedctx // Checked.
 type InboundPersistentStream struct {
-	ctx            context.Context
-	stream         streams.Stream[*httpclient.StreamEvent]
-	request        *ent.Request
-	requestExec    *ent.RequestExecution
-	requestService *biz.RequestService
-	transformer    transformer.Inbound
-	perf           *biz.PerformanceRecord
-	responseChunks []*httpclient.StreamEvent
-	closed         bool
-	state          *PersistenceState
+	ctx               context.Context
+	stream            streams.Stream[*httpclient.StreamEvent]
+	request           *ent.Request
+	requestExec       *ent.RequestExecution
+	requestService    *biz.RequestService
+	transformer       transformer.Inbound
+	perf              *biz.PerformanceRecord
+	responseChunks    []*httpclient.StreamEvent
+	terminalEventSeen bool
+	closed            bool
+	state             *PersistenceState
 }
 
 var _ streams.Stream[*httpclient.StreamEvent] = (*InboundPersistentStream)(nil)
@@ -71,24 +72,28 @@ func (ts *InboundPersistentStream) Next() bool {
 	return ts.stream.Next()
 }
 
+// Current returns the current stream event and buffers it for persistence. It
+// marks the stream completed when a successful terminal event is observed.
 func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	event := ts.stream.Current()
 	if event != nil {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
-		if IsTerminalStreamEvent(event) {
-			ts.state.StreamCompleted = true
+		if IsTerminalStreamEvent(event) && !ts.terminalEventSeen {
+			ts.terminalEventSeen = true
+			if isSuccessfulTerminalStreamEvent(event) {
+				ts.state.StreamCompleted = true
+			}
 		}
 	}
 
 	return event
 }
 
-// IsTerminalStreamEvent checks both SSE metadata and JSON data for a successful
-// protocol-level or semantic completion marker. The SSE writers use it to decide
-// whether the client actually received a completion marker, so this must stay the
-// single source of truth for "the stream ended properly".
+// IsTerminalStreamEvent checks both SSE metadata and JSON data for a protocol
+// level terminal marker. The SSE writers use it to decide whether the client
+// actually received a terminal marker.
 func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	if event == nil {
 		return false
@@ -96,8 +101,11 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 
 	// For chat completions, check for [DONE] event
 	if bytes.Equal(event.Data, llm.DoneStreamEvent.Data) ||
-		// For Responses API, check for response.completed event
+		// For Responses API, check for terminal response events
 		event.Type == "response.completed" ||
+		event.Type == "response.failed" ||
+		event.Type == "response.incomplete" ||
+		event.Type == "response.cancelled" ||
 		// For Anthropic Messages API, check for message_stop event
 		event.Type == "message_stop" ||
 		// For OpenAI audio APIs (TTS sse / STT stream) which have no [DONE] sentinel:
@@ -115,7 +123,7 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	// the trailing [DONE] marker is read by the server.
 	eventType := gjson.GetBytes(event.Data, "type").String()
 	switch eventType {
-	case "response.completed", "message_stop", "speech.audio.done", "transcript.text.done":
+	case "response.completed", "response.failed", "response.incomplete", "response.cancelled", "message_stop", "speech.audio.done", "transcript.text.done":
 		return true
 	}
 
@@ -127,6 +135,35 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	// Gemini generateContent streams have no [DONE] sentinel. Completion is
 	// signaled by candidates[].finishReason (e.g. STOP, MAX_TOKENS, SAFETY).
 	return hasNonEmptyJSONStringField(event.Data, "candidates", "finishReason")
+}
+
+// isSuccessfulTerminalStreamEvent distinguishes successful completion markers
+// from Responses failure, incomplete, and cancellation terminals. The broader
+// IsTerminalStreamEvent predicate remains available to SSE finalization.
+func isSuccessfulTerminalStreamEvent(event *httpclient.StreamEvent) bool {
+	if event == nil || !IsTerminalStreamEvent(event) {
+		return false
+	}
+
+	switch event.Type {
+	case "response.failed", "response.incomplete", "response.cancelled":
+		return false
+	}
+
+	eventType := gjson.GetBytes(event.Data, "type").String()
+	switch eventType {
+	case "response.failed", "response.incomplete", "response.cancelled":
+		return false
+	}
+
+	if event.Type == "response.completed" || eventType == "response.completed" {
+		switch gjson.GetBytes(event.Data, "response.status").String() {
+		case "failed", "incomplete", "cancelled", "canceled":
+			return false
+		}
+	}
+
+	return true
 }
 
 func hasNonEmptyJSONStringField(data []byte, arrayPath, field string) bool {
@@ -150,6 +187,9 @@ func (ts *InboundPersistentStream) Err() error {
 	return ts.stream.Err()
 }
 
+// Close finalizes the stream and persists the request outcome. A successful
+// terminal or aggregated response is recorded as completed; an incomplete or
+// errored stream is recorded as failed.
 func (ts *InboundPersistentStream) Close() error {
 	if ts.closed {
 		return nil
@@ -163,7 +203,7 @@ func (ts *InboundPersistentStream) Close() error {
 	streamErr := ts.stream.Err()
 	ctxErr := ctx.Err()
 
-	// If we received the [DONE] event, treat the stream as successfully completed
+	// If we received a successful terminal event, treat the stream as completed
 	// even if there's a context cancellation error. This handles the case where
 	// the client disconnects immediately after receiving the last chunk.
 	if ts.state.StreamCompleted {
@@ -197,7 +237,7 @@ func (ts *InboundPersistentStream) Close() error {
 	var meta llm.ResponseMeta
 	var aggErr error
 
-	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted {
+	if len(ts.responseChunks) > 0 && !ts.state.StreamCompleted && !ts.terminalEventSeen {
 		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.responseChunks)
 		if aggErr == nil && meta.ID != "" && len(responseBody) > 0 && isCompletedAggregated(meta) {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -229,6 +229,101 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 	assert.True(t, mockStream.closed, "Stream should be closed")
 }
 
+// TestInboundPersistentStream_Close_ResponsesFailureTerminalDoesNotComplete
+// verifies that failed, incomplete, and cancelled Responses terminals do not
+// mark the request completed.
+func TestInboundPersistentStream_Close_ResponsesFailureTerminalDoesNotComplete(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      string
+	}{
+		{
+			name:      "response.failed event field",
+			eventType: "response.failed",
+			data:      `{"type":"response.failed","response":{"status":"failed"}}`,
+		},
+		{
+			name:      "response.incomplete event field",
+			eventType: "response.incomplete",
+			data:      `{"type":"response.incomplete","response":{"status":"incomplete"}}`,
+		},
+		{
+			name: "response.cancelled JSON type",
+			data: `{"type":"response.cancelled","response":{"status":"cancelled"}}`,
+		},
+		{
+			name:      "response.completed with failed status",
+			eventType: "response.completed",
+			data:      `{"type":"response.completed","response":{"status":"failed"}}`,
+		},
+		{
+			name: "response.completed with incomplete status",
+			data: `{"type":"response.completed","response":{"status":"incomplete"}}`,
+		},
+		{
+			name:      "response.completed with cancelled status",
+			eventType: "response.completed",
+			data:      `{"type":"response.completed","response":{"status":"cancelled"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+
+			ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+			project := createTestProject(t, ctx, client)
+			channel := createTestChannel(t, ctx, client)
+			requestService := createTestRequestService(t, client)
+
+			req, err := client.Request.Create().
+				SetProjectID(project.ID).
+				SetChannelID(channel.ID).
+				SetModelID("gpt-5").
+				SetStatus(request.StatusProcessing).
+				SetRequestBody([]byte(`{"stream":true}`)).
+				SetStream(true).
+				Save(ctx)
+			require.NoError(t, err)
+
+			state := &PersistenceState{}
+			mockStream := &mockStream{events: []*httpclient.StreamEvent{{
+				Type: tt.eventType,
+				Data: []byte(tt.data),
+			}}}
+			mockTransformer := &mockInboundTransformer{
+				aggregateResponseBody: []byte(`{"id":"resp_terminal_failure"}`),
+				aggregateMeta: llm.ResponseMeta{
+					ID:    "resp_terminal_failure",
+					Usage: &llm.Usage{CompletionTokens: 1},
+				},
+			}
+			stream := NewInboundPersistentStream(
+				ctx,
+				mockStream,
+				req,
+				nil,
+				requestService,
+				mockTransformer,
+				nil,
+				state,
+			)
+
+			require.True(t, stream.Next())
+			require.NotNil(t, stream.Current())
+			require.True(t, IsTerminalStreamEvent(mockStream.events[0]))
+			require.False(t, state.StreamCompleted)
+			require.NoError(t, stream.Close())
+
+			dbReq, err := client.Request.Get(ctx, req.ID)
+			require.NoError(t, err)
+			require.NotEqual(t, request.StatusCompleted, dbReq.Status)
+		})
+	}
+}
+
 // TestInboundPersistentStream_Close_WithAggregationError tests the error path:
 // aggregation fails but fallback behavior still works (persistResponseChunks called in final block).
 func TestInboundPersistentStream_Close_WithAggregationError(t *testing.T) {

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -36,11 +36,12 @@ type OutboundPersistentStream struct {
 	request     *ent.Request
 	requestExec *ent.RequestExecution
 
-	transformer    transformer.Outbound
-	perf           *biz.PerformanceRecord
-	responseChunks []*httpclient.StreamEvent
-	closed         bool
-	state          *PersistenceState
+	transformer       transformer.Outbound
+	perf              *biz.PerformanceRecord
+	responseChunks    []*httpclient.StreamEvent
+	terminalEventSeen bool
+	closed            bool
+	state             *PersistenceState
 }
 
 var _ streams.Stream[*httpclient.StreamEvent] = (*OutboundPersistentStream)(nil)
@@ -77,17 +78,22 @@ func (ts *OutboundPersistentStream) Next() bool {
 	return ts.stream.Next()
 }
 
+// Current returns the current stream event and buffers it for persistence. It
+// marks the stream completed when a successful terminal event is observed.
 func (ts *OutboundPersistentStream) Current() *httpclient.StreamEvent {
 	event := ts.stream.Current()
 	if event != nil {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
-		// Check if this is a terminal event, which indicates the stream completed successfully.
-		// For Chat Completions API this is the raw [DONE] event; for Responses API this is
-		// response.completed; for Anthropic Messages API this is message_stop.
-		if IsTerminalStreamEvent(event) {
-			ts.state.StreamCompleted = true
+		// A successful terminal event marks the stream completed. For Chat Completions
+		// this is the raw [DONE] event; for Responses this is response.completed; for
+		// Anthropic Messages this is message_stop.
+		if IsTerminalStreamEvent(event) && !ts.terminalEventSeen {
+			ts.terminalEventSeen = true
+			if isSuccessfulTerminalStreamEvent(event) {
+				ts.state.StreamCompleted = true
+			}
 		}
 	}
 
@@ -98,6 +104,9 @@ func (ts *OutboundPersistentStream) Err() error {
 	return ts.stream.Err()
 }
 
+// Close finalizes the stream and persists the request execution outcome. A
+// successful terminal or aggregated response is recorded as completed; an
+// incomplete or errored stream is recorded as failed.
 func (ts *OutboundPersistentStream) Close() error {
 	if ts.closed {
 		return nil
@@ -147,7 +156,7 @@ func (ts *OutboundPersistentStream) Close() error {
 	var aggErr error
 	aggregatedCompleted := false
 
-	if len(ts.responseChunks) > 0 {
+	if len(ts.responseChunks) > 0 && !ts.terminalEventSeen {
 		responseBody, meta, aggErr = ts.transformer.AggregateStreamChunks(context.WithoutCancel(ctx), ts.state.RawProviderRequest, ts.responseChunks)
 		aggregatedCompleted = aggErr == nil && isCompletedAggregated(meta)
 		ts.logFinalizationDecision(ctx, "aggregated_outbound_chunks", streamErr, ctxErr, aggregatedCompleted, aggErr)

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -789,6 +789,9 @@ func (s *sliceEventStream) Close() error {
 	return nil
 }
 
+// TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling
+// verifies that aggregated Responses chunks and terminal events produce the
+// correct request execution completion status.
 func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t *testing.T) {
 	ctx := context.Background()
 	ctx = authz.WithTestBypass(ctx)
@@ -857,6 +860,63 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 
 		// Incomplete streams must still persist buffered chunks for debugging.
 		require.Len(t, dbExec.ResponseChunks, 1, "failed execution should keep response_chunks in DB")
+	})
+	t.Run("response failure terminal is not completed", func(t *testing.T) {
+		client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+		defer client.Close()
+
+		ctx := ent.NewContext(ctx, client)
+		project := createTestProject(t, ctx, client)
+		ch := createTestChannel(t, ctx, client)
+		_, requestService, _, usageLogService := setupTestServices(t, client)
+
+		req, err := client.Request.Create().
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetStatus(request.StatusPending).
+			SetRequestBody([]byte(`{"stream":true}`)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		exec, err := client.RequestExecution.Create().
+			SetRequestID(req.ID).
+			SetProjectID(project.ID).
+			SetChannelID(ch.ID).
+			SetModelID("gpt-4.1").
+			SetRequestBody([]byte(`{"stream":true}`)).
+			SetFormat("openai/responses").
+			SetStatus(requestexecution.StatusPending).
+			SetStream(true).
+			Save(ctx)
+		require.NoError(t, err)
+
+		stream := &sliceEventStream{
+			events: []*httpclient.StreamEvent{{
+				Type: "response.failed",
+				Data: []byte(`{"type":"response.failed","response":{"id":"resp_failed","status":"failed"}}`),
+			}},
+		}
+		transformer := &mockTransformer{
+			apiFormat:          llm.APIFormatOpenAIResponse,
+			aggregatedResponse: []byte(`{"id":"resp_failed","status":"completed"}`),
+			aggregatedMeta: llm.ResponseMeta{
+				ID:    "resp_failed",
+				Usage: &llm.Usage{CompletionTokens: 1},
+			},
+		}
+		state := &PersistenceState{}
+
+		persistentStream := NewOutboundPersistentStream(ctx, stream, req, exec, requestService, usageLogService, transformer, nil, state)
+		require.True(t, persistentStream.Next())
+		_ = persistentStream.Current()
+		require.False(t, state.StreamCompleted)
+		require.NoError(t, persistentStream.Close())
+
+		dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+		require.NoError(t, err)
+		require.Equal(t, requestexecution.StatusFailed, dbExec.Status)
+		require.NotEqual(t, requestexecution.StatusCompleted, dbExec.Status)
 	})
 
 	t.Run("aggregated completed response without terminal event is completed", func(t *testing.T) {

--- a/llm/pipeline/responses_disconnect_after_completed_test.go
+++ b/llm/pipeline/responses_disconnect_after_completed_test.go
@@ -1,0 +1,126 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+	responsestransformer "github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+// errAfterSliceStream yields the given events, then surfaces err from Err()
+// (like an upstream that sends response.completed and then the chunked body is
+// truncated — the decoder returns io.ErrUnexpectedEOF / "unexpected EOF").
+type errAfterSliceStream struct {
+	events []*httpclient.StreamEvent
+	index  int
+	err    error
+}
+
+// Next reports whether more events remain in the slice.
+func (s *errAfterSliceStream) Next() bool { return s.index < len(s.events) }
+
+// Current returns the next buffered event.
+func (s *errAfterSliceStream) Current() *httpclient.StreamEvent {
+	if s.index < len(s.events) {
+		item := s.events[s.index]
+		s.index++
+		return item
+	}
+	return nil
+}
+
+// Err returns the configured stream error.
+func (s *errAfterSliceStream) Err() error { return s.err }
+
+// Close is a no-op for the in-memory slice stream.
+func (s *errAfterSliceStream) Close() error { return nil }
+
+// TestPipeline_ResponsesUpstreamDisconnectAfterCompleted reproduces the
+// production incident: the upstream sends a full event sequence ending in
+// response.completed, then the connection breaks (chunked body truncated,
+// decoder returns "unexpected EOF"). The client (pi) must receive the
+// already-delivered response.completed event with a clean stream end, without a
+// conflicting response.failed or bare error.
+func TestPipeline_ResponsesUpstreamDisconnectAfterCompleted(t *testing.T) {
+	inbound := responsestransformer.NewInboundTransformer()
+	outbound, err := responsestransformer.NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	streamEvents := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_disconnect","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"gAAAA_1"}}`)},
+		{Type: "response.output_item.done", Data: []byte(`{"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"gAAAA_1"}}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_disconnect","object":"response","created_at":1700000000,"model":"gpt-5","status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}}`)},
+	}
+
+	executor := &mockExecutor{doStreamFunc: func(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+		return &errAfterSliceStream{
+			events: streamEvents,
+			err:    errors.New("unexpected EOF"),
+		}, nil
+	}}
+
+	pipe := pipeline.NewFactory(executor).Pipeline(inbound, outbound)
+	body, err := json.Marshal(map[string]any{
+		"model":  "gpt-5",
+		"stream": true,
+		"input":  "hello",
+	})
+	require.NoError(t, err)
+
+	result, err := pipe.Process(context.Background(), &httpclient.Request{
+		Method:      http.MethodPost,
+		URL:         "/v1/responses",
+		ContentType: "application/json",
+		Headers:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:        body,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+
+	var eventTypes []string
+	var lastEvent map[string]any
+	for result.EventStream.Next() {
+		cur := result.EventStream.Current()
+		var ev map[string]any
+		require.NoError(t, json.Unmarshal(cur.Data, &ev))
+		eventTypes = append(eventTypes, ev["type"].(string))
+		lastEvent = ev
+	}
+
+	streamErr := result.EventStream.Err()
+	t.Logf("events: %v", eventTypes)
+	t.Logf("stream err: %v", streamErr)
+
+	// After response.completed was delivered, an upstream disconnect must not
+	// degrade the client stream into any second terminal outcome.
+	require.Contains(t, eventTypes, string(responsestransformer.StreamEventTypeResponseCompleted))
+	completedCount := 0
+	for _, et := range eventTypes {
+		switch et {
+		case string(responsestransformer.StreamEventTypeResponseCompleted):
+			completedCount++
+		case string(responsestransformer.StreamEventTypeResponseFailed), "error":
+			t.Fatalf("unexpected terminal event after response.completed: %s", et)
+		}
+	}
+	require.Equal(t, 1, completedCount)
+
+	if streamErr != nil {
+		// A non-nil stream error after a completed terminal event is a bug: the
+		// SSE writer turns it into `event: error`, which the openai SDK treats
+		// as a fatal error even though the response already completed.
+		t.Fatalf("stream error after response.completed must be nil, got: %v", streamErr)
+	}
+
+	_ = lastEvent
+}

--- a/llm/pipeline/responses_truncated_upstream_test.go
+++ b/llm/pipeline/responses_truncated_upstream_test.go
@@ -1,0 +1,147 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+	responsestransformer "github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+// TestPipeline_ResponsesRealUpstreamTruncatedChunkedBody reproduces the
+// production incident end-to-end with a REAL HTTP upstream: the upstream
+// streams a full Responses event sequence (response.created ... response.completed)
+// and then the chunked response body is truncated (connection closed mid-chunk,
+// no terminating 0\r\n\r\n). This is the exact "unexpected EOF" shape observed
+// with pi behind axonhub.
+//
+// Expected client-visible behavior: once response.completed is delivered, the
+// stream ends cleanly without a conflicting response.failed or bare error event.
+func TestPipeline_ResponsesRealUpstreamTruncatedChunkedBody(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		flusher := w.(http.Flusher)
+		flusher.Flush()
+
+		events := []string{
+			`event: response.created
+data: {"type":"response.created","response":{"id":"resp_trunc","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}
+
+`,
+			`event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"enc_1"}}
+
+`,
+			`event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_trunc","object":"response","created_at":1700000000,"model":"gpt-5","status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}}
+
+`,
+		}
+
+		for _, e := range events {
+			_, _ = fmt.Fprint(w, e)
+			flusher.Flush()
+		}
+
+		// Hold the connection open like a real provider would (client is
+		// consuming the completed response / executing tool calls), then break
+		// the chunked body mid-stream: closing the connection without the
+		// terminating chunk produces io.ErrUnexpectedEOF on the reader side.
+		time.Sleep(200 * time.Millisecond)
+
+		// Write a partial chunk then hijack-close without terminating the
+		// chunked encoding.
+		if hj, ok := w.(http.Hijacker); ok {
+			conn, _, err := hj.Hijack()
+			if err == nil {
+				_, _ = conn.Write([]byte("event: response.output_text.de")) // partial frame, no terminator
+				_ = conn.Close()
+				return
+			}
+		}
+
+		// Fallback: abrupt close.
+		panic("cannot hijack connection")
+	}))
+	defer upstream.Close()
+
+	// Real HTTP executor: exercises the actual DoStream path with the real
+	// SSE decoder, so truncation errors match production shapes.
+	httpClient := httpclient.NewHttpClient()
+	executor := &mockExecutor{
+		doStreamFunc: func(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+			request.URL = upstream.URL + "/v1/responses"
+			return httpClient.DoStream(ctx, request)
+		},
+	}
+
+	inbound := responsestransformer.NewInboundTransformer()
+	outbound, err := responsestransformer.NewOutboundTransformer(upstream.URL, "test-api-key")
+	require.NoError(t, err)
+
+	pipe := pipeline.NewFactory(executor).Pipeline(inbound, outbound)
+
+	body, err := json.Marshal(map[string]any{
+		"model":  "gpt-5",
+		"stream": true,
+		"input":  "hello",
+	})
+	require.NoError(t, err)
+
+	result, err := pipe.Process(context.Background(), &httpclient.Request{
+		Method:      http.MethodPost,
+		URL:         "/v1/responses",
+		ContentType: "application/json",
+		Headers:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:        body,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+
+	var eventTypes []string
+	for result.EventStream.Next() {
+		cur := result.EventStream.Current()
+		var ev map[string]any
+		require.NoError(t, json.Unmarshal(cur.Data, &ev))
+		if typ, ok := ev["type"].(string); ok {
+			eventTypes = append(eventTypes, typ)
+		}
+	}
+
+	streamErr := result.EventStream.Err()
+	t.Logf("events: %v", eventTypes)
+	t.Logf("stream err: %v (nil=%v)", streamErr, streamErr == nil)
+
+	// The completed terminal event was delivered to the client.
+	require.Contains(t, eventTypes, string(responsestransformer.StreamEventTypeResponseCompleted))
+
+	// After the completed terminal event, the stream must NOT surface a bare
+	// error: the SSE writer would append `event: error`, which openai SDK
+	// clients treat as fatal even though the response already completed.
+	if streamErr != nil {
+		t.Fatalf("bare stream error after response.completed breaks SDK clients: %v", streamErr)
+	}
+
+	// No second terminal event may arrive after response.completed.
+	completedCount := 0
+	for _, et := range eventTypes {
+		switch et {
+		case string(responsestransformer.StreamEventTypeResponseCompleted):
+			completedCount++
+		case string(responsestransformer.StreamEventTypeResponseFailed), "error":
+			t.Fatalf("unexpected terminal event after response.completed: %s", et)
+		}
+	}
+	require.Equal(t, 1, completedCount)
+}

--- a/llm/transformer/openai/responses/inbound_stream.go
+++ b/llm/transformer/openai/responses/inbound_stream.go
@@ -114,11 +114,22 @@ func (s *responsesInboundStream) enqueueEvent(ev *StreamEvent) error {
 	return nil
 }
 
+// Next advances the downstream stream to the next event. It stops returning
+// events after response.completed so a late transport error cannot become a
+// conflicting response.failed event.
+//
 //nolint:maintidx,gocognit // It is complex and hard to split.
 func (s *responsesInboundStream) Next() bool {
 	// If we have events in the queue, return them first
 	if s.queueIndex < len(s.eventQueue) {
 		return true
+	}
+
+	// A completed terminal event ends the downstream response. Do not read the
+	// source again, because a late transport error would otherwise become a
+	// conflicting response.failed event.
+	if s.responseCompleted {
+		return false
 	}
 
 	// Clear the queue and reset index for new events
@@ -1210,6 +1221,8 @@ func (s *responsesInboundStream) emitStreamErrorEvent(err error) error {
 	return nil
 }
 
+// classifyStreamError maps an error to a stable code and human-readable
+// message used in Responses error events.
 func classifyStreamError(err error) (code, message string) {
 	code = "stream_error"
 	message = err.Error()
@@ -1220,6 +1233,15 @@ func classifyStreamError(err error) (code, message string) {
 		return code, message
 	}
 
+	// io.ErrUnexpectedEOF means the upstream body was truncated mid-chunk
+	// (connection cut before the terminal chunk) — a transport disconnect,
+	// not a provider-level failure. Classify it so response.failed events
+	// carry a stable, filterable code instead of the raw Go error text.
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		code = "upstream_eof"
+		message = "upstream connection closed unexpectedly"
+		return code, message
+	}
 	if errors.Is(err, context.Canceled) {
 		code = "client_cancel"
 		message = "client disconnected"
@@ -1285,6 +1307,8 @@ func (s *responsesInboundStream) Current() *httpclient.StreamEvent {
 	return nil
 }
 
+// Err returns the stream error. Errors already emitted as an error event or
+// observed after response.completed are suppressed to avoid double emission.
 func (s *responsesInboundStream) Err() error {
 	// If we've already emitted an error event to the client, return nil
 	// to avoid double error emission by the SSE writer
@@ -1294,6 +1318,12 @@ func (s *responsesInboundStream) Err() error {
 
 	if s.err != nil {
 		return s.err
+	}
+
+	// A transport error observed after response.completed is outside the
+	// completed response and must not turn the downstream stream into an error.
+	if s.responseCompleted {
+		return nil
 	}
 
 	return s.source.Err()

--- a/llm/transformer/openai/responses/inbound_stream_test.go
+++ b/llm/transformer/openai/responses/inbound_stream_test.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -488,6 +489,55 @@ func TestInboundTransformer_TransformStream_EmitsUpstreamErrorEvents(t *testing.
 	}
 }
 
+// TestInboundTransformer_TransformStream_DoesNotEmitFailureAfterCompleted
+// verifies that a transport error after response.completed is not emitted as a
+// conflicting response.failed event.
+func TestInboundTransformer_TransformStream_DoesNotEmitFailureAfterCompleted(t *testing.T) {
+	transformedStream, err := NewInboundTransformer().TransformStream(t.Context(), &errorResponseStream{
+		items: []*llm.Response{
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Choices: []llm.Choice{{Index: 0, Delta: &llm.Message{Role: "assistant"}}},
+			},
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Choices: []llm.Choice{{
+					Index:        0,
+					Delta:        &llm.Message{},
+					FinishReason: lo.ToPtr("stop"),
+				}},
+			},
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Usage:   &llm.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			},
+		},
+		err: errors.New("unexpected EOF"),
+	})
+	require.NoError(t, err)
+
+	var eventTypes []StreamEventType
+	for transformedStream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(transformedStream.Current().Data, &event))
+		eventTypes = append(eventTypes, event.Type)
+	}
+
+	require.NoError(t, transformedStream.Err())
+	require.Contains(t, eventTypes, StreamEventTypeResponseCompleted)
+	require.NotContains(t, eventTypes, StreamEventTypeResponseFailed)
+	require.NotContains(t, eventTypes, StreamEventTypeError)
+}
+
 type errorResponseStream struct {
 	items []*llm.Response
 	index int
@@ -528,10 +578,10 @@ func (s *errorResponseStream) Close() error {
 // reported as a successful completion downstream.
 func TestInboundTransformer_TransformStream_MapsFinishReasonToCompletedStatus(t *testing.T) {
 	tests := []struct {
-		name                 string
-		finishReason         string
-		expectedStatus       string
-		expectedIncomplete   *ResponseIncompleteDetails
+		name               string
+		finishReason       string
+		expectedStatus     string
+		expectedIncomplete *ResponseIncompleteDetails
 	}{
 		{name: "length maps to incomplete", finishReason: "length", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "max_output_tokens"}},
 		{name: "content_filter maps to incomplete", finishReason: "content_filter", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "content_filter"}},
@@ -643,4 +693,25 @@ func TestInboundTransformer_TransformStream_UsageBeforeFinishReasonKeepsMappedSt
 	require.Equal(t, "incomplete", *completed.Status)
 	require.NotNil(t, completed.IncompleteDetails)
 	require.Equal(t, "max_output_tokens", completed.IncompleteDetails.Reason)
+}
+
+// TestClassifyStreamError_UnexpectedEOF verifies that truncated upstream
+// connections (io.ErrUnexpectedEOF and io.EOF) map to the upstream_eof code.
+func TestClassifyStreamError_UnexpectedEOF(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, wantCode: "upstream_eof"},
+		{name: "clean EOF", err: io.EOF, wantCode: "upstream_eof"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, message := classifyStreamError(tt.err)
+			require.Equal(t, tt.wantCode, code)
+			require.Equal(t, "upstream connection closed unexpectedly", message)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- suppress trailing SSE error frames after a terminal SSE event has already been delivered
- recognize Responses API failed, incomplete, and cancelled events as terminal
- classify io.ErrUnexpectedEOF as upstream_eof

## Validation
- `go test ./internal/server/api ./internal/server/orchestrator`
- `cd llm && go test ./pipeline ./transformer/openai/responses`

Fixes #2318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented completed streaming responses from being followed by misleading fatal error events when an upstream connection closes unexpectedly.
  - Preserved terminal events and embedded error details in affected streaming responses.
  - Correctly distinguished successful completion from failed, incomplete, and cancelled response states.
  - Prevented unsuccessful terminal responses from being incorrectly marked as completed or aggregated into a successful result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->