### PR TITLE
fix: skip spurious default-value changes that trigger SQLite rebuilds

### DIFF
--- a/internal/server/db/ent.go
+++ b/internal/server/db/ent.go
@@ -71,6 +71,7 @@ func NewEntClient(cfg Config) *ent.Client {
 			migrate.WithDropIndex(true),
 			migrate.WithDropColumn(true),
 			schema.WithHooks(schemahook.V0_3_0),
+			filterEquivalentDefaultChanges(),
 		)
 		if err != nil {
 			panic(err)

--- a/internal/server/db/schema_default_filter.go
+++ b/internal/server/db/schema_default_filter.go
@@ -1,0 +1,148 @@
+package db
+
+import (
+	"strings"
+
+	aschema "ariga.io/atlas/sql/schema"
+	eschema "entgo.io/ent/dialect/sql/schema"
+)
+
+// filterEquivalentDefaultChanges returns a diff hook that filters out ChangeDefault
+// changes where the current and desired defaults only differ by formatting
+// (outer parentheses, or MySQL's now() spelling of CURRENT_TIMESTAMP).
+//
+// Without this, ent wraps Expr defaults (e.g. entsql.DefaultExpr("CURRENT_TIMESTAMP"))
+// in parentheses when building the desired schema, while SQLite/MySQL report the
+// stored default without them (CURRENT_TIMESTAMP / now()), so a ChangeDefault is
+// computed on every startup. SQLite then rebuilds the whole table to "fix" the
+// default (it cannot ALTER one), which on a partially cleaned table resets its
+// AUTOINCREMENT sequence to MAX(id) and causes request ids to be reused. MySQL
+// merely runs a redundant ALTER each startup. PostgreSQL is unaffected: its
+// driver compares defaults semantically. Real default changes still pass through.
+func filterEquivalentDefaultChanges() eschema.MigrateOption {
+	return eschema.WithDiffHook(func(next eschema.Differ) eschema.Differ {
+		return eschema.DiffFunc(func(current, desired *aschema.Schema) ([]aschema.Change, error) {
+			changes, err := next.Diff(current, desired)
+			if err != nil {
+				return nil, err
+			}
+			return filterEquivalentDefaultChangesFrom(changes), nil
+		})
+	})
+}
+
+// filterEquivalentDefaultChangesFrom prunes equivalent default-only changes
+// from the computed diff and drops tables whose changes become empty.
+func filterEquivalentDefaultChangesFrom(changes []aschema.Change) []aschema.Change {
+	filtered := make([]aschema.Change, 0, len(changes))
+	for _, c := range changes {
+		mt, ok := c.(*aschema.ModifyTable)
+		if !ok {
+			filtered = append(filtered, c)
+			continue
+		}
+		kept := make([]aschema.Change, 0, len(mt.Changes))
+		for _, ic := range mt.Changes {
+			mc, ok := ic.(*aschema.ModifyColumn)
+			if !ok || !isEquivalentDefaultChange(mc) {
+				kept = append(kept, ic)
+				continue
+			}
+		}
+		if len(kept) == 0 {
+			// The whole table-level change was a no-op after filtering.
+			continue
+		}
+		mt.Changes = kept
+		filtered = append(filtered, mt)
+	}
+	return filtered
+}
+
+// isEquivalentDefaultChange reports whether the only change on mc is the
+// default value and the current/desired defaults are semantically equivalent.
+func isEquivalentDefaultChange(mc *aschema.ModifyColumn) bool {
+	// Only touch pure default changes; any other column change
+	// (type, nullability, generated, charset, ...) must be left untouched.
+	if mc.Change != aschema.ChangeDefault {
+		return false
+	}
+	from, ok := columnDefault(mc.From)
+	if !ok {
+		return false
+	}
+	to, ok := columnDefault(mc.To)
+	if !ok {
+		return false
+	}
+	return normalizeDefault(from) == normalizeDefault(to)
+}
+
+// columnDefault returns the string form of the column default value.
+func columnDefault(c *aschema.Column) (string, bool) {
+	if c == nil || c.Default == nil {
+		return "", false
+	}
+	switch x := aschema.UnderlyingExpr(c.Default).(type) {
+	case *aschema.Literal:
+		return x.V, true
+	case *aschema.RawExpr:
+		return x.X, true
+	default:
+		return "", false
+	}
+}
+
+// normalizeDefault returns a canonical form used to compare default values:
+// strips outer parentheses and unifies the timestamp spellings
+// (CURRENT_TIMESTAMP/CURRENT_TIMESTAMP()/now()) into one form. Quoted
+// literals are left untouched.
+func normalizeDefault(s string) string {
+	s = strings.TrimSpace(s)
+	// Strip one level of semantically insignificant outer parentheses,
+	// e.g. "(CURRENT_TIMESTAMP)" -> "CURRENT_TIMESTAMP".
+	for strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") && fullyParenWrapped(s) {
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
+	// MySQL reports DEFAULT (CURRENT_TIMESTAMP) columns as now().
+	switch strings.ToLower(s) {
+	case "current_timestamp", "current_timestamp()", "now()":
+		return "current_timestamp"
+	default:
+		return s
+	}
+}
+
+// fullyParenWrapped reports whether s is fully enclosed by a balanced pair of
+// outermost parentheses. Parentheses inside single-quoted literals are ignored.
+func fullyParenWrapped(s string) bool {
+	depth := 0
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			// A doubled quote is an escaped quote inside the literal.
+			if inQuote && i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				continue
+			}
+			inQuote = !inQuote
+			continue
+		}
+		if inQuote {
+			continue
+		}
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i < len(s)-1 {
+				return false
+			}
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}

--- a/internal/server/db/schema_default_filter_test.go
+++ b/internal/server/db/schema_default_filter_test.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"testing"
+
+	aschema "ariga.io/atlas/sql/schema"
+)
+
+func TestNormaliizeDefault(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"CURRENT_TIMESTAMP", "current_timestamp"},
+		{"(CURRENT_TIMESTAMP)", "current_timestamp"},
+		{"now()", "current_timestamp"},
+		{"(now())", "current_timestamp"},
+		{"NOW()", "current_timestamp"},
+		{"CURRENT_TIMESTAMP()", "current_timestamp"},
+		{"('2026-01-01')", "'2026-01-01'"},
+		{"(1 + 2)", "1 + 2"},
+		{"0", "0"},
+		{"(('nested'))", "'nested'"},
+		// Quoted literals must never be normalized into keywords.
+		{"'now()'", "'now()'"},
+		{"'CURRENT_TIMESTAMP'", "'CURRENT_TIMESTAMP'"},
+		{"'Pending'", "'Pending'"},
+		{"'pending'", "'pending'"},
+		// Parentheses inside quoted literals are ignored when unwrapping.
+		{"'('", "'('"},
+		{"('(')", "'('"},
+		{"(')')", "')'"},
+		{"'(('", "'(('"},
+		{"(('a''b'))", "'a''b'"},
+	}
+	for _, tt := range tests {
+		if got := normalizeDefault(tt.in); got != tt.want {
+			t.Errorf("normalizeDefault(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsEquivalentDefaultChange(t *testing.T) {
+	col := func(name, def string) *aschema.Column {
+		c := &aschema.Column{Name: name}
+		if def != "" {
+			c.Default = &aschema.RawExpr{X: def}
+		}
+		return c
+	}
+
+	tests := []struct {
+		name string
+		from *aschema.Column
+		to   *aschema.Column
+		want bool
+	}{
+		{
+			name: "paren difference IS equivalent",
+			from: col("created_at", "CURRENT_TIMESTAMP"),
+			to:   col("created_at", "(CURRENT_TIMESTAMP)"),
+			want: true,
+		},
+		{
+			name: "mysql now() IS equivalent to paren form",
+			from: col("created_at", "now()"),
+			to:   col("created_at", "(CURRENT_TIMESTAMP)"),
+			want: true,
+		},
+		{
+			name: "identical",
+			from: col("created_at", "CURRENT_TIMESTAMP"),
+			to:   col("created_at", "CURRENT_TIMESTAMP"),
+			want: true,
+		},
+		{
+			name: "real default change NOT equivalent",
+			from: col("status", "active"),
+			to:   col("status", "disabled"),
+			want: false,
+		},
+		{
+			name: "not both present NOT equivalent",
+			from: col("created_at", "CURRENT_TIMESTAMP"),
+			to:   col("created_at", ""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := &aschema.ModifyColumn{From: tt.from, To: tt.to, Change: aschema.ChangeDefault}
+			if got := isEquivalentDefaultChange(mc); got != tt.want {
+				t.Errorf("isEquivalentDefaultChange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterEquivalentDefaultChangesFrom(t *testing.T) {
+	col := func(name, def string) *aschema.Column {
+		c := &aschema.Column{Name: name}
+		if def != "" {
+			c.Default = &aschema.RawExpr{X: def}
+		}
+		return c
+	}
+	modifyTable := func(name string, changes ...aschema.Change) *aschema.ModifyTable {
+		mt := &aschema.ModifyTable{T: &aschema.Table{Name: name}}
+		mt.Changes = changes
+		return mt
+	}
+
+	changes := []aschema.Change{
+		&aschema.AddTable{T: &aschema.Table{Name: "brand_new"}},
+		modifyTable("only_default_paren_diff",
+			&aschema.ModifyColumn{From: col("created_at", "CURRENT_TIMESTAMP"), To: col("created_at", "(CURRENT_TIMESTAMP)"), Change: aschema.ChangeDefault},
+		),
+		modifyTable("real_change",
+			&aschema.ModifyColumn{From: col("status", "active"), To: col("status", "disabled"), Change: aschema.ChangeDefault},
+			&aschema.ModifyColumn{From: col("created_at", "CURRENT_TIMESTAMP"), To: col("created_at", "(CURRENT_TIMESTAMP)"), Change: aschema.ChangeDefault},
+		),
+	}
+
+	out := filterEquivalentDefaultChangesFrom(changes)
+	if len(out) != 2 {
+		t.Fatalf("got %d changes, want 2 (AddTable + real_change)", len(out))
+	}
+	// AddTable must pass through untouched.
+	if _, ok := out[0].(*aschema.AddTable); !ok {
+		t.Errorf("first change should be AddTable, got %T", out[0])
+	}
+	mt, ok := out[1].(*aschema.ModifyTable)
+	if !ok {
+		t.Fatalf("second change should be ModifyTable, got %T", out[1])
+	}
+	if mt.T.Name != "real_change" {
+		t.Errorf("got table %q, want real_change", mt.T.Name)
+	}
+	if len(mt.Changes) != 1 {
+		t.Errorf("real_change should keep exactly 1 inner change, got %d", len(mt.Changes))
+	}
+}


### PR DESCRIPTION
# fix: 默认值格式差异被误判,触发 SQLite 整表重建

> 关联 issue:[#2216](https://github.com/looplj/axonhub/issues/2216)

---

## 摘要

本 PR 修复 issue [#2216](https://github.com/looplj/axonhub/issues/2216)(`Fixes #2216`)。

该 issue 描述的问题:SQLite 数据库下,执行 GC(仅删除 `requests` 记录、保留 `usage_logs`)后重启 `./axonhub`,`requests` 表的 `sqlite_sequence.seq` 被重置为残余最大 id,导致新请求复用旧 request_id、与残留 `usage_logs.request_id` 冲突、数据显示错乱。

**根因不是 GC,也不是 seq 被"显式重置",而是 `created_at`/`updated_at` 的数据库默认值存在括号差异,导致启动自动迁移每次都对所有带时间戳的表执行整表重建,重建时按现存行 id 重算 seq。**

修复方式:在启动自动迁移的 diff 阶段过滤掉"仅括号/规范化不同"的默认值伪差异,消除不必要的整表重建——**不动 schema、不删数据库默认值、不做任何结构性变更**(尤其不影响 MySQL/PostgreSQL)。

---

## 现象

- SQLite 下,GC 删除 `requests` 全部/部分记录后,`requests` 表内 `MAX(id)` 变小,但 `sqlite_sequence.seq` 不随 DELETE 回落(SQLite 语义:seq 只增不减)。
- 重启 `./axonhub` 时,ent 自动迁移(`client.Schema.Create`)对 `requests` 表执行**整表重建**:
  `CREATE TABLE new_requests → INSERT INTO new_requests (含 id) SELECT ... FROM requests → DROP TABLE requests → ALTER TABLE new_requests RENAME TO requests`
- 重建时 `INSERT ... SELECT` 显式带上 id 列,SQLite 将 `sqlite_sequence.seq` 更新为**现存行的最大 id**(如 1)。
- 此后新请求从 `seq+1 = 2` 开始分配 id,一路复用 2..128 这些已被删除但 **`usage_logs` 中仍残留 request_id** 的旧 id → 数据串表、显示错乱。

> 重要澄清:重建**每 次 启动都在发生**,不只是 GC 后。未删数据时(seq == MAX(id)),重建后 seq 不变,用户观察不到;GC 制造了 `seq(128) != MAX(id)(1)` 的剪刀差后,重建才把 seq 拉低、才第一次暴露出问题。

---

## 根因(逐环)

1. **schema 定义**([internal/ent/schema/mixin.go:28,36](internal/ent/schema/mixin.go#L28-L36)、[user_role.go:47,57](internal/ent/schema/user_role.go#L47-L57)):
   `created_at`/`updated_at` 使用 `entsql.DefaultExpr("CURRENT_TIMESTAMP")` 声明数据库层默认值。
2. **ent 侧强制加括号**:ent 构造期望 schema 时([ent atlas.go:1011-1015](https://github.com/ent/ent/blob/v0.14.6/dialect/sql/schema/atlas.go#L1011-L1015)),对 `Expr` 类型默认值强制套括号:`CURRENT_TIMESTAMP` → `(CURRENT_TIMESTAMP)`。
3. **数据库侧无括号**:
   - SQLite:`PRAGMA table_xinfo` 的 `dflt_value` 返回 `CURRENT_TIMESTAMP`(无括号)。
   - MySQL:`INFORMATION_SCHEMA.COLUMNS.COLUMN_DEFAULT` 返回 `now()`(无括号、函数写法)。
   - PostgreSQL:`column_default` 返回 `CURRENT_TIMESTAMP`(无括号),但见第 5 点——PG 天生免疫。
4. **diff 判定**(分库行为不同):
   - SQLite、MySQL:`defaultChanged` 做**字符串比较**([sqlite/diff.go:110-123](https://github.com/ariga/atlas/blob/v0.38.0/sql/sqlite/diff.go#L110-L123)),`CURRENT_TIMESTAMP`(或 `now()`)≠ `(CURRENT_TIMESTAMP)` → 每次启动都对每张带时间戳的表判出 `ChangeDefault`。
   - PostgreSQL:atlas 在字符串不等后**走 `SELECT expr = expr` 语义比较**([diff_oss.go:126-148](https://github.com/ariga/atlas/blob/v0.38.0/sql/postgres/diff_oss.go#L126-L148)),`SELECT CURRENT_TIMESTAMP = (CURRENT_TIMESTAMP)` 为真 → **不判 ChangeDefault → PG 天生免疫**。
5. **SQLite 无法 ALTER 默认值 → 整表重建**:SQLite 不支持 `ALTER TABLE ... MODIFY COLUMN`,atlas 的 SQLite 实现将"要改默认值"升级为整表重建;重建按现存 id 重算 seq → 触发本 bug。
   - 对比:**MySQL 支持 ALTER 默认值,不重建表,不会出现本 bug**,但 MySQL 同样每次启动都会白跑 23 条 `ALTER TABLE ... MODIFY COLUMN`(实测证实,见下)。
   - PostgreSQL:本就无伪差异,无任何多余操作。本修复对 PG 是纯 no-op(完全无害)。

---

## 证据

### 实验 1:SQLite 重建触发条件(用户 DB 副本,4 场景对照)

| 场景 | 表内 MAX(id) | sqlite_sequence.seq | 迁移后 seq | 是否重建 |
|---|---|---|---|---|
| A: 插入 id=128 后删除 | 1 | 128 | 1 | ✅ |
| B: 仅 `UPDATE sqlite_sequence SET seq=128` | 1 | 128 | 1 | ✅ |
| C: 插入 128 删除 + seq 改回 1 | 1 | 1 | 1 | ❌ |
| D: 原样不动 | 1 | 1 | 1 | ❌ |

**触发条件 = `seq ≠ MAX(rowid)`。** Debug SQL 确认重建路径:`CREATE TABLE new_requests` → `INSERT INTO new_requests(...id...) SELECT ... FROM requests` → `DROP` → `RENAME`。

### 实验 2:diff 真凶(挂 `WithDiffHook`)

diff 输出(seq=1 与 seq=128 两场景**完全相同**):

```
ModifyColumn created_at -> created_at  Change=ChangeDefault
  fromDefault = CURRENT_TIMESTAMP      ← 数据库侧(无括号)
  toDefault   = (CURRENT_TIMESTAMP)    ← ent 期望(有括号)
```

**重建与 seq 无关,而是恒定的 ChangeDefault。** 影响面:所有带 `created_at/updated_at` 的表(约 25 张),每次启动都在重建。

### 实验 3:MySQL 实测(真实启动远程库,db.debug 日志)

- 每次启动执行 **23 条完全相同的 `ALTER TABLE ... MODIFY COLUMN ... DEFAULT (CURRENT_TIMESTAMP)`**,覆盖 requests/api_keys/channels 等所有带时间戳表。
- 无 `CREATE TABLE new_`/`DROP`/`RENAME`——不重建、不丢数据、不动 AUTO_INCREMENT。
- 直连查询 `INFORMATION_SCHEMA.COLUMNS`:`COLUMN_DEFAULT` 返回 `now()` → 与期望 `(CURRENT_TIMESTAMP)` 永远不等 → **每次启动重复执行、永不收敛**。

### 实验 4:修复后端到端验证(SQLite)

模拟 GC 后状态(seq=128,表内 MAX(id)=1),走生产入口 `db.NewEntClient` 执行迁移:

```
迁移前 seq=128 | 迁移后 seq=128 | requests MAX(id)=1
>>> PASS: seq 保留 128,未重建
```

修复后新请求从 129 分配,不再复用旧 id,issue 2216 根治。

---

## 修复方案

### 改动内容(共 3 个文件)

1. **新增 [internal/server/db/schema_default_filter.go](internal/server/db/schema_default_filter.go)**:一个 `schema.WithDiffHook` 迁移钩子,在 diff 后剔除满足以下条件的 `ModifyColumn`:
   - `Change` **仅含 `ChangeDefault`**(不含类型/可空/生成表达式等其他变化位);
   - 且 from/to 默认值经规范化(去外层括号、`now()`→`current_timestamp` 归一、大小写不敏感)后**字符串相等**。
   - 剔除后若某表内层 changes 为空,整表跳过。
2. **新增 [internal/server/db/schema_default_filter_test.go](internal/server/db/schema_default_filter_test.go)**:单元测试覆盖规范化、等价判断、整表过滤逻辑。
3. **修改 [internal/server/db/ent.go:74](internal/server/db/ent.go#L74)**:在 `client.Schema.Create(...)` 挂载 `filterEquivalentDefaultChanges()`。

### 为什么这是正确且最小的影响方式

- **保留 schema**:不删除 `entsql.DefaultExpr("CURRENT_TIMESTAMP")`,数据库层默认值兜底能力不受影响。
- **保留 DDL**:SQLite 的 `DEFAULT (CURRENT_TIMESTAMP)` 原样保留,不做结构变更。
- **不影响真实迁移**:只剔除"规范化后等价"的伪差异。真正的默认值变更(如改成 `'2026-01-01'`)规范化后不相等,照常触发迁移;任何非默认值的列变更(类型/可空/生成),`Change` 不只含 `ChangeDefault`,一律不过滤。
- **三数据库的影响矩阵**:
  - SQLite:不再整表重建 → seq 稳定 → request_id 不复用 → **issue 2216 根治**。
  - MySQL:不再每次启动白跑 23 条重复 `ALTER TABLE MODIFY COLUMN`。
  - PostgreSQL:本就无此伪差异(PG 用语义比较),hook 为纯 no-op,无任何影响。

### 安全边界(为什么不会"该重建时不重建")

过滤判定 = (`Change` 仅 `ChangeDefault`) **且** (规范化后相等)。只要默认值语义真的不同,规范化后不相等的,不会被过滤;列有其他变化(Change 带其他位),直接放行。逐场景:

| 场景 | 判定 | 结果 |
|---|---|---|
| `CURRENT_TIMESTAMP` vs `(CURRENT_TIMESTAMP)` | 规范化后相等 | 过滤(本次修复目标) |
| `now()` vs `(CURRENT_TIMESTAMP)`(MySQL) | 规范化后相等 | 过滤(本次修复目标) |
| `CURRENT_TIMESTAMP` vs `'2026-01-01'` | 规范化后不等 | **保留**,照常迁移 |
| 同时改类型 + 默认值 | Change 不只是 ChangeDefault | **保留**,照常迁移 |

---

## 验证清单

- [x] `go build ./...` 通过
- [x] `go test ./internal/server/db/` 通过(新增单元测试)
- [x] SQLite 端到端(生产入口 `db.NewEntClient`):GC 后 seq=128 保留,不再重建
- [x] SQLite 启动实测(修复后):日志无 `CREATE TABLE new_`/`DROP`/`RENAME`,服务正常启动
- [x] MySQL 启动实测(修复后):`MODIFY COLUMN` 0 条(修复前 23 条),无任何迁移 DDL 执行

## 附:源码参考位置

| 位置 | 说明 |
|---|---|
| [ent atlas.go:1011-1015](https://github.com/ent/ent/blob/v0.14.6/dialect/sql/schema/atlas.go#L1011-L1015) | `atDefault`:Expr 默认值强制包括号 |
| [atlas sqlite/diff.go:110-123](https://github.com/ariga/atlas/blob/v0.38.0/sql/sqlite/diff.go#L110-L123) | `defaultChanged`:字符串比较 |
| [atlas sqlite/inspect.go:666](https://github.com/ariga/atlas/blob/v0.38.0/sql/sqlite/inspect.go#L666) | SQLite `dflt_value`(无括号) |
| [internal/ent/schema/mixin.go:25-38](internal/ent/schema/mixin.go#L25-L38) | `entsql.DefaultExpr("CURRENT_TIMESTAMP")` |
| [internal/ent/schema/user_role.go:47,57](internal/ent/schema/user_role.go#L47-L57) | 同款默认值定义 |
| [internal/server/gc/gc.go](internal/server/gc/gc.go) | GC:批量删除 requests(触发场景) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migrations by ignoring harmless formatting differences in column defaults.
  * Prevented unnecessary changes for equivalent timestamp expressions, including parenthesized values and `now()` versus `CURRENT_TIMESTAMP`.
  * Preserved genuine default changes and other schema updates for more reliable migrations.

* **Tests**
  * Added coverage for default-value normalization and migration filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->