### PR TITLE
fix(frontend): support clipboard copy on insecure HTTP origins

### DIFF
--- a/frontend/src/components/ai-elements/code-block.tsx
+++ b/frontend/src/components/ai-elements/code-block.tsx
@@ -4,6 +4,7 @@ import { type ComponentProps, createContext, type HTMLAttributes, useContext, us
 import type { Element } from 'hast';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import { type BundledLanguage, codeToHtml, type ShikiTransformer } from 'shiki';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
@@ -103,13 +104,8 @@ export const CodeBlockCopyButton = ({ onCopy, onError, timeout = 2000, children,
   const { code } = useContext(CodeBlockContext);
 
   const copyToClipboard = async () => {
-    if (typeof window === 'undefined' || !navigator?.clipboard?.writeText) {
-      onError?.(new Error('Clipboard API not available'));
-      return;
-    }
-
     try {
-      await navigator.clipboard.writeText(code);
+      await copyTextToClipboard(code);
       setIsCopied(true);
       onCopy?.();
       setTimeout(() => setIsCopied(false), timeout);

--- a/frontend/src/components/ai-elements/masked-code-block.tsx
+++ b/frontend/src/components/ai-elements/masked-code-block.tsx
@@ -4,6 +4,7 @@ import { type ComponentProps, createContext, type HTMLAttributes, useContext, us
 import type { Element } from 'hast';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import { type BundledLanguage, codeToHtml, type ShikiTransformer } from 'shiki';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
@@ -126,13 +127,8 @@ export const MaskedCodeBlockCopyButton = ({ onCopy, onError, timeout = 2000, chi
   const { realCode } = useContext(MaskedCodeBlockContext);
 
   const copyToClipboard = async () => {
-    if (typeof window === 'undefined' || !navigator?.clipboard?.writeText) {
-      onError?.(new Error('Clipboard API not available'));
-      return;
-    }
-
     try {
-      await navigator.clipboard.writeText(realCode);
+      await copyTextToClipboard(realCode);
       setIsCopied(true);
       onCopy?.();
       setTimeout(() => setIsCopied(false), timeout);

--- a/frontend/src/components/json-tree-view.tsx
+++ b/frontend/src/components/json-tree-view.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { ChevronRight, ChevronDown, Copy, Check, MoreHorizontal, ChevronUp } from 'lucide-react';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -90,11 +91,15 @@ function JsonNode({ name, data, parentData, isRoot = false, isArrayItem = false,
 
   const handleToggle = () => setIsExpanded((v) => !v);
 
-  const copyToClipboard = (e: React.MouseEvent) => {
+  const copyToClipboard = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-    setIsCopied(true);
-    setTimeout(() => setIsCopied(false), 2000);
+    try {
+      await copyTextToClipboard(JSON.stringify(data, null, 2));
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy JSON:', error);
+    }
   };
 
   const dataType = data === null ? 'null' : Array.isArray(data) ? 'array' : typeof data;

--- a/frontend/src/features/apikeys/components/apikeys-columns.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-columns.tsx
@@ -2,8 +2,8 @@ import { format } from 'date-fns';
 import { ColumnDef, Table, Row } from '@tanstack/react-table';
 import { Copy, Eye, Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import { cn, extractNumberID, formatUserName } from '@/lib/utils';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { DataTableColumnHeader } from '@/components/data-table-column-header';
@@ -19,10 +19,10 @@ function ApiKeyCell({ apiKey, fullApiKey }: { apiKey: string; fullApiKey: ApiKey
   // Keep the masked value compact so the identifying suffix is never clipped by the table cell.
   const maskedKey = apiKey.length > 4 ? `${'•'.repeat(8)}${apiKey.slice(-4)}` : '•'.repeat(apiKey.length);
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(apiKey);
-    toast.success(t('apikeys.messages.copied'));
-  };
+  const { handleCopy: copyToClipboard } = useCopyToClipboard({
+    text: apiKey,
+    copyMessage: t('apikeys.messages.copied'),
+  });
 
   const handleViewKey = () => {
     openDialog('view', fullApiKey);

--- a/frontend/src/features/apikeys/components/apikeys-rotate-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-rotate-dialog.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Copy, RefreshCw, AlertTriangle, CheckIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
@@ -12,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useApiKeysContext } from '../context/apikeys-context';
 import { useRotateApiKey } from '../data/apikeys';
 
@@ -20,7 +20,10 @@ export function ApiKeysRotateDialog() {
   const { isDialogOpen, closeDialog, selectedApiKey, setSelectedApiKey } = useApiKeysContext();
   const rotateApiKey = useRotateApiKey();
   const [newKey, setNewKey] = useState<string | null>(null);
-  const [isCopied, setIsCopied] = useState(false);
+  const { isCopied, handleCopy } = useCopyToClipboard({
+    text: newKey ?? '',
+    copyMessage: t('apikeys.messages.copied'),
+  });
 
   const handleRotate = async () => {
     if (!selectedApiKey) return;
@@ -32,15 +35,6 @@ export function ApiKeysRotateDialog() {
       setSelectedApiKey({ ...selectedApiKey, key: result.key });
     } catch {
       // Error is handled by the mutation
-    }
-  };
-
-  const handleCopy = async () => {
-    if (newKey) {
-      await navigator.clipboard.writeText(newKey);
-      setIsCopied(true);
-      toast.success(t('apikeys.messages.copied'));
-      setTimeout(() => setIsCopied(false), 2000);
     }
   };
 

--- a/frontend/src/features/apikeys/components/apikeys-view-dialog.tsx
+++ b/frontend/src/features/apikeys/components/apikeys-view-dialog.tsx
@@ -1,25 +1,21 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Copy, Eye, EyeOff, AlertTriangle, Link, CheckIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { MaskedCodeBlock, MaskedCodeBlockCopyButton, highlightMaskedCode } from '@/components/ai-elements/masked-code-block';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useApiKeysContext } from '../context/apikeys-context';
 
 function CopyBaseUrlButton({ baseUrl }: { baseUrl: string }) {
   const { t } = useTranslation();
-  const [isCopied, setIsCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(baseUrl);
-    setIsCopied(true);
-    toast.success(t('apikeys.messages.baseUrlCopied'));
-    setTimeout(() => setIsCopied(false), 2000);
-  };
+  const { isCopied, handleCopy } = useCopyToClipboard({
+    text: baseUrl,
+    copyMessage: t('apikeys.messages.baseUrlCopied'),
+  });
 
   return (
     <Tooltip>
@@ -38,6 +34,10 @@ export function ApiKeysViewDialog() {
   const { isDialogOpen, closeDialog, selectedApiKey } = useApiKeysContext();
   const [isVisible, setIsVisible] = useState(false);
   const [preRenderedCode, setPreRenderedCode] = useState<Record<string, { light: string; dark: string }>>({});
+  const { handleCopy: copyApiKey } = useCopyToClipboard({
+    text: selectedApiKey?.key ?? '',
+    copyMessage: t('apikeys.messages.copied'),
+  });
 
   const apiKey = selectedApiKey?.key || '';
   const maskedApiKey = selectedApiKey?.key ? selectedApiKey.key.slice(0, 3) + '...' + selectedApiKey.key.slice(-4) : '';
@@ -245,13 +245,6 @@ print(response.text)`
     renderAllCodeBlocks();
   }, [selectedApiKey?.key, codeExamples]);
 
-  const copyToClipboard = () => {
-    if (selectedApiKey?.key) {
-      navigator.clipboard.writeText(selectedApiKey.key);
-      toast.success(t('apikeys.messages.copied'));
-    }
-  };
-
   const maskedKey = selectedApiKey?.key ? selectedApiKey.key.replace(/./g, '*').slice(0, -4) + selectedApiKey.key.slice(-4) : '';
 
   return (
@@ -282,7 +275,7 @@ print(response.text)`
               <Button variant='outline' size='sm' onClick={() => setIsVisible(!isVisible)} className='flex-shrink-0'>
                 {isVisible ? <EyeOff className='h-4 w-4' /> : <Eye className='h-4 w-4' />}
               </Button>
-              <Button variant='outline' size='sm' onClick={copyToClipboard} className='flex-shrink-0'>
+              <Button variant='outline' size='sm' onClick={copyApiKey} className='flex-shrink-0'>
                 <Copy className='h-4 w-4' />
               </Button>
             </div>

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -8,6 +8,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { X, RefreshCw, Search, ChevronLeft, ChevronRight, PanelLeft, Plus, Trash2, Eye, EyeOff, Copy, Play, Info, Ban } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { useHorizontalScroll } from '@/hooks/use-horizontal-scroll';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -2363,11 +2364,15 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                           variant='ghost'
                                           size='sm'
                                           className='h-7 w-7 p-0'
-                                          onClick={() => {
+                                          onClick={async () => {
                                             const keys = field.value || [];
                                             if (keys.length > 0) {
-                                              navigator.clipboard.writeText(keys.join('\n'));
-                                              toast.success(t('channels.messages.credentialsCopied'));
+                                              try {
+                                                await copyTextToClipboard(keys.join('\n'));
+                                                toast.success(t('channels.messages.credentialsCopied'));
+                                              } catch {
+                                                toast.error(t('common.errors.copyFailed'));
+                                              }
                                             }
                                           }}
                                         >

--- a/frontend/src/features/channels/components/channels-api-key-management-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-api-key-management-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -436,7 +437,7 @@ export function ChannelsAPIKeyManagementDialog({ open, onOpenChange }: ChannelsA
                       const result = getKeyResult(key);
                       const handleCopy = async () => {
                         try {
-                          await navigator.clipboard.writeText(key);
+                          await copyTextToClipboard(key);
                           toast.success(t('channels.dialogs.keyManagement.copySuccess'));
                         } catch {
                           toast.error(t('common.errors.copyFailed'));

--- a/frontend/src/features/channels/components/channels-test-history-drawer.tsx
+++ b/frontend/src/features/channels/components/channels-test-history-drawer.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberID } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -77,13 +78,20 @@ export function ChannelsTestHistoryDrawer({ open, onOpenChange, channel }: Props
     enabled: open && !!selectedRequestId,
   });
 
-  const copyBody = (data: any) => {
+  const copyBody = async (data: any) => {
+    let text: string;
     try {
-      navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+      text = JSON.stringify(data, null, 2);
     } catch {
-      navigator.clipboard.writeText(String(data));
+      text = String(data);
     }
-    toast.success(t('requests.actions.copy'));
+
+    try {
+      await copyTextToClipboard(text);
+      toast.success(t('requests.actions.copy'));
+    } catch {
+      toast.error(t('common.errors.copyFailed'));
+    }
   };
 
   const handleCurlPreview = () => {

--- a/frontend/src/features/channels/components/copilot-device-flow.tsx
+++ b/frontend/src/features/channels/components/copilot-device-flow.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { Copy, ExternalLink, Loader2, CheckCircle2, AlertCircle, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { Button } from '@/components/ui/button';
 import { FormLabel } from '@/components/ui/form';
 import { useDeviceFlow } from '../hooks/use-device-flow';
@@ -39,6 +40,17 @@ export function CopilotDeviceFlow({ onSuccess, onError, existingCredentials }: C
   const handleReconnect = () => {
     deviceFlow.reset();
     deviceFlow.start();
+  };
+
+  const handleCopyUserCode = async () => {
+    if (!deviceFlow.userCode) return;
+
+    try {
+      await copyTextToClipboard(deviceFlow.userCode);
+      toast.success(t('channels.messages.credentialsCopied'));
+    } catch {
+      toast.error(t('common.errors.copyFailed'));
+    }
   };
 
   // Show already authenticated state
@@ -139,12 +151,7 @@ export function CopilotDeviceFlow({ onSuccess, onError, existingCredentials }: C
 
               <Button
                 type='button'
-                onClick={() => {
-                  if (deviceFlow.userCode) {
-                    navigator.clipboard.writeText(deviceFlow.userCode);
-                    toast.success(t('channels.messages.credentialsCopied'));
-                  }
-                }}
+                onClick={handleCopyUserCode}
                 variant='outline'
                 size='icon'
                 title={t('copilot_device.copy_code')}

--- a/frontend/src/features/playground/index.tsx
+++ b/frontend/src/features/playground/index.tsx
@@ -25,6 +25,7 @@ import { AutoCompleteSelect } from '@/components/auto-complete-select';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { useQueryModels } from '@/features/models/data/models';
 import { usePermissions } from '@/hooks/usePermissions';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
 
 type PlaygroundModelSource = 'channel' | 'model_gateway';
@@ -515,7 +516,16 @@ export default function Playground() {
                                 <Action onClick={() => regenerate()} label={t('playground.chat.retry')}>
                                   <RefreshCcw className='size-3' />
                                 </Action>
-                                <Action onClick={() => navigator.clipboard.writeText(textContent)} label={t('copy')}>
+                                <Action
+                                  onClick={async () => {
+                                    try {
+                                      await copyTextToClipboard(textContent);
+                                    } catch {
+                                      toast.error(t('common.errors.copyFailed'));
+                                    }
+                                  }}
+                                  label={t('copy')}
+                                >
                                   <Copy className='size-3' />
                                 </Action>
                               </Actions>

--- a/frontend/src/features/proejct-users/components/users-invite-dialog.tsx
+++ b/frontend/src/features/proejct-users/components/users-invite-dialog.tsx
@@ -6,6 +6,7 @@ import { IconCheck, IconCopy, IconMailPlus } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { apiRequest } from '@/lib/api-client';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberIDAsNumber } from '@/lib/utils';
 import { useSelectedProjectId } from '@/stores/projectStore';
 import { useRoles } from '@/features/project-roles/data/roles';
@@ -85,7 +86,7 @@ export function UsersInviteDialog({ open, onOpenChange }: Props) {
 
   const copyInviteLink = async () => {
     try {
-      await navigator.clipboard.writeText(inviteLink);
+      await copyTextToClipboard(inviteLink);
       setIsCopied(true);
       toast.success(t('users.messages.invitationCopied'));
     } catch {

--- a/frontend/src/features/requests/components/chunk-item.tsx
+++ b/frontend/src/features/requests/components/chunk-item.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Copy, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { JsonViewer } from '@/components/json-tree-view';
 import { Button } from '@/components/ui/button';
 
@@ -23,11 +24,15 @@ export function ChunkItem({ chunk, index }: ChunkItemProps) {
     }
   };
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(formatJson(chunk));
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-    toast.success(t('requests.actions.copy'));
+  const copyToClipboard = async () => {
+    try {
+      await copyTextToClipboard(formatJson(chunk));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast.success(t('requests.actions.copy'));
+    } catch {
+      toast.error(t('common.errors.copyFailed'));
+    }
   };
 
   const downloadChunk = () => {

--- a/frontend/src/features/requests/components/chunks-dialog.tsx
+++ b/frontend/src/features/requests/components/chunks-dialog.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from '@radix-ui/react-icons';
 import { Layers, Copy, Check, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -35,7 +36,7 @@ export function ChunksDialog({ open, onOpenChange, chunks, title, isLive }: Chun
 
   const handleCopyAll = async () => {
     try {
-      await navigator.clipboard.writeText(JSON.stringify(chunks, null, 2));
+      await copyTextToClipboard(JSON.stringify(chunks, null, 2));
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {

--- a/frontend/src/features/requests/components/curl-preview-dialog.tsx
+++ b/frontend/src/features/requests/components/curl-preview-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Terminal, Copy, Check, CopyX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -19,7 +20,7 @@ export function CurlPreviewDialog({ open, onOpenChange, curlCommand, title }: Cu
 
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(curlCommand);
+      await copyTextToClipboard(curlCommand);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -37,7 +38,7 @@ export function CurlPreviewDialog({ open, onOpenChange, curlCommand, title }: Cu
       // 3. 清理对象开头多余的逗号: { , "a": 1} -> {"a": 1}
       modified = modified.replace(/{\s*,/g, '{');
       
-      await navigator.clipboard.writeText(modified);
+      await copyTextToClipboard(modified);
       setNonStreamCopied(true);
       setTimeout(() => setNonStreamCopied(false), 2000);
     } catch (err) {

--- a/frontend/src/features/requests/components/request-body-drawer.tsx
+++ b/frontend/src/features/requests/components/request-body-drawer.tsx
@@ -14,6 +14,7 @@ import {
   Terminal,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberID, cn } from '@/lib/utils';
 import { usePaginationSearch } from '@/hooks/use-pagination-search';
 import { useSelectedProjectId } from '@/stores/projectStore';
@@ -152,13 +153,20 @@ export function RequestBodyDrawer({
   const [curlCommand, setCurlCommand] = useState('');
 
   const copyBody = useCallback(
-    (data: any) => {
+    async (data: any) => {
+      let text: string;
       try {
-        navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+        text = JSON.stringify(data, null, 2);
       } catch {
-        navigator.clipboard.writeText(String(data));
+        text = String(data);
       }
-      toast.success(t('requests.actions.copy'));
+
+      try {
+        await copyTextToClipboard(text);
+        toast.success(t('requests.actions.copy'));
+      } catch {
+        toast.error(t('common.errors.copyFailed'));
+      }
     },
     [t]
   );

--- a/frontend/src/features/requests/components/request-detail-content.tsx
+++ b/frontend/src/features/requests/components/request-detail-content.tsx
@@ -5,6 +5,7 @@ import { zhCN, enUS } from 'date-fns/locale';
 import { Copy, Clock, Key, Database, FileText, Layers, Download, Terminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberID } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -119,9 +120,13 @@ export function RequestDetailContent({ requestId, projectId, previewRequest, isP
     return result.trim();
   }, [request, parsedResponse]);
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    toast.success(t('requests.actions.copy'));
+  const copyToClipboard = async (text: string) => {
+    try {
+      await copyTextToClipboard(text);
+      toast.success(t('requests.actions.copy'));
+    } catch {
+      toast.error(t('common.errors.copyFailed'));
+    }
   };
 
   const downloadFile = (content: string, filename: string) => {

--- a/frontend/src/features/requests/components/request-detail-global-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-global-page.tsx
@@ -3,6 +3,7 @@ import { useParams, useRouter } from '@tanstack/react-router';
 import { ArrowLeft, Copy, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberID } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -20,8 +21,7 @@ export default function RequestDetailGlobalPage() {
 
   const copyRequestID = async () => {
     try {
-      if (!navigator.clipboard) throw new Error('Clipboard unavailable');
-      await navigator.clipboard.writeText(request?.id ?? requestId);
+      await copyTextToClipboard(request?.id ?? requestId);
       toast.success(t('requests.actions.copied'));
     } catch {
       toast.error(t('common.errors.copyFailed'));

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { getTokenFromStorage } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { extractNumberID } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -350,8 +351,7 @@ export default function RequestDetailPage() {
 
   const copyRequestID = async () => {
     try {
-      if (!navigator.clipboard) throw new Error('Clipboard unavailable');
-      await navigator.clipboard.writeText(request?.id ?? requestId);
+      await copyTextToClipboard(request?.id ?? requestId);
       toast.success(t('requests.actions.copied'));
     } catch {
       toast.error(t('common.errors.copyFailed'));

--- a/frontend/src/features/requests/components/response-flow.tsx
+++ b/frontend/src/features/requests/components/response-flow.tsx
@@ -7,6 +7,7 @@ import { Message, MessageContent } from '@/components/ai-elements/message';
 import { Tool, ToolHeader, ToolContent } from '@/components/ai-elements/tool';
 import { CodeBlock } from '@/components/ai-elements/code-block';
 import { Badge } from '@/components/ui/badge';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 import { parseResponse } from '../utils/response-parser';
 
@@ -90,11 +91,15 @@ export function ResponseFlow({ chunks, body, isLive, reasoningDurationMs }: Resp
                         <button
                           type='button'
                           className='text-muted-foreground hover:text-foreground text-xs flex items-center gap-1 transition-colors cursor-pointer'
-                          onClick={() => {
+                          onClick={async () => {
                             const text = typeof tc.function?.arguments === 'string'
                               ? tc.function.arguments
                               : JSON.stringify(parseJson(tc.function?.arguments || '{}'), null, 2);
-                            navigator.clipboard.writeText(text);
+                            try {
+                              await copyTextToClipboard(text);
+                            } catch (error) {
+                              console.error('Failed to copy tool parameters:', error);
+                            }
                           }}
                         >
                           <CopyIcon className='size-3' />

--- a/frontend/src/hooks/use-copy-to-clipboard.ts
+++ b/frontend/src/hooks/use-copy-to-clipboard.ts
@@ -1,34 +1,33 @@
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 type UseCopyToClipboardProps = {
   text: string;
   copyMessage?: string;
 };
 
-export function useCopyToClipboard({ text, copyMessage = 'Copied to clipboard!' }: UseCopyToClipboardProps) {
+export function useCopyToClipboard({ text, copyMessage }: UseCopyToClipboardProps) {
   const { t } = useTranslation();
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        toast.success(t('common.success.copiedToClipboard'));
-        setIsCopied(true);
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-          timeoutRef.current = null;
-        }
-        timeoutRef.current = setTimeout(() => {
-          setIsCopied(false);
-        }, 2000);
-      })
-      .catch(() => {
-        toast.error(t('common.errors.copyFailed'));
-      });
+  const handleCopy = useCallback(async () => {
+    try {
+      await copyTextToClipboard(text);
+      toast.success(copyMessage ?? t('common.success.copiedToClipboard'));
+      setIsCopied(true);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      timeoutRef.current = setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+    } catch {
+      toast.error(t('common.errors.copyFailed'));
+    }
   }, [text, copyMessage, t]);
 
   return { isCopied, handleCopy };

--- a/frontend/src/lib/clipboard.test.mjs
+++ b/frontend/src/lib/clipboard.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { copyTextToClipboard } from './clipboard.ts';
+
+function replaceGlobals(values) {
+  const previous = new Map();
+
+  for (const [name, value] of Object.entries(values)) {
+    previous.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value,
+    });
+  }
+
+  return () => {
+    for (const [name, descriptor] of previous) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        delete globalThis[name];
+      }
+    }
+  };
+}
+
+function createFallbackDocument(copyResult) {
+  const state = {
+    appended: false,
+    command: null,
+    focused: false,
+    range: null,
+    removed: false,
+    selected: false,
+    textarea: null,
+  };
+
+  const document = {
+    body: {
+      appendChild(textarea) {
+        state.appended = true;
+        state.textarea = textarea;
+      },
+    },
+    createElement(name) {
+      assert.equal(name, 'textarea');
+      return {
+        attributes: {},
+        focus() {
+          state.focused = true;
+        },
+        remove() {
+          state.removed = true;
+        },
+        select() {
+          state.selected = true;
+        },
+        setAttribute(name, value) {
+          this.attributes[name] = value;
+        },
+        setSelectionRange(start, end) {
+          state.range = [start, end];
+        },
+        style: {},
+        value: '',
+      };
+    },
+    execCommand(command) {
+      state.command = command;
+      return copyResult;
+    },
+  };
+
+  return { document, state };
+}
+
+test('uses the modern Clipboard API when available', async () => {
+  let copiedText = null;
+  const restore = replaceGlobals({
+    navigator: {
+      clipboard: {
+        async writeText(text) {
+          copiedText = text;
+        },
+      },
+    },
+  });
+
+  try {
+    await copyTextToClipboard('modern');
+    assert.equal(copiedText, 'modern');
+  } finally {
+    restore();
+  }
+});
+
+test('falls back to the document copy command when the Clipboard API is unavailable', async () => {
+  const { document, state } = createFallbackDocument(true);
+  const restore = replaceGlobals({ document, navigator: {} });
+
+  try {
+    await copyTextToClipboard('fallback');
+    assert.equal(state.textarea.value, 'fallback');
+    assert.equal(state.textarea.attributes.readonly, '');
+    assert.equal(state.command, 'copy');
+    assert.equal(state.appended, true);
+    assert.equal(state.focused, true);
+    assert.equal(state.selected, true);
+    assert.deepEqual(state.range, [0, 8]);
+    assert.equal(state.removed, true);
+  } finally {
+    restore();
+  }
+});
+
+test('rejects when neither clipboard path can copy the text', async () => {
+  const { document, state } = createFallbackDocument(false);
+  const restore = replaceGlobals({ document, navigator: {} });
+
+  try {
+    await assert.rejects(copyTextToClipboard('failure'), /compatibility copy command failed/);
+    assert.equal(state.removed, true);
+  } finally {
+    restore();
+  }
+});

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+function copyTextWithDocumentCommand(text: string): void {
+  if (typeof document === 'undefined' || !document.body || typeof document.execCommand !== 'function') {
+    throw new Error('Clipboard API is unavailable and the compatibility copy command is not supported.');
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    if (!document.execCommand('copy')) {
+      throw new Error('Clipboard API is unavailable and the compatibility copy command failed.');
+    }
+  } finally {
+    textarea.remove();
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  copyTextWithDocumentCommand(text);
+}


### PR DESCRIPTION
## Summary

- add a shared low-level clipboard utility for the frontend
- route every current frontend copy action through the shared utility or hook
- keep existing success messages, copied indicators, and timeouts while only showing them after a confirmed copy
- add focused unit coverage for the modern API, HTTP fallback, and total failure paths

## Problem

When AxonHub is opened over a plain LAN HTTP origin, the modern Clipboard API may be unavailable. The current frontend contains 27 direct `navigator.clipboard` references across 21 files, so copy actions can fail throughout request details, channels, API keys, the playground, and project invitations.

## Implementation

- introduce `copyTextToClipboard(text)` in `frontend/src/lib/clipboard.ts`
- prefer `navigator.clipboard.writeText` when it is available
- encapsulate `document.execCommand('copy')` as the legacy fallback used only when the modern API is unavailable
- throw when the selected clipboard path cannot copy, allowing callers to preserve their existing error feedback
- update `useCopyToClipboard` and all direct callers to await the shared implementation before reporting success
- keep the existing UI structure, copy wording, copied state, and timeout behavior

## Tests

- `node --test src/lib/clipboard.test.mjs` — 3 tests passed
- TypeScript compiler comparison for the 22 changed TS/TSX source files — no new diagnostics versus `upstream/unstable`
- `git diff --check` — passed
- full-repository search confirms direct `navigator.clipboard` and `execCommand('copy')` access remains only in `frontend/src/lib/clipboard.ts`

Full frontend lint/build was not run locally because the repository instructions prohibit agents from running those commands unless explicitly requested.

## Risk

The fallback uses the deprecated `execCommand('copy')` API, but it is isolated to insecure origins where the modern Clipboard API is unavailable. If a browser removes that legacy command entirely, the utility rejects and existing caller error handling remains active.

## Related

Related to #2018

#2018 covers only part of the API Key copy paths. This PR is related to that draft, but expands the same clipboard handling into one shared implementation across the entire frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved copying across code, JSON, API keys, requests, responses, links, and chat content.
  * Added a compatibility fallback for browsers without modern clipboard support.
  * Copy actions now provide accurate success and failure feedback.
* **Bug Fixes**
  * Prevented misleading success messages when copying fails.
  * Improved copying of serialized request and response data.
* **Tests**
  * Added coverage for modern clipboard support, fallback behavior, failures, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->