### PR TITLE
Pass the caller's context through the v0.3.0 and v0.4.0 migrations

### DIFF
--- a/internal/ent/migrate/datamigrate/v0.3.0.go
+++ b/internal/ent/migrate/datamigrate/v0.3.0.go
@@ -31,7 +31,7 @@ func (v *V0_3_0) Version() string {
 
 // Migrate performs the version 0.3.0 data migration.
 func (v *V0_3_0) Migrate(ctx context.Context, client *ent.Client) (err error) {
-	ctx = authz.WithSystemBypass(context.Background(), "database-migrate")
+	ctx = authz.WithSystemBypass(ctx, "database-migrate")
 	// Check if a project already exists
 	_, err = client.Project.Query().Limit(1).First(ctx)
 	if err == nil {

--- a/internal/ent/migrate/datamigrate/v0.4.0.go
+++ b/internal/ent/migrate/datamigrate/v0.4.0.go
@@ -28,7 +28,7 @@ func (v *V0_4_0) Version() string {
 // Migrate performs the version 0.4.0 data migration.
 // Creates a primary data storage if it doesn't exist.
 func (v *V0_4_0) Migrate(ctx context.Context, client *ent.Client) (err error) {
-	ctx = authz.WithSystemBypass(context.Background(), "database-migrate")
+	ctx = authz.WithSystemBypass(ctx, "database-migrate")
 
 	// Check if a primary data storage already exists
 	exists, err := client.DataStorage.Query().


### PR DESCRIPTION
## The problem

`v0.3.0.go:34` and `v0.4.0.go:31` overwrite the `ctx` parameter before it is ever read:

```go
func (v *V0_3_0) Migrate(ctx context.Context, client *ent.Client) (err error) {
	ctx = authz.WithSystemBypass(context.Background(), "database-migrate")
```

Everything the caller attached is dropped: cancellation, deadline, and values. `staticcheck` flags it as SA4009, "argument ctx is overwritten before first use".

The runner passes a live context into every migrator in the same loop, at `datamigrate/migrator.go:136`:

```go
if err := migration.Migrate(ctx, m.client); err != nil {
```

So for these two versions only, a cancellation cannot reach the migration and the values the other migrators keep are lost.

## The four newer migrators already do this correctly

| File | Argument |
|---|---|
| `v0.3.0.go` | `context.Background()` |
| `v0.4.0.go` | `context.Background()` |
| `v1.0.0-beta6.go` | `ctx` |
| `v1.0.0-beta7.go` | `ctx` |
| `v1.0.0-beta8.go` | `ctx` |
| `v1.0.0-beta9.go` | `ctx` |

This change makes the two older ones match the four newer ones.

`authz.WithSystemBypass` does not need a clean context, it wraps whatever it is given:

```go
func WithSystemBypass(ctx context.Context, reason string) context.Context {
	bypassCtx, _ := WithBypassPrivacy(NewSystemContext(ctx), reason)
	return bypassCtx
}
```

## Verification

`go build ./internal/ent/...`, `go vet` and `go test ./internal/ent/migrate/datamigrate/...` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Data migrations now honor the calling operation’s cancellation signals and deadlines.
  - Migration processes consistently retain relevant context, improving reliability when operations are interrupted or time-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->