### PR TITLE
fix(channels): validate bulk ordering weight input

### DIFF
--- a/frontend/src/features/channels-ordering-weight.test.mjs
+++ b/frontend/src/features/channels-ordering-weight.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+
+const srcRoot = join(import.meta.dirname, '..');
+
+function read(relativePath) {
+  return readFileSync(join(srcRoot, relativePath), 'utf8');
+}
+
+const validationSource = read('features/channels/utils/ordering-weight.ts');
+const transpiledValidation = ts.transpileModule(validationSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2023,
+  },
+}).outputText;
+const validationModuleUrl = `data:text/javascript;base64,${Buffer.from(transpiledValidation).toString('base64')}`;
+const { parseOrderingWeightInput } = await import(validationModuleUrl);
+
+test('bulk ordering weight accepts integers from 0 through 100', () => {
+  assert.equal(parseOrderingWeightInput('0', 0, 100), 0);
+  assert.equal(parseOrderingWeightInput('100', 0, 100), 100);
+  assert.equal(parseOrderingWeightInput('42', 0, 100), 42);
+});
+
+test('bulk ordering weight rejects invalid manual input', () => {
+  assert.equal(parseOrderingWeightInput('-1', 0, 100), null);
+  assert.equal(parseOrderingWeightInput('101', 0, 100), null);
+  assert.equal(parseOrderingWeightInput('12.5', 0, 100), null);
+  assert.equal(parseOrderingWeightInput('', 0, 100), null);
+  assert.equal(parseOrderingWeightInput('Infinity', 0, 100), null);
+});
+
+test('bulk ordering input restores invalid values without committing them', () => {
+  const component = read('features/channels/components/channels-bulk-ordering-dialog.tsx');
+  const handlerStart = component.indexOf('const handleWeightBlur = () => {');
+  const handlerEnd = component.indexOf('const getTypeDisplayName', handlerStart);
+
+  assert.ok(handlerStart !== -1 && handlerEnd > handlerStart);
+
+  const handler = component.slice(handlerStart, handlerEnd);
+  const invalidBranch = handler.match(/if \(value === null\) \{[\s\S]*?return;[\s\S]*?\}/)?.[0] ?? '';
+
+  assert.match(invalidBranch, /setLocalWeight\(orderingWeight\.toString\(\)\)/);
+  assert.match(invalidBranch, /toast\.error/);
+  assert.doesNotMatch(invalidBranch, /onWeightChange/);
+  assert.match(handler, /if \(value !== orderingWeight\) \{\s*onWeightChange\(channel\.id, value\)/);
+  assert.match(component, /inputMode='numeric'[\s\S]*?step=\{1\}/);
+  assert.match(component, /if \(e\.key === 'Enter'\) \{\s*e\.currentTarget\.blur\(\)/);
+});
+
+test('bulk ordering weight error is localized in English and Chinese', () => {
+  const key = 'channels.dialogs.bulkOrdering.errors.invalidWeight';
+  const en = JSON.parse(read('locales/en/channels.json'));
+  const zh = JSON.parse(read('locales/zh-CN/channels.json'));
+
+  assert.ok(en[key]);
+  assert.ok(zh[key]);
+});

--- a/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-ordering-dialog.tsx
@@ -5,6 +5,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, ArrowUpToLine, ArrowDownToLine } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -12,6 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { useAllChannelSummarys, useBulkUpdateChannelOrdering } from '../data/channels';
 import { ChannelSummary } from '../data/schema';
+import { parseOrderingWeightInput } from '../utils/ordering-weight';
 
 const WEIGHT_PRECISION = 0;
 const MIN_WEIGHT = 0;
@@ -65,14 +67,21 @@ const ChannelOrderingItemComponent = memo(function ChannelOrderingItemComponent(
   }, [orderingWeight]);
 
   const handleWeightBlur = () => {
-    if (localWeight.trim() === '') {
+    const value = parseOrderingWeightInput(localWeight, MIN_WEIGHT, MAX_WEIGHT);
+
+    if (value === null) {
       setLocalWeight(orderingWeight.toString());
+      toast.error(
+        t('channels.dialogs.bulkOrdering.errors.invalidWeight', {
+          min: MIN_WEIGHT,
+          max: MAX_WEIGHT,
+        })
+      );
       return;
     }
 
-    const val = Number(localWeight);
-    if (!Number.isNaN(val) && val !== orderingWeight) {
-      onWeightChange(channel.id, val);
+    if (value !== orderingWeight) {
+      onWeightChange(channel.id, value);
     } else {
       setLocalWeight(orderingWeight.toString());
     }
@@ -157,8 +166,8 @@ const ChannelOrderingItemComponent = memo(function ChannelOrderingItemComponent(
           <span className='text-muted-foreground text-[10px]'>{t('channels.dialogs.bulkOrdering.orderingWeight')}</span>
           <Input
             type='number'
-            inputMode='decimal'
-            step='any'
+            inputMode='numeric'
+            step={1}
             min={MIN_WEIGHT}
             max={MAX_WEIGHT}
             className='h-6 w-16 px-1 text-center text-xs'

--- a/frontend/src/features/channels/utils/ordering-weight.ts
+++ b/frontend/src/features/channels/utils/ordering-weight.ts
@@ -1,0 +1,12 @@
+export function parseOrderingWeightInput(rawValue: string, min: number, max: number): number | null {
+  if (rawValue.trim() === '') {
+    return null;
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < min || value > max) {
+    return null;
+  }
+
+  return value;
+}

--- a/frontend/src/locales/en/channels.json
+++ b/frontend/src/locales/en/channels.json
@@ -575,6 +575,7 @@
   "channels.dialogs.bulkOrdering.saveButton": "Save Order",
   "channels.dialogs.bulkOrdering.orderingWeight": "Weight",
   "channels.dialogs.bulkOrdering.noChannels": "No channels available for ordering",
+  "channels.dialogs.bulkOrdering.errors.invalidWeight": "Weight must be an integer from {{min}} to {{max}}.",
   "channels.dialogs.bulkArchive.title": "Bulk Archive Channels",
   "channels.dialogs.bulkArchive.description": "Are you sure you want to archive {{count}} selected channels? Archived channels are hidden from the default list.",
   "channels.dialogs.bulkArchive.warning": "This action will hide all selected channels from regular views. You can still find them by filtering by archived status.",

--- a/frontend/src/locales/zh-CN/channels.json
+++ b/frontend/src/locales/zh-CN/channels.json
@@ -572,6 +572,7 @@
   "channels.dialogs.bulkOrdering.saveButton": "保存排序",
   "channels.dialogs.bulkOrdering.orderingWeight": "权重",
   "channels.dialogs.bulkOrdering.noChannels": "没有可用于排序的渠道",
+  "channels.dialogs.bulkOrdering.errors.invalidWeight": "权重必须是 {{min}} 到 {{max}} 之间的整数。",
   "channels.dialogs.bulkArchive.title": "批量归档渠道",
   "channels.dialogs.bulkArchive.description": "确定要归档所选 {{count}} 条渠道吗？归档的渠道默认不会出现在列表中。",
   "channels.dialogs.bulkArchive.warning": "此操作会将所有选中的渠道从常规视图中隐藏。你仍然可以通过筛选归档状态来查看它们。",


### PR DESCRIPTION
## Problem

The channel bulk-ordering dialog silently clamped or rounded invalid manual weights, so the displayed and saved value could differ from what the user entered.

Refs #2247

## Behavior before/after

Before, values such as -1, 101, decimals, and empty input could be silently rewritten on blur or Enter and mark the dialog as changed. After this change, only finite integers from 0 through 100 are committed. Invalid input restores the previous valid weight, shows a localized error toast, and does not call the weight-change handler or set hasChanges. Valid 0, 100, and ordinary integers remain supported.

## Implementation

- Add a small pure parser for finite integer range validation.
- Validate on blur; Enter continues to blur and run the same validation path.
- Use numeric input mode with an integer step.
- Keep the existing MIN_WEIGHT, MAX_WEIGHT, and clampWeight behavior for drag/reorder calculations.

## i18n

Add channels.dialogs.bulkOrdering.errors.invalidWeight to the current English and Simplified Chinese channel locale files.

## Tests

- node --test src/features/channels-ordering-weight.test.mjs: 4 tests passed, covering -1, 101, decimals, empty input, non-finite input, 0, 100, and a normal integer, plus component wiring and locale presence.
- Focused strict TypeScript check for the new pure validation helper passed.
- Prettier check for all five changed files passed.
- git diff --check passed.
- Full frontend lint/build were not run per repository instructions. The full-project TypeScript check is currently blocked by unrelated baseline errors outside these files.

## Risk / compatibility

This is frontend-only validation. It does not change backend schemas, database constraints, the bulk API, drag/reorder clamping, clipboard behavior, or pagination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk channel-ordering weight validation.
  * Only whole numbers within the allowed range are accepted.
  * Invalid entries are restored to their previous values and display an error message.
  * Numeric input controls now prevent decimal values and support pressing Enter to confirm.

* **Documentation**
  * Added validation messages in English and Simplified Chinese.

* **Tests**
  * Added coverage for valid and invalid ordering-weight inputs and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->