### PR TITLE
fix(anthropic): reject invalid tool input on clean EOF

### DIFF
--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -468,9 +468,14 @@ func (s *anthropicInboundStream) closeOpenContentBlocks() error {
 }
 
 func (s *anthropicInboundStream) enqueueTerminalEvents() error {
+	usage := s.pendingUsage
+	if usage == nil {
+		usage = &Usage{}
+	}
+
 	streamEvent := StreamEvent{
 		Type:  "message_delta",
-		Usage: s.pendingUsage,
+		Usage: usage,
 	}
 
 	if s.stopReason != nil {

--- a/llm/transformer/anthropic/inbound_stream.go
+++ b/llm/transformer/anthropic/inbound_stream.go
@@ -152,8 +152,6 @@ func (s *anthropicInboundStream) emitBufferedReadToolArguments(toolCallIndex int
 		return fmt.Errorf("failed to enqueue buffered Read input_json_delta event: %w", err)
 	}
 
-	toolCall.Function.Arguments = ""
-
 	return nil
 }
 
@@ -186,6 +184,21 @@ func (s *anthropicInboundStream) closeToolBlock() error {
 	}
 
 	s.contentIndex += 1
+
+	return nil
+}
+
+func (s *anthropicInboundStream) validateToolArguments() error {
+	for index, toolCall := range s.toolCalls {
+		if toolCall == nil || toolCall.Function.Arguments == "" {
+			continue
+		}
+
+		var input map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil || input == nil {
+			return fmt.Errorf("invalid tool call arguments for tool call index %d", index)
+		}
+	}
 
 	return nil
 }
@@ -515,6 +528,12 @@ func (s *anthropicInboundStream) Next() bool {
 	if !s.source.Next() {
 		if s.source.Err() != nil || !s.hasStarted || s.messageStoped {
 			return false
+		}
+		if !s.hasFinished {
+			if err := s.validateToolArguments(); err != nil {
+				s.err = fmt.Errorf("failed to validate tool arguments at stream end: %w", err)
+				return false
+			}
 		}
 
 		if err := s.closeOpenContentBlocks(); err != nil {

--- a/llm/transformer/anthropic/inbound_stream_test.go
+++ b/llm/transformer/anthropic/inbound_stream_test.go
@@ -173,10 +173,10 @@ func TestInboundStream_FinalizesOnCleanExhaustionWithoutFinishReason(t *testing.
 			require.Equal(t, "message_delta", terminalEvents[1].Type)
 			require.NotNil(t, terminalEvents[1].Delta)
 			require.Equal(t, tt.expectedStopReason, *terminalEvents[1].Delta.StopReason)
+			require.NotNil(t, terminalEvents[1].Usage)
 			if tt.usage == nil {
-				require.Nil(t, terminalEvents[1].Usage)
+				require.Zero(t, terminalEvents[1].Usage.OutputTokens)
 			} else {
-				require.NotNil(t, terminalEvents[1].Usage)
 				require.Equal(t, int64(7), terminalEvents[1].Usage.OutputTokens)
 			}
 			require.Equal(t, "message_stop", terminalEvents[2].Type)

--- a/llm/transformer/anthropic/inbound_stream_test.go
+++ b/llm/transformer/anthropic/inbound_stream_test.go
@@ -72,6 +72,21 @@ func TestInboundStream_FinalizesOnCleanExhaustionWithoutFinishReason(t *testing.
 			expectedStopReason: "tool_use",
 		},
 		{
+			name: "tool call with empty arguments",
+			delta: &llm.Message{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{{
+					Index: 0,
+					ID:    "call_empty",
+					Type:  "function",
+					Function: llm.FunctionCall{
+						Name: "list",
+					},
+				}},
+			},
+			expectedStopReason: "tool_use",
+		},
+		{
 			name: "server tool call",
 			delta: &llm.Message{
 				Role: "assistant",
@@ -166,6 +181,231 @@ func TestInboundStream_FinalizesOnCleanExhaustionWithoutFinishReason(t *testing.
 			}
 			require.Equal(t, "message_stop", terminalEvents[2].Type)
 		})
+	}
+}
+
+func TestInboundStream_RejectsIncompleteToolArgumentsOnCleanExhaustion(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+	}{
+		{name: "truncated object", arguments: `{"content":"unfinished`},
+		{name: "null", arguments: `null`},
+		{name: "array", arguments: `[]`},
+		{name: "string", arguments: `"value"`},
+		{name: "number", arguments: `1`},
+		{name: "boolean", arguments: `true`},
+		{name: "whitespace", arguments: ` `},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := NewInboundTransformer()
+			input := []*llm.Response{{
+				ID:     "msg_incomplete_tool",
+				Object: "chat.completion.chunk",
+				Model:  "test-model",
+				Choices: []llm.Choice{{
+					Index: 0,
+					Delta: &llm.Message{
+						Role: "assistant",
+						ToolCalls: []llm.ToolCall{{
+							Index: 0,
+							ID:    "call_incomplete",
+							Type:  "function",
+							Function: llm.FunctionCall{
+								Name:      "write",
+								Arguments: tt.arguments,
+							},
+						}},
+					},
+				}},
+			}}
+
+			stream, err := transformer.TransformStream(t.Context(), streams.SliceStream(input))
+			require.NoError(t, err)
+
+			var events []StreamEvent
+			for stream.Next() {
+				var event StreamEvent
+				require.NoError(t, json.Unmarshal(stream.Current().Data, &event))
+				events = append(events, event)
+			}
+
+			require.ErrorContains(t, stream.Err(), "invalid tool call arguments")
+			require.Zero(t, countStreamEvents(events, "content_block_stop"))
+			require.Zero(t, countStreamEvents(events, "message_delta"))
+			require.Zero(t, countStreamEvents(events, "message_stop"))
+		})
+	}
+}
+
+func TestInboundStream_PreservesExplicitFinishReasonWithMalformedToolArguments(t *testing.T) {
+	transformer := NewInboundTransformer()
+	finishReason := "tool_calls"
+	input := []*llm.Response{
+		{
+			ID:     "msg_incomplete_tool",
+			Object: "chat.completion.chunk",
+			Model:  "test-model",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{{
+						Index: 0,
+						ID:    "call_incomplete",
+						Type:  "function",
+						Function: llm.FunctionCall{
+							Name:      "write",
+							Arguments: `{"content":"unfinished`,
+						},
+					}},
+				},
+			}},
+		},
+		{
+			ID:     "msg_incomplete_tool",
+			Object: "chat.completion.chunk",
+			Model:  "test-model",
+			Choices: []llm.Choice{{
+				Index:        0,
+				FinishReason: &finishReason,
+			}},
+			Usage: &llm.Usage{CompletionTokens: 10},
+		},
+	}
+
+	stream, err := transformer.TransformStream(t.Context(), streams.SliceStream(input))
+	require.NoError(t, err)
+
+	var events []StreamEvent
+	for stream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(stream.Current().Data, &event))
+		events = append(events, event)
+	}
+
+	require.NoError(t, stream.Err())
+	require.Equal(t, 1, countStreamEvents(events, "content_block_stop"))
+	require.Equal(t, 1, countStreamEvents(events, "message_delta"))
+	require.Equal(t, 1, countStreamEvents(events, "message_stop"))
+	for _, event := range events {
+		if event.Type == "message_delta" {
+			require.NotNil(t, event.Delta)
+			require.NotNil(t, event.Delta.StopReason)
+			require.Equal(t, "tool_use", *event.Delta.StopReason)
+			require.NotNil(t, event.Usage)
+			require.Equal(t, int64(10), event.Usage.OutputTokens)
+		}
+	}
+}
+
+func TestInboundStream_RejectsInvalidEarlierReadArgumentsOnCleanExhaustion(t *testing.T) {
+	transformer := NewInboundTransformer()
+	input := []*llm.Response{{
+		ID:     "msg_multiple_tools",
+		Object: "chat.completion.chunk",
+		Model:  "test-model",
+		Choices: []llm.Choice{{
+			Index: 0,
+			Delta: &llm.Message{
+				Role: "assistant",
+				ToolCalls: []llm.ToolCall{
+					{
+						Index: 0,
+						ID:    "call_invalid",
+						Type:  "function",
+						Function: llm.FunctionCall{
+							Name:      "Read",
+							Arguments: `{"content":"unfinished`,
+						},
+					},
+					{
+						Index: 1,
+						ID:    "call_valid",
+						Type:  "function",
+						Function: llm.FunctionCall{
+							Name:      "bash",
+							Arguments: `{"command":"true"}`,
+						},
+					},
+				},
+			},
+		}},
+	}}
+
+	stream, err := transformer.TransformStream(t.Context(), streams.SliceStream(input))
+	require.NoError(t, err)
+
+	var events []StreamEvent
+	for stream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(stream.Current().Data, &event))
+		events = append(events, event)
+	}
+
+	require.ErrorContains(t, stream.Err(), "invalid tool call arguments")
+	require.Zero(t, countStreamEvents(events, "message_delta"))
+	require.Zero(t, countStreamEvents(events, "message_stop"))
+}
+
+func TestInboundStream_PreservesExplicitFinishReasonWithoutUsage(t *testing.T) {
+	transformer := NewInboundTransformer()
+	finishReason := "tool_calls"
+	input := []*llm.Response{
+		{
+			ID:     "msg_incomplete_tool",
+			Object: "chat.completion.chunk",
+			Model:  "test-model",
+			Choices: []llm.Choice{{
+				Index: 0,
+				Delta: &llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{{
+						Index: 0,
+						ID:    "call_incomplete",
+						Type:  "function",
+						Function: llm.FunctionCall{
+							Name:      "write",
+							Arguments: `{"content":"unfinished`,
+						},
+					}},
+				},
+			}},
+		},
+		{
+			ID:     "msg_incomplete_tool",
+			Object: "chat.completion.chunk",
+			Model:  "test-model",
+			Choices: []llm.Choice{{
+				Index:        0,
+				FinishReason: &finishReason,
+			}},
+		},
+	}
+
+	stream, err := transformer.TransformStream(t.Context(), streams.SliceStream(input))
+	require.NoError(t, err)
+
+	var events []StreamEvent
+	for stream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(stream.Current().Data, &event))
+		events = append(events, event)
+	}
+
+	require.NoError(t, stream.Err())
+	require.Equal(t, 1, countStreamEvents(events, "message_delta"))
+	require.Equal(t, 1, countStreamEvents(events, "message_stop"))
+	for _, event := range events {
+		if event.Type == "message_delta" {
+			require.NotNil(t, event.Delta)
+			require.NotNil(t, event.Delta.StopReason)
+			require.Equal(t, "tool_use", *event.Delta.StopReason)
+			require.NotNil(t, event.Usage)
+			require.Zero(t, event.Usage.OutputTokens)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate every accumulated non-empty tool argument as a JSON object before synthesizing Anthropic terminal events on clean stream exhaustion
- retain buffered `Read` arguments long enough for final validation, including earlier calls in multi-tool responses
- always emit an Anthropic `message_delta.usage` object when synthesizing a terminal sequence, using zero values when the upstream omitted usage

## Problem

Some OpenAI-compatible providers can end a streamed tool call without a source error, `finish_reason`, or usage chunk while the accumulated function arguments are still truncated.

The Anthropic inbound transformer previously treated that clean exhaustion as success through the compatibility fallback introduced in #2000:

1. close the open `tool_use` block
2. infer `stop_reason: tool_use`
3. emit `message_delta`
4. emit `message_stop`

That produced two client-visible protocol failures:

- the completed `tool_use` block contained unterminated JSON, so strict clients failed to parse the tool input
- synthesized `message_delta` omitted `usage`, so clients validating the Anthropic event shape rejected the terminal event

The request was consequently persisted as completed even though the downstream client could not consume the response.

## Trigger conditions

The invalid-success path required all of the following:

- downstream API format is Anthropic Messages
- response is streaming and passes through `anthropicInboundStream`
- one or more tool calls were accumulated
- the source stream exhausts cleanly without an explicit `finish_reason`
- at least one non-empty tool argument is truncated or is not a JSON object

This is provider-agnostic. It is more visible with models that generate large streamed tool inputs, but it is not model-specific.

Non-stream responses, source-error exits, empty-argument tools, and explicit upstream finish reasons are unchanged.

## Implementation

Before applying the clean-EOF terminal fallback, the transformer now checks every accumulated tool call:

- empty arguments remain valid and continue to use the existing `{}` block input
- non-empty arguments must decode to a non-nil `map[string]json.RawMessage`
- malformed, scalar, array, `null`, and whitespace-only inputs return a stream error before `message_delta` or `message_stop` is synthesized

Buffered `Read` arguments are no longer cleared after their delayed delta is emitted, so an earlier malformed `Read` followed by a later valid tool cannot evade final validation. The data remains request-scoped and is released with the stream.

Validation is intentionally limited to clean exhaustion when no explicit finish was observed. This preserves the existing explicit-finish compatibility established by earlier stream-completion work.

When clean exhaustion is otherwise valid, synthesized terminal events now contain `usage: { ...zero values... }` if the provider supplied no usage chunk.

## Compatibility

- preserves #2000 clean-EOF synthesis for valid tools, empty tools, text, thinking, server tools, and MCP tools
- preserves explicit `finish_reason` handling
- preserves source-error propagation and duplicate-terminal prevention
- does not change public APIs or non-stream conversion

## Tests

Coverage includes:

- truncated JSON object
- `null`, array, string, number, boolean, and whitespace inputs
- malformed earlier buffered `Read` followed by a valid second tool
- explicit finish with malformed arguments, with and without usage
- empty-argument tools
- text, thinking, client tool, server tool, and MCP clean-EOF streams
- source errors and duplicate terminal events

```text
go test -race -shuffle=on -count=1 ./transformer/anthropic
ok github.com/looplj/axonhub/llm/transformer/anthropic
```

Run from the independent `llm/` module. No build or lint command was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-call arguments are now preserved correctly for Read operations.
  * Invalid or malformed tool-call arguments are detected before the stream closes, preventing incomplete or misleading results.
  * Tool calls with empty arguments are handled correctly.
  * Streams now complete reliably when usage information is unavailable, while preserving explicit finish reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->