### PR TITLE
Add MiniMax image generation support

### DIFF
--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -102,6 +102,11 @@ var openAIChatOnlyDefaultEndpoints = []objects.ChannelEndpoint{
 	{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
 }
 
+var minimaxDefaultEndpoints = []objects.ChannelEndpoint{
+	{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
+	{APIFormat: llm.APIFormatOpenAIImageGeneration.String()},
+}
+
 // defaultEndpointsForChannelType defines the built-in default endpoints for
 // each channel type.
 //
@@ -177,7 +182,7 @@ var defaultEndpointsForChannelType = map[channel.Type][]objects.ChannelEndpoint{
 	channel.TypeVolcengineAnthropic: {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
 	channel.TypeLongcat:             {{APIFormat: llm.APIFormatOpenAIChatCompletion.String()}},
 	channel.TypeLongcatAnthropic:    {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
-	channel.TypeMinimax:             openAIChatOnlyDefaultEndpoints,
+	channel.TypeMinimax:             minimaxDefaultEndpoints,
 	channel.TypeMinimaxAnthropic:    {{APIFormat: llm.APIFormatAnthropicMessage.String()}},
 	channel.TypeAihubmix:            openAICompatibleDefaultEndpoints,
 	channel.TypeAihubmixAnthropic:   {{APIFormat: llm.APIFormatAnthropicMessage.String()}},

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -92,9 +92,12 @@ func TestDefaultEndpointsForChannelType_UseLLMAPIFormatValues(t *testing.T) {
 			expected: []string{llm.APIFormatOpenAIChatCompletion.String()},
 		},
 		{
-			name:     "minimax exposes chat only",
-			typ:      channel.TypeMinimax,
-			expected: []string{llm.APIFormatOpenAIChatCompletion.String()},
+			name: "minimax exposes chat and image generation",
+			typ:  channel.TypeMinimax,
+			expected: []string{
+				llm.APIFormatOpenAIChatCompletion.String(),
+				llm.APIFormatOpenAIImageGeneration.String(),
+			},
 		},
 		{
 			name:     "xiaomi exposes chat only",

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -32,6 +32,7 @@ import (
 	geminioai "github.com/looplj/axonhub/llm/transformer/gemini/openai"
 	"github.com/looplj/axonhub/llm/transformer/jina"
 	"github.com/looplj/axonhub/llm/transformer/longcat"
+	"github.com/looplj/axonhub/llm/transformer/minimax"
 	"github.com/looplj/axonhub/llm/transformer/modelscope"
 	"github.com/looplj/axonhub/llm/transformer/moonshot"
 	"github.com/looplj/axonhub/llm/transformer/nanogpt"
@@ -414,6 +415,13 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 		llm.APIFormatOpenAISpeech.String(),
 		llm.APIFormatOpenAITranscription.String(),
 		llm.APIFormatOpenAITranslation.String():
+		if c.Type == channel.TypeMinimax && ep.APIFormat == llm.APIFormatOpenAIImageGeneration.String() {
+			return minimax.NewOutboundTransformerWithConfig(&minimax.Config{
+				BaseURL:        baseURL,
+				EndpointPath:   ep.Path,
+				APIKeyProvider: apiKeyProvider(),
+			})
+		}
 		if (c.Type == channel.TypeCodex || c.Type == channel.TypeFenno) &&
 			(ep.APIFormat == llm.APIFormatOpenAIImageGeneration.String() ||
 				ep.APIFormat == llm.APIFormatOpenAIImageEdit.String()) {
@@ -1036,7 +1044,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel, apiKeyOve
 		})
 
 		return ch, nil
-	case channel.TypeOpenai, channel.TypeAtlascloud, channel.TypeDeepinfra, channel.TypeQiniu, channel.TypeMinimax,
+	case channel.TypeOpenai, channel.TypeAtlascloud, channel.TypeDeepinfra, channel.TypeQiniu,
 		channel.TypePpio, channel.TypeSiliconflow,
 		channel.TypeVercel, channel.TypeAihubmix, channel.TypeBurncloud, channel.TypeGithub,
 		channel.TypeEvolink, channel.TypeGroq:
@@ -1056,6 +1064,16 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel, apiKeyOve
 
 		ch.Outbound = transformer
 
+		return ch, nil
+	case channel.TypeMinimax:
+		transformer, err := minimax.NewOutboundTransformerWithConfig(&minimax.Config{
+			BaseURL:        c.BaseURL,
+			APIKeyProvider: getAPIKeyProvider(ch),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create MiniMax outbound transformer: %w", err)
+		}
+		ch.Outbound = transformer
 		return ch, nil
 	case channel.TypeOpenaiResponses:
 		transformer, err := responses.NewOutboundTransformerWithConfig(&responses.Config{

--- a/llm/image.go
+++ b/llm/image.go
@@ -1,5 +1,7 @@
 package llm
 
+import "encoding/json"
+
 // ImageRequest is the unified image request structure (similar to EmbeddingRequest).
 // Note: Common fields like Model are in the parent Request struct, not here.
 type ImageRequest struct {
@@ -47,6 +49,17 @@ type ImageRequest struct {
 
 	// Style is the style for DALL-E 3 (vivid or natural).
 	Style string `json:"style,omitempty"`
+
+	// SubjectReference contains provider-specific reference image descriptors.
+	SubjectReference json.RawMessage `json:"subject_reference,omitempty"`
+
+	// AspectRatio, Width and Height control provider-specific image dimensions.
+	AspectRatio string `json:"aspect_ratio,omitempty"`
+	Width       *int64 `json:"width,omitempty"`
+	Height      *int64 `json:"height,omitempty"`
+
+	// PromptOptimizer enables provider prompt optimization when supported.
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"`
 }
 
 // ImageResponse represents the unified image response model.

--- a/llm/transformer/minimax/outbound.go
+++ b/llm/transformer/minimax/outbound.go
@@ -1,0 +1,159 @@
+// Package minimax implements MiniMax's OpenAI-compatible chat and image APIs.
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/auth"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+)
+
+// Config configures the MiniMax outbound transformer.
+type Config struct {
+	BaseURL        string              `json:"base_url,omitempty"`
+	EndpointPath   string              `json:"endpoint_path,omitempty"`
+	APIKeyProvider auth.APIKeyProvider `json:"-"`
+}
+
+// OutboundTransformer handles chat through OpenAI compatibility and MiniMax image generation.
+type OutboundTransformer struct {
+	transformer.Outbound
+	baseURL      string
+	endpointPath string
+	apiKeys      auth.APIKeyProvider
+}
+
+func NewOutboundTransformer(baseURL, apiKey string) (transformer.Outbound, error) {
+	return NewOutboundTransformerWithConfig(&Config{BaseURL: baseURL, APIKeyProvider: auth.NewStaticKeyProvider(apiKey)})
+}
+
+func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, error) {
+	if config == nil || strings.TrimSpace(config.BaseURL) == "" {
+		return nil, fmt.Errorf("base URL is required for MiniMax transformer")
+	}
+	if config.APIKeyProvider == nil {
+		return nil, fmt.Errorf("API key provider is required for MiniMax transformer")
+	}
+	oai, err := openai.NewOutboundTransformerWithConfig(&openai.Config{
+		PlatformType:   openai.PlatformOpenAI,
+		BaseURL:        config.BaseURL,
+		APIKeyProvider: config.APIKeyProvider,
+		ReasoningField: openai.ReasoningFieldContent,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid MiniMax transformer configuration: %w", err)
+	}
+	return &OutboundTransformer{Outbound: oai, baseURL: transformer.NormalizeBaseURL(config.BaseURL, "v1"), endpointPath: config.EndpointPath, apiKeys: config.APIKeyProvider}, nil
+}
+
+func (t *OutboundTransformer) TransformRequest(ctx context.Context, req *llm.Request) (*httpclient.Request, error) {
+	if req != nil && req.RequestType == llm.RequestTypeImage {
+		return t.buildImageRequest(ctx, req)
+	}
+	return t.Outbound.TransformRequest(ctx, req)
+}
+
+func (t *OutboundTransformer) buildImageRequest(ctx context.Context, req *llm.Request) (*httpclient.Request, error) {
+	if req.Image == nil {
+		return nil, fmt.Errorf("%w: image request is required", transformer.ErrInvalidRequest)
+	}
+	if strings.TrimSpace(req.Image.Prompt) == "" {
+		return nil, fmt.Errorf("%w: prompt is required for image generation", transformer.ErrInvalidRequest)
+	}
+	body := map[string]any{"model": req.Model, "prompt": req.Image.Prompt}
+	if len(req.Image.SubjectReference) > 0 {
+		var refs any
+		if err := json.Unmarshal(req.Image.SubjectReference, &refs); err != nil {
+			return nil, fmt.Errorf("%w: invalid subject_reference: %v", transformer.ErrInvalidRequest, err)
+		}
+		body["subject_reference"] = refs
+	}
+	if req.Image.AspectRatio != "" {
+		body["aspect_ratio"] = req.Image.AspectRatio
+	}
+	if req.Image.Width != nil {
+		body["width"] = *req.Image.Width
+	}
+	if req.Image.Height != nil {
+		body["height"] = *req.Image.Height
+	}
+	if req.Seed != nil {
+		body["seed"] = *req.Seed
+	}
+	if req.Image.N != nil {
+		body["n"] = *req.Image.N
+	}
+	if req.Image.PromptOptimizer != nil {
+		body["prompt_optimizer"] = *req.Image.PromptOptimizer
+	}
+	if req.Image.ResponseFormat != "" {
+		body["response_format"] = req.Image.ResponseFormat
+	}
+	if _, ok := body["response_format"]; !ok {
+		body["response_format"] = "url"
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal MiniMax image request: %w", err)
+	}
+	path := t.endpointPath
+	if path == "" {
+		path = "/image_generation"
+	}
+	url := t.baseURL + path
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+	h.Set("Accept", "application/json")
+	return &httpclient.Request{
+		Method: http.MethodPost, URL: url, Headers: h, Body: raw,
+		Auth:        &httpclient.AuthConfig{Type: "bearer", APIKey: t.apiKeys.Get(ctx)},
+		RequestType: llm.RequestTypeImage.String(), APIFormat: llm.APIFormatOpenAIImageGeneration.String(),
+		TransformerMetadata: map[string]any{"model": req.Model},
+	}, nil
+}
+
+func (t *OutboundTransformer) TransformResponse(ctx context.Context, resp *httpclient.Response) (*llm.Response, error) {
+	if resp == nil || resp.Request == nil || resp.Request.RequestType != llm.RequestTypeImage.String() {
+		return t.Outbound.TransformResponse(ctx, resp)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("MiniMax image API returned HTTP %d", resp.StatusCode)
+	}
+	var payload struct {
+		Created int64 `json:"created"`
+		Data    struct {
+			ImageURLs   []string `json:"image_urls"`
+			ImageBase64 []string `json:"image_base64"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to decode MiniMax image response: %w", err)
+	}
+	created := payload.Created
+	if created == 0 {
+		created = time.Now().Unix()
+	}
+	model := "image-01"
+	if m, ok := resp.Request.TransformerMetadata["model"].(string); ok && m != "" {
+		model = m
+	}
+	data := make([]llm.ImageData, 0, len(payload.Data.ImageURLs)+len(payload.Data.ImageBase64))
+	for _, url := range payload.Data.ImageURLs {
+		data = append(data, llm.ImageData{URL: url})
+	}
+	for _, b64 := range payload.Data.ImageBase64 {
+		data = append(data, llm.ImageData{B64JSON: b64})
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("%w: MiniMax image response contained no images", transformer.ErrInvalidResponse)
+	}
+	return &llm.Response{ID: fmt.Sprintf("minimax-img-%d", created), Object: "image.generation", Created: created, Model: model, RequestType: llm.RequestTypeImage, APIFormat: llm.APIFormatOpenAIImageGeneration, Image: &llm.ImageResponse{Created: created, Data: data}}, nil
+}

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -69,6 +69,13 @@ type ImageGenerationRequest struct {
 	PartialImages     *int64          `json:"partial_images,omitempty"`
 	Stream            bool            `json:"stream,omitempty"`
 	Image             json.RawMessage `json:"image,omitempty"`
+	// Provider-specific image generation controls accepted by MiniMax.
+	SubjectReference json.RawMessage `json:"subject_reference,omitempty"`
+	AspectRatio      string          `json:"aspect_ratio,omitempty"`
+	Width            *int64          `json:"width,omitempty"`
+	Height           *int64          `json:"height,omitempty"`
+	Seed             *int64          `json:"seed,omitempty"`
+	PromptOptimizer  *bool           `json:"prompt_optimizer,omitempty"`
 }
 
 type ImageInboundTransformer struct {
@@ -243,6 +250,12 @@ func (t *ImageInboundTransformer) transformGenerationRequest(httpReq *httpclient
 		Moderation:        genReq.Moderation,
 		PartialImages:     genReq.PartialImages,
 		Style:             genReq.Style,
+		SubjectReference:  genReq.SubjectReference,
+		AspectRatio:       genReq.AspectRatio,
+		Width:             genReq.Width,
+		Height:            genReq.Height,
+		Seed:              genReq.Seed,
+		PromptOptimizer:   genReq.PromptOptimizer,
 	}
 
 	llmReq := &llm.Request{

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -254,12 +254,12 @@ func (t *ImageInboundTransformer) transformGenerationRequest(httpReq *httpclient
 		AspectRatio:       genReq.AspectRatio,
 		Width:             genReq.Width,
 		Height:            genReq.Height,
-		Seed:              genReq.Seed,
 		PromptOptimizer:   genReq.PromptOptimizer,
 	}
 
 	llmReq := &llm.Request{
 		Model:       model,
+		Seed:        genReq.Seed,
 		Modalities:  []string{"image"},
 		Stream:      lo.ToPtr(false),
 		RawRequest:  httpReq,


### PR DESCRIPTION
Reason: Add MiniMax image generation support to the image endpoint.

Added MiniMax image-generation request and response handling for global and China endpoints, including image models, prompt options, dimensions, subject references, URL or base64 output, and bearer authentication. Registered image generation as a MiniMax channel endpoint while preserving OpenAI-compatible chat behavior.

Checks: `go test ./llm/transformer/minimax ./llm/transformer/openai ./internal/server/biz` (dependency download in progress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax support for OpenAI-compatible chat completions.
  * Added MiniMax image generation with image URL and Base64 responses.
  * Added image-generation options for subject references, aspect ratios, custom dimensions, seeds, and prompt optimization.
  * MiniMax endpoints are selected automatically for chat and image-generation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->