### PR TITLE
fix: preserve transformed Responses stream events

### DIFF
--- a/internal/server/orchestrator/responses_session.go
+++ b/internal/server/orchestrator/responses_session.go
@@ -281,6 +281,7 @@ type responsesSessionStream struct {
 	store       *responsesSessionStore
 	requestBody []byte
 	inner       streams.Stream[*httpclient.StreamEvent]
+	current     *httpclient.StreamEvent
 	chunks      []*httpclient.StreamEvent
 	chunksBytes int
 	terminal    bool
@@ -290,26 +291,27 @@ type responsesSessionStream struct {
 
 func (s *responsesSessionStream) Next() bool {
 	if !s.inner.Next() {
+		s.current = nil
 		return false
 	}
 
-	event := s.inner.Current()
-	if event != nil {
+	s.current = s.inner.Current()
+	if s.current != nil {
 		if !s.overflow {
-			s.chunksBytes += len(event.Type) + len(event.LastEventID) + len(event.Data)
+			s.chunksBytes += len(s.current.Type) + len(s.current.LastEventID) + len(s.current.Data)
 			if s.chunksBytes > responsesSessionMaxResponse {
 				s.chunks = nil
 				s.overflow = true
 			} else {
 				s.chunks = append(s.chunks, &httpclient.StreamEvent{
-					Type:        event.Type,
-					LastEventID: event.LastEventID,
-					Data:        append([]byte(nil), event.Data...),
-					Size:        event.Size,
+					Type:        s.current.Type,
+					LastEventID: s.current.LastEventID,
+					Data:        append([]byte(nil), s.current.Data...),
+					Size:        s.current.Size,
 				})
 			}
 		}
-		if IsTerminalStreamEvent(event) {
+		if IsTerminalStreamEvent(s.current) {
 			s.terminal = true
 			s.recordCompleted()
 		}
@@ -318,7 +320,7 @@ func (s *responsesSessionStream) Next() bool {
 	return true
 }
 
-func (s *responsesSessionStream) Current() *httpclient.StreamEvent { return s.inner.Current() }
+func (s *responsesSessionStream) Current() *httpclient.StreamEvent { return s.current }
 
 func (s *responsesSessionStream) Err() error { return s.inner.Err() }
 

--- a/internal/server/orchestrator/responses_session_test.go
+++ b/internal/server/orchestrator/responses_session_test.go
@@ -155,6 +155,27 @@ func TestResponsesSessionStoreRecordsCompletedStream(t *testing.T) {
 	)
 }
 
+func TestResponsesSessionStreamPreservesEveryEventForConsumer(t *testing.T) {
+	// Given
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created"}`)},
+		{Type: "response.output_item.added", Data: []byte(`{"type":"response.output_item.added"}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed"}`)},
+	}
+	store := newResponsesSessionStore()
+	ctx := shared.WithSessionScope(shared.WithResponsesAPI(context.Background()), "api-key:1")
+	stream := store.wrapStream(ctx, []byte(`{"model":"gpt-5","input":"one"}`), streams.SliceStream(events))
+
+	// When
+	var received []*httpclient.StreamEvent
+	for stream.Next() {
+		received = append(received, stream.Current())
+	}
+
+	// Then
+	require.Equal(t, events, received)
+}
+
 func TestResponsesSessionStoreRecordsBeforeStreamClose(t *testing.T) {
 	store := newResponsesSessionStore()
 	ctx := shared.WithSessionScope(shared.WithResponsesAPI(context.Background()), "api-key:1")


### PR DESCRIPTION
﻿## Summary

Cache the event consumed by `responsesSessionStream.Next` and return that cached event from `Current` instead of calling `inner.Current()` a second time. Add a regression test proving every wrapped event reaches the downstream consumer.

## Root cause

For transformed (non-pass-through) Responses streams, `responsesSessionStream.Next` reads one event from the inner stream to record session data, and `Current` then calls `inner.Current()` again. Queue-backed streams such as `responsesInboundStream` advance their cursor on every `Current()` call, so events were consumed in pairs:

- `Next` consumed event 0 internally
- the client received event 1
- `Next` consumed event 2 internally
- the client received event 3

The client never received `response.completed`, so the request ended as `stream ended without terminal event or completed response`.

Native Responses pass-through masked the bug because its `Current()` returns a cached pointer and is idempotent.

## Impact

Affected when all of the following are true:

1. downstream API format is `openai/responses`
2. `stream=true`
3. response pass-through is not applied
4. the final Responses event stream has consumptive `Current()` semantics

This includes Responses requests transformed through Chat Completions, Anthropic, Gemini, or a non-pass-through Responses path. Both SSE and downstream Responses WebSocket use the same `Next`/`Current` contract.

## Verification

- Added `TestResponsesSessionStreamPreservesEveryEventForConsumer`.
- No build or lint commands were run locally.

## Related

- https://github.com/looplj/axonhub/issues/2364
- https://github.com/looplj/axonhub/pull/2357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming event handling to ensure consumers receive every event in the correct order and unchanged.
  * Preserved terminal events reliably when processing streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->