### PR TITLE
fix(anthropic): preserve client cache_control breakpoints to keep prompt cache hits

### DIFF
--- a/llm/transformer/anthropic/cache_control_test.go
+++ b/llm/transformer/anthropic/cache_control_test.go
@@ -397,8 +397,10 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.NotNil(t, anthropicReq.System)
 		require.Len(t, anthropicReq.System.MultiplePrompts, 2)
 
-		// strict mode 下仅保留 system 最后一个结构锚点
-		require.Nil(t, anthropicReq.System.MultiplePrompts[0].CacheControl)
+		// 客户端声明的断点原样保留（含 TTL），不再清空重排
+		require.NotNil(t, anthropicReq.System.MultiplePrompts[0].CacheControl)
+		require.Equal(t, "ephemeral", anthropicReq.System.MultiplePrompts[0].CacheControl.Type)
+		require.Equal(t, "5m", anthropicReq.System.MultiplePrompts[0].CacheControl.TTL)
 
 		// Check second system prompt has cache control
 		require.NotNil(t, anthropicReq.System.MultiplePrompts[1].CacheControl)
@@ -484,7 +486,8 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.Len(t, anthropicReq.Tools, 1)
 		require.NotNil(t, anthropicReq.Tools[0].CacheControl)
 		require.Equal(t, "ephemeral", anthropicReq.Tools[0].CacheControl.Type)
-		require.Empty(t, anthropicReq.Tools[0].CacheControl.TTL)
+		// 客户端声明的 TTL 原样保留，不再被清除
+		require.Equal(t, "1h", anthropicReq.Tools[0].CacheControl.TTL)
 	})
 
 	t.Run("tool result with cache control", func(t *testing.T) {
@@ -564,7 +567,8 @@ func TestOutboundTransformer_CacheControl(t *testing.T) {
 		require.Equal(t, "image", block.Type)
 		require.NotNil(t, block.CacheControl)
 		require.Equal(t, "ephemeral", block.CacheControl.Type)
-		require.Empty(t, block.CacheControl.TTL)
+		// 客户端声明的 TTL 原样保留，不再被清除
+		require.Equal(t, "5m", block.CacheControl.TTL)
 	})
 }
 

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -7,36 +7,31 @@ const (
 	adaptiveCacheControlBlockWindow = 20
 )
 
-// optimizeCacheControl 统一自动修复 cache_control：
-//   - strict mode：先清空全部断点，再按固定规划重建，避免历史断点造成抖动
-//   - 强制结构锚点：tools(last) + system(last)
-//   - 消息锚点策略：短内容 1 个、长内容 2 个（受 4 个上限约束）
-//   - 消息首选“最后一条消息的最后一个可缓存块”，更贴近官方示例
-//   - 第 2 个消息锚点优先落在“距离末尾约 20 块”的窗口边界
-//   - thinking 与空 text 不允许打点
+const (
+	cacheControlSectionTools = iota
+	cacheControlSectionSystem
+	cacheControlSectionMessages
+)
+
 func optimizeCacheControl(req *MessageRequest) {
-	// 统一归一化：将 Content 字符串形式转为 MultipleContent 数组，
-	// 后续所有函数只处理数组格式，消除隐式结构改写副作用。
 	normalizeMessageContents(req)
+	sanitizeUnsupportedCacheControls(req)
+	trimCacheControlsToLimit(req, maxCacheControlBreakpoints)
 
-	// 客户端在消息上声明的 cache_control 是其缓存前缀键的一部分，位置必须
-	// 逐字节稳定：缓存命中要求断点前的内容与断点位置完全一致。原实现固定把
-	// 第二锚点放在"距末尾约 20 块"的窗口边界，对话增长后锚点随之后移，
-	// 前缀 hash 失效 -> 每次请求全量缓存重写（cache_read 恒为 0）。
-	// 因此：消息上已有断点时原样保留，仅在总数超限时从最早的消息断点裁剪；
-	// 消息上没有任何断点时，保持原有自动注入策略不变。
-	structural := ensureStructuralCacheControls(req)
-
-	if countMessageBreakpoints(req) > 0 {
-		trimMessageBreakpointsToLimit(req, maxCacheControlBreakpoints)
-	} else if remaining := maxCacheControlBreakpoints - structural; remaining > 0 {
-		refs := collectMessageBlockRefs(req)
-		messageAnchors := min(desiredMessageCacheAnchors(len(refs)), remaining)
-		injectPlannedMessageCacheControls(refs, messageAnchors)
+	remaining := maxCacheControlBreakpoints - countCacheControls(req)
+	if remaining <= 0 {
+		return
 	}
 
-	// 最终安全检查：确保 thinking 和空 text 块上不会被意外注入 cache_control。
-	sanitizeUnsupportedCacheControls(req)
+	ensureStructuralCacheControls(req, remaining)
+	if countMessageBreakpoints(req) > 0 {
+		return
+	}
+
+	remaining = maxCacheControlBreakpoints - countCacheControls(req)
+	refs := collectMessageBlockRefs(req)
+	messageAnchors := min(desiredMessageCacheAnchors(len(refs)), remaining)
+	injectPlannedMessageCacheControls(refs, messageAnchors)
 }
 
 // countMessageBreakpoints 统计 messages 上已存在的 cache_control 断点数（不含 tools/system）。
@@ -54,12 +49,11 @@ func countMessageBreakpoints(req *MessageRequest) int {
 	return count
 }
 
-// trimMessageBreakpointsToLimit 在断点总数超过 Anthropic 上限（4）时，
-// 从最早的消息断点开始裁剪：最早断点覆盖的前缀最短，去掉它对其余
-// 断点的缓存前缀无影响，且保留的较新断点更靠近会话末尾。
-func trimMessageBreakpointsToLimit(req *MessageRequest, limit int) {
+// trimCacheControlsToLimit trims message breakpoints first to preserve the
+// existing policy, then deterministically trims structural-only overflow.
+func trimCacheControlsToLimit(req *MessageRequest, limit int) {
 	for countCacheControls(req) > limit {
-		if !removeEarliestMessageBreakpoint(req) {
+		if !removeEarliestMessageBreakpoint(req) && !removeEarliestStructuralBreakpoint(req) {
 			return
 		}
 	}
@@ -70,6 +64,26 @@ func removeEarliestMessageBreakpoint(req *MessageRequest) bool {
 		for j := range req.Messages[i].Content.MultipleContent {
 			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
 				req.Messages[i].Content.MultipleContent[j].CacheControl = nil
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func removeEarliestStructuralBreakpoint(req *MessageRequest) bool {
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			req.Tools[i].CacheControl = nil
+			return true
+		}
+	}
+
+	if req.System != nil {
+		for i := range req.System.MultiplePrompts {
+			if req.System.MultiplePrompts[i].CacheControl != nil {
+				req.System.MultiplePrompts[i].CacheControl = nil
 				return true
 			}
 		}
@@ -94,31 +108,26 @@ func normalizeMessageContents(req *MessageRequest) {
 	}
 }
 
-// ensureStructuralCacheControls 确保 tools 和 system 的最后一个元素有 cache_control，
-// 返回实际注入的结构锚点数量。
-// 这些位置内容稳定、每次请求重复发送，是 Anthropic 推荐的缓存锚点。
-func ensureStructuralCacheControls(req *MessageRequest) int {
-	count := 0
-
-	// 区块内已有客户端断点时不再补齐，尊重客户端的锚点选择，
-	// 也避免把总数推过 4 个上限后被迫裁剪消息断点。
-	if len(req.Tools) > 0 && !anyToolHasCacheControl(req) {
+// ensureStructuralCacheControls fills tools and system within the global
+// budget. Generated 5m anchors are never placed before a client 1h anchor.
+func ensureStructuralCacheControls(req *MessageRequest, remaining int) {
+	oneHourSection := lastOneHourCacheControlSection(req)
+	if remaining > 0 && oneHourSection <= cacheControlSectionTools && len(req.Tools) > 0 && !anyToolHasCacheControl(req) {
 		req.Tools[len(req.Tools)-1].CacheControl = &CacheControl{Type: "ephemeral"}
-		count++
+		remaining--
 	}
 
-	if req.System == nil {
-		return count
+	if remaining <= 0 || oneHourSection > cacheControlSectionSystem || req.System == nil {
+		return
 	}
 
 	if len(req.System.MultiplePrompts) > 0 {
 		if !anySystemPromptHasCacheControl(req) {
 			last := len(req.System.MultiplePrompts) - 1
 			req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
-			count++
 		}
 
-		return count
+		return
 	}
 
 	// system 是字符串形式时归一化为 MultiplePrompts 数组格式，
@@ -131,10 +140,7 @@ func ensureStructuralCacheControls(req *MessageRequest) int {
 			Text:         text,
 			CacheControl: &CacheControl{Type: "ephemeral"},
 		}}
-		count++
 	}
-
-	return count
 }
 
 func anyToolHasCacheControl(req *MessageRequest) bool {
@@ -155,6 +161,34 @@ func anySystemPromptHasCacheControl(req *MessageRequest) bool {
 	}
 
 	return false
+}
+
+func lastOneHourCacheControlSection(req *MessageRequest) int {
+	section := -1
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil && req.Tools[i].CacheControl.TTL == "1h" {
+			section = cacheControlSectionTools
+		}
+	}
+
+	if req.System != nil {
+		for i := range req.System.MultiplePrompts {
+			if req.System.MultiplePrompts[i].CacheControl != nil && req.System.MultiplePrompts[i].CacheControl.TTL == "1h" {
+				section = cacheControlSectionSystem
+			}
+		}
+	}
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			control := req.Messages[i].Content.MultipleContent[j].CacheControl
+			if control != nil && control.TTL == "1h" {
+				return cacheControlSectionMessages
+			}
+		}
+	}
+
+	return section
 }
 
 // sanitizeUnsupportedCacheControls 清理不允许设置 cache_control 的内容块。
@@ -249,26 +283,6 @@ func collectMessageBlockRefs(req *MessageRequest) []**CacheControl {
 	}
 
 	return refs
-}
-
-// clearCacheControls removes all cache_control breakpoints from tools/system/messages.
-func clearCacheControls(req *MessageRequest) {
-	for i := range req.Tools {
-		req.Tools[i].CacheControl = nil
-	}
-
-	if req.System != nil {
-		for i := range req.System.MultiplePrompts {
-			req.System.MultiplePrompts[i].CacheControl = nil
-		}
-	}
-
-	for i := range req.Messages {
-		msg := &req.Messages[i]
-		for j := range msg.Content.MultipleContent {
-			msg.Content.MultipleContent[j].CacheControl = nil
-		}
-	}
 }
 
 // countCacheControls counts all cache_control breakpoints in tools/system/messages.

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -39,11 +39,7 @@ func countMessageBreakpoints(req *MessageRequest) int {
 	count := 0
 
 	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
-				count++
-			}
-		}
+		count += countContentCacheControls(&req.Messages[i].Content)
 	}
 
 	return count
@@ -61,11 +57,29 @@ func trimCacheControlsToLimit(req *MessageRequest, limit int) {
 
 func removeEarliestMessageBreakpoint(req *MessageRequest) bool {
 	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
-				req.Messages[i].Content.MultipleContent[j].CacheControl = nil
-				return true
-			}
+		if removeEarliestContentBreakpoint(&req.Messages[i].Content) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func removeEarliestContentBreakpoint(content *MessageContent) bool {
+	// Raw content is emitted verbatim. Mutating its structured mirror would make
+	// the budget appear valid without changing the serialized request.
+	if len(content.Raw) > 0 {
+		return false
+	}
+
+	for i := range content.MultipleContent {
+		block := &content.MultipleContent[i]
+		if block.CacheControl != nil {
+			block.CacheControl = nil
+			return true
+		}
+		if block.Content != nil && removeEarliestContentBreakpoint(block.Content) {
+			return true
 		}
 	}
 
@@ -180,11 +194,8 @@ func lastOneHourCacheControlSection(req *MessageRequest) int {
 	}
 
 	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			control := req.Messages[i].Content.MultipleContent[j].CacheControl
-			if control != nil && control.TTL == "1h" {
-				return cacheControlSectionMessages
-			}
+		if contentHasOneHourCacheControl(&req.Messages[i].Content) {
+			return cacheControlSectionMessages
 		}
 	}
 
@@ -196,11 +207,22 @@ func lastOneHourCacheControlSection(req *MessageRequest) int {
 // 在 strict mode 下用作最终安全检查，防止注入逻辑意外命中不可缓存块。
 func sanitizeUnsupportedCacheControls(req *MessageRequest) {
 	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			block := &req.Messages[i].Content.MultipleContent[j]
-			if !isCacheableMessageBlock(*block) && block.CacheControl != nil {
-				block.CacheControl = nil
-			}
+		sanitizeContentCacheControls(&req.Messages[i].Content)
+	}
+}
+
+func sanitizeContentCacheControls(content *MessageContent) {
+	if len(content.Raw) > 0 {
+		return
+	}
+
+	for i := range content.MultipleContent {
+		block := &content.MultipleContent[i]
+		if !isCacheableMessageBlock(*block) && block.CacheControl != nil {
+			block.CacheControl = nil
+		}
+		if block.Content != nil {
+			sanitizeContentCacheControls(block.Content)
 		}
 	}
 }
@@ -273,12 +295,24 @@ func collectMessageBlockRefs(req *MessageRequest) []**CacheControl {
 	refs := make([]**CacheControl, 0)
 
 	for i := range req.Messages {
-		for j := range req.Messages[i].Content.MultipleContent {
-			if !isCacheableMessageBlock(req.Messages[i].Content.MultipleContent[j]) {
-				continue
-			}
+		refs = appendCacheControlRefs(refs, &req.Messages[i].Content)
+	}
 
-			refs = append(refs, &req.Messages[i].Content.MultipleContent[j].CacheControl)
+	return refs
+}
+
+func appendCacheControlRefs(refs []**CacheControl, content *MessageContent) []**CacheControl {
+	if len(content.Raw) > 0 {
+		return refs
+	}
+
+	for i := range content.MultipleContent {
+		block := &content.MultipleContent[i]
+		if isCacheableMessageBlock(*block) {
+			refs = append(refs, &block.CacheControl)
+		}
+		if block.Content != nil {
+			refs = appendCacheControlRefs(refs, block.Content)
 		}
 	}
 
@@ -307,15 +341,39 @@ func countCacheControls(req *MessageRequest) int {
 
 	// Count message content blocks.
 	for i := range req.Messages {
-		msg := &req.Messages[i]
-		for j := range msg.Content.MultipleContent {
-			if isCacheableMessageBlock(msg.Content.MultipleContent[j]) && msg.Content.MultipleContent[j].CacheControl != nil {
-				count++
-			}
+		count += countContentCacheControls(&req.Messages[i].Content)
+	}
+
+	return count
+}
+
+func countContentCacheControls(content *MessageContent) int {
+	count := 0
+	for i := range content.MultipleContent {
+		block := &content.MultipleContent[i]
+		if isCacheableMessageBlock(*block) && block.CacheControl != nil {
+			count++
+		}
+		if block.Content != nil {
+			count += countContentCacheControls(block.Content)
 		}
 	}
 
 	return count
+}
+
+func contentHasOneHourCacheControl(content *MessageContent) bool {
+	for i := range content.MultipleContent {
+		block := &content.MultipleContent[i]
+		if block.CacheControl != nil && block.CacheControl.TTL == "1h" {
+			return true
+		}
+		if block.Content != nil && contentHasOneHourCacheControl(block.Content) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isCacheableMessageBlock(block MessageContentBlock) bool {

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -18,21 +18,64 @@ func optimizeCacheControl(req *MessageRequest) {
 	// 统一归一化：将 Content 字符串形式转为 MultipleContent 数组，
 	// 后续所有函数只处理数组格式，消除隐式结构改写副作用。
 	normalizeMessageContents(req)
-	clearCacheControls(req)
 
+	// 客户端在消息上声明的 cache_control 是其缓存前缀键的一部分，位置必须
+	// 逐字节稳定：缓存命中要求断点前的内容与断点位置完全一致。原实现固定把
+	// 第二锚点放在"距末尾约 20 块"的窗口边界，对话增长后锚点随之后移，
+	// 前缀 hash 失效 -> 每次请求全量缓存重写（cache_read 恒为 0）。
+	// 因此：消息上已有断点时原样保留，仅在总数超限时从最早的消息断点裁剪；
+	// 消息上没有任何断点时，保持原有自动注入策略不变。
 	structural := ensureStructuralCacheControls(req)
 
-	remaining := maxCacheControlBreakpoints - structural
-	if remaining <= 0 {
-		return
+	if countMessageBreakpoints(req) > 0 {
+		trimMessageBreakpointsToLimit(req, maxCacheControlBreakpoints)
+	} else if remaining := maxCacheControlBreakpoints - structural; remaining > 0 {
+		refs := collectMessageBlockRefs(req)
+		messageAnchors := min(desiredMessageCacheAnchors(len(refs)), remaining)
+		injectPlannedMessageCacheControls(refs, messageAnchors)
 	}
-
-	refs := collectMessageBlockRefs(req)
-	messageAnchors := min(desiredMessageCacheAnchors(len(refs)), remaining)
-	injectPlannedMessageCacheControls(refs, messageAnchors)
 
 	// 最终安全检查：确保 thinking 和空 text 块上不会被意外注入 cache_control。
 	sanitizeUnsupportedCacheControls(req)
+}
+
+// countMessageBreakpoints 统计 messages 上已存在的 cache_control 断点数（不含 tools/system）。
+func countMessageBreakpoints(req *MessageRequest) int {
+	count := 0
+
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// trimMessageBreakpointsToLimit 在断点总数超过 Anthropic 上限（4）时，
+// 从最早的消息断点开始裁剪：最早断点覆盖的前缀最短，去掉它对其余
+// 断点的缓存前缀无影响，且保留的较新断点更靠近会话末尾。
+func trimMessageBreakpointsToLimit(req *MessageRequest, limit int) {
+	for countCacheControls(req) > limit {
+		if !removeEarliestMessageBreakpoint(req) {
+			return
+		}
+	}
+}
+
+func removeEarliestMessageBreakpoint(req *MessageRequest) bool {
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content.MultipleContent {
+			if req.Messages[i].Content.MultipleContent[j].CacheControl != nil {
+				req.Messages[i].Content.MultipleContent[j].CacheControl = nil
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // normalizeMessageContents 将 Messages 中的纯字符串 Content 统一归一化为 MultipleContent 数组格式。
@@ -57,7 +100,9 @@ func normalizeMessageContents(req *MessageRequest) {
 func ensureStructuralCacheControls(req *MessageRequest) int {
 	count := 0
 
-	if len(req.Tools) > 0 {
+	// 区块内已有客户端断点时不再补齐，尊重客户端的锚点选择，
+	// 也避免把总数推过 4 个上限后被迫裁剪消息断点。
+	if len(req.Tools) > 0 && !anyToolHasCacheControl(req) {
 		req.Tools[len(req.Tools)-1].CacheControl = &CacheControl{Type: "ephemeral"}
 		count++
 	}
@@ -67,9 +112,11 @@ func ensureStructuralCacheControls(req *MessageRequest) int {
 	}
 
 	if len(req.System.MultiplePrompts) > 0 {
-		last := len(req.System.MultiplePrompts) - 1
-		req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
-		count++
+		if !anySystemPromptHasCacheControl(req) {
+			last := len(req.System.MultiplePrompts) - 1
+			req.System.MultiplePrompts[last].CacheControl = &CacheControl{Type: "ephemeral"}
+			count++
+		}
 
 		return count
 	}
@@ -88,6 +135,26 @@ func ensureStructuralCacheControls(req *MessageRequest) int {
 	}
 
 	return count
+}
+
+func anyToolHasCacheControl(req *MessageRequest) bool {
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func anySystemPromptHasCacheControl(req *MessageRequest) bool {
+	for i := range req.System.MultiplePrompts {
+		if req.System.MultiplePrompts[i].CacheControl != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 // sanitizeUnsupportedCacheControls 清理不允许设置 cache_control 的内容块。

--- a/llm/transformer/anthropic/ensure_cache_control.go
+++ b/llm/transformer/anthropic/ensure_cache_control.go
@@ -1,5 +1,10 @@
 package anthropic
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // maxCacheControlBreakpoints is the maximum number of cache_control breakpoints allowed by Anthropic.
 // See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.
 const (
@@ -66,10 +71,8 @@ func removeEarliestMessageBreakpoint(req *MessageRequest) bool {
 }
 
 func removeEarliestContentBreakpoint(content *MessageContent) bool {
-	// Raw content is emitted verbatim. Mutating its structured mirror would make
-	// the budget appear valid without changing the serialized request.
 	if len(content.Raw) > 0 {
-		return false
+		return removeEarliestRawCacheControl(content)
 	}
 
 	for i := range content.MultipleContent {
@@ -348,6 +351,23 @@ func countCacheControls(req *MessageRequest) int {
 }
 
 func countContentCacheControls(content *MessageContent) int {
+	if len(content.Raw) > 0 {
+		value, err := decodeRawContent(content.Raw)
+		if err != nil {
+			return 0
+		}
+
+		count := 0
+		walkRawContent(value, func(block map[string]any) bool {
+			if block["cache_control"] != nil {
+				count++
+			}
+			return false
+		})
+
+		return count
+	}
+
 	count := 0
 	for i := range content.MultipleContent {
 		block := &content.MultipleContent[i]
@@ -363,6 +383,25 @@ func countContentCacheControls(content *MessageContent) int {
 }
 
 func contentHasOneHourCacheControl(content *MessageContent) bool {
+	if len(content.Raw) > 0 {
+		value, err := decodeRawContent(content.Raw)
+		if err != nil {
+			return false
+		}
+
+		found := false
+		walkRawContent(value, func(block map[string]any) bool {
+			control, ok := block["cache_control"].(map[string]any)
+			if ok && control["ttl"] == "1h" {
+				found = true
+				return true
+			}
+			return false
+		})
+
+		return found
+	}
+
 	for i := range content.MultipleContent {
 		block := &content.MultipleContent[i]
 		if block.CacheControl != nil && block.CacheControl.TTL == "1h" {
@@ -370,6 +409,71 @@ func contentHasOneHourCacheControl(content *MessageContent) bool {
 		}
 		if block.Content != nil && contentHasOneHourCacheControl(block.Content) {
 			return true
+		}
+	}
+
+	return false
+}
+
+func removeEarliestRawCacheControl(content *MessageContent) bool {
+	value, err := decodeRawContent(content.Raw)
+	if err != nil {
+		return false
+	}
+
+	removed := walkRawContent(value, func(block map[string]any) bool {
+		if block["cache_control"] == nil {
+			return false
+		}
+		delete(block, "cache_control")
+		return true
+	})
+	if !removed {
+		return false
+	}
+
+	updated, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+
+	var blocks []MessageContentBlock
+	if err := json.Unmarshal(updated, &blocks); err != nil {
+		return false
+	}
+
+	content.Raw = updated
+	content.MultipleContent = blocks
+
+	return true
+}
+
+func decodeRawContent(raw json.RawMessage) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}
+
+func walkRawContent(value any, visit func(map[string]any) bool) bool {
+	switch value := value.(type) {
+	case []any:
+		for _, item := range value {
+			if walkRawContent(item, visit) {
+				return true
+			}
+		}
+	case map[string]any:
+		if visit(value) {
+			return true
+		}
+		if nested, ok := value["content"]; ok {
+			return walkRawContent(nested, visit)
 		}
 	}
 

--- a/llm/transformer/anthropic/ensure_cache_control_regression_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_regression_test.go
@@ -166,14 +166,15 @@ func TestOptimizeCacheControl_preservesClientAnchorsAsConversationGrows(t *testi
 }
 
 func TestOptimizeCacheControl_countsNestedRawBreakpoints(t *testing.T) {
-	var content MessageContent
-	require.NoError(t, json.Unmarshal([]byte(`[
+	raw := json.RawMessage(`[
 		{"type":"tool_result","tool_use_id":"tool-1","content":[
 			{"type":"text","text":"cached result","cache_control":{"type":"ephemeral","ttl":"1h"}},
 			{"type":"text","text":"more result","cache_control":{"type":"ephemeral"}}
 		]},
 		{"type":"text","text":"client tail","cache_control":{"type":"ephemeral"}}
-	]`), &content))
+	]`)
+	var content MessageContent
+	content.SetRaw(raw)
 	req := &MessageRequest{
 		Tools:    []Tool{{Name: "tool", CacheControl: &CacheControl{Type: "ephemeral"}}},
 		Messages: []MessageParam{{Role: "user", Content: content}},
@@ -182,16 +183,16 @@ func TestOptimizeCacheControl_countsNestedRawBreakpoints(t *testing.T) {
 	optimizeCacheControl(req)
 
 	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
-	require.JSONEq(t, string(content.Raw), string(req.Messages[0].Content.Raw))
+	require.Equal(t, raw, req.Messages[0].Content.Raw)
 }
 
 func TestOptimizeCacheControl_doesNotInjectBeforeNestedRawOneHourBreakpoint(t *testing.T) {
 	var content MessageContent
-	require.NoError(t, json.Unmarshal([]byte(`[
+	content.SetRaw(json.RawMessage(`[
 		{"type":"tool_result","tool_use_id":"tool-1","content":[
 			{"type":"text","text":"cached result","cache_control":{"type":"ephemeral","ttl":"1h"}}
 		]}
-	]`), &content))
+	]`))
 	req := &MessageRequest{
 		Tools:    []Tool{{Name: "tool"}},
 		System:   &SystemPrompt{MultiplePrompts: []SystemPromptPart{{Type: "text", Text: "system"}}},
@@ -203,4 +204,26 @@ func TestOptimizeCacheControl_doesNotInjectBeforeNestedRawOneHourBreakpoint(t *t
 	require.Nil(t, req.Tools[0].CacheControl)
 	require.Nil(t, req.System.MultiplePrompts[0].CacheControl)
 	require.Equal(t, 1, countCacheControls(req))
+}
+
+func TestOptimizeCacheControl_trimsRawBreakpointsToLimit(t *testing.T) {
+	var content MessageContent
+	content.SetRaw(json.RawMessage(`[
+		{"type":"text","text":"one","cache_control":{"type":"ephemeral"}},
+		{"type":"text","text":"two","cache_control":{"type":"ephemeral"}},
+		{"type":"text","text":"three","cache_control":{"type":"ephemeral"}},
+		{"type":"text","text":"four","cache_control":{"type":"ephemeral"}},
+		{"type":"text","text":"five","cache_control":{"type":"ephemeral"}}
+	]`))
+	req := &MessageRequest{Messages: []MessageParam{{Role: "user", Content: content}}}
+
+	optimizeCacheControl(req)
+
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
+	serialized, err := json.Marshal(req.Messages[0].Content)
+	require.NoError(t, err)
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(serialized, &blocks))
+	require.NotContains(t, blocks[0], "cache_control")
+	require.Contains(t, blocks[4], "cache_control")
 }

--- a/llm/transformer/anthropic/ensure_cache_control_regression_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_regression_test.go
@@ -1,0 +1,165 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptimizeCacheControl_trimsStructuralOnlyOverflow(t *testing.T) {
+	// Given
+	req := &MessageRequest{
+		Tools: []Tool{
+			{Name: "tool-1", CacheControl: &CacheControl{Type: "ephemeral"}},
+			{Name: "tool-2", CacheControl: &CacheControl{Type: "ephemeral"}},
+			{Name: "tool-3", CacheControl: &CacheControl{Type: "ephemeral"}},
+		},
+		System: &SystemPrompt{MultiplePrompts: []SystemPromptPart{
+			{Type: "text", Text: "system-1", CacheControl: &CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "system-2", CacheControl: &CacheControl{Type: "ephemeral"}},
+		}},
+	}
+
+	// When
+	optimizeCacheControl(req)
+
+	// Then
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
+	require.Nil(t, req.Tools[0].CacheControl)
+	require.NotNil(t, req.Tools[1].CacheControl)
+	require.NotNil(t, req.Tools[2].CacheControl)
+	require.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+	require.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
+}
+
+func TestOptimizeCacheControl_generatedAnchorsDoNotDisplaceFourClientBreakpoints(t *testing.T) {
+	// Given
+	req := &MessageRequest{
+		Tools: []Tool{{Name: "tool"}},
+		System: &SystemPrompt{MultiplePrompts: []SystemPromptPart{
+			{Type: "text", Text: "system"},
+		}},
+		Messages: []MessageParam{{
+			Role: "user",
+			Content: MessageContent{MultipleContent: []MessageContentBlock{
+				{Type: "text", Text: lo.ToPtr("client-1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+				{Type: "text", Text: lo.ToPtr("client-2"), CacheControl: &CacheControl{Type: "ephemeral"}},
+				{Type: "text", Text: lo.ToPtr("client-3"), CacheControl: &CacheControl{Type: "ephemeral"}},
+				{Type: "text", Text: lo.ToPtr("client-4"), CacheControl: &CacheControl{Type: "ephemeral"}},
+			}},
+		}},
+	}
+
+	// When
+	optimizeCacheControl(req)
+
+	// Then
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
+	require.Nil(t, req.Tools[0].CacheControl)
+	require.Nil(t, req.System.MultiplePrompts[0].CacheControl)
+	for i := range req.Messages[0].Content.MultipleContent {
+		require.NotNil(t, req.Messages[0].Content.MultipleContent[i].CacheControl)
+	}
+}
+
+func TestOptimizeCacheControl_placesGeneratedFiveMinuteAnchorAfterClientOneHourAnchor(t *testing.T) {
+	// Given
+	req := &MessageRequest{
+		Tools: []Tool{{Name: "tool"}},
+		System: &SystemPrompt{MultiplePrompts: []SystemPromptPart{
+			{
+				Type:         "text",
+				Text:         "system",
+				CacheControl: &CacheControl{Type: "ephemeral", TTL: "1h"},
+			},
+		}},
+		Messages: []MessageParam{{
+			Role:    "user",
+			Content: MessageContent{Content: lo.ToPtr("question")},
+		}},
+	}
+
+	// When
+	optimizeCacheControl(req)
+
+	// Then
+	require.Nil(t, req.Tools[0].CacheControl)
+	require.Equal(t, "1h", req.System.MultiplePrompts[0].CacheControl.TTL)
+	require.Len(t, req.Messages[0].Content.MultipleContent, 1)
+	require.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+	require.Empty(t, req.Messages[0].Content.MultipleContent[0].CacheControl.TTL)
+	require.Equal(t, 2, countCacheControls(req))
+}
+
+func TestOptimizeCacheControl_sanitizesUnsupportedMarkerBeforePlanning(t *testing.T) {
+	// Given
+	req := &MessageRequest{Messages: []MessageParam{{
+		Role: "assistant",
+		Content: MessageContent{MultipleContent: []MessageContentBlock{
+			{
+				Type:         "thinking",
+				Thinking:     lo.ToPtr("thought"),
+				CacheControl: &CacheControl{Type: "ephemeral"},
+			},
+			{Type: "text", Text: lo.ToPtr("answer")},
+		}},
+	}}}
+
+	// When
+	optimizeCacheControl(req)
+
+	// Then
+	require.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+	require.NotNil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
+	require.Equal(t, 1, countCacheControls(req))
+}
+
+func TestOptimizeCacheControl_preservesClientAnchorsAsConversationGrows(t *testing.T) {
+	// Given
+	first := &MessageRequest{
+		Tools: []Tool{{Name: "tool", CacheControl: &CacheControl{Type: "ephemeral"}}},
+		System: &SystemPrompt{MultiplePrompts: []SystemPromptPart{
+			{Type: "text", Text: "system", CacheControl: &CacheControl{Type: "ephemeral"}},
+		}},
+		Messages: []MessageParam{
+			{
+				Role: "user",
+				Content: MessageContent{MultipleContent: []MessageContentBlock{
+					{Type: "text", Text: lo.ToPtr("stable-1"), CacheControl: &CacheControl{Type: "ephemeral"}},
+				}},
+			},
+			{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("reply")}},
+			{
+				Role: "user",
+				Content: MessageContent{MultipleContent: []MessageContentBlock{
+					{Type: "text", Text: lo.ToPtr("stable-2"), CacheControl: &CacheControl{Type: "ephemeral"}},
+				}},
+			},
+		},
+	}
+	second := &MessageRequest{
+		Tools: []Tool{{Name: "tool", CacheControl: &CacheControl{Type: "ephemeral"}}},
+		System: &SystemPrompt{MultiplePrompts: []SystemPromptPart{
+			{Type: "text", Text: "system", CacheControl: &CacheControl{Type: "ephemeral"}},
+		}},
+		Messages: append(append([]MessageParam(nil), first.Messages...),
+			MessageParam{Role: "assistant", Content: MessageContent{Content: lo.ToPtr("new reply")}},
+			MessageParam{Role: "user", Content: MessageContent{Content: lo.ToPtr("new question")}},
+		),
+	}
+
+	// When
+	optimizeCacheControl(first)
+	optimizeCacheControl(second)
+
+	// Then
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(first))
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(second))
+	require.NotNil(t, first.Messages[0].Content.MultipleContent[0].CacheControl)
+	require.NotNil(t, first.Messages[2].Content.MultipleContent[0].CacheControl)
+	require.NotNil(t, second.Messages[0].Content.MultipleContent[0].CacheControl)
+	require.NotNil(t, second.Messages[2].Content.MultipleContent[0].CacheControl)
+	require.Nil(t, second.Messages[3].Content.MultipleContent[0].CacheControl)
+	require.Nil(t, second.Messages[4].Content.MultipleContent[0].CacheControl)
+}

--- a/llm/transformer/anthropic/ensure_cache_control_regression_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_regression_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/samber/lo"
@@ -162,4 +163,44 @@ func TestOptimizeCacheControl_preservesClientAnchorsAsConversationGrows(t *testi
 	require.NotNil(t, second.Messages[2].Content.MultipleContent[0].CacheControl)
 	require.Nil(t, second.Messages[3].Content.MultipleContent[0].CacheControl)
 	require.Nil(t, second.Messages[4].Content.MultipleContent[0].CacheControl)
+}
+
+func TestOptimizeCacheControl_countsNestedRawBreakpoints(t *testing.T) {
+	var content MessageContent
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type":"tool_result","tool_use_id":"tool-1","content":[
+			{"type":"text","text":"cached result","cache_control":{"type":"ephemeral","ttl":"1h"}},
+			{"type":"text","text":"more result","cache_control":{"type":"ephemeral"}}
+		]},
+		{"type":"text","text":"client tail","cache_control":{"type":"ephemeral"}}
+	]`), &content))
+	req := &MessageRequest{
+		Tools:    []Tool{{Name: "tool", CacheControl: &CacheControl{Type: "ephemeral"}}},
+		Messages: []MessageParam{{Role: "user", Content: content}},
+	}
+
+	optimizeCacheControl(req)
+
+	require.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
+	require.JSONEq(t, string(content.Raw), string(req.Messages[0].Content.Raw))
+}
+
+func TestOptimizeCacheControl_doesNotInjectBeforeNestedRawOneHourBreakpoint(t *testing.T) {
+	var content MessageContent
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type":"tool_result","tool_use_id":"tool-1","content":[
+			{"type":"text","text":"cached result","cache_control":{"type":"ephemeral","ttl":"1h"}}
+		]}
+	]`), &content))
+	req := &MessageRequest{
+		Tools:    []Tool{{Name: "tool"}},
+		System:   &SystemPrompt{MultiplePrompts: []SystemPromptPart{{Type: "text", Text: "system"}}},
+		Messages: []MessageParam{{Role: "user", Content: content}},
+	}
+
+	optimizeCacheControl(req)
+
+	require.Nil(t, req.Tools[0].CacheControl)
+	require.Nil(t, req.System.MultiplePrompts[0].CacheControl)
+	require.Equal(t, 1, countCacheControls(req))
 }

--- a/llm/transformer/anthropic/ensure_cache_control_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_test.go
@@ -210,7 +210,7 @@ func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
 		assert.Equal(t, 2, countCacheControls(req))
 	})
 
-	t.Run("客户端设了 4 个断点时会按策略重排并去重", func(t *testing.T) {
+	t.Run("客户端设了 4 个断点（上限内）时原样保留", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{
 				{Name: "t1", CacheControl: &CacheControl{Type: "ephemeral"}},
@@ -234,7 +234,14 @@ func TestEnsureCacheControl_WithinLimit_NoModification(t *testing.T) {
 		}
 
 		optimizeCacheControl(req)
-		assert.Equal(t, 3, countCacheControls(req))
+
+		// 客户端 4 个断点在上限内，原样保留不重排：
+		// 重排会移动断点位置，使已缓存的前缀失效（cache_read 归零）。
+		assert.Equal(t, 4, countCacheControls(req))
+		assert.NotNil(t, req.Tools[0].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
 	})
 }
 
@@ -252,7 +259,7 @@ func TestEnsureCacheControl_ExistingBreakpoints_KeepAsIs(t *testing.T) {
 }
 
 func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
-	t.Run("5 个断点会自动裁剪为最近 4 个", func(t *testing.T) {
+	t.Run("5 个断点裁剪最早的消息断点到 4 个上限", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{
 				{Name: "tool_a", CacheControl: &CacheControl{Type: "ephemeral"}},
@@ -288,21 +295,22 @@ func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
 
 		optimizeCacheControl(req)
 
-		// strict 模式按新策略重建：结构锚点 + 会话末尾消息锚点。
-		assert.Nil(t, req.Tools[0].CacheControl)
+		// 客户端断点原样保留，仅从最早的消息断点裁剪到 4 个上限：
+		// 裁掉 turn1-a（最早、前缀最短），其余断点位置不变。
+		assert.NotNil(t, req.Tools[0].CacheControl)
 		assert.NotNil(t, req.Tools[1].CacheControl)
 
-		assert.Nil(t, req.System.MultiplePrompts[0].CacheControl)
-		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.Nil(t, req.System.MultiplePrompts[1].CacheControl)
 
 		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
 		assert.Nil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
 		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
 
-		assert.Equal(t, 3, countCacheControls(req))
+		assert.Equal(t, 4, countCacheControls(req))
 	})
 
-	t.Run("6 个断点也会自动裁剪为最近 4 个", func(t *testing.T) {
+	t.Run("6 个断点裁剪最早的消息断点到 4 个上限", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools: []Tool{
 				{Name: "tool_a", CacheControl: &CacheControl{Type: "ephemeral"}},
@@ -330,15 +338,17 @@ func TestEnsureCacheControl_ExceedsLimit_TrimToLastFour(t *testing.T) {
 		}
 
 		optimizeCacheControl(req)
-		assert.Equal(t, 3, countCacheControls(req))
-		assert.Nil(t, req.Tools[0].CacheControl)
+
+		// 裁掉两个最早的消息断点（turn1、turn1-b），结构锚点全保留。
+		assert.Equal(t, 4, countCacheControls(req))
+		assert.NotNil(t, req.Tools[0].CacheControl)
 		assert.NotNil(t, req.Tools[1].CacheControl)
-		assert.Nil(t, req.System.MultiplePrompts[0].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
 		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
 		assert.Nil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
 		assert.Nil(t, req.Messages[0].Content.MultipleContent[1].CacheControl)
 		require.Len(t, req.Messages[2].Content.MultipleContent, 1)
-		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
+		assert.Nil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
 	})
 }
 
@@ -977,6 +987,13 @@ func TestEnsureCacheControl_OpenCodePluginScenario(t *testing.T) {
 		}
 
 		optimizeCacheControl(req)
-		assert.Equal(t, 3, countCacheControls(req))
+
+		// 客户端断点在 4 个上限内时原样保留，不重排：
+		// 重排会移动断点位置，使已缓存的前缀失效（cache_read 归零）。
+		assert.Equal(t, 4, countCacheControls(req))
+		assert.NotNil(t, req.Tools[1].CacheControl)
+		assert.NotNil(t, req.System.MultiplePrompts[1].CacheControl)
+		assert.NotNil(t, req.Messages[0].Content.MultipleContent[0].CacheControl)
+		assert.NotNil(t, req.Messages[2].Content.MultipleContent[0].CacheControl)
 	})
 }

--- a/llm/transformer/anthropic/ensure_cache_control_test.go
+++ b/llm/transformer/anthropic/ensure_cache_control_test.go
@@ -568,7 +568,7 @@ func TestEnsureCacheControl_StructuralAnchors(t *testing.T) {
 		assert.Nil(t, req.Tools[0].CacheControl)
 	})
 
-	t.Run("满额消息断点场景仍优先保留 tools/system 锚点", func(t *testing.T) {
+	t.Run("满额消息断点场景不会生成 tools/system 锚点", func(t *testing.T) {
 		req := &MessageRequest{
 			Tools:  []Tool{{Name: "bash"}, {Name: "edit"}},
 			System: &SystemPrompt{Prompt: lo.ToPtr("You are helpful")},
@@ -587,11 +587,10 @@ func TestEnsureCacheControl_StructuralAnchors(t *testing.T) {
 
 		optimizeCacheControl(req)
 
-		assert.NotNil(t, req.Tools[1].CacheControl)
+		assert.Nil(t, req.Tools[1].CacheControl)
 		require.NotNil(t, req.System)
-		require.Len(t, req.System.MultiplePrompts, 1)
-		assert.NotNil(t, req.System.MultiplePrompts[0].CacheControl)
-		assert.LessOrEqual(t, countCacheControls(req), 4)
+		assert.Empty(t, req.System.MultiplePrompts)
+		assert.Equal(t, maxCacheControlBreakpoints, countCacheControls(req))
 	})
 }
 

--- a/llm/transformer/anthropic/integration_test.go
+++ b/llm/transformer/anthropic/integration_test.go
@@ -544,7 +544,7 @@ func TestTransformRequest_Integration(t *testing.T) {
 	}
 
 	// 单独测试 cache_control 超限的 fixture：该文件包含 6 个 cache_control 断点。
-	// strict mode 下会重建为结构锚点 + 受预算约束的消息锚点（此场景为 3 个）。
+	// 客户端断点原样保留，仅在超限时从最早的消息断点裁剪到 4 个上限。
 	t.Run("cache control exceeds limit", func(t *testing.T) {
 		var wantReq MessageRequest
 
@@ -572,7 +572,8 @@ func TestTransformRequest_Integration(t *testing.T) {
 
 		err = json.Unmarshal(outboundReq.Body, &gotReq)
 		require.NoError(t, err)
-		require.Equal(t, 3, countCacheControls(&gotReq))
+		// 6 个断点 -> 裁剪掉 2 个最早的消息断点，保留 4 个。
+		require.Equal(t, 4, countCacheControls(&gotReq))
 	})
 }
 


### PR DESCRIPTION
## Problem

The auto-optimization pipeline (`optimizeCacheControl`) clears all client-provided `cache_control` breakpoints and re-plans them. The second message anchor is placed at a fixed window boundary (~20 blocks from the end, `pickWindowAnchorIndex`), so **as a conversation grows, the anchor lands on a different block in every request**.

Anthropic prompt caching only hits when the prefix up to a breakpoint is byte-identical to a previously cached entry. A moving breakpoint invalidates the prefix hash on every turn, so every request pays a **full cache write** and `cache_read_input_tokens` stays 0 — even though the actual conversation prefix is unchanged.

## Evidence (real deployment, single user, single conversation)

From `request_executions` on one channel over a few hours: **139/148 requests had `cache_read_input_tokens = 0`**, all paying full cache writes (~24K tokens each).

Controlled replay directly against the upstream (identical headers, only the body varying):

| Scenario | cache_read |
|---|---|
| Same request body sent twice | **24232** (full hit) |
| Same conversation +2 messages, breakpoints re-planned (old behavior) | **0** (full rewrite) |
| Same conversation +2 messages, breakpoint kept at original position | **24419** (hit) |

The upstream relay/cache itself works fine — the moving breakpoint is the sole cause.

Secondary issue: client-set `TTL` values (`1h`/`5m`) were silently wiped by the strict re-plan; they are now preserved.

## Fix

- **Client message breakpoints are preserved verbatim** (position + TTL) — they are part of the cache prefix key and must be byte-stable across turns
- Structural anchors (tools/system last) are only filled when the section has **no** breakpoint at all, so client anchor choices are respected and the total is not pushed over the limit unnecessarily
- When the total exceeds the 4-breakpoint API limit, **the earliest message breakpoints are trimmed** (they cover the shortest prefix, so removing them does not invalidate the remaining cached entries) instead of re-planning everything
- Requests with **zero** message breakpoints keep the existing auto-inject behavior unchanged

## Tests

- Updated `ensure_cache_control_test.go`, `cache_control_test.go`, `integration_test.go` to the preserve/trim semantics (kept all zero-breakpoint auto-inject tests as-is)
- `go test ./...` passes in `llm/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved client-defined cache-control settings for system prompts, tools, images, and messages.
  * Improved handling when cache-control breakpoints exceed the allowed limit by trimming only the earliest message breakpoints.
  * Retained valid client breakpoints instead of rebuilding or removing them unnecessarily.
  * Maintained structural cache anchors unless client-defined breakpoints are already present.
  * Improved cache-control handling for nested and raw message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->