### PR TITLE
fix(frontend): paginate API key selectors and filters

### DIFF
--- a/frontend/src/components/auto-complete-select.tsx
+++ b/frontend/src/components/auto-complete-select.tsx
@@ -19,6 +19,12 @@ type Props<T extends string> = {
   portalContainer?: HTMLElement | null;
   /** 自定义输入框的 className */
   inputClassName?: string;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void | Promise<unknown>;
+  onOpenChange?: (open: boolean) => void;
 };
 
 // AutoCompleteSelect: strictly selects from provided items. No free-form values are allowed.
@@ -31,9 +37,23 @@ export function AutoCompleteSelect<T extends string>({
   placeholder = 'Search...',
   portalContainer,
   inputClassName,
+  searchValue: controlledSearchValue,
+  onSearchValueChange,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
+  onOpenChange,
 }: Props<T>) {
   const [open, setOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
+  const [internalSearchValue, setInternalSearchValue] = useState('');
+  const searchValue = controlledSearchValue ?? internalSearchValue;
+  const setSearchValue = onSearchValueChange ?? setInternalSearchValue;
+  const isServerSearch = !!onSearchValueChange;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
 
   // map value -> label for quick lookup
   const labels = useMemo(
@@ -50,10 +70,10 @@ export function AutoCompleteSelect<T extends string>({
 
   // Filter items locally based on search string
   const filtered = useMemo(() => {
-    if (!searchValue) return items;
+    if (isServerSearch || !searchValue) return items;
     const q = searchValue.toLowerCase();
     return items.filter((it) => it.label.toLowerCase().includes(q));
-  }, [items, searchValue]);
+  }, [isServerSearch, items, searchValue]);
 
   const onInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     // Strict mode: on blur, revert input text to the selected label
@@ -69,34 +89,31 @@ export function AutoCompleteSelect<T extends string>({
     if (!exists) return;
     onSelectedValueChange(inputValue as T);
     setSearchValue(labels[inputValue] ?? '');
-    setOpen(false);
+    handleOpenChange(false);
   };
 
-  // Keep the search field in sync with the selected item when selection changes externally
-  // This also initializes the field with the current label.
+  // Keep the closed input synchronized with the selection without overwriting an active server search.
   useEffect(() => {
-    setSearchValue(labels[selectedValue] ?? '');
-  }, [labels, selectedValue]);
+    if (!open) setSearchValue(labels[selectedValue] ?? '');
+  }, [labels, open, selectedValue]);
 
   return (
     <div className='flex w-full min-w-0 items-center'>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <Command shouldFilter={false} className='w-full bg-transparent'>
           <PopoverAnchor asChild>
             <CommandPrimitive.Input
               asChild
               value={searchValue}
               onValueChange={setSearchValue}
-              onKeyDown={(e) => setOpen(e.key !== 'Escape')}
+              onKeyDown={(e) => handleOpenChange(e.key !== 'Escape')}
               onMouseDown={() => {
-                setOpen((prev) => {
-                  if (!prev) {
-                    setSearchValue(''); // 打开时清空搜索，显示所有选项
-                  }
-                  return !prev;
-                });
+                if (!open) {
+                  setSearchValue('');
+                  handleOpenChange(true);
+                }
               }}
-              onFocus={() => setOpen(true)}
+              onFocus={() => handleOpenChange(true)}
               onBlur={onInputBlur}
             >
               <Input placeholder={placeholder} className={cn('w-full', inputClassName)} />
@@ -110,10 +127,10 @@ export function AutoCompleteSelect<T extends string>({
                 e.preventDefault();
               }
             }}
-            className='min-w-[var(--radix-popover-trigger-width)] w-max max-w-[min(400px,90vw)] p-0'
+            className='w-max max-w-[min(400px,90vw)] min-w-[var(--radix-popover-trigger-width)] p-0'
             container={portalContainer}
           >
-            <CommandList>
+            <CommandList hasMore={hasMore} isLoadingMore={isLoadingMore} onLoadMore={onLoadMore}>
               {isLoading && (
                 <CommandPrimitive.Loading>
                   <div className='p-1'>
@@ -138,6 +155,13 @@ export function AutoCompleteSelect<T extends string>({
                 </CommandGroup>
               ) : null}
               {!isLoading ? <CommandEmpty>{emptyMessage ?? 'No items.'}</CommandEmpty> : null}
+              {isLoadingMore && (
+                <CommandPrimitive.Loading>
+                  <div className='p-1'>
+                    <Skeleton className='h-6 w-full' />
+                  </div>
+                </CommandPrimitive.Loading>
+              )}
             </CommandList>
           </PopoverContent>
         </Command>

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -19,6 +19,12 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   }[];
   singleSelect?: boolean;
   footer?: React.ReactNode;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
+  isLoading?: boolean;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void | Promise<unknown>;
 }
 
 /** Renders the searchable faceted filter backed by a TanStack Table column. */
@@ -28,15 +34,26 @@ export function DataTableFacetedFilter<TData, TValue>({
   options = [],
   singleSelect = false,
   footer,
+  searchValue,
+  onSearchValueChange,
+  isLoading = false,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
+  const loadingMoreRef = React.useRef(false);
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
   const selectedValues = singleSelect ? new Set(filterValue ? [filterValue as string] : []) : new Set((filterValue || []) as string[]);
 
   return (
-    <Popover>
+    <Popover
+      onOpenChange={(open) => {
+        if (!open) onSearchValueChange?.('');
+      }}
+    >
       <PopoverTrigger asChild>
         <Button variant='outline' size='sm' className='h-8 border-dashed'>
           <PlusCircledIcon className='h-4 w-4' />
@@ -67,49 +84,81 @@ export function DataTableFacetedFilter<TData, TValue>({
         </Button>
       </PopoverTrigger>
       <PopoverContent className='w-[200px] p-0' align='start'>
-        <Command>
-          <CommandInput placeholder={title} />
-          <CommandList>
-            <CommandEmpty>{t('common.noResultsFound')}</CommandEmpty>
-            <CommandGroup>
-              {options?.map((option) => {
-                const isSelected = selectedValues.has(option.value);
-                return (
-                  <CommandItem
-                    key={option.value}
-                    onSelect={() => {
-                      if (singleSelect) {
-                        // Single select mode: set value directly or clear if already selected
-                        column?.setFilterValue(isSelected ? undefined : option.value);
-                      } else {
-                        // Multi select mode: toggle selection
-                        if (isSelected) {
-                          selectedValues.delete(option.value);
+        <Command shouldFilter={onSearchValueChange ? false : undefined}>
+          <CommandInput
+            placeholder={title}
+            value={onSearchValueChange ? (searchValue ?? '') : undefined}
+            onValueChange={onSearchValueChange}
+          />
+          <CommandList
+            onScroll={(event) => {
+              const list = event.currentTarget;
+              if (
+                onLoadMore &&
+                hasMore &&
+                !isLoadingMore &&
+                !loadingMoreRef.current &&
+                list.scrollHeight - list.scrollTop - list.clientHeight < 32
+              ) {
+                loadingMoreRef.current = true;
+                try {
+                  void Promise.resolve(onLoadMore()).finally(() => {
+                    loadingMoreRef.current = false;
+                  });
+                } catch (error) {
+                  loadingMoreRef.current = false;
+                  throw error;
+                }
+              }
+            }}
+          >
+            {!onSearchValueChange && <CommandEmpty>{t('common.noResultsFound')}</CommandEmpty>}
+            {onSearchValueChange && options.length === 0 ? (
+              <div className='py-6 text-center text-sm'>{isLoading ? t('common.loading') : t('common.noResultsFound')}</div>
+            ) : (
+              <CommandGroup>
+                {options?.map((option) => {
+                  const isSelected = selectedValues.has(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      onSelect={() => {
+                        if (singleSelect) {
+                          // Single select mode: set value directly or clear if already selected
+                          column?.setFilterValue(isSelected ? undefined : option.value);
                         } else {
-                          selectedValues.add(option.value);
+                          // Multi select mode: toggle selection
+                          if (isSelected) {
+                            selectedValues.delete(option.value);
+                          } else {
+                            selectedValues.add(option.value);
+                          }
+                          const filterValues = Array.from(selectedValues);
+                          column?.setFilterValue(filterValues?.length ? filterValues : undefined);
                         }
-                        const filterValues = Array.from(selectedValues);
-                        column?.setFilterValue(filterValues?.length ? filterValues : undefined);
-                      }
-                    }}
-                  >
-                    <div
-                      className={cn(
-                        'border-primary flex h-4 w-4 items-center justify-center rounded-sm border',
-                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
-                      )}
+                      }}
                     >
-                      <CheckIcon className={cn('h-4 w-4')} />
-                    </div>
-                    {option.icon && <option.icon className='text-muted-foreground h-4 w-4' />}
-                    <span>{option.label}</span>
-                    {facets?.has(option.value) && (
-                      <span className='ml-auto flex h-4 w-4 items-center justify-center font-mono text-xs'>{facets.get(option.value)}</span>
-                    )}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
+                      <div
+                        className={cn(
+                          'border-primary flex h-4 w-4 items-center justify-center rounded-sm border',
+                          isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
+                        )}
+                      >
+                        <CheckIcon className={cn('h-4 w-4')} />
+                      </div>
+                      {option.icon && <option.icon className='text-muted-foreground h-4 w-4' />}
+                      <span>{option.label}</span>
+                      {facets?.has(option.value) && (
+                        <span className='ml-auto flex h-4 w-4 items-center justify-center font-mono text-xs'>
+                          {facets.get(option.value)}
+                        </span>
+                      )}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            )}
+            {isLoadingMore && <div className='py-2 text-center text-sm'>{t('common.loading')}</div>}
             {footer && (
               <>
                 <CommandSeparator />

--- a/frontend/src/components/data-table-faceted-filter.tsx
+++ b/frontend/src/components/data-table-faceted-filter.tsx
@@ -42,7 +42,6 @@ export function DataTableFacetedFilter<TData, TValue>({
   onLoadMore,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation();
-  const loadingMoreRef = React.useRef(false);
 
   const facets = column?.getFacetedUniqueValues() || new Map();
   const filterValue = column?.getFilterValue();
@@ -90,28 +89,7 @@ export function DataTableFacetedFilter<TData, TValue>({
             value={onSearchValueChange ? (searchValue ?? '') : undefined}
             onValueChange={onSearchValueChange}
           />
-          <CommandList
-            onScroll={(event) => {
-              const list = event.currentTarget;
-              if (
-                onLoadMore &&
-                hasMore &&
-                !isLoadingMore &&
-                !loadingMoreRef.current &&
-                list.scrollHeight - list.scrollTop - list.clientHeight < 32
-              ) {
-                loadingMoreRef.current = true;
-                try {
-                  void Promise.resolve(onLoadMore()).finally(() => {
-                    loadingMoreRef.current = false;
-                  });
-                } catch (error) {
-                  loadingMoreRef.current = false;
-                  throw error;
-                }
-              }
-            }}
-          >
+          <CommandList hasMore={hasMore} isLoadingMore={isLoadingMore} onLoadMore={onLoadMore}>
             {!onSearchValueChange && <CommandEmpty>{t('common.noResultsFound')}</CommandEmpty>}
             {onSearchValueChange && options.length === 0 ? (
               <div className='py-6 text-center text-sm'>{isLoading ? t('common.loading') : t('common.noResultsFound')}</div>

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -58,11 +58,36 @@ function CommandInput({ className, ...props }: React.ComponentProps<typeof Comma
   );
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+type CommandListProps = React.ComponentProps<typeof CommandPrimitive.List> & {
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void | Promise<unknown>;
+};
+
+function CommandList({ className, onScroll, hasMore = false, isLoadingMore = false, onLoadMore, ...props }: CommandListProps) {
+  const loadingMoreRef = React.useRef(false);
+
+  const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    onScroll?.(event);
+    const list = event.currentTarget;
+    if (onLoadMore && hasMore && !isLoadingMore && !loadingMoreRef.current && list.scrollHeight - list.scrollTop - list.clientHeight < 32) {
+      loadingMoreRef.current = true;
+      try {
+        void Promise.resolve(onLoadMore()).finally(() => {
+          loadingMoreRef.current = false;
+        });
+      } catch (error) {
+        loadingMoreRef.current = false;
+        throw error;
+      }
+    }
+  };
+
   return (
     <CommandPrimitive.List
       data-slot='command-list'
       className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+      onScroll={onLoadMore ? handleScroll : onScroll}
       {...props}
     />
   );

--- a/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
+++ b/frontend/src/features/analytics/components/analytics-faceted-filter.tsx
@@ -18,6 +18,11 @@ interface AnalyticsFacetedFilterProps {
   selectedValues: string[];
   onSelectedValuesChange: (values: string[]) => void;
   isLoading?: boolean;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void | Promise<unknown>;
 }
 
 /** Renders a searchable faceted filter controlled by the analytics filter store. */
@@ -27,6 +32,11 @@ export function AnalyticsFacetedFilter({
   selectedValues,
   onSelectedValuesChange,
   isLoading = false,
+  searchValue,
+  onSearchValueChange,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
 }: AnalyticsFacetedFilterProps) {
   const { t } = useTranslation();
   const selectedValueSet = new Set(selectedValues);
@@ -50,7 +60,11 @@ export function AnalyticsFacetedFilter({
   };
 
   return (
-    <Popover>
+    <Popover
+      onOpenChange={(open) => {
+        if (!open) onSearchValueChange?.('');
+      }}
+    >
       <div className='bg-background dark:bg-input/30 dark:border-input flex h-8 w-fit items-center rounded-md border border-dashed shadow-xs'>
         <PopoverTrigger asChild>
           <Button variant='ghost' size='sm' className='h-full rounded-md border-0 shadow-none'>
@@ -86,38 +100,47 @@ export function AnalyticsFacetedFilter({
         )}
       </div>
       <PopoverContent className='w-[200px] p-0' align='start'>
-        <Command>
-          <CommandInput placeholder={title} />
-          <CommandList>
-            <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>
-            <CommandGroup>
-              {orderedOptions.map((option) => {
-                const isSelected = selectedValueSet.has(option.value);
-                return (
-                  <CommandItem
-                    key={option.value}
-                    onSelect={() =>
-                      onSelectedValuesChange(
-                        isSelected
-                          ? selectedValues.filter((selectedValue) => selectedValue !== option.value)
-                          : [...selectedValues, option.value]
-                      )
-                    }
-                  >
-                    <div
-                      className={cn(
-                        'border-primary flex h-4 w-4 items-center justify-center rounded-sm border',
-                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
-                      )}
+        <Command shouldFilter={onSearchValueChange ? false : undefined}>
+          <CommandInput
+            placeholder={title}
+            value={onSearchValueChange ? (searchValue ?? '') : undefined}
+            onValueChange={onSearchValueChange}
+          />
+          <CommandList hasMore={hasMore} isLoadingMore={isLoadingMore} onLoadMore={onLoadMore}>
+            {!onSearchValueChange && <CommandEmpty>{isLoading ? t('common.loading') : t('common.noResultsFound')}</CommandEmpty>}
+            {onSearchValueChange && orderedOptions.length === 0 ? (
+              <div className='py-6 text-center text-sm'>{isLoading ? t('common.loading') : t('common.noResultsFound')}</div>
+            ) : (
+              <CommandGroup>
+                {orderedOptions.map((option) => {
+                  const isSelected = selectedValueSet.has(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      onSelect={() =>
+                        onSelectedValuesChange(
+                          isSelected
+                            ? selectedValues.filter((selectedValue) => selectedValue !== option.value)
+                            : [...selectedValues, option.value]
+                        )
+                      }
                     >
-                      <CheckIcon className='h-4 w-4' />
-                    </div>
-                    {option.icon && <option.icon className='text-muted-foreground h-4 w-4' />}
-                    <span>{option.label}</span>
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
+                      <div
+                        className={cn(
+                          'border-primary flex h-4 w-4 items-center justify-center rounded-sm border',
+                          isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
+                        )}
+                      >
+                        <CheckIcon className='h-4 w-4' />
+                      </div>
+                      {option.icon && <option.icon className='text-muted-foreground h-4 w-4' />}
+                      <span>{option.label}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            )}
+            {isLoadingMore && <div className='py-2 text-center text-sm'>{t('common.loading')}</div>}
             {selectedValueSet.size > 0 && (
               <>
                 <CommandSeparator />

--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -1,16 +1,17 @@
 import { useState, useCallback, useMemo } from 'react';
+import { IconCalendar, IconX, IconFilter } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { IconCalendar, IconX, IconFilter } from '@tabler/icons-react';
+import { useAnalyticsFilterStore } from '@/stores/analyticsStore';
 import { cn, formatUserName } from '@/lib/utils';
+import { useDebounce } from '@/hooks/use-debounce';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { useAnalyticsFilterStore } from '@/stores/analyticsStore';
+import { useApiKeyOptions, useApiKeyOptionsByIDs } from '@/features/apikeys/data/apikeys';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
-import { useApiKeys } from '@/features/apikeys/data/apikeys';
-import { useUsers } from '@/features/users/data/users';
 import { useProjects } from '@/features/projects/data/projects';
+import { useUsers } from '@/features/users/data/users';
 import { AnalyticsFacetedFilter } from './analytics-faceted-filter';
 
 // Calendar Date → 'YYYY-MM-DD' 字符串（直接取本地年月日，不做时区转换）
@@ -75,22 +76,14 @@ function DateRangePicker({ startDate, endDate, onStartChange, onEndChange }: Dat
         <PopoverTrigger asChild>
           <Button
             variant='outline'
-            className={cn(
-              'h-8 w-[130px] justify-start text-left text-xs font-normal',
-              !startDate && 'text-muted-foreground'
-            )}
+            className={cn('h-8 w-[130px] justify-start text-left text-xs font-normal', !startDate && 'text-muted-foreground')}
           >
             <IconCalendar className='mr-1 h-3 w-3' />
             {startDate || t('analytics.filter.startDate')}
           </Button>
         </PopoverTrigger>
         <PopoverContent className='w-auto p-0' align='start'>
-          <Calendar
-            mode='single'
-            selected={startDate ? parseDate(startDate) : undefined}
-            onSelect={handleStartDateSelect}
-            initialFocus
-          />
+          <Calendar mode='single' selected={startDate ? parseDate(startDate) : undefined} onSelect={handleStartDateSelect} initialFocus />
         </PopoverContent>
       </Popover>
 
@@ -100,10 +93,7 @@ function DateRangePicker({ startDate, endDate, onStartChange, onEndChange }: Dat
         <PopoverTrigger asChild>
           <Button
             variant='outline'
-            className={cn(
-              'h-8 w-[130px] justify-start text-left text-xs font-normal',
-              !endDate && 'text-muted-foreground'
-            )}
+            className={cn('h-8 w-[130px] justify-start text-left text-xs font-normal', !endDate && 'text-muted-foreground')}
           >
             <IconCalendar className='mr-1 h-3 w-3' />
             {endDate || t('analytics.filter.endDate')}
@@ -130,20 +120,23 @@ interface AnalyticsFilterBarProps {
 export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
   const { t } = useTranslation();
   const filter = useAnalyticsFilterStore((state) => state.filter);
-  const {
-    setStartTime,
-    setEndTime,
-    setProjectIDs,
-    setChannelIDs,
-    setModelIDs,
-    setAPIKeyIDs,
-    setUserIDs,
-    resetFilter,
-  } = useAnalyticsFilterStore();
+  const [apiKeySearch, setApiKeySearch] = useState('');
+  const debouncedApiKeySearch = useDebounce(apiKeySearch, 300);
+  const { setStartTime, setEndTime, setProjectIDs, setChannelIDs, setModelIDs, setAPIKeyIDs, setUserIDs, resetFilter } =
+    useAnalyticsFilterStore();
 
   // Fetch real data for dropdowns
   const { data: channels, isLoading: isLoadingChannels } = useAllChannelSummarys();
-  const { data: apiKeysData, isLoading: isLoadingApiKeys } = useApiKeys({ first: 100 });
+  const {
+    data: apiKeysData,
+    isFetching: isFetchingApiKeys,
+    fetchNextPage: fetchNextApiKeyPage,
+    hasNextPage: hasNextApiKeyPage,
+    isFetchingNextPage: isFetchingNextApiKeyPage,
+  } = useApiKeyOptions({ search: debouncedApiKeySearch, includeArchived: true });
+  const { data: selectedApiKeysData } = useApiKeyOptionsByIDs(filter.apiKeyIDs, {
+    enabled: !!filter.apiKeyIDs?.length,
+  });
   const { data: usersData, isLoading: isLoadingUsers } = useUsers({ first: 100 });
   const { data: projectsData, isLoading: isLoadingProjects } = useProjects({ first: 100 });
 
@@ -163,17 +156,23 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
         if (entry.actualModel) modelSet.add(entry.actualModel);
       });
     });
-    return Array.from(modelSet).sort().map((m) => ({ label: m, value: m }));
+    return Array.from(modelSet)
+      .sort()
+      .map((m) => ({ label: m, value: m }));
   }, [channels]);
 
-  const apiKeyOptions = useMemo(
-    () =>
-      (apiKeysData?.edges || []).map((edge) => ({
-        label: edge.node.name,
-        value: String(edge.node.id),
-      })),
-    [apiKeysData]
-  );
+  const apiKeyOptions = useMemo(() => {
+    const options = new Map<string, { label: string; value: string }>();
+    for (const edge of selectedApiKeysData?.edges ?? []) {
+      options.set(edge.node.id, { label: edge.node.name, value: edge.node.id });
+    }
+    for (const page of apiKeysData?.pages ?? []) {
+      for (const edge of page.edges) {
+        options.set(edge.node.id, { label: edge.node.name, value: edge.node.id });
+      }
+    }
+    return Array.from(options.values());
+  }, [apiKeysData, selectedApiKeysData]);
 
   const userOptions = useMemo(
     () =>
@@ -241,20 +240,14 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
   }, [earliestDate, setStartTime, setEndTime]);
 
   const hasFilters =
-    filter.startTime ||
-    filter.endTime ||
-    filter.projectIDs ||
-    filter.channelIDs ||
-    filter.modelIDs ||
-    filter.apiKeyIDs ||
-    filter.userIDs;
+    filter.startTime || filter.endTime || filter.projectIDs || filter.channelIDs || filter.modelIDs || filter.apiKeyIDs || filter.userIDs;
 
   return (
-    <div className='space-y-3 rounded-lg border bg-card p-4'>
+    <div className='bg-card space-y-3 rounded-lg border p-4'>
       {/* Date Filters */}
       <div className='flex flex-wrap items-center gap-2'>
         <div className='flex items-center gap-1.5 text-sm font-medium'>
-          <IconFilter className='h-4 w-4 text-muted-foreground' />
+          <IconFilter className='text-muted-foreground h-4 w-4' />
           {t('analytics.filter.dateRange')}
         </div>
 
@@ -320,7 +313,12 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
           options={apiKeyOptions}
           selectedValues={filter.apiKeyIDs || []}
           onSelectedValuesChange={setAPIKeyIDs}
-          isLoading={isLoadingApiKeys}
+          isLoading={isFetchingApiKeys && !apiKeysData}
+          searchValue={apiKeySearch}
+          onSearchValueChange={setApiKeySearch}
+          hasMore={!!hasNextApiKeyPage}
+          isLoadingMore={isFetchingNextApiKeyPage}
+          onLoadMore={fetchNextApiKeyPage}
         />
 
         <AnalyticsFacetedFilter
@@ -333,7 +331,7 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
 
         {/* Reset Button */}
         {hasFilters && (
-          <Button variant='ghost' size='sm' className='h-8 text-xs text-muted-foreground' onClick={resetFilter}>
+          <Button variant='ghost' size='sm' className='text-muted-foreground h-8 text-xs' onClick={resetFilter}>
             <IconX className='mr-1 h-3 w-3' />
             {t('analytics.filter.reset')}
           </Button>

--- a/frontend/src/features/apikeys/data/apikeys.ts
+++ b/frontend/src/features/apikeys/data/apikeys.ts
@@ -1,4 +1,5 @@
-import { useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { z } from 'zod';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { graphqlRequest } from '@/gql/graphql';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -19,6 +20,7 @@ import type {
 } from './schema';
 import {
   apiKeyConnectionSchema,
+  apiKeyStatusSchema,
   apiKeyProfileQuotaUsageSchema,
   apiKeyProfileTemplateSchema,
   apiKeySchema,
@@ -417,7 +419,114 @@ const LOAD_APIKEY_PROFILE_TEMPLATE_MUTATION = `
   }
 `;
 
+const API_KEY_OPTIONS_QUERY = `
+  query GetAPIKeyOptions($first: Int!, $after: Cursor, $orderBy: APIKeyOrder, $where: APIKeyWhereInput) {
+    apiKeys(first: $first, after: $after, orderBy: $orderBy, where: $where) {
+      edges {
+        node {
+          id
+          name
+          status
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+const apiKeyOptionConnectionSchema = z.object({
+  edges: z.array(
+    z.object({
+      node: z.object({
+        id: z.string(),
+        name: z.string(),
+        status: apiKeyStatusSchema,
+      }),
+    })
+  ),
+  pageInfo: z.object({
+    hasNextPage: z.boolean(),
+    endCursor: z.string().optional().nullable(),
+  }),
+});
+
+async function fetchAPIKeyOptions(
+  selectedProjectId: string | null | undefined,
+  variables: { first: number; after?: string; where: Record<string, unknown> }
+) {
+  const headers = selectedProjectId ? { 'X-Project-ID': selectedProjectId } : undefined;
+  const data = await graphqlRequest<{ apiKeys: unknown }>(
+    API_KEY_OPTIONS_QUERY,
+    {
+      ...variables,
+      orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+    },
+    headers
+  );
+  return apiKeyOptionConnectionSchema.parse(data?.apiKeys);
+}
+
 // React Query hooks
+export function useApiKeyOptions(options?: { search?: string; includeArchived?: boolean; enabled?: boolean }) {
+  const { t } = useTranslation();
+  const { handleError } = useErrorHandler();
+  const selectedProjectId = useSelectedProjectId();
+  const search = options?.search?.trim();
+  const includeArchived = options?.includeArchived ?? false;
+
+  return useInfiniteQuery({
+    queryKey: ['apiKeys', 'options', selectedProjectId, includeArchived, search],
+    queryFn: async ({ pageParam }) => {
+      try {
+        return await fetchAPIKeyOptions(selectedProjectId, {
+          first: 100,
+          after: pageParam,
+          where: {
+            typeNotIn: [NOAUTH_API_KEY_TYPE],
+            statusIn: includeArchived ? ['enabled', 'disabled', 'archived'] : ['enabled', 'disabled'],
+            ...(search ? { nameContainsFold: search } : {}),
+          },
+        });
+      } catch (error) {
+        handleError(error, t('common.errors.internalServerError'));
+        throw error;
+      }
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => (lastPage.pageInfo.hasNextPage ? (lastPage.pageInfo.endCursor ?? undefined) : undefined),
+    enabled: options?.enabled !== false && !!selectedProjectId,
+  });
+}
+
+export function useApiKeyOptionsByIDs(ids: string[] | undefined, options?: { enabled?: boolean }) {
+  const { t } = useTranslation();
+  const { handleError } = useErrorHandler();
+  const selectedProjectId = useSelectedProjectId();
+
+  return useQuery({
+    queryKey: ['apiKeys', 'options', 'selected', selectedProjectId, ids],
+    queryFn: async () => {
+      try {
+        return await fetchAPIKeyOptions(selectedProjectId, {
+          first: Math.min(ids?.length ?? 1, 1000),
+          where: {
+            typeNotIn: [NOAUTH_API_KEY_TYPE],
+            statusIn: ['enabled', 'disabled', 'archived'],
+            idIn: ids,
+          },
+        });
+      } catch (error) {
+        handleError(error, t('common.errors.internalServerError'));
+        throw error;
+      }
+    },
+    enabled: options?.enabled !== false && !!selectedProjectId && !!ids?.length,
+  });
+}
+
 export function useApiKeys(
   variables?: {
     first?: number;

--- a/frontend/src/features/prompts/components/prompts-action-dialog.tsx
+++ b/frontend/src/features/prompts/components/prompts-action-dialog.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useCallback, useState, useRef, useMemo } from 'react';
+import { z } from 'zod';
 import { useForm, useFieldArray, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useTranslation } from 'react-i18next';
-import { z } from 'zod';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { useQueryModels } from '@/gql/models';
+import { useTranslation } from 'react-i18next';
+import { useSelectedProjectId } from '@/stores/projectStore';
+import { extractNumberIDAsNumber, buildGUID } from '@/lib/utils';
+import { useDebounce } from '@/hooks/use-debounce';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
@@ -11,13 +15,11 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { AutoComplete } from '@/components/auto-complete';
-import { useQueryModels } from '@/gql/models';
-import { useApiKeys } from '@/features/apikeys/data/apikeys';
+import { AutoCompleteSelect } from '@/components/auto-complete-select';
+import { useApiKeyOptions, useApiKeyOptionsByIDs } from '@/features/apikeys/data/apikeys';
 import { usePrompts } from '../context/prompts-context';
 import { useCreatePrompt, useUpdatePrompt } from '../data/prompts';
 import { CreatePromptInput, UpdatePromptInput } from '../data/schema';
-import { useSelectedProjectId } from '@/stores/projectStore';
-import { extractNumberIDAsNumber, buildGUID } from '@/lib/utils';
 
 const conditionSchema = z.object({
   type: z.enum(['model_id', 'model_pattern', 'api_key']),
@@ -56,12 +58,12 @@ interface ModelAutoCompleteWrapperProps {
   portalContainer: HTMLDivElement | null;
 }
 
-function ModelAutoCompleteWrapper({ field, modelOptions,  portalContainer }: ModelAutoCompleteWrapperProps) {
+function ModelAutoCompleteWrapper({ field, modelOptions, portalContainer }: ModelAutoCompleteWrapperProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState('');
 
   useEffect(() => {
-    const selectedOption = modelOptions.find(opt => opt.value === field.value);
+    const selectedOption = modelOptions.find((opt) => opt.value === field.value);
     setSearchValue(selectedOption?.label || field.value || '');
   }, [field.value, modelOptions]);
 
@@ -78,6 +80,63 @@ function ModelAutoCompleteWrapper({ field, modelOptions,  portalContainer }: Mod
     />
   );
 }
+interface APIKeyAutoCompleteWrapperProps {
+  field: { value: string; onChange: (value: string) => void };
+  portalContainer: HTMLDivElement | null;
+}
+
+function APIKeyAutoCompleteWrapper({ field, portalContainer }: APIKeyAutoCompleteWrapperProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const debouncedSearchValue = useDebounce(searchValue, 300);
+  const {
+    data: apiKeysData,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useApiKeyOptions({
+    search: debouncedSearchValue,
+    includeArchived: true,
+    enabled: open,
+  });
+  const { data: selectedApiKeyData } = useApiKeyOptionsByIDs(field.value ? [field.value] : undefined, {
+    enabled: !!field.value,
+  });
+
+  const apiKeyOptions = useMemo(() => {
+    const options = new Map<string, { value: string; label: string }>();
+    for (const edge of selectedApiKeyData?.edges ?? []) {
+      options.set(edge.node.id, { value: edge.node.id, label: edge.node.name });
+    }
+    for (const page of apiKeysData?.pages ?? []) {
+      for (const edge of page.edges) {
+        options.set(edge.node.id, { value: edge.node.id, label: edge.node.name });
+      }
+    }
+    return Array.from(options.values());
+  }, [apiKeysData, selectedApiKeyData]);
+
+  return (
+    <AutoCompleteSelect
+      selectedValue={field.value || ''}
+      onSelectedValueChange={field.onChange}
+      items={apiKeyOptions}
+      isLoading={isFetching && !apiKeysData}
+      emptyMessage={t('common.noData')}
+      placeholder={t('prompts.fields.apiKeyPlaceholder')}
+      portalContainer={portalContainer}
+      inputClassName='h-10 text-xs'
+      searchValue={searchValue}
+      onSearchValueChange={setSearchValue}
+      hasMore={!!hasNextPage}
+      isLoadingMore={isFetchingNextPage}
+      onLoadMore={fetchNextPage}
+      onOpenChange={setOpen}
+    />
+  );
+}
 
 interface ConditionGroupProps {
   groupIndex: number;
@@ -85,11 +144,10 @@ interface ConditionGroupProps {
   onRemoveGroup: () => void;
   t: any;
   modelOptions: Array<{ value: string; label: string }>;
-  apiKeyOptions: Array<{ value: string; label: string }>;
   dialogContentRef: React.RefObject<HTMLDivElement | null>;
 }
 
-function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, apiKeyOptions, dialogContentRef }: ConditionGroupProps) {
+function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, dialogContentRef }: ConditionGroupProps) {
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: `conditionGroups.${groupIndex}.conditions`,
@@ -105,19 +163,13 @@ function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, apiK
   });
 
   return (
-    <div className='rounded-lg border bg-muted/30 p-3'>
+    <div className='bg-muted/30 rounded-lg border p-3'>
       <div className='mb-2 flex items-center justify-between'>
-        <span className='text-xs font-medium text-muted-foreground'>
+        <span className='text-muted-foreground text-xs font-medium'>
           {t('prompts.conditions.group')} {groupIndex + 1}
         </span>
         <div className='flex gap-1'>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={handleAddCondition}
-            className='h-7 px-2 text-xs'
-          >
+          <Button type='button' variant='ghost' size='sm' onClick={handleAddCondition} className='h-7 px-2 text-xs'>
             <IconPlus className='mr-1 h-3 w-3' />
             {t('prompts.conditions.add')}
           </Button>
@@ -126,7 +178,7 @@ function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, apiK
             variant='ghost'
             size='sm'
             onClick={onRemoveGroup}
-            className='h-7 px-2 text-xs text-muted-foreground hover:text-destructive'
+            className='text-muted-foreground hover:text-destructive h-7 px-2 text-xs'
           >
             <IconTrash className='h-3 w-3' />
           </Button>
@@ -136,12 +188,12 @@ function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, apiK
         {fields.map((field, conditionIndex) => (
           <div key={field.id}>
             {conditionIndex > 0 && (
-              <div className='relative mb-3 mt-1'>
+              <div className='relative mt-1 mb-3'>
                 <div className='absolute inset-0 flex items-center' aria-hidden='true'>
                   <div className='w-full border-t border-dashed'></div>
                 </div>
                 <div className='relative flex justify-center'>
-                  <span className='bg-muted/50 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground'>
+                  <span className='bg-muted/50 text-muted-foreground px-2 text-[10px] font-semibold tracking-wider uppercase'>
                     {t('prompts.conditions.or')}
                   </span>
                 </div>
@@ -149,73 +201,57 @@ function ConditionGroup({ groupIndex, form, onRemoveGroup, t, modelOptions, apiK
             )}
             <div className='grid grid-cols-[10rem_1fr_2.5rem] items-center gap-2'>
               <FormField
-                 control={form.control}
-                 name={`conditionGroups.${groupIndex}.conditions.${conditionIndex}.type`}
-                 render={({ field }) => (
-                   <FormItem className='space-y-0'>
-                     <Select onValueChange={(value) => {
-                       field.onChange(value);
-                       form.setValue(`conditionGroups.${groupIndex}.conditions.${conditionIndex}.value`, '');
-                     }} value={field.value}>
-                       <FormControl>
-                         <SelectTrigger className='h-10 w-full text-xs'>
-                           <SelectValue />
-                         </SelectTrigger>
-                       </FormControl>
-                       <SelectContent>
-                         <SelectItem value='model_id'>{t('prompts.conditionTypes.model_id')}</SelectItem>
-                         <SelectItem value='model_pattern'>{t('prompts.conditionTypes.model_pattern')}</SelectItem>
-                         <SelectItem value='api_key'>{t('prompts.conditionTypes.api_key')}</SelectItem>
-                       </SelectContent>
-                     </Select>
-                   </FormItem>
-                 )}
-               />
-               <FormField
-                 control={form.control}
-                 name={`conditionGroups.${groupIndex}.conditions.${conditionIndex}.value`}
-                 render={({ field }) => (
-                   <FormItem className='space-y-0'>
-                     <FormControl>
-                       {conditions?.[conditionIndex]?.type === 'model_id' ? (
-                         <ModelAutoCompleteWrapper
-                           field={field}
-                           modelOptions={modelOptions}
-                           portalContainer={dialogContentRef.current}
-                         />
-                       ) : conditions?.[conditionIndex]?.type === 'api_key' ? (
-                         <Select onValueChange={field.onChange} value={field.value}>
-                           <SelectTrigger className='h-10 w-full text-xs'>
-                             <SelectValue placeholder={t('prompts.fields.apiKeyPlaceholder')} />
-                           </SelectTrigger>
-                           <SelectContent>
-                             {apiKeyOptions.map((option) => (
-                               <SelectItem key={option.value} value={option.value}>
-                                 {option.label}
-                               </SelectItem>
-                             ))}
-                           </SelectContent>
-                         </Select>
-                       ) : (
-                         <Input
-                           {...field}
-                           placeholder={t('prompts.fields.conditionValuePlaceholder')}
-                           className='h-10 text-xs'
-                         />
-                       )}
-                     </FormControl>
-                   </FormItem>
-                 )}
-               />
-               <Button
-                 type='button'
-                 variant='ghost'
-                 size='icon'
-                 onClick={() => remove(conditionIndex)}
-                 className='h-10 w-10 text-muted-foreground hover:text-destructive'
-               >
-                 <IconTrash className='h-4 w-4' />
-               </Button>
+                control={form.control}
+                name={`conditionGroups.${groupIndex}.conditions.${conditionIndex}.type`}
+                render={({ field }) => (
+                  <FormItem className='space-y-0'>
+                    <Select
+                      onValueChange={(value) => {
+                        field.onChange(value);
+                        form.setValue(`conditionGroups.${groupIndex}.conditions.${conditionIndex}.value`, '');
+                      }}
+                      value={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger className='h-10 w-full text-xs'>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value='model_id'>{t('prompts.conditionTypes.model_id')}</SelectItem>
+                        <SelectItem value='model_pattern'>{t('prompts.conditionTypes.model_pattern')}</SelectItem>
+                        <SelectItem value='api_key'>{t('prompts.conditionTypes.api_key')}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`conditionGroups.${groupIndex}.conditions.${conditionIndex}.value`}
+                render={({ field }) => (
+                  <FormItem className='space-y-0'>
+                    <FormControl>
+                      {conditions?.[conditionIndex]?.type === 'model_id' ? (
+                        <ModelAutoCompleteWrapper field={field} modelOptions={modelOptions} portalContainer={dialogContentRef.current} />
+                      ) : conditions?.[conditionIndex]?.type === 'api_key' ? (
+                        <APIKeyAutoCompleteWrapper field={field} portalContainer={dialogContentRef.current} />
+                      ) : (
+                        <Input {...field} placeholder={t('prompts.fields.conditionValuePlaceholder')} className='h-10 text-xs' />
+                      )}
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                onClick={() => remove(conditionIndex)}
+                className='text-muted-foreground hover:text-destructive h-10 w-10'
+              >
+                <IconTrash className='h-4 w-4' />
+              </Button>
             </div>
           </div>
         ))}
@@ -231,7 +267,6 @@ export function PromptsActionDialog() {
   const updatePrompt = useUpdatePrompt();
   const selectedProjectId = useSelectedProjectId();
   const { data: availableModels, mutateAsync: fetchModels } = useQueryModels();
-  const { data: apiKeysData } = useApiKeys({ first: 100 });
   const dialogContentRef = useRef<HTMLDivElement>(null);
 
   const isEdit = open === 'edit';
@@ -244,14 +279,6 @@ export function PromptsActionDialog() {
       label: model.id,
     }));
   }, [availableModels]);
-
-  const apiKeyOptions = useMemo(() => {
-    if (!apiKeysData?.edges) return [];
-    return apiKeysData.edges.map((edge) => ({
-      value: String(edge.node.id),
-      label: edge.node.name || `API Key #${edge.node.id}`,
-    }));
-  }, [apiKeysData]);
 
   const form = useForm<FormData>({
     resolver: zodResolver(isEdit ? updatePromptSchema : createPromptSchema) as any,
@@ -266,7 +293,11 @@ export function PromptsActionDialog() {
     },
   });
 
-  const { fields: groupFields, append: appendGroup, remove: removeGroup } = useFieldArray({
+  const {
+    fields: groupFields,
+    append: appendGroup,
+    remove: removeGroup,
+  } = useFieldArray({
     control: form.control,
     name: 'conditionGroups',
   });
@@ -283,23 +314,25 @@ export function PromptsActionDialog() {
 
   useEffect(() => {
     if (isEdit && currentRow) {
-      const conditionGroups = currentRow.settings?.conditions?.map((composite: any) => ({
-        conditions: composite.conditions?.map((condition: any) => {
-          let value = '';
-          if (condition.type === 'model_id' && condition.modelId) {
-            value = condition.modelId;
-          } else if (condition.type === 'model_pattern' && condition.modelPattern) {
-            value = condition.modelPattern;
-          } else if (condition.type === 'api_key' && condition.apiKeyId != null) {
-            // apiKeyId 是数字，需要转换为完整的 GUID 格式以匹配下拉选项
-            value = buildGUID('APIKey', String(condition.apiKeyId));
-          }
-          return {
-            type: condition.type,
-            value,
-          };
-        }) || []
-      })) || [];
+      const conditionGroups =
+        currentRow.settings?.conditions?.map((composite: any) => ({
+          conditions:
+            composite.conditions?.map((condition: any) => {
+              let value = '';
+              if (condition.type === 'model_id' && condition.modelId) {
+                value = condition.modelId;
+              } else if (condition.type === 'model_pattern' && condition.modelPattern) {
+                value = condition.modelPattern;
+              } else if (condition.type === 'api_key' && condition.apiKeyId != null) {
+                // apiKeyId 是数字，需要转换为完整的 GUID 格式以匹配下拉选项
+                value = buildGUID('APIKey', String(condition.apiKeyId));
+              }
+              return {
+                type: condition.type,
+                value,
+              };
+            }) || [],
+        })) || [];
       form.reset({
         name: currentRow.name,
         description: currentRow.description || '',
@@ -326,18 +359,19 @@ export function PromptsActionDialog() {
     async (data: FormData) => {
       if (!selectedProjectId) return;
 
-      const conditions = data.conditionGroups?.map(group => ({
-        conditions: group.conditions.map((condition) => {
-          if (condition.type === 'model_id') {
-            return { type: condition.type, modelId: condition.value };
-          } else if (condition.type === 'model_pattern') {
-            return { type: condition.type, modelPattern: condition.value };
-          } else {
-            const apiKeyId = extractNumberIDAsNumber(condition.value);
-            return { type: condition.type, apiKeyId };
-          }
-        })
-      })) || [];
+      const conditions =
+        data.conditionGroups?.map((group) => ({
+          conditions: group.conditions.map((condition) => {
+            if (condition.type === 'model_id') {
+              return { type: condition.type, modelId: condition.value };
+            } else if (condition.type === 'model_pattern') {
+              return { type: condition.type, modelPattern: condition.value };
+            } else {
+              const apiKeyId = extractNumberIDAsNumber(condition.value);
+              return { type: condition.type, apiKeyId };
+            }
+          }),
+        })) || [];
 
       if (isEdit && currentRow) {
         const input: UpdatePromptInput = {
@@ -387,42 +421,40 @@ export function PromptsActionDialog() {
       <DialogContent className='flex h-[85vh] max-h-[85vh] flex-col overflow-hidden sm:max-w-6xl' ref={dialogContentRef}>
         <DialogHeader className='flex-shrink-0'>
           <DialogTitle>{isEdit ? t('prompts.dialogs.edit.title') : t('prompts.dialogs.create.title')}</DialogTitle>
-          <DialogDescription>
-            {isEdit ? t('prompts.dialogs.edit.description') : t('prompts.dialogs.create.description')}
-          </DialogDescription>
+          <DialogDescription>{isEdit ? t('prompts.dialogs.edit.description') : t('prompts.dialogs.create.description')}</DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className='flex flex-1 flex-col overflow-hidden'>
             <div className='flex flex-1 gap-6 overflow-hidden pb-4'>
               <div className='w-1/3 flex-shrink-0 space-y-4 overflow-y-auto pr-2'>
-            <FormField
-              control={form.control}
-              name='name'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('prompts.fields.name')}</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name='name'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('prompts.fields.name')}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name='description'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('prompts.fields.description')}</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name='description'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('prompts.fields.description')}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
                 <FormField
                   control={form.control}
@@ -433,36 +465,34 @@ export function PromptsActionDialog() {
                       <FormControl>
                         <Input {...field} type='number' />
                       </FormControl>
-                      <FormDescription>
-                        {t('prompts.fields.orderHelp')}
-                      </FormDescription>
+                      <FormDescription>{t('prompts.fields.orderHelp')}</FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
 
-            <FormField
-              control={form.control}
-              name='role'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('prompts.fields.role')}</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder={t('prompts.fields.rolePlaceholder')} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value='system'>system</SelectItem>
-                      <SelectItem value='user'>user</SelectItem>
-                      <SelectItem value='assistant'>assistant</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name='role'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('prompts.fields.role')}</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder={t('prompts.fields.rolePlaceholder')} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value='system'>system</SelectItem>
+                          <SelectItem value='user'>user</SelectItem>
+                          <SelectItem value='assistant'>assistant</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
                 <FormField
                   control={form.control}
@@ -482,9 +512,7 @@ export function PromptsActionDialog() {
                         </SelectContent>
                       </Select>
                       <FormDescription>
-                        {field.value === 'prepend'
-                          ? t('prompts.fields.actionTypeHelpPrepend')
-                          : t('prompts.fields.actionTypeHelpAppend')}
+                        {field.value === 'prepend' ? t('prompts.fields.actionTypeHelpPrepend') : t('prompts.fields.actionTypeHelpAppend')}
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -500,11 +528,7 @@ export function PromptsActionDialog() {
                     <FormItem className='flex min-h-0 flex-1 flex-col'>
                       <FormLabel>{t('prompts.fields.content')}</FormLabel>
                       <FormControl className='flex-1'>
-                        <Textarea
-                          {...field}
-                          placeholder={t('prompts.fields.contentPlaceholder')}
-                          className='h-full min-h-0 resize-none'
-                        />
+                        <Textarea {...field} placeholder={t('prompts.fields.contentPlaceholder')} className='h-full min-h-0 resize-none' />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -515,7 +539,7 @@ export function PromptsActionDialog() {
                   <div className='flex-shrink-0 p-4 pb-2'>
                     <div className='flex items-center justify-between'>
                       <div className='space-y-1'>
-                        <h3 className='text-sm font-medium leading-none'>{t('prompts.conditions.title')}</h3>
+                        <h3 className='text-sm leading-none font-medium'>{t('prompts.conditions.title')}</h3>
                         <p className='text-muted-foreground text-xs'>{t('prompts.conditions.description')}</p>
                       </div>
                       <Button type='button' variant='outline' size='sm' onClick={handleAddGroup} className='h-8'>
@@ -526,7 +550,7 @@ export function PromptsActionDialog() {
                   </div>
                   <div className='flex-1 overflow-y-auto px-4 pb-4'>
                     {groupFields.length === 0 ? (
-                      <div className='text-muted-foreground rounded-lg border border-dashed bg-muted/20 p-8 text-center text-sm'>
+                      <div className='text-muted-foreground bg-muted/20 rounded-lg border border-dashed p-8 text-center text-sm'>
                         {t('prompts.conditions.empty')}
                       </div>
                     ) : (
@@ -536,10 +560,10 @@ export function PromptsActionDialog() {
                             {groupIndex > 0 && (
                               <div className='relative py-2'>
                                 <div className='absolute inset-0 flex items-center' aria-hidden='true'>
-                                  <div className='w-full border-t border-muted-foreground/20'></div>
+                                  <div className='border-muted-foreground/20 w-full border-t'></div>
                                 </div>
                                 <div className='relative flex justify-center'>
-                                  <span className='bg-background px-3 text-xs font-bold uppercase tracking-widest text-primary'>
+                                  <span className='bg-background text-primary px-3 text-xs font-bold tracking-widest uppercase'>
                                     {t('prompts.conditions.and')}
                                   </span>
                                 </div>
@@ -551,7 +575,6 @@ export function PromptsActionDialog() {
                               onRemoveGroup={() => removeGroup(groupIndex)}
                               t={t}
                               modelOptions={modelOptions}
-                              apiKeyOptions={apiKeyOptions}
                               dialogContentRef={dialogContentRef}
                             />
                           </div>

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -7,19 +7,20 @@ import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
 import type { DateTimeRangeValue } from '@/utils/date-range';
 import type { AutoRefreshInterval } from '@/hooks/use-auto-refresh-interval';
+import { useDebounce } from '@/hooks/use-debounce';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { AutoRefreshControl } from '@/components/auto-refresh-control';
+import { DataTableColumnOrderDialog } from '@/components/data-table-column-order-dialog';
 import { DataTableFacetedFilter } from '@/components/data-table-faceted-filter';
 import { DateRangePicker } from '@/components/date-range-picker';
-import { useApiKeys } from '@/features/apikeys/data';
+import { useApiKeyOptions, useApiKeyOptionsByIDs } from '@/features/apikeys/data';
 import { useMe } from '@/features/auth/data/auth';
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { RequestStatus } from '../data/schema';
-import { DataTableColumnOrderDialog } from '@/components/data-table-column-order-dialog';
 import { DataTableViewOptions } from './data-table-view-options';
 import { MODEL_ID_COLUMN } from './requests-columns';
 
@@ -53,6 +54,11 @@ interface RequestFilterControlsProps {
   canViewApiKeys: boolean;
   apiKeyOptions: { value: string; label: string }[];
   isFetchingApiKeys: boolean;
+  apiKeySearch: string;
+  onApiKeySearchChange: (value: string) => void;
+  hasMoreApiKeys: boolean;
+  isFetchingMoreApiKeys: boolean;
+  onLoadMoreApiKeys: () => void;
   showArchivedApiKeys: boolean;
   handleToggleShowArchivedApiKeys: (checked: boolean) => void;
   isMobile?: boolean;
@@ -76,6 +82,11 @@ function RequestFilterControls({
   canViewApiKeys,
   apiKeyOptions,
   isFetchingApiKeys,
+  apiKeySearch,
+  onApiKeySearchChange,
+  hasMoreApiKeys,
+  isFetchingMoreApiKeys,
+  onLoadMoreApiKeys,
   showArchivedApiKeys,
   handleToggleShowArchivedApiKeys,
   isMobile = false,
@@ -141,6 +152,12 @@ function RequestFilterControls({
           column={table.getColumn('caller')}
           title={t('requests.filters.apiKey')}
           options={apiKeyOptions}
+          searchValue={apiKeySearch}
+          onSearchValueChange={onApiKeySearchChange}
+          isLoading={isFetchingApiKeys}
+          hasMore={hasMoreApiKeys}
+          isLoadingMore={isFetchingMoreApiKeys}
+          onLoadMore={onLoadMoreApiKeys}
           footer={apiKeyFooter}
         />
       )}
@@ -196,14 +213,17 @@ export function DataTableToolbar<TData>({
 }: DataTableToolbarProps<TData>) {
   const { t } = useTranslation();
   const [showArchivedApiKeys, setShowArchivedApiKeys] = useState(false);
+  const [apiKeySearch, setApiKeySearch] = useState('');
   const [showArchivedChannels, setShowArchivedChannels] = useState(false);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [columnOrderOpen, setColumnOrderOpen] = useState(false);
+  const debouncedApiKeySearch = useDebounce(apiKeySearch, 300);
   const hasDateRange = !!dateRange?.from || !!dateRange?.to;
   const isFiltered = table.getState().columnFilters.length > 0 || hasDateRange;
 
   // Active filter count for mobile badge (excludes model ID filter)
   const columnFilters = table.getState().columnFilters;
+  const selectedApiKeyIDs = columnFilters.find((filter) => filter.id === 'caller')?.value as string[] | undefined;
   const activeFilterCount = useMemo(() => {
     let count = 0;
     for (const filter of columnFilters) {
@@ -221,11 +241,16 @@ export function DataTableToolbar<TData>({
       // When turning off show archived, prune any archived IDs from the filter
       const currentFilter = table.getColumn('caller')?.getFilterValue() as string[] | undefined;
       if (currentFilter && currentFilter.length > 0) {
-        // Compute visible IDs from raw data (filtering for non-archived status)
-        const visibleIds = new Set(
-          apiKeysData?.edges?.filter((edge) => edge.node.status !== 'archived')?.map((edge) => edge.node.id) ?? []
+        // Only prune IDs confirmed archived; search results do not contain every selected key.
+        const archivedIds = new Set(
+          selectedApiKeysData?.edges?.filter((edge) => edge.node.status === 'archived').map((edge) => edge.node.id) ?? []
         );
-        const prunedFilter = currentFilter.filter((id) => visibleIds.has(id));
+        for (const page of apiKeysData?.pages ?? []) {
+          for (const edge of page.edges) {
+            if (edge.node.status === 'archived') archivedIds.add(edge.node.id);
+          }
+        }
+        const prunedFilter = currentFilter.filter((id) => !archivedIds.has(id));
         table.getColumn('caller')?.setFilterValue(prunedFilter.length > 0 ? prunedFilter : undefined);
       }
     }
@@ -264,22 +289,21 @@ export function DataTableToolbar<TData>({
     includeArchived: showArchivedChannels,
   });
 
-  const { data: apiKeysData, isFetching: isFetchingApiKeys } = useApiKeys(
-    {
-      first: 100,
-      orderBy: { field: 'CREATED_AT', direction: 'DESC' },
-      where: showArchivedApiKeys
-        ? {
-            statusIn: ['enabled', 'disabled', 'archived'],
-          }
-        : {
-            statusIn: ['enabled', 'disabled'],
-          },
-    },
-    {
-      disableAutoFetch: !canViewApiKeys,
-    }
-  );
+  const {
+    data: apiKeysData,
+    isFetching: isFetchingApiKeyOptions,
+    fetchNextPage: fetchNextApiKeyPage,
+    hasNextPage: hasNextApiKeyPage,
+    isFetchingNextPage: isFetchingNextApiKeyPage,
+  } = useApiKeyOptions({
+    search: debouncedApiKeySearch,
+    includeArchived: showArchivedApiKeys,
+    enabled: canViewApiKeys,
+  });
+  const { data: selectedApiKeysData, isFetching: isFetchingSelectedApiKeys } = useApiKeyOptionsByIDs(selectedApiKeyIDs, {
+    enabled: canViewApiKeys && !!selectedApiKeyIDs?.length,
+  });
+  const isFetchingApiKeys = isFetchingApiKeyOptions || isFetchingSelectedApiKeys;
 
   const channelOptions = useMemo(() => {
     if (!canViewChannels || !channelsData?.edges) return [];
@@ -291,13 +315,19 @@ export function DataTableToolbar<TData>({
   }, [canViewChannels, channelsData]);
 
   const apiKeyOptions = useMemo(() => {
-    if (!canViewApiKeys || !apiKeysData?.edges) return [];
+    if (!canViewApiKeys) return [];
 
-    return apiKeysData.edges.map((edge) => ({
-      value: edge.node.id,
-      label: edge.node.name,
-    }));
-  }, [canViewApiKeys, apiKeysData]);
+    const options = new Map<string, { value: string; label: string }>();
+    for (const edge of selectedApiKeysData?.edges ?? []) {
+      options.set(edge.node.id, { value: edge.node.id, label: edge.node.name });
+    }
+    for (const page of apiKeysData?.pages ?? []) {
+      for (const edge of page.edges) {
+        options.set(edge.node.id, { value: edge.node.id, label: edge.node.name });
+      }
+    }
+    return Array.from(options.values());
+  }, [canViewApiKeys, apiKeysData, selectedApiKeysData]);
 
   const requestStatuses = [
     {
@@ -381,6 +411,11 @@ export function DataTableToolbar<TData>({
               canViewApiKeys={canViewApiKeys}
               apiKeyOptions={apiKeyOptions}
               isFetchingApiKeys={isFetchingApiKeys}
+              hasMoreApiKeys={!!hasNextApiKeyPage}
+              isFetchingMoreApiKeys={isFetchingNextApiKeyPage}
+              onLoadMoreApiKeys={fetchNextApiKeyPage}
+              apiKeySearch={apiKeySearch}
+              onApiKeySearchChange={setApiKeySearch}
               showArchivedApiKeys={showArchivedApiKeys}
               handleToggleShowArchivedApiKeys={handleToggleShowArchivedApiKeys}
               isMobile
@@ -408,6 +443,11 @@ export function DataTableToolbar<TData>({
         canViewApiKeys={canViewApiKeys}
         apiKeyOptions={apiKeyOptions}
         isFetchingApiKeys={isFetchingApiKeys}
+        hasMoreApiKeys={!!hasNextApiKeyPage}
+        isFetchingMoreApiKeys={isFetchingNextApiKeyPage}
+        onLoadMoreApiKeys={fetchNextApiKeyPage}
+        apiKeySearch={apiKeySearch}
+        onApiKeySearchChange={setApiKeySearch}
         showArchivedApiKeys={showArchivedApiKeys}
         handleToggleShowArchivedApiKeys={handleToggleShowArchivedApiKeys}
       />


### PR DESCRIPTION
## Problem

Every API key selector / filter in the frontend loads a single fixed page of keys (`useApiKeys({ first: 100 })`) and then filters that page client-side. On a project with more than 100 API keys this silently truncates the list:

- the key you are looking for is often not in the dropdown at all;
- typing in the search box only searches the 100 already-loaded keys;
- an API key that is already selected (e.g. restored from a saved filter) shows as a raw ID, because its record was never loaded — this also affects archived keys.

Affected surfaces: requests table toolbar, analytics filter bar, prompts action dialog.

## Changes

**Data layer** (`features/apikeys/data/apikeys.ts`)

- `useApiKeyOptions({ search, includeArchived })` — `useInfiniteQuery` over `apiKeys(first: 100, after: …)`, ordered by `CREATED_AT DESC`, with server-side search via `nameContainsFold` and `typeNotIn: [noauth]`.
- `useApiKeyOptionsByIDs(ids)` — resolves the currently selected IDs (including `archived`) so selected labels always render, no matter how deep the key is in the list.

**Components**

- `CommandList` takes optional `hasMore` / `isLoadingMore` / `onLoadMore` and fetches the next page when scrolled near the bottom (guarded against duplicate in-flight loads).
- `DataTableFacetedFilter`, `AnalyticsFacetedFilter` and `AutoCompleteSelect` accept a controlled `searchValue` + `onSearchValueChange` and the pagination props. When a search handler is supplied, cmdk's built-in filtering is disabled (`shouldFilter={false}`) so the server result is shown as-is; the search box is cleared when the popover closes.

**Call sites**

- Requests toolbar, analytics filter bar and prompts action dialog switch to the new hooks with a 300 ms debounce on the search input. The prompts dialog's API key `Select` becomes an `AutoCompleteSelect` so it can search and paginate too.

All new props are optional — components keep their previous local-filtering behavior when the props are not passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added searchable API-key filters with server-side search and debounced results.
  - Added pagination and infinite loading for API-key options in analytics, requests, and prompt actions.
  - API-key selectors now preserve selected values while loading additional results.
  - Added loading indicators and improved empty-state messaging during searches and pagination.

- **Bug Fixes**
  - Archived API keys are now handled consistently when filtering and selecting keys.
  - Search and selection state now reset appropriately when filter menus close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->