### PR TITLE
fix(api): report server stream deadlines to SSE clients

### DIFF
--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -145,6 +145,8 @@ type StreamErrorFormatter func(ctx context.Context, err error) any
 // that ignore it. Pass-through channel buffers hold 64 events, so 256 is generous.
 const maxStreamEventsAfterCancel = 256
 
+const sseWriteTimeout = 30 * time.Second
+
 // WriteSSEStream writes stream events as Server-Sent Events (SSE) with default error formatting.
 func WriteSSEStream(c *gin.Context, stream streams.Stream[*httpclient.StreamEvent]) {
 	WriteSSEStreamWithErrorFormatter(c, stream, FormatStreamError)
@@ -179,6 +181,7 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 	}
 
 	defer func() {
+		clearSSEWriteDeadline(ctx, c.Writer)
 		if clientDisconnected {
 			log.Warn(ctx, "Client disconnected")
 		}
@@ -186,7 +189,12 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 
 	// Set SSE headers
 	setSSEHeaders(c)
-	c.Writer.Flush()
+	if err := flushSSE(ctx, c.Writer); err != nil {
+		clientDisconnected = true
+		log.Warn(ctx, "Failed to flush SSE headers", log.Cause(err))
+
+		return
+	}
 
 	// Do not pre-check ctx.Done() before Next(). If the client disconnects right
 	// after receiving the terminal event, a preferential ctx.Done() check can abort
@@ -221,9 +229,13 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 			terminalSeen = true
 		}
 
-		c.SSEvent(cur.Type, cur.Data)
+		if err := writeSSEEvent(ctx, c.Writer, cur.Type, cur.Data); err != nil {
+			clientDisconnected = true
+			log.Warn(ctx, "Failed to write SSE event", log.Cause(err))
+
+			return
+		}
 		log.Debug(ctx, "write stream event", log.Any("event", cur))
-		c.Writer.Flush()
 	}
 }
 
@@ -242,13 +254,19 @@ func writeSSEStreamWithHeartbeat(
 	}
 
 	defer func() {
+		clearSSEWriteDeadline(ctx, c.Writer)
 		if clientDisconnected {
 			log.Warn(ctx, "Client disconnected")
 		}
 	}()
 
 	setSSEHeaders(c)
-	c.Writer.Flush()
+	if err := flushSSE(ctx, c.Writer); err != nil {
+		clientDisconnected = true
+		log.Warn(ctx, "Failed to flush SSE headers", log.Cause(err))
+
+		return
+	}
 
 	reader := newSSEStreamReader(ctx, stream)
 	// The caller closes the stream after this function returns. Wait for the
@@ -267,7 +285,9 @@ func writeSSEStreamWithHeartbeat(
 	for {
 		select {
 		case <-ctxDone:
-			clientDisconnected = true
+			if errors.Is(ctx.Err(), context.Canceled) {
+				clientDisconnected = true
+			}
 			ctxDone = nil
 			stopTimer(timer)
 			timerC = nil
@@ -293,16 +313,20 @@ func writeSSEStreamWithHeartbeat(
 				terminalSeen = true
 			}
 
-			c.SSEvent(cur.Type, cur.Data)
+			if err := writeSSEEvent(ctx, c.Writer, cur.Type, cur.Data); err != nil {
+				clientDisconnected = true
+				log.Warn(ctx, "Failed to write SSE event", log.Cause(err))
+
+				return
+			}
 			log.Debug(ctx, "write stream event", log.Any("event", cur))
-			c.Writer.Flush()
 
 			if timerC != nil {
 				resetTimer(timer, interval)
 			}
 
 		case <-timerC:
-			if err := writeSSEHeartbeat(c.Writer, heartbeatFormat); err != nil {
+			if err := writeSSEHeartbeatEvent(ctx, c.Writer, heartbeatFormat); err != nil {
 				clientDisconnected = true
 				log.Warn(ctx, "Failed to write SSE heartbeat", log.Cause(err))
 				return
@@ -315,7 +339,6 @@ func writeSSEStreamWithHeartbeat(
 				log.Duration("interval", interval),
 			)
 
-			c.Writer.Flush()
 			timer.Reset(interval)
 		}
 	}
@@ -339,26 +362,143 @@ func writeSSEStreamEnd(
 	clientDisconnected *bool,
 ) {
 	switch {
-	case streamErr != nil:
-		if errors.Is(streamErr, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			*clientDisconnected = true
-
-			if !errors.Is(streamErr, context.Canceled) {
-				log.Warn(ctx, "Stream error after client disconnected", log.Cause(streamErr))
-			}
-		} else {
-			log.Error(ctx, "Error in stream", log.Cause(streamErr))
-			c.SSEvent("error", formatErr(ctx, orchestrator.ClassifyUpstreamTransportError(streamErr)))
-		}
+	case terminalSeen:
 	case errors.Is(ctx.Err(), context.Canceled):
 		*clientDisconnected = true
-	case !terminalSeen:
+
+		if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
+			log.Warn(ctx, "Stream error after client disconnected", log.Cause(streamErr))
+		}
+	case errors.Is(ctx.Err(), context.DeadlineExceeded) &&
+		(streamErr == nil || errors.Is(streamErr, context.Canceled) || errors.Is(streamErr, context.DeadlineExceeded)):
+		streamErr = ctx.Err()
+		log.Error(ctx, "Stream deadline exceeded", log.Cause(streamErr))
+		if err := writeSSEErrorEvent(ctx, c.Writer, formatErr, streamErr); err != nil {
+			*clientDisconnected = true
+			log.Warn(ctx, "Failed to write SSE deadline error", log.Cause(err))
+		}
+	case streamErr != nil:
+		log.Error(ctx, "Error in stream", log.Cause(streamErr))
+		if err := writeSSEErrorEvent(ctx, c.Writer, formatErr, streamErr); err != nil {
+			*clientDisconnected = true
+			log.Warn(ctx, "Failed to write SSE stream error", log.Cause(err))
+		}
+	default:
 		log.Error(ctx, "Stream ended without terminal event, reporting incomplete stream to client",
 			log.Cause(orchestrator.ErrStreamIncomplete))
-		c.SSEvent("error", formatErr(ctx, orchestrator.ClassifyUpstreamTransportError(orchestrator.ErrStreamIncomplete)))
+		if err := writeSSEErrorEvent(ctx, c.Writer, formatErr, orchestrator.ErrStreamIncomplete); err != nil {
+			*clientDisconnected = true
+			log.Warn(ctx, "Failed to write incomplete SSE stream error", log.Cause(err))
+		}
+	}
+}
+
+func writeSSEErrorEvent(ctx context.Context, writer http.ResponseWriter, formatErr StreamErrorFormatter, err error) error {
+	return writeSSEEvent(ctx, writer, "error", formatErr(ctx, orchestrator.ClassifyUpstreamTransportError(err)))
+}
+
+func writeSSEEvent(ctx context.Context, writer http.ResponseWriter, event string, data any) error {
+	return writeAndFlushSSE(ctx, writer, func(writer io.Writer) error {
+		errorWriter := &sseErrorWriter{writer: writer}
+		if err := sse.Encode(errorWriter, sse.Event{Event: event, Data: data}); err != nil {
+			return err
+		}
+
+		return errorWriter.err
+	})
+}
+
+type sseErrorWriter struct {
+	writer io.Writer
+	err    error
+}
+
+func (w *sseErrorWriter) Write(data []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
 	}
 
-	c.Writer.Flush()
+	n, err := w.writer.Write(data)
+	if err != nil {
+		w.err = err
+	}
+
+	return n, err
+}
+
+func (w *sseErrorWriter) WriteString(data string) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	n, err := io.WriteString(w.writer, data)
+	if err != nil {
+		w.err = err
+	}
+
+	return n, err
+}
+
+func writeSSEHeartbeatEvent(ctx context.Context, writer http.ResponseWriter, format sseHeartbeatFormat) error {
+	return writeAndFlushSSE(ctx, writer, func(writer io.Writer) error {
+		return writeSSEHeartbeat(writer, format)
+	})
+}
+
+func flushSSE(ctx context.Context, writer http.ResponseWriter) error {
+	return writeAndFlushSSE(ctx, writer, nil)
+}
+
+func writeAndFlushSSE(ctx context.Context, writer http.ResponseWriter, write func(io.Writer) error) error {
+	refreshSSEWriteDeadline(ctx, writer)
+	defer clearSSEWriteDeadline(ctx, writer)
+
+	if write != nil {
+		if err := write(writer); err != nil {
+			return err
+		}
+	}
+
+	return flushResponseWriter(writer)
+}
+
+type responseWriterFlushError interface {
+	FlushError() error
+}
+
+type responseWriterUnwrapper interface {
+	Unwrap() http.ResponseWriter
+}
+
+func flushResponseWriter(writer http.ResponseWriter) error {
+	if flusher, ok := writer.(responseWriterFlushError); ok {
+		return flusher.FlushError()
+	}
+	if unwrapper, ok := writer.(responseWriterUnwrapper); ok {
+		return flushResponseWriter(unwrapper.Unwrap())
+	}
+	if flusher, ok := writer.(http.Flusher); ok {
+		flusher.Flush()
+
+		return nil
+	}
+
+	return http.ErrNotSupported
+}
+
+func refreshSSEWriteDeadline(ctx context.Context, writer http.ResponseWriter) {
+	setSSEWriteDeadline(ctx, writer, time.Now().Add(sseWriteTimeout))
+}
+
+func clearSSEWriteDeadline(ctx context.Context, writer http.ResponseWriter) {
+	setSSEWriteDeadline(ctx, writer, time.Time{})
+}
+
+func setSSEWriteDeadline(ctx context.Context, writer http.ResponseWriter, deadline time.Time) {
+	err := http.NewResponseController(writer).SetWriteDeadline(deadline)
+	if err != nil && !errors.Is(err, http.ErrNotSupported) {
+		log.Warn(ctx, "Failed to set SSE write deadline", log.Cause(err))
+	}
 }
 
 func stopTimer(timer *time.Timer) {

--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -215,10 +215,9 @@ func writeSSEStreamWithoutHeartbeat(c *gin.Context, stream streams.Stream[*httpc
 		if ctx.Err() != nil {
 			eventsAfterCancel++
 			if eventsAfterCancel > maxStreamEventsAfterCancel {
-				clientDisconnected = true
-
 				log.Warn(ctx, "Stream still producing after cancellation, aborting drain",
 					log.Int("events_after_cancel", eventsAfterCancel))
+				writeSSEStreamEnd(c, ctx, ctx.Err(), formatErr, terminalSeen, &clientDisconnected)
 
 				return
 			}
@@ -301,9 +300,9 @@ func writeSSEStreamWithHeartbeat(
 			if ctx.Err() != nil {
 				eventsAfterCancel++
 				if eventsAfterCancel > maxStreamEventsAfterCancel {
-					clientDisconnected = true
 					log.Warn(ctx, "Stream still producing after cancellation, aborting drain",
 						log.Int("events_after_cancel", eventsAfterCancel))
+					writeSSEStreamEnd(c, ctx, ctx.Err(), formatErr, terminalSeen, &clientDisconnected)
 					return
 				}
 			}

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -213,6 +213,7 @@ func (w *heartbeatFailingResponseWriter) WriteString(data string) (int, error) {
 
 type flushFailingResponseWriter struct {
 	*httptest.ResponseRecorder
+
 	err error
 }
 
@@ -222,6 +223,7 @@ func (w *flushFailingResponseWriter) FlushError() error {
 
 type deadlineTrackingResponseWriter struct {
 	gin.ResponseWriter
+
 	deadlines      []time.Time
 	operations     []string
 	deadlineActive bool
@@ -507,6 +509,44 @@ func TestWriteSSEStream_CanceledContextStillDrainsBufferedEvents(t *testing.T) {
 	assert.Contains(t, body, `{"id":"1","choices":[{"delta":{"content":"Hi"}}]}`)
 	assert.Contains(t, body, `[DONE]`)
 	assert.NotContains(t, body, `"error"`)
+}
+
+func TestWriteSSEStream_DeadlineReportsErrorAtDrainLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		keepAlive SSEKeepAliveConfig
+	}{
+		{name: "without heartbeat"},
+		{
+			name: "with heartbeat",
+			keepAlive: SSEKeepAliveConfig{
+				Enabled:  true,
+				Interval: time.Hour,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			c.Request = httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+
+			events := make([]*httpclient.StreamEvent, maxStreamEventsAfterCancel+1)
+			for i := range events {
+				events[i] = &httpclient.StreamEvent{Data: []byte(`{"id":"draining"}`)}
+			}
+			stream := &trackingStream{items: events}
+
+			writeSSEStream(c, stream, FormatStreamError, tt.keepAlive, sseHeartbeatOpenAI)
+
+			parsed := parseSSEErrorEvent(t, w.Body.String())
+			errorField := parsed["error"].(map[string]any)
+			assert.Contains(t, errorField["message"], context.DeadlineExceeded.Error())
+		})
+	}
 }
 
 func TestWriteSSEStream_ErrorFormatsAsJSON(t *testing.T) {

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -187,6 +187,10 @@ func (w *failingResponseWriter) Write(_ []byte) (int, error) {
 	return 0, w.err
 }
 
+func (w *failingResponseWriter) WriteString(data string) (int, error) {
+	return w.Write([]byte(data))
+}
+
 type heartbeatFailingResponseWriter struct {
 	gin.ResponseWriter
 
@@ -207,6 +211,76 @@ func (w *heartbeatFailingResponseWriter) WriteString(data string) (int, error) {
 	return w.Write([]byte(data))
 }
 
+type flushFailingResponseWriter struct {
+	*httptest.ResponseRecorder
+	err error
+}
+
+func (w *flushFailingResponseWriter) FlushError() error {
+	return w.err
+}
+
+type deadlineTrackingResponseWriter struct {
+	gin.ResponseWriter
+	deadlines      []time.Time
+	operations     []string
+	deadlineActive bool
+}
+
+func (w *deadlineTrackingResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	w.deadlineActive = !deadline.IsZero()
+	if w.deadlineActive {
+		w.operations = append(w.operations, "deadline:set")
+	} else {
+		w.operations = append(w.operations, "deadline:clear")
+	}
+
+	return nil
+}
+
+func (w *deadlineTrackingResponseWriter) Write(data []byte) (int, error) {
+	w.operations = append(w.operations, fmt.Sprintf("write:%t", w.deadlineActive))
+
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *deadlineTrackingResponseWriter) WriteString(data string) (int, error) {
+	w.operations = append(w.operations, fmt.Sprintf("write:%t", w.deadlineActive))
+
+	return w.ResponseWriter.WriteString(data)
+}
+
+func (w *deadlineTrackingResponseWriter) Flush() {
+	_ = w.FlushError()
+}
+
+func (w *deadlineTrackingResponseWriter) FlushError() error {
+	w.operations = append(w.operations, fmt.Sprintf("flush:%t", w.deadlineActive))
+	w.ResponseWriter.Flush()
+
+	return nil
+}
+
+func activeWriteDeadlineCount(deadlines []time.Time) int {
+	count := 0
+	for _, deadline := range deadlines {
+		if !deadline.IsZero() {
+			count++
+		}
+	}
+
+	return count
+}
+
+func requireProtectedSSEWrites(t *testing.T, writer *deadlineTrackingResponseWriter) {
+	t.Helper()
+	require.NotEmpty(t, writer.operations)
+	require.NotContains(t, writer.operations, "write:false")
+	require.NotContains(t, writer.operations, "flush:false")
+	require.False(t, writer.deadlineActive)
+}
+
 func TestWriteSSEStream_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -225,9 +299,43 @@ func TestWriteSSEStream_Success(t *testing.T) {
 	assert.Contains(t, body, `[DONE]`)
 }
 
+func TestWriteSSEStream_WriteErrorStopsConsuming(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Writer = &failingResponseWriter{
+		ResponseWriter: c.Writer,
+		err:            errors.New("write failed"),
+	}
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	stream := &trackingStream{items: []*httpclient.StreamEvent{
+		{Data: []byte(`{"id":"1"}`)},
+		{Data: []byte(`[DONE]`)},
+	}}
+
+	WriteSSEStream(c, stream)
+
+	require.Equal(t, 1, stream.idx)
+}
+
+func TestWriteSSEStream_FlushErrorStopsBeforeConsuming(t *testing.T) {
+	w := &flushFailingResponseWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		err:              errors.New("flush failed"),
+	}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	stream := &trackingStream{items: []*httpclient.StreamEvent{{Data: []byte(`[DONE]`)}}}
+
+	WriteSSEStream(c, stream)
+
+	require.Zero(t, stream.idx)
+}
+
 func TestWriteSSEStream_OpenAIHeartbeat(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	deadlineWriter := &deadlineTrackingResponseWriter{ResponseWriter: c.Writer}
+	c.Writer = deadlineWriter
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 
 	stream := &delayedStream{
@@ -243,6 +351,10 @@ func TestWriteSSEStream_OpenAIHeartbeat(t *testing.T) {
 	body := w.Body.String()
 	require.Contains(t, body, ": keep-alive\n\n")
 	require.Contains(t, body, "data: [DONE]\n\n")
+	activeDeadlines := activeWriteDeadlineCount(deadlineWriter.deadlines)
+	require.GreaterOrEqual(t, activeDeadlines, 3)
+	require.GreaterOrEqual(t, len(deadlineWriter.deadlines)-activeDeadlines, activeDeadlines)
+	requireProtectedSSEWrites(t, deadlineWriter)
 }
 
 func TestWriteSSEStream_AnthropicHeartbeat(t *testing.T) {
@@ -973,6 +1085,94 @@ func TestWriteSSEStream_TransportErrorIsClassified(t *testing.T) {
 	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, errorField["code"])
 	assert.Contains(t, errorField["message"], "unexpected EOF")
 	assert.Equal(t, "req_gateway_2", parsed["request_id"])
+}
+
+func TestWriteSSEStream_ServerDeadlineReportsErrorToClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		streamErr error
+	}{
+		{name: "transport reports canceled", streamErr: context.Canceled},
+		{name: "transport reports no error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			deadlineWriter := &deadlineTrackingResponseWriter{ResponseWriter: c.Writer}
+			c.Writer = deadlineWriter
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+			WriteSSEStream(c, &errorAfterStream{err: tt.streamErr})
+
+			parsed := parseSSEErrorEvent(t, w.Body.String())
+			errorField := parsed["error"].(map[string]any)
+			assert.Contains(t, errorField["message"], context.DeadlineExceeded.Error())
+			activeDeadlines := activeWriteDeadlineCount(deadlineWriter.deadlines)
+			require.Equal(t, 2, activeDeadlines)
+			require.GreaterOrEqual(t, len(deadlineWriter.deadlines)-activeDeadlines, activeDeadlines)
+			requireProtectedSSEWrites(t, deadlineWriter)
+		})
+	}
+}
+
+func TestWriteSSEStream_SubstantiveErrorWinsDeadlineRace(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	streamErr := fmt.Errorf("read body: %w", io.ErrUnexpectedEOF)
+
+	WriteSSEStream(c, &errorAfterStream{err: streamErr})
+
+	parsed := parseSSEErrorEvent(t, w.Body.String())
+	errorField := parsed["error"].(map[string]any)
+	assert.Equal(t, orchestrator.ErrCodeUpstreamStreamInterrupted, errorField["code"])
+	assert.Contains(t, errorField["message"], io.ErrUnexpectedEOF.Error())
+}
+
+func TestWriteSSEStream_TerminalEventWinsDeadlineRace(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	stream := &errorAfterStream{
+		items: []*httpclient.StreamEvent{{Data: []byte("[DONE]")}},
+		err:   io.ErrUnexpectedEOF,
+	}
+
+	WriteSSEStream(c, stream)
+
+	require.Contains(t, w.Body.String(), "[DONE]")
+	require.NotContains(t, w.Body.String(), "event:error")
+}
+
+func TestWriteSSEStream_RefreshesWriteDeadline(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	deadlineWriter := &deadlineTrackingResponseWriter{ResponseWriter: c.Writer}
+	c.Writer = deadlineWriter
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	stream := streams.SliceStream([]*httpclient.StreamEvent{{Data: []byte("[DONE]")}})
+
+	WriteSSEStream(c, stream)
+
+	require.NotEmpty(t, deadlineWriter.deadlines)
+	activeDeadlines := activeWriteDeadlineCount(deadlineWriter.deadlines)
+	require.Equal(t, 2, activeDeadlines)
+	require.GreaterOrEqual(t, len(deadlineWriter.deadlines)-activeDeadlines, activeDeadlines)
+	requireProtectedSSEWrites(t, deadlineWriter)
+	for _, deadline := range deadlineWriter.deadlines {
+		if !deadline.IsZero() {
+			assert.WithinDuration(t, time.Now().Add(sseWriteTimeout), deadline, time.Second)
+		}
+	}
 }
 
 func TestWriteSSEStream_IncompleteStreamErrorIsClassified(t *testing.T) {


### PR DESCRIPTION
## Summary

- report server-side request deadlines to connected SSE clients instead of misclassifying them as client disconnects
- apply a rolling 30-second socket deadline around each SSE write and flush
- detect ordinary SSE encode/write and flush failures and stop consuming the upstream stream
- preserve terminal-event and substantive upstream-error precedence, including bounded post-cancellation drain exits

## Problem

Long-running LLM streams can reach `server.llm_request_timeout` before a terminal event. The outbound transport may surface the parent cancellation as `context.Canceled`, while the authoritative request context is `context.DeadlineExceeded`.

The SSE writer previously used the transport error first and treated any `context.Canceled` result as a client disconnect. It therefore emitted no error event. The global HTTP `WriteTimeout` also reaches its absolute deadline at the same default 600-second boundary, leaving no transport window for a final error write.

The client consequently observes a stream that stops after partial reasoning or content with neither a terminal event nor an explicit error.

## Trigger conditions

- an HTTP SSE response is active
- the configured request deadline expires before a recognized terminal event
- the inner stream returns `context.Canceled`, `context.DeadlineExceeded`, nil, or continues producing past the bounded drain limit

The shared path serves OpenAI-compatible SSE, Anthropic Messages, Gemini `alt=sse`, playground streaming, and request preview.

## Implementation

### End-state precedence

SSE finalization now applies this order:

1. a terminal event already written to the client wins
2. a truly canceled request context is treated as a client disconnect and remains silent
3. a server `DeadlineExceeded` context replaces nil or cancellation-like stream results
4. a substantive upstream error remains authoritative
5. clean exhaustion without a terminal remains the existing incomplete-stream error

Both heartbeat and non-heartbeat bounded-drain exits delegate to this same finalization path, so an upstream that keeps producing after cancellation cannot silently discard the server deadline.

### Streaming-safe write deadlines

The global server configuration remains unchanged for non-SSE responses. SSE intentionally replaces the absolute connection-lifetime `WriteTimeout` with a per-write deadline; the route-level `LLMRequestTimeout` remains the hard lifetime bound for the request.

Each initial flush, event, heartbeat, and terminal error runs inside a rolling write window:

1. set a 30-second socket write deadline through `http.ResponseController`
2. encode/write and flush
3. clear the deadline through `defer`

Clearing after every flush prevents an expired write deadline from killing a later event after a valid upstream-idle period, including HTTP/2 stream-local deadline behavior. A slow or non-reading client remains bounded during each actual write.

### Error-aware writes

The project SSE encoder ignores some underlying `WriteString` errors for byte payloads. A small writer wrapper records the first underlying `Write` or `WriteString` failure without changing wire encoding.

Flush handling unwraps Gin response writers, prefers an underlying `FlushError()`, then falls back to `http.Flusher`. A write or flush failure stops further stream consumption while preserving the existing synchronized reader-shutdown contract: `reader.Stop()` waits for the in-flight `Next()` before caller-owned `Close`, avoiding a `Close` versus `Next`/`Current` race.

## Compatibility and scope

- non-SSE responses continue using the configured global `http.Server.WriteTimeout`; SSE uses the rolling per-write deadline
- configured `RequestTimeout` and `LLMRequestTimeout` semantics are unchanged
- true client cancellation remains silent
- #2185 incomplete-stream reporting remains intact
- #2317 substantive transport-error classification remains intact
- binary, AI SDK JSON, normal Gemini JSON, and WebSocket writers are unchanged
- this does not implement the configurable post-first-event idle timeout discussed in #2316

Operators still need to increase `server.llm_request_timeout` if generations are expected to run longer than the configured hard request limit. This PR makes that limit explicit to clients; it does not extend it.

## Tests

Coverage includes:

- request deadline with transport `context.Canceled`
- request deadline with nil stream error
- substantive upstream error racing a deadline
- terminal event racing a later stream error or deadline
- initial flush failure before stream consumption
- ordinary SSE write failure stopping stream consumption
- OpenAI and Anthropic heartbeat paths
- ordered deadline set/write/flush/clear assertions
- error-event write deadlines
- heartbeat and non-heartbeat bounded-drain limits
- existing cancellation-drain and reader synchronization behavior

```text
go test -race -shuffle=on -count=1 ./internal/server/api
ok github.com/looplj/axonhub/internal/server/api

gopls check internal/server/api/chat.go internal/server/api/chat_test.go
```

No build or lint command was run locally. Repository CI build, lint, and test jobs pass.