### PR TITLE
fix: decode snake_case OIDC claims for email linking

### DIFF
--- a/internal/server/biz/oidc.go
+++ b/internal/server/biz/oidc.go
@@ -776,14 +776,14 @@ func (s *OIDCService) Callback(ctx context.Context, providerIdentifier, code, st
 }
 
 type oidcClaims struct {
-	Sub               string   `json:"sub"`
-	Email             string   `json:"email"`
-	EmailVerified     bool     `json:"email_verified"`
-	Name              string   `json:"name"`
-	GivenName         string   `json:"given_name"`
-	FamilyName        string   `json:"family_name"`
-	PreferredUsername string   `json:"preferred_username"`
-	Picture           string   `json:"picture"`
+	Sub               string   `json:"sub" mapstructure:"sub"`
+	Email             string   `json:"email" mapstructure:"email"`
+	EmailVerified     bool     `json:"email_verified" mapstructure:"email_verified"`
+	Name              string   `json:"name" mapstructure:"name"`
+	GivenName         string   `json:"given_name" mapstructure:"given_name"`
+	FamilyName        string   `json:"family_name" mapstructure:"family_name"`
+	PreferredUsername string   `json:"preferred_username" mapstructure:"preferred_username"`
+	Picture           string   `json:"picture" mapstructure:"picture"`
 	Groups            []string `json:"-"` // Filled manually from GroupClaim
 }
 

--- a/internal/server/biz/oidc_claims_test.go
+++ b/internal/server/biz/oidc_claims_test.go
@@ -1,0 +1,30 @@
+package biz
+
+import (
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDCClaimsDecodeSnakeCase(t *testing.T) {
+	var claims oidcClaims
+	err := mapstructure.Decode(map[string]any{
+		"sub":                "subject-1",
+		"email":              "user@example.com",
+		"email_verified":     true,
+		"given_name":         "Given",
+		"family_name":        "Family",
+		"preferred_username": "user",
+		"picture":            "https://example.com/avatar.png",
+	}, &claims)
+
+	require.NoError(t, err)
+	require.Equal(t, "subject-1", claims.Sub)
+	require.Equal(t, "user@example.com", claims.Email)
+	require.True(t, claims.EmailVerified)
+	require.Equal(t, "Given", claims.GivenName)
+	require.Equal(t, "Family", claims.FamilyName)
+	require.Equal(t, "user", claims.PreferredUsername)
+	require.Equal(t, "https://example.com/avatar.png", claims.Picture)
+}


### PR DESCRIPTION
### Summary

`OIDCService` decodes ID-token and UserInfo claims with `mapstructure.Decode`, but `oidcClaims` only declared `json` tags. Snake-case claims such as `email_verified`, `given_name`, `family_name`, and `preferred_username` were therefore silently ignored. In particular, `email_verified` stayed false and `auto_link_by_email` incorrectly fell through to JIT user creation, causing duplicate-email constraint errors.

Add explicit `mapstructure` tags and a regression test covering the snake-case claims.

### Tests

- `make test-backend-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC claim decoding so user identity and profile details are populated correctly during authentication.
* **Tests**
  * Added coverage for decoding common OIDC claims, including email verification, names, username, and profile picture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->