### PR TITLE
fix: request performance metric accurate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - depguard
     - lll
     - exhaustruct
+    - exhaustruct_v5
     - gochecknoinits
     - dupl
     - tagalign

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ replace github.com/tmaxmax/go-sse => github.com/wtj-0527/go-sse v0.0.0-202608110
 replace github.com/gin-contrib/sse => github.com/looplj/sse v0.0.0-20260223020440-b463add2d52f
 
 require (
-	ariga.io/atlas v0.38.0 // indirect
+	ariga.io/atlas v0.38.0
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.17.0 // indirect

--- a/internal/server/biz/channel_metrics.go
+++ b/internal/server/biz/channel_metrics.go
@@ -564,7 +564,14 @@ type PerformanceRecord struct {
 // Calculate calculates performance metrics from collected data.
 // It enforces minimum latency to prevent extreme TPS calculations.
 func (m *PerformanceRecord) Calculate() (firstTokenLatencyMs int64, requestLatencyMs int64, tokensPerSecond float64) {
-	totalDuration := m.EndTime.Sub(m.StartTime)
+	endTime := m.EndTime
+	if endTime.IsZero() {
+		// Streaming metrics can be calculated while the stream is being
+		// finalized, before a terminal event has marked the record complete.
+		endTime = time.Now()
+	}
+
+	totalDuration := endTime.Sub(m.StartTime)
 	requestLatencyMs = totalDuration.Milliseconds()
 
 	// Calculate first token latency

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -88,6 +88,7 @@ func (ts *OutboundPersistentStream) Current() *httpclient.StreamEvent {
 		// response.completed; for Anthropic Messages API this is message_stop.
 		if IsTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true
+			ts.markPerformanceCompleted()
 		}
 	}
 
@@ -154,6 +155,8 @@ func (ts *OutboundPersistentStream) Close() error {
 		if aggregatedCompleted {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
 			ts.state.StreamCompleted = true
+			ts.markPerformanceCompleted()
+			enqueueCompletedPerformance(ts.ctx, ts.state)
 		}
 	} else {
 		ts.logFinalizationDecision(ctx, "no_outbound_chunks_to_aggregate", streamErr, ctxErr, false, nil)
@@ -219,6 +222,14 @@ func (ts *OutboundPersistentStream) Close() error {
 	}
 
 	return ts.stream.Close()
+}
+
+func (ts *OutboundPersistentStream) markPerformanceCompleted() {
+	if ts.perf == nil || ts.perf.RequestCompleted {
+		return
+	}
+
+	ts.perf.MarkSuccess()
 }
 
 func (ts *OutboundPersistentStream) logFinalizationDecision(ctx context.Context, decision string, streamErr error, ctxErr error, aggregatedCompleted bool, aggregatedErr error) {

--- a/internal/server/orchestrator/performance.go
+++ b/internal/server/orchestrator/performance.go
@@ -119,9 +119,11 @@ func (m *performanceRecording) OnOutboundRawStream(ctx context.Context, stream s
 
 func (m *performanceRecording) OnOutboundLlmStream(ctx context.Context, stream streams.Stream[*llm.Response]) (streams.Stream[*llm.Response], error) {
 	return &recordPerformanceStream{
-		ctx:    ctx,
 		stream: stream,
 		state:  m.outbound.state,
+		onClose: func() {
+			enqueueCompletedPerformance(ctx, m.outbound.state)
+		},
 	}, nil
 }
 
@@ -143,12 +145,11 @@ func (m *performanceRecording) OnOutboundRawError(ctx context.Context, err error
 }
 
 // recordPerformanceStream records performance metrics for a stream of responses.
-//
-//nolint:containedctx // ctx is used for logging.
 type recordPerformanceStream struct {
-	ctx    context.Context
-	stream streams.Stream[*llm.Response]
-	state  *PersistenceState
+	stream  streams.Stream[*llm.Response]
+	state   *PersistenceState
+	onClose func()
+	closed  bool
 
 	firstTokenSet     bool
 	reasoningStartSet bool
@@ -161,7 +162,7 @@ func (s *recordPerformanceStream) Current() *llm.Response {
 		return event
 	}
 
-	if !s.firstTokenSet && s.state.Perf != nil {
+	if !s.firstTokenSet && s.state.Perf != nil && hasMeaningfulStreamOutput(event) {
 		s.state.Perf.MarkFirstToken()
 		s.firstTokenSet = true
 	}
@@ -185,11 +186,39 @@ func (s *recordPerformanceStream) Current() *llm.Response {
 
 	if tokenCount := event.Usage.GetCompletionTokens(); tokenCount != nil && *tokenCount > 0 {
 		s.state.Perf.CompletionTokens = *tokenCount
-		s.state.Perf.MarkSuccess()
-		s.state.ChannelService.AsyncRecordPerformance(s.ctx, s.state.Perf)
 	}
 
 	return event
+}
+
+// hasMeaningfulStreamOutput reports whether a normalized stream event contains
+// model output. Provider lifecycle events (for example Anthropic's
+// message_start) may carry usage snapshots but do not count as the first token.
+func hasMeaningfulStreamOutput(event *llm.Response) bool {
+	if event == nil {
+		return false
+	}
+
+	for _, choice := range event.Choices {
+		delta := choice.Delta
+		if delta == nil {
+			continue
+		}
+
+		if delta.Content.Content != nil && *delta.Content.Content != "" ||
+			len(delta.Content.MultipleContent) > 0 ||
+			len(delta.ToolCalls) > 0 ||
+			delta.ReasoningContent != nil && *delta.ReasoningContent != "" ||
+			delta.Reasoning != nil && *delta.Reasoning != "" ||
+			len(delta.ReasoningItems) > 0 ||
+			len(delta.InlineToolResults) > 0 ||
+			delta.Audio != nil ||
+			delta.Refusal != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *recordPerformanceStream) Next() bool {
@@ -197,7 +226,26 @@ func (s *recordPerformanceStream) Next() bool {
 }
 
 func (s *recordPerformanceStream) Close() error {
+	if s.closed {
+		return nil
+	}
+
+	s.closed = true
+	if s.onClose != nil {
+		s.onClose()
+	}
+
 	return s.stream.Close()
+}
+
+// enqueueCompletedPerformance submits a completed stream only after its normalized
+// events have been consumed, so final usage is visible to the metrics worker.
+func enqueueCompletedPerformance(ctx context.Context, state *PersistenceState) {
+	if state == nil || state.Perf == nil || !state.Perf.RequestCompleted || state.ChannelService == nil {
+		return
+	}
+
+	state.ChannelService.AsyncRecordPerformance(ctx, state.Perf)
 }
 
 func (s *recordPerformanceStream) Err() error {

--- a/internal/server/orchestrator/performance_test.go
+++ b/internal/server/orchestrator/performance_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -342,3 +344,103 @@ func TestPerformanceRecording_StreamFlagBugRegression(t *testing.T) {
 
 // TestRecordPerformanceStream_MarksFirstToken verifies that recordPerformanceStream
 // correctly marks the first token time.
+func TestRecordPerformanceStream_UsageDoesNotMarkFirstTokenOrComplete(t *testing.T) {
+	perf := &biz.PerformanceRecord{
+		StartTime: time.Now(),
+		Stream:    true,
+	}
+	state := &PersistenceState{Perf: perf}
+	stream := &responseSliceStream{
+		events: []*llm.Response{
+			{
+				Choices: []llm.Choice{{Delta: &llm.Message{Role: "assistant"}}},
+				Usage:   &llm.Usage{CompletionTokens: 2},
+			},
+			{
+				Choices: []llm.Choice{{Delta: &llm.Message{Content: llm.MessageContent{Content: lo.ToPtr("hello")}}}},
+			},
+		},
+	}
+	recording := &recordPerformanceStream{stream: stream, state: state}
+
+	require.True(t, recording.Next())
+	recording.Current()
+
+	assert.Nil(t, perf.FirstTokenTime, "usage on a lifecycle event must not count as the first token")
+	assert.Equal(t, int64(2), perf.CompletionTokens)
+	assert.False(t, perf.RequestCompleted, "usage must not complete an active stream")
+
+	require.True(t, recording.Next())
+	recording.Current()
+
+	assert.NotNil(t, perf.FirstTokenTime, "the first non-empty output delta should mark first token")
+}
+
+func TestRecordPerformanceStream_QueuesCompletedPerformanceAfterFinalUsage(t *testing.T) {
+	perf := &biz.PerformanceRecord{
+		StartTime: time.Now(),
+		Stream:    true,
+	}
+	state := &PersistenceState{Perf: perf}
+	stream := &responseSliceStream{
+		events: []*llm.Response{
+			{Choices: []llm.Choice{{Delta: &llm.Message{}, FinishReason: lo.ToPtr("stop")}}},
+			{Usage: &llm.Usage{CompletionTokens: 9}},
+		},
+	}
+
+	var recorded *biz.PerformanceRecord
+	recordCalls := 0
+	recording := &recordPerformanceStream{
+		stream: stream,
+		state:  state,
+		onClose: func() {
+			recordCalls++
+			recorded = state.Perf
+		},
+	}
+
+	// The raw terminal event is observed before the normalized finish and usage events.
+	perf.MarkSuccess()
+	require.True(t, recording.Next())
+	recording.Current()
+	assert.Nil(t, recorded, "finish event must not submit metrics before the final usage event")
+
+	require.True(t, recording.Next())
+	recording.Current()
+	assert.Nil(t, recorded, "usage must be applied before metrics are submitted")
+
+	require.NoError(t, recording.Close())
+
+	require.Same(t, perf, recorded)
+	assert.Equal(t, int64(9), recorded.CompletionTokens)
+	assert.Equal(t, 1, recordCalls)
+	require.NoError(t, recording.Close())
+	assert.Equal(t, 1, recordCalls)
+}
+
+type responseSliceStream struct {
+	events []*llm.Response
+	index  int
+}
+
+func (s *responseSliceStream) Next() bool {
+	if s.index >= len(s.events) {
+		return false
+	}
+
+	s.index++
+	return true
+}
+
+func (s *responseSliceStream) Current() *llm.Response {
+	return s.events[s.index-1]
+}
+
+func (s *responseSliceStream) Err() error {
+	return nil
+}
+
+func (s *responseSliceStream) Close() error {
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming performance metrics while responses are still being finalized.
  * Lifecycle events containing usage data alone no longer count as the first response token or mark a stream complete.
  * Streaming requests are now recorded as successful when completion is detected, including when a terminal event is missing.
  * Prevented duplicate completion records for streaming responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->