### PR TITLE
fix: recover requests with invalid encrypted content

### DIFF
--- a/frontend/src/features/system/components/retry-settings.tsx
+++ b/frontend/src/features/system/components/retry-settings.tsx
@@ -36,6 +36,7 @@ export function RetrySettings() {
       enabled: false,
       statuses: [],
     },
+    retryInvalidEncryptedContent: true,
   });
 
   useEffect(() => {
@@ -58,6 +59,7 @@ export function RetrySettings() {
           enabled: retryPolicy.autoDisableChannel?.enabled || false,
           statuses: retryPolicy.autoDisableChannel?.statuses || [],
         },
+        retryInvalidEncryptedContent: retryPolicy.retryInvalidEncryptedContent,
       });
     }
   }, [retryPolicy]);
@@ -340,6 +342,24 @@ export function RetrySettings() {
                   id='empty-response-detection'
                   checked={formData.emptyResponseDetection || false}
                   onCheckedChange={(checked) => handleInputChange('emptyResponseDetection', checked)}
+                />
+              </div>
+
+              {/* Invalid encrypted content recovery */}
+              <div className='flex items-center justify-between'>
+                <div className='space-y-0.5'>
+                  <Label htmlFor='retry-invalid-encrypted-content' className='text-base'>
+                    {t('system.retry.invalidEncryptedContent.label')}
+                  </Label>
+                  <div className='text-muted-foreground text-sm'>
+                    {t('system.retry.invalidEncryptedContent.description')}
+                  </div>
+                </div>
+                <Switch
+                  id='retry-invalid-encrypted-content'
+                  data-testid='retry-invalid-encrypted-content'
+                  checked={formData.retryInvalidEncryptedContent ?? true}
+                  onCheckedChange={(checked) => handleInputChange('retryInvalidEncryptedContent', checked)}
                 />
               </div>
 

--- a/frontend/src/features/system/data/system.ts
+++ b/frontend/src/features/system/data/system.ts
@@ -103,6 +103,7 @@ const RETRY_POLICY_QUERY = `
       traceStickyMode
       enabled
       emptyResponseDetection
+      retryInvalidEncryptedContent
       upstreamErrorPolicy {
         mode
         customMessage
@@ -358,6 +359,7 @@ export interface RetryPolicy {
   enabled: boolean;
   autoDisableChannel: AutoDisableChannel;
   emptyResponseDetection: boolean;
+  retryInvalidEncryptedContent: boolean;
   upstreamErrorPolicy: UpstreamErrorPolicy;
 }
 
@@ -387,6 +389,7 @@ export interface RetryPolicyInput {
   enabled?: boolean;
   autoDisableChannel?: AutoDisableChannelInput;
   emptyResponseDetection?: boolean;
+  retryInvalidEncryptedContent?: boolean;
   upstreamErrorPolicy?: Partial<UpstreamErrorPolicy>;
 }
 

--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -178,6 +178,8 @@
   "system.retry.nonStreamResponseTimeoutSeconds.description": "Maximum seconds to wait for a non-streaming response to complete (0-600s). Set to 0 to disable.",
   "system.retry.emptyResponseDetection.label": "Empty Response Detection",
   "system.retry.emptyResponseDetection.description": "When enabled, the system pre-reads stream events to detect empty responses (no content generated). If detected, the empty response is treated as a failed attempt for subsequent retry handling.",
+  "system.retry.invalidEncryptedContent.label": "Retry Invalid Encrypted Content",
+  "system.retry.invalidEncryptedContent.description": "When enabled, and global retry is enabled, Responses requests that fail because encrypted reasoning content cannot be verified will remove the opaque fields and retry once on the same upstream.",
   "system.retry.upstreamErrorPolicy.label": "Upstream Error Display",
   "system.retry.upstreamErrorPolicy.description": "Control whether API users see raw provider errors. Request traces still keep the original error for administrators.",
   "system.retry.upstreamErrorPolicy.placeholder": "Select display mode",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -178,6 +178,8 @@
   "system.retry.nonStreamResponseTimeoutSeconds.description": "等待非流式响应完成的最长秒数 (0-600s)。设为 0 时关闭。",
   "system.retry.emptyResponseDetection.label": "空回检测",
   "system.retry.emptyResponseDetection.description": "启用后，系统会预读流式响应事件来检测空回（未生成任何内容）。如果检测到空回，会将其视为一次失败尝试，供后续重试处理使用。",
+  "system.retry.invalidEncryptedContent.label": "重试加密内容校验失败",
+  "system.retry.invalidEncryptedContent.description": "启用此项且系统总重试已开启时，Responses 请求因加密 reasoning 内容无法校验而失败，会移除这些不透明字段，并在同一上游重试一次。",
   "system.retry.upstreamErrorPolicy.label": "上游错误展示",
   "system.retry.upstreamErrorPolicy.description": "控制 API 用户是否能看到原始服务商报错。请求追踪仍会保留原始错误，方便管理员排查。",
   "system.retry.upstreamErrorPolicy.placeholder": "选择展示模式",

--- a/internal/server/biz/system.go
+++ b/internal/server/biz/system.go
@@ -368,6 +368,12 @@ type RetryPolicy struct {
 	// contains meaningful content, and marks empty responses as failed attempts for retry handling.
 	EmptyResponseDetection bool `json:"empty_response_detection"`
 
+	// RetryInvalidEncryptedContent controls the one-shot recovery for Responses
+	// requests whose account-bound encrypted reasoning content cannot be verified.
+	// It defaults to true for backward compatibility and can be disabled from
+	// the system retry settings.
+	RetryInvalidEncryptedContent bool `json:"retry_invalid_encrypted_content"`
+
 	// UpstreamErrorPolicy controls how provider errors are exposed to API users.
 	UpstreamErrorPolicy UpstreamErrorPolicy `json:"upstream_error_policy"`
 }
@@ -1091,6 +1097,18 @@ func (s *SystemService) RetryPolicy(ctx context.Context) (*RetryPolicy, error) {
 	var policy RetryPolicy
 	if err := json.Unmarshal([]byte(value), &policy); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal retry policy: %w", err)
+	}
+	// Policies written before this option existed should retain the behavior
+	// that was active when the Responses recovery was introduced. A pointer
+	// probe distinguishes an omitted field from an explicit false value.
+	var stored struct {
+		RetryInvalidEncryptedContent *bool `json:"retry_invalid_encrypted_content"`
+	}
+	if err := json.Unmarshal([]byte(value), &stored); err != nil {
+		return nil, fmt.Errorf("failed to inspect retry policy: %w", err)
+	}
+	if stored.RetryInvalidEncryptedContent == nil {
+		policy.RetryInvalidEncryptedContent = defaultRetryPolicy.RetryInvalidEncryptedContent
 	}
 
 	normalizeRetryPolicy(&policy)

--- a/internal/server/biz/system_default.go
+++ b/internal/server/biz/system_default.go
@@ -75,12 +75,13 @@ var defaultStoragePolicy = StoragePolicy{
 }
 
 var defaultRetryPolicy = RetryPolicy{
-	MaxChannelRetries:       3,
-	MaxSingleChannelRetries: 2,
-	RetryDelayMs:            1000,
-	LoadBalancerStrategy:    "adaptive",
-	TraceStickyMode:         TraceStickyPreferPreviousChannel,
-	Enabled:                 true,
+	MaxChannelRetries:            3,
+	MaxSingleChannelRetries:      2,
+	RetryDelayMs:                 1000,
+	LoadBalancerStrategy:         "adaptive",
+	TraceStickyMode:              TraceStickyPreferPreviousChannel,
+	Enabled:                      true,
+	RetryInvalidEncryptedContent: true,
 	UpstreamErrorPolicy: UpstreamErrorPolicy{
 		Mode: UpstreamErrorModePassthrough,
 	},

--- a/internal/server/biz/system_test.go
+++ b/internal/server/biz/system_test.go
@@ -1375,3 +1375,35 @@ func TestNormalizeRetryPolicy_LoadBalancerStrategy(t *testing.T) {
 		}
 	})
 }
+
+func TestSystemService_RetryPolicy_InvalidEncryptedContentSetting(t *testing.T) {
+	service, client := setupTestSystemService(t, xcache.Config{Mode: xcache.ModeMemory})
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+
+	// A missing policy uses the default, which keeps the recovery enabled for
+	// installations upgrading from the pre-toggle behavior.
+	policy, err := service.RetryPolicy(ctx)
+	require.NoError(t, err)
+	require.True(t, policy.RetryInvalidEncryptedContent)
+
+	// Existing stored policies without the field are backfilled to the same
+	// default, while an explicit false value remains disabled.
+	_, err = client.System.Create().
+		SetKey(SystemKeyRetryPolicy).
+		SetValue(`{"enabled":true}`).
+		Save(ctx)
+	require.NoError(t, err)
+
+	policy, err = service.RetryPolicy(ctx)
+	require.NoError(t, err)
+	require.True(t, policy.RetryInvalidEncryptedContent)
+
+	policy.RetryInvalidEncryptedContent = false
+	require.NoError(t, service.SetRetryPolicy(ctx, policy))
+
+	policy, err = service.RetryPolicy(ctx)
+	require.NoError(t, err)
+	require.False(t, policy.RetryInvalidEncryptedContent)
+}

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1579,6 +1579,7 @@ type ComplexityRoot struct {
 		MaxSingleChannelRetries         func(childComplexity int) int
 		NonStreamResponseTimeoutSeconds func(childComplexity int) int
 		RetryDelayMs                    func(childComplexity int) int
+		RetryInvalidEncryptedContent    func(childComplexity int) int
 		StreamFirstEventTimeoutSeconds  func(childComplexity int) int
 		TraceStickyMode                 func(childComplexity int) int
 		UpstreamErrorPolicy             func(childComplexity int) int
@@ -9424,6 +9425,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.RetryPolicy.RetryDelayMs(childComplexity), true
+	case "RetryPolicy.retryInvalidEncryptedContent":
+		if e.complexity.RetryPolicy.RetryInvalidEncryptedContent == nil {
+			break
+		}
+
+		return e.complexity.RetryPolicy.RetryInvalidEncryptedContent(childComplexity), true
 	case "RetryPolicy.streamFirstEventTimeoutSeconds":
 		if e.complexity.RetryPolicy.StreamFirstEventTimeoutSeconds == nil {
 			break
@@ -46018,6 +46025,8 @@ func (ec *executionContext) fieldContext_Query_retryPolicy(_ context.Context, fi
 				return ec.fieldContext_RetryPolicy_autoDisableChannel(ctx, field)
 			case "emptyResponseDetection":
 				return ec.fieldContext_RetryPolicy_emptyResponseDetection(ctx, field)
+			case "retryInvalidEncryptedContent":
+				return ec.fieldContext_RetryPolicy_retryInvalidEncryptedContent(ctx, field)
 			case "upstreamErrorPolicy":
 				return ec.fieldContext_RetryPolicy_upstreamErrorPolicy(ctx, field)
 			}
@@ -50861,6 +50870,35 @@ func (ec *executionContext) _RetryPolicy_emptyResponseDetection(ctx context.Cont
 }
 
 func (ec *executionContext) fieldContext_RetryPolicy_emptyResponseDetection(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RetryPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RetryPolicy_retryInvalidEncryptedContent(ctx context.Context, field graphql.CollectedField, obj *biz.RetryPolicy) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RetryPolicy_retryInvalidEncryptedContent,
+		func(ctx context.Context) (any, error) {
+			return obj.RetryInvalidEncryptedContent, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RetryPolicy_retryInvalidEncryptedContent(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "RetryPolicy",
 		Field:      field,
@@ -85203,7 +85241,7 @@ func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"maxChannelRetries", "maxSingleChannelRetries", "retryDelayMs", "streamFirstEventTimeoutSeconds", "nonStreamResponseTimeoutSeconds", "loadBalancerStrategy", "traceStickyMode", "enabled", "autoDisableChannel", "emptyResponseDetection", "upstreamErrorPolicy"}
+	fieldsInOrder := [...]string{"maxChannelRetries", "maxSingleChannelRetries", "retryDelayMs", "streamFirstEventTimeoutSeconds", "nonStreamResponseTimeoutSeconds", "loadBalancerStrategy", "traceStickyMode", "enabled", "autoDisableChannel", "emptyResponseDetection", "retryInvalidEncryptedContent", "upstreamErrorPolicy"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -85280,6 +85318,13 @@ func (ec *executionContext) unmarshalInputUpdateRetryPolicyInput(ctx context.Con
 				return it, err
 			}
 			it.EmptyResponseDetection = data
+		case "retryInvalidEncryptedContent":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("retryInvalidEncryptedContent"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RetryInvalidEncryptedContent = data
 		case "upstreamErrorPolicy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("upstreamErrorPolicy"))
 			data, err := ec.unmarshalOUpstreamErrorPolicyInput2githubᚗcomᚋloopljᚋaxonhubᚋinternalᚋserverᚋbizᚐUpstreamErrorPolicy(ctx, v)
@@ -104196,6 +104241,11 @@ func (ec *executionContext) _RetryPolicy(ctx context.Context, sel ast.SelectionS
 			}
 		case "emptyResponseDetection":
 			out.Values[i] = ec._RetryPolicy_emptyResponseDetection(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "retryInvalidEncryptedContent":
+			out.Values[i] = ec._RetryPolicy_retryInvalidEncryptedContent(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/server/gql/system.graphql
+++ b/internal/server/gql/system.graphql
@@ -129,6 +129,7 @@ type RetryPolicy {
   enabled: Boolean!
   autoDisableChannel: AutoDisableChannel!
   emptyResponseDetection: Boolean!
+  retryInvalidEncryptedContent: Boolean!
   upstreamErrorPolicy: UpstreamErrorPolicy!
 }
 
@@ -163,6 +164,7 @@ input UpdateRetryPolicyInput {
   enabled: Boolean
   autoDisableChannel: AutoDisableChannelInput
   emptyResponseDetection: Boolean
+  retryInvalidEncryptedContent: Boolean
   upstreamErrorPolicy: UpstreamErrorPolicyInput
 }
 

--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -213,6 +213,12 @@ func (processor *ChatCompletionOrchestrator) Process(ctx context.Context, reques
 	}
 
 	var pipelineOpts []pipeline.Option
+	// This recovery is a Responses-specific exception to the normal retry
+	// policy. Pass the system toggle into each request so executor decorators
+	// can honor it without sharing mutable transformer state.
+	pipelineOpts = append(pipelineOpts, pipeline.WithInvalidEncryptedContentRetry(
+		retryPolicy.Enabled && retryPolicy.RetryInvalidEncryptedContent,
+	))
 
 	// Only apply retry if policy is enabled
 	if retryPolicy.Enabled {

--- a/llm/httpclient/model.go
+++ b/llm/httpclient/model.go
@@ -53,6 +53,11 @@ type Request struct {
 	// This supports any type of value for flexibility.
 	TransformerMetadata map[string]any `json:"-"`
 
+	// RetryInvalidEncryptedContent controls the Responses API encrypted-content
+	// recovery for this request. The pipeline sets it from the system retry
+	// policy; a zero value disables the recovery for direct executor callers.
+	RetryInvalidEncryptedContent bool `json:"-"`
+
 	// SkipInboundQueryMerge when set to true, prevents query parameters from the original
 	// inbound request from being merged into this request during MergeInboundRequest.
 	SkipInboundQueryMerge bool `json:"-"`

--- a/llm/pipeline/pipeline.go
+++ b/llm/pipeline/pipeline.go
@@ -81,6 +81,14 @@ func WithResponseTimeouts(streamFirstEventTimeout, nonStreamTimeout time.Duratio
 	}
 }
 
+// WithInvalidEncryptedContentRetry controls the one-shot Responses API
+// recovery for account-bound encrypted reasoning content.
+func WithInvalidEncryptedContentRetry(enabled bool) Option {
+	return func(p *pipeline) {
+		p.retryInvalidEncryptedContent = enabled
+	}
+}
+
 // Factory creates pipeline instances.
 type Factory struct {
 	Executor Executor
@@ -103,6 +111,9 @@ func (f *Factory) Pipeline(
 		Executor: f.Executor,
 		Inbound:  inbound,
 		Outbound: outbound,
+		// Preserve the pre-option behavior for callers that build a pipeline
+		// directly; AxonHub's system policy can explicitly override this.
+		retryInvalidEncryptedContent: true,
 	}
 
 	// Apply options
@@ -115,16 +126,17 @@ func (f *Factory) Pipeline(
 
 // pipeline implements the main pipeline logic with retry capabilities.
 type pipeline struct {
-	Executor                Executor
-	Inbound                 transformer.Inbound
-	Outbound                transformer.Outbound
-	middlewares             []Middleware
-	maxChannelRetries       int
-	maxSameChannelRetries   int
-	retryDelay              time.Duration
-	emptyResponseDetection  bool
-	streamFirstEventTimeout time.Duration
-	nonStreamTimeout        time.Duration
+	Executor                     Executor
+	Inbound                      transformer.Inbound
+	Outbound                     transformer.Outbound
+	middlewares                  []Middleware
+	maxChannelRetries            int
+	maxSameChannelRetries        int
+	retryDelay                   time.Duration
+	emptyResponseDetection       bool
+	streamFirstEventTimeout      time.Duration
+	nonStreamTimeout             time.Duration
+	retryInvalidEncryptedContent bool
 }
 
 type Result struct {
@@ -380,6 +392,7 @@ func (p *pipeline) processRequest(ctx context.Context, request *llm.Request) (*R
 
 		return nil, fmt.Errorf("failed to apply raw request middlewares: %w", err)
 	}
+	httpReq.RetryInvalidEncryptedContent = p.retryInvalidEncryptedContent
 
 	executor := p.Executor
 	if c, ok := p.Outbound.(ChannelCustomizedExecutor); ok {

--- a/llm/pipeline/pipeline_test.go
+++ b/llm/pipeline/pipeline_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -242,6 +243,35 @@ func TestWithRetry(t *testing.T) {
 	require.Equal(t, 100*time.Millisecond, p.retryDelay)
 }
 
+func TestWithInvalidEncryptedContentRetry(t *testing.T) {
+	p := &pipeline{}
+
+	WithInvalidEncryptedContentRetry(true)(p)
+	require.True(t, p.retryInvalidEncryptedContent)
+
+	WithInvalidEncryptedContentRetry(false)(p)
+	require.False(t, p.retryInvalidEncryptedContent)
+}
+
+func TestInvalidEncryptedContentRetryOptionPropagatesToRequest(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enabled=%t", enabled), func(t *testing.T) {
+			executor := &requestCaptureExecutor{}
+			outbound := &testCustomExecutorOutbound{customExecutor: executor}
+			pipe := NewFactory(executor).Pipeline(
+				&testInbound{},
+				outbound,
+				WithInvalidEncryptedContentRetry(enabled),
+			)
+
+			_, err := pipe.Process(context.Background(), &httpclient.Request{})
+			require.NoError(t, err)
+			require.NotNil(t, executor.request)
+			require.Equal(t, enabled, executor.request.RetryInvalidEncryptedContent)
+		})
+	}
+}
+
 func TestWithDecorators(t *testing.T) {
 	p := &pipeline{}
 
@@ -266,6 +296,22 @@ func TestFactory_NewFactory(t *testing.T) {
 type testExecutor struct {
 	callCount int
 }
+
+type requestCaptureExecutor struct {
+	request *httpclient.Request
+}
+
+func (e *requestCaptureExecutor) Do(_ context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	e.request = request
+	return &httpclient.Response{}, nil
+}
+
+func (e *requestCaptureExecutor) DoStream(_ context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	e.request = request
+	return streams.SliceStream([]*httpclient.StreamEvent{}), nil
+}
+
+var _ Executor = (*requestCaptureExecutor)(nil)
 
 func (t *testExecutor) Do(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
 	t.callCount++

--- a/llm/transformer/openai/codex/encrypted_retry_integration_test.go
+++ b/llm/transformer/openai/codex/encrypted_retry_integration_test.go
@@ -1,0 +1,62 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+func TestCodexExecutorRetriesInvalidEncryptedContent(t *testing.T) {
+	stub := &codexEncryptedRetryStub{}
+	executor := &codexExecutor{inner: stub, httpExecutor: stub}
+	request := &httpclient.Request{
+		Method:    http.MethodPost,
+		APIFormat: llm.APIFormatOpenAIResponse.String(),
+		Body:      []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+	}
+
+	stream, err := executor.DoStream(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.Len(t, stub.requests, 2)
+	require.Contains(t, string(stub.requests[0].Body), "gAAAA")
+	require.NotContains(t, string(stub.requests[1].Body), "gAAAA")
+}
+
+type codexEncryptedRetryStub struct {
+	requests []*httpclient.Request
+}
+
+var _ pipeline.Executor = (*codexEncryptedRetryStub)(nil)
+
+func (s *codexEncryptedRetryStub) Do(_ context.Context, _ *httpclient.Request) (*httpclient.Response, error) {
+	return nil, errors.New("unexpected non-streaming call")
+}
+
+func (s *codexEncryptedRetryStub) DoStream(_ context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	copyRequest := *request
+	copyRequest.Body = append([]byte(nil), request.Body...)
+	s.requests = append(s.requests, &copyRequest)
+
+	if len(s.requests) == 1 {
+		return nil, &httpclient.Error{
+			StatusCode: http.StatusBadRequest,
+			Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
+		}
+	}
+
+	return streams.SliceStream([]*httpclient.StreamEvent{{
+		Type: "response.completed",
+		Data: []byte(`{"type":"response.completed"}`),
+	}}), nil
+}

--- a/llm/transformer/openai/codex/encrypted_retry_integration_test.go
+++ b/llm/transformer/openai/codex/encrypted_retry_integration_test.go
@@ -18,9 +18,10 @@ func TestCodexExecutorRetriesInvalidEncryptedContent(t *testing.T) {
 	stub := &codexEncryptedRetryStub{}
 	executor := &codexExecutor{inner: stub, httpExecutor: stub}
 	request := &httpclient.Request{
-		Method:    http.MethodPost,
-		APIFormat: llm.APIFormatOpenAIResponse.String(),
-		Body:      []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+		Method:                       http.MethodPost,
+		APIFormat:                    llm.APIFormatOpenAIResponse.String(),
+		RetryInvalidEncryptedContent: true,
+		Body:                         []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
 	}
 
 	stream, err := executor.DoStream(context.Background(), request)

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -446,6 +446,15 @@ type codexExecutor struct {
 }
 
 func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	response, err := e.doOnce(ctx, request)
+	if retryRequest, ok := responses.PrepareEncryptedContentRetryRequest(request, response, err); ok {
+		return e.doOnce(ctx, retryRequest)
+	}
+
+	return response, err
+}
+
+func (e *codexExecutor) doOnce(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
 	// Compact and alpha search are non-streaming endpoints; proxy them
 	// through the real HTTP client instead of the SSE stream path.
 	if request.RequestType == string(llm.RequestTypeCompact) ||
@@ -596,5 +605,14 @@ func decodeSSEChunks(ctx context.Context, body []byte) ([]*httpclient.StreamEven
 }
 
 func (e *codexExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
-	return e.inner.DoStream(ctx, request)
+	stream, err := e.inner.DoStream(ctx, request)
+	if retryRequest, ok := responses.PrepareEncryptedContentRetryRequest(request, nil, err); ok {
+		if stream != nil {
+			_ = stream.Close()
+		}
+
+		return e.inner.DoStream(ctx, retryRequest)
+	}
+
+	return stream, err
 }

--- a/llm/transformer/openai/responses/encrypted_retry.go
+++ b/llm/transformer/openai/responses/encrypted_retry.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -75,14 +78,15 @@ func (e *encryptedContentRetryExecutor) DoStream(ctx context.Context, request *h
 
 // PrepareEncryptedContentRetryRequest returns a request copy with opaque,
 // account-bound encrypted content removed when response/err identifies a 400
-// invalid_encrypted_content failure. Callers should issue at most one retry
-// with the returned request.
+// invalid_encrypted_content failure. The request's
+// RetryInvalidEncryptedContent flag must be enabled. Callers should issue at
+// most one retry with the returned request.
 func PrepareEncryptedContentRetryRequest(
 	request *httpclient.Request,
 	response *httpclient.Response,
 	err error,
 ) (*httpclient.Request, bool) {
-	if request == nil || !isResponsesRequest(request) {
+	if request == nil || !request.RetryInvalidEncryptedContent || !isResponsesRequest(request) {
 		return nil, false
 	}
 
@@ -95,13 +99,41 @@ func PrepareEncryptedContentRetryRequest(
 		return nil, false
 	}
 
-	retryRequest := *request
+	retryRequest := cloneRequest(request)
 	retryRequest.Body = strippedBody
 	if len(request.JSONBody) > 0 {
 		retryRequest.JSONBody = append([]byte(nil), strippedBody...)
 	}
 
-	return &retryRequest, true
+	return retryRequest, true
+}
+
+// cloneRequest makes a request copy suitable for a second executor attempt.
+// Request contains maps and pointers that must not be shared with the first
+// attempt: HTTP request construction and provider executors may mutate them.
+func cloneRequest(request *httpclient.Request) *httpclient.Request {
+	if request == nil {
+		return nil
+	}
+
+	cloned := *request
+	cloned.Headers = request.Headers.Clone()
+	if request.Query != nil {
+		cloned.Query = make(url.Values, len(request.Query))
+		for key, values := range request.Query {
+			cloned.Query[key] = slices.Clone(values)
+		}
+	}
+	cloned.Body = slices.Clone(request.Body)
+	cloned.JSONBody = slices.Clone(request.JSONBody)
+	cloned.Metadata = maps.Clone(request.Metadata)
+	cloned.TransformerMetadata = maps.Clone(request.TransformerMetadata)
+	if request.Auth != nil {
+		auth := *request.Auth
+		cloned.Auth = &auth
+	}
+
+	return &cloned
 }
 
 func isResponsesRequest(request *httpclient.Request) bool {

--- a/llm/transformer/openai/responses/encrypted_retry.go
+++ b/llm/transformer/openai/responses/encrypted_retry.go
@@ -35,8 +35,8 @@ const (
 // encryptedContentRetryExecutor retries a Responses request once after an
 // upstream reports that an account-bound encrypted item cannot be verified.
 // The retry uses the same underlying executor and removes opaque encrypted
-// fields plus resource-bound item IDs when the provider reports a resource
-// mismatch.
+// fields plus resource-bound item and call IDs when the provider reports a
+// resource mismatch.
 type encryptedContentRetryExecutor struct {
 	inner pipeline.Executor
 }
@@ -254,10 +254,10 @@ func detectEncryptedContentFailure(err error, response *httpclient.Response) enc
 
 // stripAccountBoundResponseItems removes account-bound encrypted blobs while
 // retaining visible messages, reasoning summaries, and tool call linkage. A
-// cross-resource failure also requires removing server-generated item IDs;
-// call_id is intentionally preserved because it links function calls to their
-// outputs and is not an item lookup key.
-func stripAccountBoundResponseItems(body []byte, stripItemIDs bool) ([]byte, bool) {
+// cross-resource failure also requires replacing server-generated item IDs and
+// call IDs. Each call_id is remapped consistently so function calls remain
+// linked to their outputs without retaining an upstream resource reference.
+func stripAccountBoundResponseItems(body []byte, stripResourceReferences bool) ([]byte, bool) {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return body, false
 	}
@@ -269,12 +269,26 @@ func stripAccountBoundResponseItems(body []byte, stripItemIDs bool) ([]byte, boo
 
 	out := body
 	stripped := false
+	callIDMap := make(map[string]string)
 
 	for i, item := range input.Array() {
-		if stripItemIDs {
+		if stripResourceReferences {
 			id := item.Get("id")
 			if id.Exists() && id.Type != gjson.Null {
 				if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.id", i)); err == nil {
+					out = next
+					stripped = true
+				}
+			}
+
+			callID := strings.TrimSpace(item.Get("call_id").String())
+			if callID != "" {
+				replacement, ok := callIDMap[callID]
+				if !ok {
+					replacement = fmt.Sprintf("call_recovered_%d", len(callIDMap)+1)
+					callIDMap[callID] = replacement
+				}
+				if next, err := sjson.SetBytes(out, fmt.Sprintf("input.%d.call_id", i), replacement); err == nil {
 					out = next
 					stripped = true
 				}

--- a/llm/transformer/openai/responses/encrypted_retry.go
+++ b/llm/transformer/openai/responses/encrypted_retry.go
@@ -22,10 +22,21 @@ import (
 
 const invalidEncryptedContentCode = "invalid_encrypted_content"
 
+const crossResourceItemErrorFragment = "created under a different azure openai resource"
+
+type encryptedContentFailure uint8
+
+const (
+	encryptedContentFailureNone encryptedContentFailure = iota
+	encryptedContentFailureInvalid
+	encryptedContentFailureCrossResource
+)
+
 // encryptedContentRetryExecutor retries a Responses request once after an
 // upstream reports that an account-bound encrypted item cannot be verified.
-// The retry uses the same underlying executor and only removes opaque encrypted
-// fields from the request body.
+// The retry uses the same underlying executor and removes opaque encrypted
+// fields plus resource-bound item IDs when the provider reports a resource
+// mismatch.
 type encryptedContentRetryExecutor struct {
 	inner pipeline.Executor
 }
@@ -78,7 +89,7 @@ func (e *encryptedContentRetryExecutor) DoStream(ctx context.Context, request *h
 
 // PrepareEncryptedContentRetryRequest returns a request copy with opaque,
 // account-bound encrypted content removed when response/err identifies a 400
-// invalid_encrypted_content failure. The request's
+// invalid_encrypted_content or cross-resource item failure. The request's
 // RetryInvalidEncryptedContent flag must be enabled. Callers should issue at
 // most one retry with the returned request.
 func PrepareEncryptedContentRetryRequest(
@@ -90,11 +101,19 @@ func PrepareEncryptedContentRetryRequest(
 		return nil, false
 	}
 
-	if responseStatusCode(response, err) != http.StatusBadRequest || !isInvalidEncryptedContentError(err, response) {
+	if responseStatusCode(response, err) != http.StatusBadRequest {
 		return nil, false
 	}
 
-	strippedBody, stripped := stripEncryptedReasoningContent(request.Body)
+	failure := detectEncryptedContentFailure(err, response)
+	if failure == encryptedContentFailureNone {
+		return nil, false
+	}
+
+	strippedBody, stripped := stripAccountBoundResponseItems(
+		request.Body,
+		failure == encryptedContentFailureCrossResource,
+	)
 	if !stripped {
 		return nil, false
 	}
@@ -184,17 +203,23 @@ func responseErrorBody(response *httpclient.Response, err error) []byte {
 	return nil
 }
 
-// isInvalidEncryptedContentError accepts the regular OpenAI error envelope
-// and gateway envelopes that put a JSON error object inside message.
-func isInvalidEncryptedContentError(err error, response *httpclient.Response) bool {
+// detectEncryptedContentFailure accepts the regular OpenAI error envelope and
+// gateway envelopes that put a JSON error object inside message. Azure can
+// report the same account-bound item failure without a provider error code,
+// using a "different Azure OpenAI resource" message instead.
+func detectEncryptedContentFailure(err error, response *httpclient.Response) encryptedContentFailure {
 	body := responseErrorBody(response, err)
 	if len(bytes.TrimSpace(body)) == 0 {
-		return false
+		return encryptedContentFailureNone
 	}
 
 	// Walk the small number of envelopes used by Responses gateways. ModelHub
 	// commonly returns {"code":-4201,"message":"<JSON error>"}.
 	originalBody := body
+	if strings.Contains(strings.ToLower(string(originalBody)), crossResourceItemErrorFragment) {
+		return encryptedContentFailureCrossResource
+	}
+
 	hasGatewayCode := false
 	for depth := 0; depth < 4; depth++ {
 		if gjson.GetBytes(body, "code").Int() == -4201 {
@@ -203,7 +228,7 @@ func isInvalidEncryptedContentError(err error, response *httpclient.Response) bo
 
 		for _, path := range []string{"error.code", "message.error.code", "code"} {
 			if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, path).String()), invalidEncryptedContentCode) {
-				return true
+				return encryptedContentFailureInvalid
 			}
 		}
 
@@ -220,14 +245,19 @@ func isInvalidEncryptedContentError(err error, response *httpclient.Response) bo
 
 	// A few gateways preserve only their numeric error code at the outer layer
 	// and leave the provider code in plain text. Keep this fallback narrow.
-	return hasGatewayCode && strings.Contains(string(originalBody), invalidEncryptedContentCode)
+	if hasGatewayCode && strings.Contains(string(originalBody), invalidEncryptedContentCode) {
+		return encryptedContentFailureInvalid
+	}
+
+	return encryptedContentFailureNone
 }
 
-// stripEncryptedReasoningContent removes account-bound encrypted blobs while
-// retaining visible messages and reasoning summaries. The supported wire
-// shapes are a reasoning item's encrypted_content field and encrypted_content
-// variants nested in function_call_output.output.
-func stripEncryptedReasoningContent(body []byte) ([]byte, bool) {
+// stripAccountBoundResponseItems removes account-bound encrypted blobs while
+// retaining visible messages, reasoning summaries, and tool call linkage. A
+// cross-resource failure also requires removing server-generated item IDs;
+// call_id is intentionally preserved because it links function calls to their
+// outputs and is not an item lookup key.
+func stripAccountBoundResponseItems(body []byte, stripItemIDs bool) ([]byte, bool) {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return body, false
 	}
@@ -241,13 +271,21 @@ func stripEncryptedReasoningContent(body []byte) ([]byte, bool) {
 	stripped := false
 
 	for i, item := range input.Array() {
-		if strings.EqualFold(item.Get("type").String(), "reasoning") {
-			encrypted := item.Get("encrypted_content")
-			if encrypted.Exists() && encrypted.Type != gjson.Null {
-				if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.encrypted_content", i)); err == nil {
+		if stripItemIDs {
+			id := item.Get("id")
+			if id.Exists() && id.Type != gjson.Null {
+				if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.id", i)); err == nil {
 					out = next
 					stripped = true
 				}
+			}
+		}
+
+		encrypted := item.Get("encrypted_content")
+		if encrypted.Exists() && encrypted.Type != gjson.Null {
+			if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.encrypted_content", i)); err == nil {
+				out = next
+				stripped = true
 			}
 		}
 

--- a/llm/transformer/openai/responses/encrypted_retry.go
+++ b/llm/transformer/openai/responses/encrypted_retry.go
@@ -1,0 +1,241 @@
+package responses
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+const invalidEncryptedContentCode = "invalid_encrypted_content"
+
+// encryptedContentRetryExecutor retries a Responses request once after an
+// upstream reports that an account-bound encrypted item cannot be verified.
+// The retry uses the same underlying executor and only removes opaque encrypted
+// fields from the request body.
+type encryptedContentRetryExecutor struct {
+	inner pipeline.Executor
+}
+
+var _ pipeline.Executor = (*encryptedContentRetryExecutor)(nil)
+
+// NewEncryptedContentRetryExecutor decorates an executor with the one-shot
+// invalid_encrypted_content recovery used by Responses API channels.
+func NewEncryptedContentRetryExecutor(inner pipeline.Executor) pipeline.Executor {
+	if inner == nil {
+		return nil
+	}
+
+	if existing, ok := inner.(*encryptedContentRetryExecutor); ok {
+		return existing
+	}
+
+	return &encryptedContentRetryExecutor{inner: inner}
+}
+
+func (e *encryptedContentRetryExecutor) Do(ctx context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	if e == nil || e.inner == nil {
+		return nil, errors.New("encrypted content retry executor is not initialized")
+	}
+
+	response, err := e.inner.Do(ctx, request)
+	if retryRequest, ok := PrepareEncryptedContentRetryRequest(request, response, err); ok {
+		return e.inner.Do(ctx, retryRequest)
+	}
+
+	return response, err
+}
+
+func (e *encryptedContentRetryExecutor) DoStream(ctx context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	if e == nil || e.inner == nil {
+		return nil, errors.New("encrypted content retry executor is not initialized")
+	}
+
+	stream, err := e.inner.DoStream(ctx, request)
+	if retryRequest, ok := PrepareEncryptedContentRetryRequest(request, nil, err); ok {
+		if stream != nil {
+			_ = stream.Close()
+		}
+
+		return e.inner.DoStream(ctx, retryRequest)
+	}
+
+	return stream, err
+}
+
+// PrepareEncryptedContentRetryRequest returns a request copy with opaque,
+// account-bound encrypted content removed when response/err identifies a 400
+// invalid_encrypted_content failure. Callers should issue at most one retry
+// with the returned request.
+func PrepareEncryptedContentRetryRequest(
+	request *httpclient.Request,
+	response *httpclient.Response,
+	err error,
+) (*httpclient.Request, bool) {
+	if request == nil || !isResponsesRequest(request) {
+		return nil, false
+	}
+
+	if responseStatusCode(response, err) != http.StatusBadRequest || !isInvalidEncryptedContentError(err, response) {
+		return nil, false
+	}
+
+	strippedBody, stripped := stripEncryptedReasoningContent(request.Body)
+	if !stripped {
+		return nil, false
+	}
+
+	retryRequest := *request
+	retryRequest.Body = strippedBody
+	if len(request.JSONBody) > 0 {
+		retryRequest.JSONBody = append([]byte(nil), strippedBody...)
+	}
+
+	return &retryRequest, true
+}
+
+func isResponsesRequest(request *httpclient.Request) bool {
+	if request == nil {
+		return false
+	}
+
+	switch request.RequestType {
+	case llm.RequestTypeImage.String(), llm.RequestTypeAlphaSearch.String():
+		return false
+	}
+
+	switch request.APIFormat {
+	case llm.APIFormatOpenAIResponse.String(), llm.APIFormatOpenAIResponseCompact.String():
+		return true
+	case "":
+		// Keep direct executor users and tests working when APIFormat was not
+		// populated, while still requiring the Responses input shape.
+		return gjson.GetBytes(request.Body, "input").Exists()
+	default:
+		return false
+	}
+}
+
+func responseStatusCode(response *httpclient.Response, err error) int {
+	var httpErr *httpclient.Error
+	if errors.As(err, &httpErr) && httpErr != nil && httpErr.StatusCode != 0 {
+		return httpErr.StatusCode
+	}
+
+	if response != nil {
+		return response.StatusCode
+	}
+
+	return 0
+}
+
+func responseErrorBody(response *httpclient.Response, err error) []byte {
+	var httpErr *httpclient.Error
+	if errors.As(err, &httpErr) && httpErr != nil && len(httpErr.Body) > 0 {
+		return httpErr.Body
+	}
+
+	if response != nil && len(response.Body) > 0 {
+		return response.Body
+	}
+
+	return nil
+}
+
+// isInvalidEncryptedContentError accepts the regular OpenAI error envelope
+// and gateway envelopes that put a JSON error object inside message.
+func isInvalidEncryptedContentError(err error, response *httpclient.Response) bool {
+	body := responseErrorBody(response, err)
+	if len(bytes.TrimSpace(body)) == 0 {
+		return false
+	}
+
+	// Walk the small number of envelopes used by Responses gateways. ModelHub
+	// commonly returns {"code":-4201,"message":"<JSON error>"}.
+	originalBody := body
+	hasGatewayCode := false
+	for depth := 0; depth < 4; depth++ {
+		if gjson.GetBytes(body, "code").Int() == -4201 {
+			hasGatewayCode = true
+		}
+
+		for _, path := range []string{"error.code", "message.error.code", "code"} {
+			if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, path).String()), invalidEncryptedContentCode) {
+				return true
+			}
+		}
+
+		message := gjson.GetBytes(body, "message")
+		if message.Type != gjson.String {
+			break
+		}
+		nested := strings.TrimSpace(message.String())
+		if nested == "" || nested == string(body) {
+			break
+		}
+		body = []byte(nested)
+	}
+
+	// A few gateways preserve only their numeric error code at the outer layer
+	// and leave the provider code in plain text. Keep this fallback narrow.
+	return hasGatewayCode && strings.Contains(string(originalBody), invalidEncryptedContentCode)
+}
+
+// stripEncryptedReasoningContent removes account-bound encrypted blobs while
+// retaining visible messages and reasoning summaries. The supported wire
+// shapes are a reasoning item's encrypted_content field and encrypted_content
+// variants nested in function_call_output.output.
+func stripEncryptedReasoningContent(body []byte) ([]byte, bool) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, false
+	}
+
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, false
+	}
+
+	out := body
+	stripped := false
+
+	for i, item := range input.Array() {
+		if strings.EqualFold(item.Get("type").String(), "reasoning") {
+			encrypted := item.Get("encrypted_content")
+			if encrypted.Exists() && encrypted.Type != gjson.Null {
+				if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.encrypted_content", i)); err == nil {
+					out = next
+					stripped = true
+				}
+			}
+		}
+
+		output := item.Get("output")
+		if !output.IsArray() {
+			continue
+		}
+
+		// Delete array elements in reverse order so indexes remain stable.
+		outputItems := output.Array()
+		for j := len(outputItems) - 1; j >= 0; j-- {
+			if !strings.EqualFold(outputItems[j].Get("type").String(), "encrypted_content") {
+				continue
+			}
+			if next, err := sjson.DeleteBytes(out, fmt.Sprintf("input.%d.output.%d", i, j)); err == nil {
+				out = next
+				stripped = true
+			}
+		}
+	}
+
+	return out, stripped
+}

--- a/llm/transformer/openai/responses/encrypted_retry_test.go
+++ b/llm/transformer/openai/responses/encrypted_retry_test.go
@@ -136,8 +136,10 @@ func TestPrepareEncryptedContentRetryRequestCrossResource(t *testing.T) {
 	require.False(t, gjson.GetBytes(retry.Body, "input.3.id").Exists())
 	require.Equal(t, "keep me", gjson.GetBytes(retry.Body, "input.0.content.0.text").String())
 	require.Equal(t, "keep summary", gjson.GetBytes(retry.Body, "input.1.summary.0.text").String())
-	require.Equal(t, "call_1", gjson.GetBytes(retry.Body, "input.2.call_id").String())
-	require.Equal(t, "call_1", gjson.GetBytes(retry.Body, "input.3.call_id").String())
+	recoveredCallID := gjson.GetBytes(retry.Body, "input.2.call_id").String()
+	require.Equal(t, "call_recovered_1", recoveredCallID)
+	require.NotEqual(t, "call_1", recoveredCallID)
+	require.Equal(t, recoveredCallID, gjson.GetBytes(retry.Body, "input.3.call_id").String())
 	require.Equal(t, "keep output", gjson.GetBytes(retry.Body, "input.3.output.0.text").String())
 }
 

--- a/llm/transformer/openai/responses/encrypted_retry_test.go
+++ b/llm/transformer/openai/responses/encrypted_retry_test.go
@@ -1,0 +1,250 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+)
+
+func TestIsInvalidEncryptedContentError(t *testing.T) {
+	native := &httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
+	}
+	require.True(t, isInvalidEncryptedContentError(native, nil))
+
+	// Some gateways put the provider JSON in a string-valued top-level message.
+	wrapper := map[string]any{
+		"code":    -4201,
+		"message": `{"error":{"message":"could not be verified","code":"invalid_encrypted_content"}}`,
+	}
+	wrapperBody, err := json.Marshal(wrapper)
+	require.NoError(t, err)
+	require.True(t, isInvalidEncryptedContentError(&httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       wrapperBody,
+	}, nil))
+	require.True(t, isInvalidEncryptedContentError(&httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"code":-4201,"message":"invalid_encrypted_content: could not be verified"}`),
+	}, nil))
+
+	require.False(t, isInvalidEncryptedContentError(&httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"error":{"code":"invalid_request_error"}}`),
+	}, nil))
+}
+
+func TestStripEncryptedReasoningContent(t *testing.T) {
+	input := []byte(`{
+		"model":"gpt-5.6",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"keep me"}]},
+			{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"visible summary"}],"encrypted_content":"gAAAA_reasoning"},
+			{"type":"function_call_output","output":[
+				{"type":"input_text","text":"keep output"},
+				{"type":"encrypted_content","encrypted_content":"gAAAA_function"},
+				{"type":"input_text","text":"keep order"}
+			]}
+		]
+	}`)
+
+	stripped, ok := stripEncryptedReasoningContent(input)
+	require.True(t, ok)
+	require.Equal(t, input, []byte(`{
+		"model":"gpt-5.6",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"keep me"}]},
+			{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"visible summary"}],"encrypted_content":"gAAAA_reasoning"},
+			{"type":"function_call_output","output":[
+				{"type":"input_text","text":"keep output"},
+				{"type":"encrypted_content","encrypted_content":"gAAAA_function"},
+				{"type":"input_text","text":"keep order"}
+			]}
+		]
+	}`), "strip must not mutate the original request")
+	require.False(t, gjson.GetBytes(stripped, "input.1.encrypted_content").Exists())
+	require.Equal(t, "visible summary", gjson.GetBytes(stripped, "input.1.summary.0.text").String())
+	require.Equal(t, "keep me", gjson.GetBytes(stripped, "input.0.content.0.text").String())
+	require.Equal(t, float64(2), gjson.GetBytes(stripped, "input.2.output.#").Float())
+	require.Equal(t, "keep output", gjson.GetBytes(stripped, "input.2.output.0.text").String())
+	require.Equal(t, "keep order", gjson.GetBytes(stripped, "input.2.output.1.text").String())
+	require.NotContains(t, string(stripped), "gAAAA_")
+}
+
+func TestStripEncryptedReasoningContentNoOp(t *testing.T) {
+	cases := [][]byte{
+		[]byte(`{"input":[{"type":"reasoning","encrypted_content":null}]}`),
+		[]byte(`{"input":[{"type":"message","content":[]}]}`),
+		[]byte(`{"input":"plain text"}`),
+		[]byte(`not json`),
+	}
+
+	for _, input := range cases {
+		stripped, ok := stripEncryptedReasoningContent(input)
+		require.False(t, ok)
+		require.Equal(t, input, stripped)
+	}
+}
+
+func TestPrepareEncryptedContentRetryRequest(t *testing.T) {
+	request := &httpclient.Request{
+		Method:    http.MethodPost,
+		APIFormat: llm.APIFormatOpenAIResponse.String(),
+		Body:      []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+		JSONBody:  []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+	}
+	err := &httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
+	}
+
+	retry, ok := PrepareEncryptedContentRetryRequest(request, nil, err)
+	require.True(t, ok)
+	require.NotSame(t, request, retry)
+	require.Equal(t, request.Body, []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`))
+	require.NotContains(t, string(retry.Body), "gAAAA")
+	require.NotContains(t, string(retry.JSONBody), "gAAAA")
+
+	_, ok = PrepareEncryptedContentRetryRequest(request, nil, &httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"error":{"code":"rate_limit_exceeded"}}`),
+	})
+	require.False(t, ok)
+}
+
+func TestEncryptedContentRetryExecutorRetriesStreamingRequest(t *testing.T) {
+	firstBody := []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`)
+	stub := &encryptedRetryExecutorStub{
+		streamErrs: []error{
+			&httpclient.Error{
+				StatusCode: http.StatusBadRequest,
+				Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
+			},
+		},
+		streamResults: []streams.Stream[*httpclient.StreamEvent]{
+			nil,
+			streams.SliceStream([]*httpclient.StreamEvent{{Type: "response.completed", Data: []byte(`{"type":"response.completed"}`)}}),
+		},
+	}
+
+	executor := NewEncryptedContentRetryExecutor(stub)
+	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
+		Method:    http.MethodPost,
+		APIFormat: llm.APIFormatOpenAIResponse.String(),
+		Body:      firstBody,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	require.True(t, stream.Next())
+	require.Equal(t, "response.completed", stream.Current().Type)
+	require.Len(t, stub.streamRequests, 2)
+	require.Equal(t, firstBody, stub.streamRequests[0].Body)
+	require.NotContains(t, string(stub.streamRequests[1].Body), "gAAAA")
+}
+
+func TestEncryptedContentRetryExecutorRetriesNonStreamingRequest(t *testing.T) {
+	stub := &encryptedRetryExecutorStub{
+		doErrs: []error{
+			&httpclient.Error{
+				StatusCode: http.StatusBadRequest,
+				Body:       []byte(`{"code":-4201,"message":"{\"error\":{\"code\":\"invalid_encrypted_content\"}}"}`),
+			},
+		},
+		doResponses: []*httpclient.Response{nil, {
+			StatusCode: http.StatusOK,
+			Body:       []byte(`{"id":"resp_1"}`),
+		}},
+	}
+
+	executor := NewEncryptedContentRetryExecutor(stub)
+	response, err := executor.Do(context.Background(), &httpclient.Request{
+		Method:      http.MethodPost,
+		RequestType: llm.RequestTypeChat.String(),
+		APIFormat:   llm.APIFormatOpenAIResponse.String(),
+		Body:        []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Len(t, stub.doRequests, 2)
+	require.NotContains(t, string(stub.doRequests[1].Body), "gAAAA")
+}
+
+func TestOutboundCustomizeExecutorUsesRetryForHTTPResponses(t *testing.T) {
+	outbound, err := NewOutboundTransformerWithConfig(&Config{
+		BaseURL:        "https://example.test/v1",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+	})
+	require.NoError(t, err)
+
+	stub := &encryptedRetryExecutorStub{}
+	customized := outbound.CustomizeExecutor(stub)
+	require.IsType(t, &encryptedContentRetryExecutor{}, customized)
+	require.Same(t, customized, outbound.CustomizeExecutor(customized))
+}
+
+type encryptedRetryExecutorStub struct {
+	mu             sync.Mutex
+	doRequests     []*httpclient.Request
+	doErrs         []error
+	doResponses    []*httpclient.Response
+	streamRequests []*httpclient.Request
+	streamErrs     []error
+	streamResults  []streams.Stream[*httpclient.StreamEvent]
+}
+
+var _ pipeline.Executor = (*encryptedRetryExecutorStub)(nil)
+
+func (s *encryptedRetryExecutorStub) Do(_ context.Context, request *httpclient.Request) (*httpclient.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.doRequests = append(s.doRequests, cloneEncryptedRetryRequest(request))
+	index := len(s.doRequests) - 1
+	if index < len(s.doErrs) && s.doErrs[index] != nil {
+		return nil, s.doErrs[index]
+	}
+	if index < len(s.doResponses) {
+		response := s.doResponses[index]
+		if response != nil {
+			response.Request = request
+		}
+		return response, nil
+	}
+	return nil, errors.New("encrypted retry stub exhausted")
+}
+
+func (s *encryptedRetryExecutorStub) DoStream(_ context.Context, request *httpclient.Request) (streams.Stream[*httpclient.StreamEvent], error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streamRequests = append(s.streamRequests, cloneEncryptedRetryRequest(request))
+	index := len(s.streamRequests) - 1
+	if index < len(s.streamErrs) && s.streamErrs[index] != nil {
+		return nil, s.streamErrs[index]
+	}
+	if index < len(s.streamResults) {
+		return s.streamResults[index], nil
+	}
+	return nil, errors.New("encrypted retry stream stub exhausted")
+}
+
+func cloneEncryptedRetryRequest(request *httpclient.Request) *httpclient.Request {
+	if request == nil {
+		return nil
+	}
+	cloned := *request
+	cloned.Body = append([]byte(nil), request.Body...)
+	cloned.JSONBody = append([]byte(nil), request.JSONBody...)
+	return &cloned
+}

--- a/llm/transformer/openai/responses/encrypted_retry_test.go
+++ b/llm/transformer/openai/responses/encrypted_retry_test.go
@@ -24,7 +24,7 @@ func TestIsInvalidEncryptedContentError(t *testing.T) {
 		StatusCode: http.StatusBadRequest,
 		Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
 	}
-	require.True(t, isInvalidEncryptedContentError(native, nil))
+	require.Equal(t, encryptedContentFailureInvalid, detectEncryptedContentFailure(native, nil))
 
 	// Some gateways put the provider JSON in a string-valued top-level message.
 	wrapper := map[string]any{
@@ -33,18 +33,25 @@ func TestIsInvalidEncryptedContentError(t *testing.T) {
 	}
 	wrapperBody, err := json.Marshal(wrapper)
 	require.NoError(t, err)
-	require.True(t, isInvalidEncryptedContentError(&httpclient.Error{
+	require.Equal(t, encryptedContentFailureInvalid, detectEncryptedContentFailure(&httpclient.Error{
 		StatusCode: http.StatusBadRequest,
 		Body:       wrapperBody,
 	}, nil))
-	require.True(t, isInvalidEncryptedContentError(&httpclient.Error{
+	require.Equal(t, encryptedContentFailureInvalid, detectEncryptedContentFailure(&httpclient.Error{
 		StatusCode: http.StatusBadRequest,
 		Body:       []byte(`{"code":-4201,"message":"invalid_encrypted_content: could not be verified"}`),
 	}, nil))
 
-	require.False(t, isInvalidEncryptedContentError(&httpclient.Error{
+	require.Equal(t, encryptedContentFailureNone, detectEncryptedContentFailure(&httpclient.Error{
 		StatusCode: http.StatusBadRequest,
 		Body:       []byte(`{"error":{"code":"invalid_request_error"}}`),
+	}, nil))
+}
+
+func TestDetectEncryptedContentFailureCrossResource(t *testing.T) {
+	require.Equal(t, encryptedContentFailureCrossResource, detectEncryptedContentFailure(&httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"code":-4201,"message":"{\"error\":{\"message\":\"The requested item was created under a different Azure OpenAI resource. Use the same resource that created the item to access it.\",\"type\":\"invalid_request_error\",\"code\":null}}"}`),
 	}, nil))
 }
 
@@ -62,7 +69,7 @@ func TestStripEncryptedReasoningContent(t *testing.T) {
 		]
 	}`)
 
-	stripped, ok := stripEncryptedReasoningContent(input)
+	stripped, ok := stripAccountBoundResponseItems(input, false)
 	require.True(t, ok)
 	require.Equal(t, input, []byte(`{
 		"model":"gpt-5.6",
@@ -77,6 +84,7 @@ func TestStripEncryptedReasoningContent(t *testing.T) {
 		]
 	}`), "strip must not mutate the original request")
 	require.False(t, gjson.GetBytes(stripped, "input.1.encrypted_content").Exists())
+	require.Equal(t, "rs_1", gjson.GetBytes(stripped, "input.1.id").String())
 	require.Equal(t, "visible summary", gjson.GetBytes(stripped, "input.1.summary.0.text").String())
 	require.Equal(t, "keep me", gjson.GetBytes(stripped, "input.0.content.0.text").String())
 	require.Equal(t, float64(2), gjson.GetBytes(stripped, "input.2.output.#").Float())
@@ -94,10 +102,43 @@ func TestStripEncryptedReasoningContentNoOp(t *testing.T) {
 	}
 
 	for _, input := range cases {
-		stripped, ok := stripEncryptedReasoningContent(input)
+		stripped, ok := stripAccountBoundResponseItems(input, false)
 		require.False(t, ok)
 		require.Equal(t, input, stripped)
 	}
+}
+
+func TestPrepareEncryptedContentRetryRequestCrossResource(t *testing.T) {
+	request := &httpclient.Request{
+		Method:                       http.MethodPost,
+		APIFormat:                    llm.APIFormatOpenAIResponse.String(),
+		RetryInvalidEncryptedContent: true,
+		Body: []byte(`{"input":[
+			{"id":"msg_1","type":"message","role":"user","content":[{"type":"input_text","text":"keep me"}]},
+			{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"keep summary"}],"encrypted_content":"gAAAA_reasoning"},
+			{"id":"fc_1","type":"function_call","call_id":"call_1","name":"tool","arguments":"{}"},
+			{"id":"fco_1","type":"function_call_output","call_id":"call_1","output":[{"type":"encrypted_content","encrypted_content":"gAAAA_output"},{"type":"input_text","text":"keep output"}]}
+		]}`),
+	}
+	err := &httpclient.Error{
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(`{"error":{"message":"The requested item was created under a different Azure OpenAI resource. Use the same resource that created the item to access it.","code":null}}`),
+	}
+
+	retry, ok := PrepareEncryptedContentRetryRequest(request, nil, err)
+	require.True(t, ok)
+	require.Equal(t, "rs_1", gjson.GetBytes(request.Body, "input.1.id").String())
+	require.Equal(t, "gAAAA_reasoning", gjson.GetBytes(request.Body, "input.1.encrypted_content").String())
+	require.NotContains(t, string(retry.Body), "gAAAA")
+	require.False(t, gjson.GetBytes(retry.Body, "input.0.id").Exists())
+	require.False(t, gjson.GetBytes(retry.Body, "input.1.id").Exists())
+	require.False(t, gjson.GetBytes(retry.Body, "input.2.id").Exists())
+	require.False(t, gjson.GetBytes(retry.Body, "input.3.id").Exists())
+	require.Equal(t, "keep me", gjson.GetBytes(retry.Body, "input.0.content.0.text").String())
+	require.Equal(t, "keep summary", gjson.GetBytes(retry.Body, "input.1.summary.0.text").String())
+	require.Equal(t, "call_1", gjson.GetBytes(retry.Body, "input.2.call_id").String())
+	require.Equal(t, "call_1", gjson.GetBytes(retry.Body, "input.3.call_id").String())
+	require.Equal(t, "keep output", gjson.GetBytes(retry.Body, "input.3.output.0.text").String())
 }
 
 func TestPrepareEncryptedContentRetryRequest(t *testing.T) {

--- a/llm/transformer/openai/responses/encrypted_retry_test.go
+++ b/llm/transformer/openai/responses/encrypted_retry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -101,10 +102,16 @@ func TestStripEncryptedReasoningContentNoOp(t *testing.T) {
 
 func TestPrepareEncryptedContentRetryRequest(t *testing.T) {
 	request := &httpclient.Request{
-		Method:    http.MethodPost,
-		APIFormat: llm.APIFormatOpenAIResponse.String(),
-		Body:      []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
-		JSONBody:  []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+		Method:                       http.MethodPost,
+		APIFormat:                    llm.APIFormatOpenAIResponse.String(),
+		RetryInvalidEncryptedContent: true,
+		Headers:                      make(http.Header),
+		Query:                        make(url.Values),
+		Metadata:                     map[string]string{"existing": "value"},
+		TransformerMetadata:          map[string]any{"existing": true},
+		Auth:                         &httpclient.AuthConfig{Type: httpclient.AuthTypeBearer, APIKey: "test-key"},
+		Body:                         []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+		JSONBody:                     []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
 	}
 	err := &httpclient.Error{
 		StatusCode: http.StatusBadRequest,
@@ -118,11 +125,44 @@ func TestPrepareEncryptedContentRetryRequest(t *testing.T) {
 	require.NotContains(t, string(retry.Body), "gAAAA")
 	require.NotContains(t, string(retry.JSONBody), "gAAAA")
 
+	retry.Headers.Set("X-Retry-Only", "true")
+	retry.Query.Set("retry_only", "true")
+	retry.Metadata["retry_only"] = "true"
+	retry.TransformerMetadata["retry_only"] = true
+	retry.Auth.APIKey = "retry-only"
+	require.Empty(t, request.Headers.Get("X-Retry-Only"))
+	require.Empty(t, request.Query.Get("retry_only"))
+	require.Empty(t, request.Metadata["retry_only"])
+	require.Nil(t, request.TransformerMetadata["retry_only"])
+	require.Equal(t, "test-key", request.Auth.APIKey)
+
+	disabled := *request
+	disabled.RetryInvalidEncryptedContent = false
+	_, ok = PrepareEncryptedContentRetryRequest(&disabled, nil, err)
+	require.False(t, ok)
+
 	_, ok = PrepareEncryptedContentRetryRequest(request, nil, &httpclient.Error{
 		StatusCode: http.StatusBadRequest,
 		Body:       []byte(`{"error":{"code":"rate_limit_exceeded"}}`),
 	})
 	require.False(t, ok)
+}
+
+func TestEncryptedContentRetryExecutorDoesNotRetryWhenDisabled(t *testing.T) {
+	stub := &encryptedRetryExecutorStub{
+		streamErrs: []error{&httpclient.Error{
+			StatusCode: http.StatusBadRequest,
+			Body:       []byte(`{"error":{"code":"invalid_encrypted_content"}}`),
+		}},
+	}
+
+	executor := NewEncryptedContentRetryExecutor(stub)
+	_, err := executor.DoStream(context.Background(), &httpclient.Request{
+		APIFormat: llm.APIFormatOpenAIResponse.String(),
+		Body:      []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+	})
+	require.Error(t, err)
+	require.Len(t, stub.streamRequests, 1)
 }
 
 func TestEncryptedContentRetryExecutorRetriesStreamingRequest(t *testing.T) {
@@ -142,9 +182,10 @@ func TestEncryptedContentRetryExecutorRetriesStreamingRequest(t *testing.T) {
 
 	executor := NewEncryptedContentRetryExecutor(stub)
 	stream, err := executor.DoStream(context.Background(), &httpclient.Request{
-		Method:    http.MethodPost,
-		APIFormat: llm.APIFormatOpenAIResponse.String(),
-		Body:      firstBody,
+		Method:                       http.MethodPost,
+		APIFormat:                    llm.APIFormatOpenAIResponse.String(),
+		RetryInvalidEncryptedContent: true,
+		Body:                         firstBody,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, stream)
@@ -171,10 +212,11 @@ func TestEncryptedContentRetryExecutorRetriesNonStreamingRequest(t *testing.T) {
 
 	executor := NewEncryptedContentRetryExecutor(stub)
 	response, err := executor.Do(context.Background(), &httpclient.Request{
-		Method:      http.MethodPost,
-		RequestType: llm.RequestTypeChat.String(),
-		APIFormat:   llm.APIFormatOpenAIResponse.String(),
-		Body:        []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
+		Method:                       http.MethodPost,
+		RequestType:                  llm.RequestTypeChat.String(),
+		APIFormat:                    llm.APIFormatOpenAIResponse.String(),
+		RetryInvalidEncryptedContent: true,
+		Body:                         []byte(`{"input":[{"type":"reasoning","encrypted_content":"gAAAA"}]}`),
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode)

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -28,8 +28,8 @@ var (
 
 // Config holds all configuration for the OpenAI Responses outbound transformer.
 const (
-	TransportHTTP       = "http"
-	TransportWebSocket  = "websocket"
+	TransportHTTP      = "http"
+	TransportWebSocket = "websocket"
 	// ResponsesLiteHeader is the Codex Responses Lite signal. It uses the
 	// canonical spelling ("Openai"): http.Header canonicalizes keys, so lookups
 	// match whatever case a Codex client sends.
@@ -96,8 +96,15 @@ func NewOutboundTransformerWithConfig(config *Config) (*OutboundTransformer, err
 }
 
 func (t *OutboundTransformer) CustomizeExecutor(executor pipeline.Executor) pipeline.Executor {
-	if t == nil || t.config == nil || t.config.Transport != TransportWebSocket {
+	if t == nil || t.config == nil {
 		return executor
+	}
+
+	if t.config.Transport != TransportWebSocket {
+		// Responses reasoning blobs are signed by the serving account. If
+		// affinity drifts between turns, recover the request before the
+		// pipeline gives up or switches channels.
+		return NewEncryptedContentRetryExecutor(executor)
 	}
 
 	if !ExecutorComparable(executor) {


### PR DESCRIPTION
## Summary

- detect HTTP 400 `invalid_encrypted_content` failures on OpenAI Responses and Codex executor paths, including errors wrapped as nested JSON strings
- also recover Azure/ModelHub errors stating that an item was created under a different Azure OpenAI resource, even when the provider error code is null
- retry once after removing opaque encrypted content; cross-resource recovery removes server-generated input item IDs and consistently remaps `call_id` pairs so tool calls remain linked without retaining resource-bound identifiers
- deep-copy mutable request state before retry so caller-owned headers, query values, body, metadata, and auth data are not mutated
- add a system-level **Retry invalid encrypted content** switch under Retry settings; it defaults on for backward compatibility and follows the main retry enablement

## Why

Encrypted reasoning content, Responses item IDs, and tool call IDs can be bound to an upstream account or Azure OpenAI resource. If a later request is routed to an upstream that cannot decrypt or resolve those items, the request currently fails permanently. This adds a bounded recovery path that preserves portable conversation and tool content while replacing stale resource-bound fields.

## Validation

- `make generate`
- affected `llm` package tests (`httpclient`, `pipeline`, OpenAI Responses, and Codex)
- root package tests for `internal/server/biz`, `internal/server/orchestrator`, and `internal/server/gql`
- focused cross-resource error-envelope, item-ID removal, call-ID remapping, and request-copy tests
- locale JSON parsing and `git diff --check`

Commits on top of `unstable`: `9fc1f566`, `584f2879`, `8ed801f9`, and `2200ab6f`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a system setting to recover from invalid encrypted content.
  * Enabled by default for streaming and non-streaming Responses requests.
  * Failed requests can be retried once after unverifiable encrypted content is removed.
  * Added recovery for related cross-resource encrypted-content failures.
  * Added English and Chinese translations for the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->