### PR TITLE
fix: dockerfile compitable, close #2367

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ RUN addgroup -S -g 65532 axonhub \
 WORKDIR /app
 COPY --from=backend-builder --chown=axonhub:axonhub /build/axonhub /app/axonhub
 
-# The service does not need root privileges at runtime. Keep this in the image
-# as well as in Compose so the protection is preserved for other deployments.
-USER 65532:65532
+# Keep root as the image default for backward compatibility with SQLite data
+# directories created by older images. Deployments that have prepared writable
+# volumes can still opt in to the unprivileged 65532:65532 user.
 
 EXPOSE 8090
 ENTRYPOINT ["/app/axonhub"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored default container compatibility for SQLite data directories created by older images.
  * Deployments with prepared writable volumes can still run using an unprivileged user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->