### PR TITLE
fix: preserve transformed Responses stream events

### DIFF
--- a/internal/server/orchestrator/responses_session.go
+++ b/internal/server/orchestrator/responses_session.go
@@ -281,6 +281,7 @@ type responsesSessionStream struct {
 	store       *responsesSessionStore
 	requestBody []byte
 	inner       streams.Stream[*httpclient.StreamEvent]
+	current     *httpclient.StreamEvent
 	chunks      []*httpclient.StreamEvent
 	chunksBytes int
 	terminal    bool
@@ -290,26 +291,27 @@ type responsesSessionStream struct {
 
 func (s *responsesSessionStream) Next() bool {
 	if !s.inner.Next() {
+		s.current = nil
 		return false
 	}
 
-	event := s.inner.Current()
-	if event != nil {
+	s.current = s.inner.Current()
+	if s.current != nil {
 		if !s.overflow {
-			s.chunksBytes += len(event.Type) + len(event.LastEventID) + len(event.Data)
+			s.chunksBytes += len(s.current.Type) + len(s.current.LastEventID) + len(s.current.Data)
 			if s.chunksBytes > responsesSessionMaxResponse {
 				s.chunks = nil
 				s.overflow = true
 			} else {
 				s.chunks = append(s.chunks, &httpclient.StreamEvent{
-					Type:        event.Type,
-					LastEventID: event.LastEventID,
-					Data:        append([]byte(nil), event.Data...),
-					Size:        event.Size,
+					Type:        s.current.Type,
+					LastEventID: s.current.LastEventID,
+					Data:        append([]byte(nil), s.current.Data...),
+					Size:        s.current.Size,
 				})
 			}
 		}
-		if IsTerminalStreamEvent(event) {
+		if IsTerminalStreamEvent(s.current) {
 			s.terminal = true
 			s.recordCompleted()
 		}
@@ -318,7 +320,7 @@ func (s *responsesSessionStream) Next() bool {
 	return true
 }
 
-func (s *responsesSessionStream) Current() *httpclient.StreamEvent { return s.inner.Current() }
+func (s *responsesSessionStream) Current() *httpclient.StreamEvent { return s.current }
 
 func (s *responsesSessionStream) Err() error { return s.inner.Err() }
 

--- a/internal/server/orchestrator/responses_session_test.go
+++ b/internal/server/orchestrator/responses_session_test.go
@@ -155,6 +155,27 @@ func TestResponsesSessionStoreRecordsCompletedStream(t *testing.T) {
 	)
 }
 
+func TestResponsesSessionStreamPreservesEveryEventForConsumer(t *testing.T) {
+	// Given
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created"}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added"}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed"}`)},
+	}
+	store := newResponsesSessionStore()
+	ctx := shared.WithSessionScope(shared.WithResponsesAPI(context.Background()), "api-key:1")
+	stream := store.wrapStream(ctx, []byte(`{"model":"gpt-5","input":"one"}`), streams.SliceStream(events))
+
+	// When
+	var received []*httpclient.StreamEvent
+	for stream.Next() {
+		received = append(received, stream.Current())
+	}
+
+	// Then
+	require.Equal(t, events, received)
+}
+
 func TestResponsesSessionStoreRecordsBeforeStreamClose(t *testing.T) {
 	store := newResponsesSessionStore()
 	ctx := shared.WithSessionScope(shared.WithResponsesAPI(context.Background()), "api-key:1")


### PR DESCRIPTION
## Summary

- cache the event consumed by `responsesSessionStream.Next`
- return that cached event from `Current` instead of advancing the inner stream again
- add a regression test proving every wrapped event reaches the downstream consumer

## Root cause

The Responses session wrapper added in #2255 reads each inner stream event in `Next` so it can record completed sessions. Its `Current` method then called `inner.Current()` a second time.

That is destructive for transformed Responses streams: queue-backed implementations such as `responsesInboundStream` advance their cursor on every `Current()` call. The wrapper consumed sequence 0 internally, returned sequence 1 to the client, consumed sequence 2 internally, returned sequence 3, and eventually returned `nil` after consuming a single queued delta. The client never received `response.completed`, so the request ended as an incomplete stream.

Native Responses pass-through masked the bug because `passThroughChannelStream.Current()` returns a cached pointer and is idempotent.

## Impact

Affected when all of the following are true:

1. downstream API format is `openai/responses`
2. `stream=true`
3. response pass-through is not applied
4. the final Responses event stream has consumptive `Current()` semantics

This includes Responses requests transformed through Chat Completions, Anthropic, Gemini, or a non-pass-through Responses path. Both SSE and downstream Responses WebSocket use the same `Next`/`Current` contract.

Not affected:

- non-streaming Responses requests
- non-Responses downstream APIs
- native Responses streams with response pass-through applied

The incident appeared model-specific because the sampled GPT-5.6 traffic used native Responses pass-through and completed, while Kimi was transformed through `openai/chat_completions` with `passThroughApplied=false`. The model itself is not the boundary.

## Verification

The regression test failed before the fix with three expected events becoming only the second event plus `nil`. It passes after caching the current event.

```text
go test -race -shuffle=on -count=1 ./internal/server/orchestrator
ok github.com/looplj/axonhub/internal/server/orchestrator
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming event handling so consumers receive each event exactly once and in the correct order.
  * Ensured the current event is cleared when the stream is exhausted.

* **Tests**
  * Added coverage verifying that all events in a response stream are preserved and forwarded unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->