### PR TITLE
fix: dialog double scrollbar introduced in 2bfea194

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -1789,7 +1789,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
         }}
       >
         <DialogContent
-          className={`flex max-h-[90vh] flex-col transition-all duration-300 ${showFetchedModelsPanel || showSupportedModelsPanel || showApiKeysPanel ? 'sm:max-w-6xl' : 'sm:max-w-4xl'}`}
+          className={`flex max-h-[90vh] flex-col overflow-hidden transition-all duration-300 ${showFetchedModelsPanel || showSupportedModelsPanel || showApiKeysPanel ? 'sm:max-w-6xl' : 'sm:max-w-4xl'}`}
         >
           <DialogHeader className='flex-shrink-0 text-left'>
             <DialogTitle>{isEdit ? t('channels.dialogs.edit.title') : t('channels.dialogs.create.title')}</DialogTitle>

--- a/frontend/src/features/channels/components/channels-api-key-management-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-api-key-management-dialog.tsx
@@ -321,7 +321,7 @@ export function ChannelsAPIKeyManagementDialog({ open, onOpenChange }: ChannelsA
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='flex max-h-[90vh] flex-col sm:max-w-4xl'>
+      <DialogContent className='flex max-h-[90vh] flex-col overflow-hidden sm:max-w-4xl'>
         <DialogHeader>
           <DialogTitle className='flex items-center gap-2'>
             <IconKey className='h-5 w-5' />

--- a/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-endpoints-dialog.tsx
@@ -399,7 +399,7 @@ export function ChannelsEndpointsDialog({ channel, open, onOpenChange }: Props) 
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent ref={setDialogContentElement} className='flex h-[90vh] max-h-[700px] w-full max-w-full flex-col sm:max-w-4xl'>
+      <DialogContent ref={setDialogContentElement} className='flex h-[90vh] max-h-[700px] w-full max-w-full flex-col overflow-hidden sm:max-w-4xl'>
         <DialogHeader className='shrink-0'>
           <DialogTitle>{t('channels.endpoints.title')}</DialogTitle>
           <DialogDescription>{channel.name}</DialogDescription>


### PR DESCRIPTION
2bfea194 的修改引入了问题，导致编辑渠道/添加渠道对话框会有双重滚动条的问题：

<img width="982" height="682" alt="image" src="https://github.com/user-attachments/assets/10fad034-2f39-4115-80d7-7357dacfff45" />

这个 PR 对 2bfea194 的修改所涉及的对话框进行了调整来解决双重滚动条的问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel dialog layouts by preventing content from overflowing rounded corners and dialog boundaries.
  * Excess content is now clipped within the available dialog area across channel actions, API key management, and endpoint dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->