### PR TITLE
feat(frontend): add 100-row pagination option

### DIFF
--- a/frontend/src/components/data-table-pagination.tsx
+++ b/frontend/src/components/data-table-pagination.tsx
@@ -35,7 +35,7 @@ export function DataTablePagination<TData>({ table }: DataTablePaginationProps<T
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side='top'>
-              {[10, 20, 30, 40, 50].map((pageSize) => (
+              {[10, 20, 30, 40, 50, 100].map((pageSize) => (
                 <SelectItem key={pageSize} value={`${pageSize}`}>
                   {pageSize}
                 </SelectItem>

--- a/frontend/src/components/server-side-pagination.tsx
+++ b/frontend/src/components/server-side-pagination.tsx
@@ -57,7 +57,7 @@ export function ServerSidePagination({
               <SelectValue placeholder={pageSize} />
             </SelectTrigger>
             <SelectContent side='top'>
-              {[10, 20, 30, 40, 50].map((size) => (
+              {[10, 20, 30, 40, 50, 100].map((size) => (
                 <SelectItem key={size} value={`${size}`}>
                   {size}
                 </SelectItem>


### PR DESCRIPTION
## Summary

- Add 100 to the page-size menu in both shared frontend pagination components.
- Keep the two menus ordered consistently as [10, 20, 30, 40, 50, 100].

## Motivation

The shared pagination menus currently stop at 50 rows, even though the existing GraphQL pagination limit already supports larger requests. Adding a 100-row option lets users inspect larger tables without changing backend behavior.

## Affected pages

The server-side shared paginator is used by:

- Project pages: Requests, API Keys, Traces, Threads, thread-detail traces, Prompts, Project Users, and Project Roles.
- System pages: Channels, API Keys, Users, Roles, Projects, Data Storages, and Prompt Protection Rules.

The shared client-side DataTablePagination option list is kept in sync for its feature wrappers as well.

## Tests

- git diff --check
- Focused source assertion confirming both shared pagination components contain exactly [10, 20, 30, 40, 50, 100], with the old option list absent.
- Changed-file whitelist confirming only the two shared pagination components changed.

Full frontend lint/build was not run, per repository instructions for this focused change.

## Compatibility and scope

- This is an additive UI-only option.
- No 500 option was added.
- The backend pagination limit remains unchanged at 1000.
- No query strategy, request payload, virtualization, clipboard, or channel-ordering behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 100-rows-per-page option to data table pagination.
  - Added the same option to server-side pagination controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->