### PR TITLE
fix(ui): add viewport height floor to DialogContent

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -47,7 +47,7 @@ const DialogContent = React.forwardRef<
           ref={ref}
           data-slot='dialog-content'
           className={cn(
-            'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+            'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
             className
           )}
           onInteractOutside={(e) => {


### PR DESCRIPTION
## Summary

`DialogContent` sets no `max-height` and no `overflow`, so every dialog has to remember to cap its own height. The overlay centres content vertically (`fixed inset-0 flex items-center`), so a dialog taller than the viewport overflows **both edges at once**, and because nothing scrolls, neither the title nor the footer buttons can be reached — the user has to zoom the browser out to interact with it.

This was fixed once per-dialog in a2409891 (model settings, #1716), but the underlying gap is still there: **25 of 60 `DialogContent` usages pass no height class at all.**

The ones most likely to hit it, by form-field count:

| Fields | File |
| --- | --- |
| 14 | `features/prompt-protection-rules/components/rules-action-dialog.tsx:157` |
| 11 | `features/channels/components/channels-proxy-dialog.tsx:195` |
| 8 | `features/channels/components/channels-transform-options-dialog.tsx:142` |
| 8 | `features/roles/components/roles-action-dialog.tsx:50` |
| 8 | `features/projects/components/projects-action-dialog.tsx:54` |

Filed as a follow-up to the per-dialog fix rather than a user-facing bug report — the original reporter's symptom is already resolved on current releases.

## Changes

`frontend/src/components/ui/dialog.tsx` (1 line)

```diff
-'... relative z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg'
+'... relative z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg'
```

- `100dvh` rather than `100vh`, so mobile address-bar collapse is handled correctly.
- This is a **floor, not a replacement**: dialogs that already pass `flex` + `max-h-[90vh]` + an inner scroll area keep their existing sticky-footer layout, because `tailwind-merge` resolves the conflict in favour of the caller's classes.

## Verification

Measured with Playwright against the real compiled Tailwind output, using the repo's actual class strings resolved through `tailwind-merge` (so the `grid`/`flex` conflict resolves exactly as `cn()` does), the real `Card` component classes and real zh-CN copy. An element counts as unreachable only if it is still outside the viewport *after* scrolling every scrollable ancestor.

| Viewport | uncapped dialog, before | uncapped dialog, after |
| --- | --- | --- |
| 1920×883 | title unreachable (top = -142px) | reachable, scrolls |
| 1536×745 | title + footer unreachable | reachable, scrolls |
| 1280×589 | title + footer unreachable | reachable, scrolls |
| 1366×640 | title + footer unreachable | reachable, scrolls |

Regression check — the settings dialog (already `flex` + inner scroll) is unchanged on all four viewports: same `display`, same computed `max-height`, same reachability. Also verified with 12 cards of content, which still scrolls end to end.

Toolchain matching `build.yml` (Node 22, pnpm 10):

```
pnpm install --frozen-lockfile   ok
npx tsc --noEmit                 exit 0, no type errors
pnpm build                       exit 0
pnpm lint                        252 problems - identical to unpatched unstable
```

Not run: repo E2E (needs a Go backend).

## Notes

Touches a component used by 60 call sites, so it carries more blast radius than its one-line diff suggests — worth reviewing separately from any dialog-specific change. The per-dialog `max-h` classes already in the tree stay valid and take precedence; this only changes behaviour for dialogs that specify nothing.

Refs #1716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialogs to remain within the viewport and support vertical scrolling when content is too tall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->