### PR TITLE
feat: auto set prompt cache key from trace id

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,6 @@ linters:
     - depguard
     - lll
     - exhaustruct
-    - exhaustruct_v5
     - gochecknoinits
     - dupl
     - tagalign
@@ -232,7 +231,6 @@ linters:
           - unused
           - deadcode
           - exhaustruct
-          - exhaustruct_v5
           - funlen
           - maintidx
           - cyclop

--- a/llm/transformer/deepseek/outbound.go
+++ b/llm/transformer/deepseek/outbound.go
@@ -100,7 +100,7 @@ func (t *OutboundTransformer) TransformRequest(
 		return nil, fmt.Errorf("%w: messages are required", transformer.ErrInvalidRequest)
 	}
 
-	oaiReq := openai.RequestFromLLM(llmReq, openai.ReasoningFieldContent)
+	oaiReq := openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldContent)
 
 	if oaiReq.ResponseFormat != nil && oaiReq.ResponseFormat.Type == "json_schema" {
 		oaiReq.ResponseFormat.Type = "json_object"

--- a/llm/transformer/doubao/outbound.go
+++ b/llm/transformer/doubao/outbound.go
@@ -133,7 +133,7 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 
 	// Convert llm.Request to openai.Request first
-	oaiReq := openai.RequestFromLLM(llmReq, openai.ReasoningFieldContent)
+	oaiReq := openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldContent)
 
 	// Create Doubao-specific request by adding request_id/user_id
 	doubaoReq := Request{

--- a/llm/transformer/gemini/openai/outbound.go
+++ b/llm/transformer/gemini/openai/outbound.go
@@ -333,7 +333,7 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 
 	// Convert llm.Request to openai.Request
-	oaiReq := openai.RequestFromLLM(&req, openai.ReasoningFieldContent)
+	oaiReq := openai.RequestFromLLM(ctx, &req, openai.ReasoningFieldContent)
 	fillGeminiThoughtSignatureForGeminiOpenAIRequest(&req, oaiReq)
 
 	geminiReq := Request{Request: *oaiReq}

--- a/llm/transformer/moonshot/outbound.go
+++ b/llm/transformer/moonshot/outbound.go
@@ -81,7 +81,7 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 
 	// Convert llm.Request to openai.Request first
-	oaiReq := openai.RequestFromLLM(llmReq, openai.ReasoningFieldContent)
+	oaiReq := openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldContent)
 
 	// Moonshot doesn't support json_schema, convert to json_object
 	if oaiReq.ResponseFormat != nil && oaiReq.ResponseFormat.Type == "json_schema" {

--- a/llm/transformer/openai/copilot/outbound.go
+++ b/llm/transformer/openai/copilot/outbound.go
@@ -120,7 +120,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		return nil, fmt.Errorf("failed to get copilot token: %w", err)
 	}
 
-	oaiReq := openai.RequestFromLLM(llmReq, openai.ReasoningFieldAll)
+	oaiReq := openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldAll)
 
 	body, err := json.Marshal(oaiReq)
 	if err != nil {

--- a/llm/transformer/openai/model_test.go
+++ b/llm/transformer/openai/model_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -246,7 +247,7 @@ func TestRoundTrip_Request(t *testing.T) {
 
 	// Convert to llm.Request and back
 	llmReq := original.ToLLMRequest()
-	roundTripped := RequestFromLLM(llmReq, ReasoningFieldNone)
+	roundTripped := RequestFromLLM(context.Background(), llmReq, ReasoningFieldNone)
 
 	require.Equal(t, original.Model, roundTripped.Model)
 	require.Len(t, roundTripped.Messages, len(original.Messages))

--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -198,7 +198,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	}
 
 	// Convert to OpenAI Request format (this strips helper fields)
-	oaiReq := RequestFromLLM(llmReq, reasoningField)
+	oaiReq := RequestFromLLM(ctx, llmReq, reasoningField)
 	// Apply per-channel reasoning_effort mapping for non-standard OpenAI-compatible providers.
 	// Entries in the map replace the effort value; values not in the map pass through unchanged.
 	// e.g. ollama channel with {"xhigh": "max"} converts Anthropic's internal "xhigh" back to "max".

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -1,13 +1,18 @@
 package openai
 
 import (
+	"context"
+
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
-// RequestFromLLM creates OpenAI Request from unified llm.Request with reasoning field configuration.
-func RequestFromLLM(r *llm.Request, reasoningField ReasoningField) *Request {
+// RequestFromLLM creates an OpenAI Request from unified llm.Request with reasoning
+// field configuration. When the request has no explicit prompt cache key, ctx's
+// session ID is used as a fallback when available.
+func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField ReasoningField) *Request {
 	if r == nil {
 		return nil
 	}
@@ -35,6 +40,12 @@ func RequestFromLLM(r *llm.Request, reasoningField ReasoningField) *Request {
 		Stream:              r.Stream,
 		ParallelToolCalls:   r.ParallelToolCalls,
 		Verbosity:           r.Verbosity,
+	}
+
+	if ctx != nil && lo.FromPtr(req.PromptCacheKey) == "" {
+		if sessionID, ok := shared.GetSessionID(ctx); ok && sessionID != "" {
+			req.PromptCacheKey = lo.ToPtr(sessionID)
+		}
 	}
 
 	// Convert messages

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -70,14 +71,14 @@ func TestRequestFromLLM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := RequestFromLLM(tt.llmReq, ReasoningFieldNone)
+			result := RequestFromLLM(context.Background(), tt.llmReq, ReasoningFieldNone)
 			tt.validate(t, result)
 		})
 	}
 }
 
 func TestRequestFromLLM_FiltersResponsesCustomTools(t *testing.T) {
-	req := RequestFromLLM(&llm.Request{
+	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model:    "gpt-4o",
 		Messages: []llm.Message{{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("hi")}}},
 		Tools: []llm.Tool{
@@ -155,7 +156,7 @@ func TestMessageContentFromLLM_IgnoresCompactionParts(t *testing.T) {
 }
 
 func TestRequestFromLLM_IgnoresCompactionPartsInMessages(t *testing.T) {
-	req := RequestFromLLM(&llm.Request{
+	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model: "gpt-4o",
 		Messages: []llm.Message{
 			{
@@ -501,7 +502,7 @@ func TestResponse_ToLLMResponse_WithCitations(t *testing.T) {
 }
 
 func TestRequestFromLLM_KeepsGoogleThoughtSignatureInRequestModel(t *testing.T) {
-	req := RequestFromLLM(&llm.Request{
+	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model: "gemini-3-pro",
 		Messages: []llm.Message{
 			{
@@ -619,7 +620,7 @@ func TestApplyReasoningEffortMapping(t *testing.T) {
 // reasoning_effort: mapping is the OutboundTransformer's responsibility (driven by
 // Config.ReasoningEffortMapping), not the package-level converter's.
 func TestRequestFromLLM_PreservesReasoningEffort(t *testing.T) {
-	req := RequestFromLLM(&llm.Request{
+	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model:           "gpt-4",
 		ReasoningEffort: "xhigh",
 		Messages: []llm.Message{
@@ -757,7 +758,7 @@ func TestMessageContentPartFromLLM_NormalizesTextPartTypes(t *testing.T) {
 // Multi-part content is the path where Responses text types actually reach an
 // upstream: a lone text part is collapsed into a plain string before this point.
 func TestRequestFromLLM_NormalizesTextPartTypesInMessages(t *testing.T) {
-	req := RequestFromLLM(&llm.Request{
+	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model: "gpt-4o",
 		Messages: []llm.Message{
 			{

--- a/llm/transformer/openai/outbound_reasoning_test.go
+++ b/llm/transformer/openai/outbound_reasoning_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -175,7 +176,7 @@ func TestRequestFromLLMWithConfig_ReasoningFieldContent(t *testing.T) {
 		},
 	}
 
-	req := RequestFromLLM(llmReq, ReasoningFieldContent)
+	req := RequestFromLLM(context.Background(), llmReq, ReasoningFieldContent)
 
 	assert.Equal(t, "test-model", req.Model)
 	assert.Len(t, req.Messages, 2)
@@ -205,7 +206,7 @@ func TestRequestFromLLMWithConfig_ReasoningFieldReasoning(t *testing.T) {
 		},
 	}
 
-	req := RequestFromLLM(llmReq, ReasoningFieldReasoning)
+	req := RequestFromLLM(context.Background(), llmReq, ReasoningFieldReasoning)
 
 	assert.Len(t, req.Messages, 1)
 
@@ -228,7 +229,7 @@ func TestRequestFromLLMWithConfig_ReasoningFieldNone(t *testing.T) {
 		},
 	}
 
-	req := RequestFromLLM(llmReq, ReasoningFieldNone)
+	req := RequestFromLLM(context.Background(), llmReq, ReasoningFieldNone)
 
 	assert.Len(t, req.Messages, 1)
 

--- a/llm/transformer/openai/outbound_test.go
+++ b/llm/transformer/openai/outbound_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func TestOutboundTransformer_TransformRequest(t *testing.T) {
@@ -188,6 +190,53 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOutboundTransformer_TransformRequest_PromptCacheKeyFallback(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-api-key")
+	require.NoError(t, err)
+
+	request := &llm.Request{
+		Model: "gpt-4",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	t.Run("uses session ID when key is absent", func(t *testing.T) {
+		ctx := shared.WithSessionID(t.Context(), "session-123")
+		httpReq, err := tr.TransformRequest(ctx, request)
+		require.NoError(t, err)
+
+		var payload Request
+		require.NoError(t, json.Unmarshal(httpReq.Body, &payload))
+		require.NotNil(t, payload.PromptCacheKey)
+		assert.Equal(t, "session-123", *payload.PromptCacheKey)
+	})
+
+	t.Run("keeps explicit key", func(t *testing.T) {
+		explicit := "explicit-key"
+		explicitRequest := *request
+		explicitRequest.PromptCacheKey = &explicit
+
+		ctx := shared.WithSessionID(t.Context(), "session-123")
+		httpReq, err := tr.TransformRequest(ctx, &explicitRequest)
+		require.NoError(t, err)
+
+		var payload Request
+		require.NoError(t, json.Unmarshal(httpReq.Body, &payload))
+		require.NotNil(t, payload.PromptCacheKey)
+		assert.Equal(t, explicit, *payload.PromptCacheKey)
+	})
+
+	t.Run("does not invent key without session", func(t *testing.T) {
+		httpReq, err := tr.TransformRequest(t.Context(), request)
+		require.NoError(t, err)
+
+		var payload Request
+		require.NoError(t, json.Unmarshal(httpReq.Body, &payload))
+		assert.Nil(t, payload.PromptCacheKey)
+	})
 }
 
 func TestOutboundTransformer_TransformRequest_StripsUnsupportedToolCallExtraContentForOpenAI(t *testing.T) {

--- a/llm/transformer/openrouter/outbound.go
+++ b/llm/transformer/openrouter/outbound.go
@@ -105,7 +105,7 @@ func (t *OutboundTransformer) TransformRequest(
 		return nil, fmt.Errorf("%w: messages are required", transformer.ErrInvalidRequest)
 	}
 
-	body, err := json.Marshal(openai.RequestFromLLM(llmReq, openai.ReasoningFieldReasoning))
+	body, err := json.Marshal(openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldReasoning))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to transform request: %w", transformer.ErrInvalidRequest, err)
 	}

--- a/llm/transformer/zai/outbound.go
+++ b/llm/transformer/zai/outbound.go
@@ -114,7 +114,7 @@ func (t *OutboundTransformer) TransformRequest(
 	}
 
 	// Convert llm.Request to openai.Request first
-	oaiReq := openai.RequestFromLLM(llmReq, openai.ReasoningFieldContent)
+	oaiReq := openai.RequestFromLLM(ctx, llmReq, openai.ReasoningFieldContent)
 
 	// Zai doesn't support json_schema, convert to json_object
 	if oaiReq.ResponseFormat != nil && oaiReq.ResponseFormat.Type == "json_schema" {

--- a/llm/transformer/zai/thinking_test.go
+++ b/llm/transformer/zai/thinking_test.go
@@ -1,6 +1,7 @@
 package zai
 
 import (
+	"context"
 	"testing"
 
 	"github.com/looplj/axonhub/llm"
@@ -131,7 +132,7 @@ func TestZAIRequestWithoutThinking(t *testing.T) {
 	}
 
 	zaiReq := Request{
-		Request: *openai.RequestFromLLM(chatReq, openai.ReasoningFieldContent),
+		Request: *openai.RequestFromLLM(context.Background(), chatReq, openai.ReasoningFieldContent),
 		UserID:  "test-user",
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically uses the current session identifier as the prompt cache key when no key is provided.
  * Preserves explicitly configured prompt cache keys and leaves them unset when no session identifier is available.

* **Bug Fixes**
  * Improved request handling across supported model integrations by preserving request context during conversion.

* **Chores**
  * Updated code quality configuration to reflect the current linter naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->