### PR TITLE
fix(models): align association priority cap with backend contract

### DIFF
--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -29,7 +29,7 @@ import { ModelAssociation, normalizeModelRoutingPolicyValue } from '../data/sche
 import { toast } from 'sonner';
 import { ChannelModelsList } from './channel-models-list';
 
-const MAX_ASSOCIATION_PRIORITY = 10;
+const MAX_ASSOCIATION_PRIORITY = 100;
 
 const requestFormatConditionOptions = [
   'openai/chat_completions',
@@ -908,11 +908,11 @@ export function ModelsAssociationDialog() {
     // Get the priority of the last rule (highest priority)
     const currentAssociations = form.getValues('associations') || [];
     const lastPriority =
-      currentAssociations.length > 0 ? Math.max(...currentAssociations.map((a) => a.priority ?? 0)) : 0;
+      currentAssociations.length > 0 ? Math.max(...currentAssociations.map((a) => a.priority ?? 0)) : -1;
 
     append({
       type: 'channel_model',
-      priority: lastPriority,
+      priority: Math.min(lastPriority + 1, MAX_ASSOCIATION_PRIORITY),
       disabled: false,
       whenEnabled: false,
       whenCondition: DEFAULT_WHEN_CONDITION,
@@ -1423,6 +1423,7 @@ function AssociationRow({ index, form, isDeveloperMode, channelOptions, allModel
                   placeholder='0'
                 />
               </FormControl>
+              <FormMessage />
             </FormItem>
           )}
         />


### PR DESCRIPTION
## Summary

The association dialog caps priority at `10`, but `modelAssociationSchema` allows `0-100` and the [Model Management Guide](https://github.com/looplj/axonhub/blob/unstable/docs/en/guides/model-management.md) recommends tiers up to 100 (primary 0-10, backup 10-50, emergency 50-100). That mismatch causes two failures:

1. Typing a value above 10 is **silently rewritten** to 10 — no error, no hint.
2. Any existing rule with `priority > 10` fails form validation, so **Save is permanently disabled with no visible reason**, and the value cannot be corrected in the UI because the input clamps back to 10.

The second one is the worse of the two: `disabled={... || !form.formState.isValid}` gates Save on the whole schema, and the priority `FormItem` is the only field in this file without a `<FormMessage />`, so the failure is invisible. A model configured through the API with tiered priorities becomes read-only in the UI.

Note: #1507 reported the cap and was closed by #1581, but that commit only extracted the literal `10` into `MAX_ASSOCIATION_PRIORITY = 10` without changing the value, so the issue is still present on `unstable`.

## Changes

`frontend/src/features/models/components/models-association-dialog.tsx` (4 lines)

- `MAX_ASSOCIATION_PRIORITY`: `10` → `100`. The zod schema, the `max` attribute and the `onChange` clamp all reference this constant.
- Added `<FormMessage />` to the priority field so validation errors surface.
- `handleAddAssociation` assigned `priority: lastPriority` — the same value as the current highest-priority rule. Colliding priorities make match order fall through to `sourceRank` and insertion order (`internal/server/biz/model_settings_inheritance.go:319-323`), which is not predictable from the UI. Now increments within the cap; the empty-list seed changes to `-1` so the first rule still gets `0`.

## Verification

Ran the real schema region of this file (L32-432, extracted verbatim) against real zod v4:

**Before**
```
MAX_ASSOCIATION_PRIORITY = 10
typed "60" -> stored 10          # silently changed
rule priority=20 (backend-legal): associations.0.priority: Priority cannot exceed 10
  formState.isValid = false -> Save DISABLED
```

**After**
```
MAX_ASSOCIATION_PRIORITY = 100
typed "60" -> 60 ; "100" -> 100 ; "101" -> 100 ; "-5" -> 0 ; "abc" -> 0
rule priority=20: no errors -> Save enabled
tiers 0 / 10 / 50 / 100 all accepted; 101 and -1 still rejected
new-rule priority: [] -> 0 ; [0] -> 1 ; [20] -> 21 ; [99] -> 100 ; [100] -> 100 (capped)
```

An incomplete new row still disables Save (it genuinely lacks channel/model) — the difference is the errors are now visible.

Toolchain matching `build.yml` (Node 22, pnpm 10):

```
pnpm install --frozen-lockfile   Done in 15.2s
npx tsc --noEmit                 exit 0, no type errors
pnpm build                       built in 1m 12s, exit 0
```

`pnpm lint` reports 252 problems (159 errors, 93 warnings) — **identical on unpatched `unstable`**, so this change adds none.

Not run: repo E2E (needs a Go backend). No formatting commit: `prettier` rewrites 169 lines of this file on unpatched `unstable` too, so reformatting would bury a 4-line change.

## Notes

`ModelAssociationInput.priority` is an unconstrained `Int` in GraphQL (`internal/server/gql/model.graphql:144`) with no range check in the resolver, which is how `> 10` values get in. This PR is UI-only; existing data becomes valid and editable with no migration. Whether the backend should enforce the same `0-100` range seems worth deciding separately.

Closes #2323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Association priorities can now be set up to 100.
  * New associations automatically receive the next available priority, capped at 100.
  * Priority validation messages are displayed directly for each field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->