### PR TITLE
fix(frontend): repair height-constrained scroll layout in mobile dialogs

### DIFF
--- a/frontend/src/features/channels/components/channels-model-price-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-model-price-dialog.tsx
@@ -1123,7 +1123,7 @@ export function ChannelsModelPriceDialog() {
                 </div>
               </CardContent>
             </Card>
-            <div ref={priceListRef} className='min-h-40 min-w-0 w-full flex-1 overflow-y-auto overflow-x-hidden pt-4 pr-4 md:min-h-0'>
+            <div ref={priceListRef} className='min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden pt-4 pr-4'>
               {fields.length === 0 && !isLoading && (
                 <div className='text-muted-foreground flex flex-col items-center justify-center py-12'>
                   <p>{t('price.noPrices')}</p>

--- a/frontend/src/features/channels/components/channels-test-history-drawer.tsx
+++ b/frontend/src/features/channels/components/channels-test-history-drawer.tsx
@@ -115,7 +115,7 @@ export function ChannelsTestHistoryDrawer({ open, onOpenChange, channel }: Props
               <p className='text-muted-foreground text-sm'>{channel.name}</p>
             </SheetHeader>
 
-            <ScrollArea className='flex-1'>
+            <ScrollArea className='min-h-0 flex-1'>
               <div className='p-4'>
                 {isLoading ? (
                   <div className='space-y-3'>

--- a/frontend/src/features/models/components/models-association-dialog.tsx
+++ b/frontend/src/features/models/components/models-association-dialog.tsx
@@ -941,46 +941,47 @@ export function ModelsAssociationDialog() {
           <DialogTitle className='text-lg sm:text-xl'>
             {isDeveloperMode ? t('models.dialogs.developerAssociation.title') : t('models.dialogs.association.title')}
           </DialogTitle>
-          <DialogDescription className='text-sm sm:text-base'>
-            {isDeveloperMode
-              ? t('models.dialogs.developerAssociation.description', { name: developerLabel })
-              : t('models.dialogs.association.description', { name: currentRow?.name })}
-          </DialogDescription>
-          <Alert className='mt-3 py-2.5'>
-            <IconInfoCircle className='h-4 w-4' />
-            <AlertDescription className='text-xs sm:text-sm'>
-              {isDeveloperMode
-                ? t('models.dialogs.developerAssociation.inheritanceHelp', { name: developerLabel })
-                : t('models.dialogs.association.inheritanceHelp')}
-            </AlertDescription>
-          </Alert>
-          {!isDeveloperMode && (
-            <div className='mt-3 flex items-start justify-between gap-4 rounded-lg border px-4 py-3'>
-              <div className='space-y-1'>
-                <div className='text-sm font-medium'>{t('models.dialogs.association.disableDeveloperInheritance.label')}</div>
-                <p className='text-muted-foreground text-xs sm:text-sm'>
-                  {t('models.dialogs.association.disableDeveloperInheritance.description')}
-                </p>
-              </div>
-              <Switch
-                checked={disableDeveloperSettingsInheritance}
-                onCheckedChange={(checked) =>
-                  form.setValue('disableDeveloperSettingsInheritance', checked, {
-                    shouldDirty: true,
-                    shouldValidate: true,
-                  })
-                }
-                className='mt-0.5 shrink-0'
-              />
-            </div>
-          )}
         </DialogHeader>
 
-        <div className='flex min-h-0 flex-1 flex-col gap-6 sm:flex-row'>
+        <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto sm:flex-row sm:overflow-hidden'>
           {/* Left Side - Association Rules */}
-          <div className='flex min-h-0 flex-1 flex-col sm:flex-[2]'>
-            {/* Scrollable Rules Section */}
-            <div className='flex-1 overflow-y-auto py-4'>
+          <div className='flex min-w-0 flex-col sm:min-h-0 sm:flex-[2]'>
+            <DialogDescription className='shrink-0 text-sm sm:text-base'>
+              {isDeveloperMode
+                ? t('models.dialogs.developerAssociation.description', { name: developerLabel })
+                : t('models.dialogs.association.description', { name: currentRow?.name })}
+            </DialogDescription>
+            <Alert className='mt-3 shrink-0 py-2.5'>
+              <IconInfoCircle className='h-4 w-4' />
+              <AlertDescription className='text-xs sm:text-sm'>
+                {isDeveloperMode
+                  ? t('models.dialogs.developerAssociation.inheritanceHelp', { name: developerLabel })
+                  : t('models.dialogs.association.inheritanceHelp')}
+              </AlertDescription>
+            </Alert>
+            {!isDeveloperMode && (
+              <div className='mt-3 flex shrink-0 items-start justify-between gap-4 rounded-lg border px-4 py-3'>
+                <div className='space-y-1'>
+                  <div className='text-sm font-medium'>{t('models.dialogs.association.disableDeveloperInheritance.label')}</div>
+                  <p className='text-muted-foreground text-xs sm:text-sm'>
+                    {t('models.dialogs.association.disableDeveloperInheritance.description')}
+                  </p>
+                </div>
+                <Switch
+                  checked={disableDeveloperSettingsInheritance}
+                  onCheckedChange={(checked) =>
+                    form.setValue('disableDeveloperSettingsInheritance', checked, {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                  className='mt-0.5 shrink-0'
+                />
+              </div>
+            )}
+
+            {/* Rules Section - scrolls internally on desktop; part of the single body scroll on mobile */}
+            <div className='flex-1 overflow-y-auto py-4 sm:min-h-0'>
               <Form {...form}>
                 <form id='association-form' onSubmit={form.handleSubmit(onSubmit)} className='space-y-3'>
                   {!isDeveloperMode && (
@@ -996,7 +997,7 @@ export function ModelsAssociationDialog() {
 
                           return (
                             <FormItem className='space-y-0'>
-                              <div className='flex items-center justify-between gap-3'>
+                              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3'>
                                 <div className='flex items-center gap-1.5'>
                                   <FormLabel className='text-sm font-medium'>{t('models.fields.loadBalancerStrategy')}</FormLabel>
                                   <Tooltip>
@@ -1011,7 +1012,7 @@ export function ModelsAssociationDialog() {
                                 </div>
                                 <FormControl>
                                   <Select value={field.value} onValueChange={field.onChange}>
-                                    <SelectTrigger className='w-[140px] shrink-0'>
+                                    <SelectTrigger className='w-full sm:w-[140px] sm:shrink-0'>
                                       <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -1041,7 +1042,7 @@ export function ModelsAssociationDialog() {
 
                           return (
                             <FormItem className='space-y-0'>
-                              <div className='flex items-center justify-between gap-3'>
+                              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3'>
                                 <div className='flex items-center gap-1.5'>
                                   <FormLabel className='text-sm font-medium'>{t('models.fields.traceStickyMode')}</FormLabel>
                                   <Tooltip>
@@ -1056,7 +1057,7 @@ export function ModelsAssociationDialog() {
                                 </div>
                                 <FormControl>
                                   <Select value={field.value} onValueChange={field.onChange}>
-                                    <SelectTrigger className='w-[160px] shrink-0'>
+                                    <SelectTrigger className='w-full sm:w-[160px] sm:shrink-0'>
                                       <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -1121,7 +1122,7 @@ export function ModelsAssociationDialog() {
           </div>
 
             {/* Right Side - Preview */}
-          <div className='flex min-h-0 flex-1 flex-col border-t sm:border-t-0 sm:border-l pt-4 sm:pt-0 sm:pl-6'>
+          <div className='flex min-w-0 flex-col border-t pt-4 sm:min-h-0 sm:flex-1 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-6'>
             <div className='shrink-0 space-y-2 pb-4'>
               <h3 className='text-sm font-semibold'>{t('models.dialogs.association.preview')}</h3>
               <p className='text-muted-foreground text-xs'>
@@ -1134,7 +1135,7 @@ export function ModelsAssociationDialog() {
                 className='h-9 sm:h-8'
               />
             </div>
-            <div className='flex-1 overflow-y-auto'>
+            <div className='flex-1 overflow-y-auto sm:min-h-0'>
               <ChannelModelsList
                 channels={filteredConnections}
                 emptyMessage={

--- a/frontend/src/features/threads/components/trace-drawer.tsx
+++ b/frontend/src/features/threads/components/trace-drawer.tsx
@@ -66,9 +66,9 @@ export function TraceDrawer({ open, onOpenChange, traceId }: TraceDrawerProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side='right' className={cn('w-full p-0 transition-all duration-300', isFullscreen ? 'sm:max-w-none' : 'sm:max-w-[900px] lg:max-w-[1100px]')}>
+      <SheetContent side='right' className={cn('flex w-full flex-col p-0 transition-all duration-300', isFullscreen ? 'sm:max-w-none' : 'sm:max-w-[900px] lg:max-w-[1100px]')}>
         <SheetHeader className={cn(
-          'border-b border-border/50 bg-gradient-to-r from-background via-background to-muted/20 px-6 py-4',
+          'shrink-0 border-b border-border/50 bg-gradient-to-r from-background via-background to-muted/20 px-6 py-4',
           isFullscreen && 'fixed top-0 left-0 right-0 z-50'
         )}>
           <div className='flex items-center justify-between'>
@@ -138,7 +138,7 @@ export function TraceDrawer({ open, onOpenChange, traceId }: TraceDrawerProps) {
         </SheetHeader>
 
         {isLoading ? (
-          <div className='flex h-[calc(100vh-80px)] items-center justify-center bg-gradient-to-b from-background to-muted/20'>
+          <div className='flex min-h-0 flex-1 items-center justify-center bg-gradient-to-b from-background to-muted/20'>
             <div className='space-y-4 text-center'>
               <div className='relative mx-auto h-12 w-12'>
                 <div className='absolute inset-0 rounded-full border-2 border-primary/10' />
@@ -150,8 +150,8 @@ export function TraceDrawer({ open, onOpenChange, traceId }: TraceDrawerProps) {
           </div>
         ) : effectiveRootSegment ? (
           <div className={cn(
-            'flex bg-gradient-to-br from-background via-background to-muted/10',
-            isFullscreen ? 'fixed inset-0 z-40 pt-16' : 'h-[calc(100vh-80px)]'
+            'min-h-0 flex-1 flex bg-gradient-to-br from-background via-background to-muted/10',
+            isFullscreen ? 'fixed inset-0 z-40 pt-16' : ''
           )}>
             {/* Left: Timeline */}
             <div className={cn(
@@ -182,7 +182,7 @@ export function TraceDrawer({ open, onOpenChange, traceId }: TraceDrawerProps) {
 
             {/* Right: Span Detail */}
             <div className={cn(
-              'border-border/50 bg-card/50 shrink-0 overflow-y-auto border-l backdrop-blur-sm transition-all duration-300',
+              'min-h-0 border-border/50 bg-card/50 shrink-0 overflow-y-auto border-l backdrop-blur-sm transition-all duration-300',
               isFullscreen ? 'w-[420px]' : 'w-[380px] lg:w-[420px]'
             )}>
               <SpanSection selectedTrace={selectedTrace} selectedSpan={selectedSpan} selectedSpanType={selectedSpanType} />
@@ -190,8 +190,8 @@ export function TraceDrawer({ open, onOpenChange, traceId }: TraceDrawerProps) {
           </div>
         ) : (
           <div className={cn(
-            'flex items-center justify-center bg-gradient-to-b from-background to-muted/20',
-            isFullscreen ? 'fixed inset-0 z-40 pt-16' : 'h-[calc(100vh-80px)]'
+            'min-h-0 flex-1 flex items-center justify-center bg-gradient-to-b from-background to-muted/20',
+            isFullscreen ? 'fixed inset-0 z-40 pt-16' : ''
           )}>
             <div className='space-y-4 text-center'>
               <div className='relative mx-auto h-16 w-16'>


### PR DESCRIPTION
## Problem

On phones the Model Association dialog was unusable: the rules scroller collapsed to a ~47px sliver (1859px of rules inside it), the Priority/Rule rows were unreachable, and the preview pane physically overlapped the footer — the "Filter by channel name" input intercepted clicks aimed at the Add Rule button. Root cause: the fixed-height shell (90vh) gave precedence to a ~450px pinned header (description + alert + inheritance toggle) plus a stacked pinned footer, leaving ~160px for two stacked flex-1 columns — the inner overflow-y-auto scroller never had a bounded height (min-height:auto flex default; models/association-dialog.tsx#L946-L986).

A repo-wide audit found the same failure class in 3 sibling surfaces:

| File | Break |
|---|---|
| models/association-dialog.tsx#L946-L986 | pinned 450px header + stacked flex-1 columns collapsed the rules scroller (measured clientH 47 / scrollH 1859, preview scroller 0px; input intercepting Add Rule clicks) |
| threads/trace-drawer.tsx#L69-L194 | h-[calc(100vh-80px)] double-counts the sheet header → timeline + span-detail panes extend past the sheet's clipped bottom (measured ~1080px of content in a 784px sheet) |
| channels/channels-test-history-drawer.tsx#L118 | ScrollArea flex-1 without min-h-0 in the 360px column |
| channels/channels-model-price-dialog.tsx#L1126 | mobile min-h-40 floor on the price-list scroller pushed card(15vh)+list+footer past the 85vh clip edge |

## Fix

- **models-association-dialog.tsx**: pin only the title and the footer; description/alert/inheritance scroll with the body; single scroll surface on mobile, independent 2/3–1/3 column scrolls on desktop (sm: unchanged); Load Balancer Strategy / Trace Sticky Mode rows stack label-above-select with full-width selects below sm (removes 320–360px horizontal overflow)
- **threads/trace-drawer.tsx**: real flex-col sheet — shrink-0 header, min-h-0 flex-1 body row replacing the wrong calc(100vh-80px), bounded (min-h-0) span-detail pane
- **channels-test-history-drawer.tsx / channels-model-price-dialog.tsx**: min-h-0 on the respective scrollers

## Verification (headless Chromium, seeded data)

- 360×784 + 390×844: rules render at natural height (130–435px) in one scroll surface, title/footer pinned, 0 nested scroll traps, 0 horizontal overflow at 320/360px
- 1280×900 + 1280×620: two-column layout unchanged, each pane scrolls independently and stays inside its sheet; span-detail + list bottoms exactly at the sheet edge
- price dialog @360: scroller client 317 inside a 666px box with footer visible (was pushed past clip edge)

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/2d430784-500f-4593-ab55-fb38fad5f06b) | ![after](https://github.com/user-attachments/assets/5bb3e920-715b-4234-aac6-f5714150cd4c) |

<details>
<summary>Other fixed-height dialogs audited (29 OK — same min-h-0 convention, no change needed)</summary>

_Reference implementation that already carries the correct chain: models-action-dialog.tsx#L288-L443. Data-storages dialogs grow with content (no viewport height) and are out of scope._

</details>
