### PR TITLE
fix(codex): strip user field from outbound requests

### DIFF
--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -247,6 +247,11 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	reqCopy.Metadata = nil
 
+	// The Codex backend rejects the `user` field with a 400 Bad Request, so
+	// strip it out as well. Chat Completions clients may set `user`, and the
+	// shared Responses outbound would otherwise forward it upstream.
+	reqCopy.User = nil
+
 	reqCopy.TransformOptions.ArrayInputs = lo.ToPtr(true)
 
 	hreq, err := t.responsesOutbound.TransformRequest(ctx, &reqCopy)

--- a/llm/transformer/openai/codex/outbound_executor_test.go
+++ b/llm/transformer/openai/codex/outbound_executor_test.go
@@ -273,6 +273,38 @@ func TestCodexOutbound_ImageEditRequestUsesResponsesImageTool(t *testing.T) {
 	require.Equal(t, "You are a helpful assistant that can generate images based on user requests. Must use the image generation tool.", payload.Instructions)
 }
 
+func TestCodexOutbound_TransformRequestStripsUserField(t *testing.T) {
+	ctx := context.Background()
+
+	outbound, err := NewOutboundTransformer(Params{
+		BaseURL: "https://chatgpt.com/backend-api/codex#",
+		TokenProvider: staticTokenGetter{
+			creds: &oauth.OAuthCredentials{
+				AccessToken: testAccessTokenWithAccountID(t),
+				ExpiresAt:   time.Now().Add(time.Hour),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req, err := outbound.TransformRequest(ctx, &llm.Request{
+		Model:     "gpt-5.6-luna",
+		APIFormat: llm.APIFormatOpenAIChatCompletion,
+		Stream:    lo.ToPtr(true),
+		User:      lo.ToPtr("user-123"),
+		Messages: []llm.Message{{
+			Role:    "user",
+			Content: llm.MessageContent{Content: lo.ToPtr("hello")},
+		}},
+	})
+	require.NoError(t, err)
+
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(req.Body, &payload))
+	_, hasUser := payload["user"]
+	assert.False(t, hasUser, "Codex backend rejects the user field with a 400 Bad Request; it must not be sent upstream")
+}
+
 func TestCodexOutbound_TransformImageResponse(t *testing.T) {
 	upstream := &responses.Response{
 		ID:        "resp_image",


### PR DESCRIPTION
## Problem

OpenAI Chat Completions clients may set the optional `user` field (a stable end-user identifier). When such a request is routed to a Codex channel, the Codex outbound transformer forwards it through the shared Responses payload, but the ChatGPT Codex backend (`/backend-api/codex/responses`) rejects any request containing `user` with a **400 Bad Request**.

Codex CLI traffic never sets this field, so it is unaffected; only Chat Completions-originated requests that carry `user` fail.

## Root cause

`llm/transformer/openai/codex/outbound.go` strips `MaxTokens`/`MaxCompletionTokens`/`Metadata` before delegating to the shared Responses outbound (which serializes `llm.Request.User` as `user`), but it does not strip `User`.

## Fix

Set `reqCopy.User = nil` in the Codex outbound transformer, next to the existing field stripping. Verified end-to-end: identical Chat Completions requests against a Codex channel succeed once the field is removed, while requests carrying it receive 400 from the upstream.

## Testing

- Added `TestCodexOutbound_TransformRequestStripsUserField` covering the strip behavior.
- `go test ./transformer/openai/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Codex requests from Chat Completions clients that included a user identifier and could be rejected with a 400 Bad Request.
  - Codex requests now omit the unsupported user field before being sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->