### PR TITLE
feat: add opencode session header, close #2361

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -228,9 +228,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.trace.extra_trace_headers", []string{})
 	v.SetDefault("server.trace.response_trace_headers", []string{})
 	v.SetDefault("server.trace.extra_trace_body_fields", []string{})
-	v.SetDefault("server.trace.claude_code_trace_enabled", false)
-	v.SetDefault("server.trace.codex_trace_enabled", false)
-	v.SetDefault("server.trace.opencode_trace_enabled", false)
+	v.SetDefault("server.trace.claude_code_trace_enabled", true)
+	v.SetDefault("server.trace.codex_trace_enabled", true)
+	v.SetDefault("server.trace.opencode_trace_enabled", true)
 
 	// Dashboard defaults
 	v.SetDefault("server.dashboard.all_time_token_stats_soft_ttl", "1h")

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -75,6 +75,26 @@ func TestSSEKeepAliveDefaultsToDisabled(t *testing.T) {
 	}
 }
 
+func TestTraceExtractionDefaultsToEnabled(t *testing.T) {
+	configFile := writeTestConfig(t, "")
+
+	cfg, _, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+
+	trace := cfg.APIServer.Trace
+	if !trace.ClaudeCodeTraceEnabled {
+		t.Error("Claude Code trace extraction should default to enabled")
+	}
+	if !trace.CodexTraceEnabled {
+		t.Error("Codex trace extraction should default to enabled")
+	}
+	if !trace.OpenCodeTraceEnabled {
+		t.Error("OpenCode trace extraction should default to enabled")
+	}
+}
+
 func writeTestConfig(t *testing.T, contents string) string {
 	t.Helper()
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -20,8 +20,9 @@ server:
     extra_trace_headers: [] # Extra trace headers (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS)
     response_trace_headers: [] # Response headers for the resolved trace ID (env: AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS)
     extra_trace_body_fields: [] # Extra trace body fields (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_BODY_FIELDS)
-    claude_code_trace_enabled: false # Enable extracting trace IDs from Claude Code request metadata (env: AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED)
-    codex_trace_enabled: false # Enable extracting trace IDs from Codex Session_id header (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)
+    claude_code_trace_enabled: true # Enable extracting trace IDs from Claude Code request metadata (env: AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED)
+    codex_trace_enabled: true # Enable extracting trace IDs from Codex Session_id header (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)
+    opencode_trace_enabled: true # Enable extracting trace IDs from OpenCode session headers (env: AXONHUB_SERVER_TRACE_OPENCODE_TRACE_ENABLED)
   debug: false                  # Enable debug mode (env: AXONHUB_SERVER_DEBUG)
   disable_ssl_verify: false     # Disable SSL certificate verification for self-signed certificates (env: AXONHUB_SERVER_DISABLE_SSL_VERIFY)
   # Max multipart form memory for large uploads (e.g. backup restore).

--- a/docs/en/deployment/configuration.md
+++ b/docs/en/deployment/configuration.md
@@ -70,8 +70,9 @@ server:
     trace_header: "AH-Trace-Id" # Trace ID header name
     extra_trace_headers: []     # Extra trace headers
     response_trace_headers: []  # Response headers that receive the resolved trace ID; empty disables it
-    claude_code_trace_enabled: false # Enable Claude Code trace extraction
-    codex_trace_enabled: false # Enable Codex trace extraction
+    claude_code_trace_enabled: true # Enable Claude Code trace extraction
+    codex_trace_enabled: true # Enable Codex trace extraction
+    opencode_trace_enabled: true # Enable OpenCode trace extraction
   debug: false                  # Enable debug mode
   disable_ssl_verify: false     # Disable SSL certificate verification for upstream requests (self-signed certificates)
 ```
@@ -90,6 +91,7 @@ server:
 - `AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS`
 - `AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
+- `AXONHUB_SERVER_TRACE_OPENCODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`
 - `AXONHUB_SERVER_DISABLE_SSL_VERIFY`
 

--- a/docs/zh/deployment/configuration.md
+++ b/docs/zh/deployment/configuration.md
@@ -70,8 +70,9 @@ server:
     trace_header: "AH-Trace-Id" # 追踪 ID 请求头名称
     extra_trace_headers: []     # 额外的追踪请求头
     response_trace_headers: []  # 回写最终追踪 ID 的响应头列表，空列表时关闭
-    claude_code_trace_enabled: false # 启用 Claude Code 追踪提取
-    codex_trace_enabled: false # 启用 Codex 追踪提取
+    claude_code_trace_enabled: true # 启用 Claude Code 追踪提取
+    codex_trace_enabled: true # 启用 Codex 追踪提取
+    opencode_trace_enabled: true # 启用 OpenCode 追踪提取
   debug: false                  # 启用调试模式
   disable_ssl_verify: false     # 禁用上游请求的 SSL 证书校验（自签名证书）
 ```
@@ -90,6 +91,7 @@ server:
 - `AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS`
 - `AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED`
+- `AXONHUB_SERVER_TRACE_OPENCODE_TRACE_ENABLED`
 - `AXONHUB_SERVER_DEBUG`
 - `AXONHUB_SERVER_DISABLE_SSL_VERIFY`
 

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -1033,7 +1033,7 @@ func (svc *ChannelService) buildChannelWithTransformer(c *ent.Channel, apiKeyOve
 			return nil, fmt.Errorf("failed to create outbound transformer: %w", err)
 		}
 
-		ch.Outbound = transformer
+		ch.Outbound = opencode.WithSessionHeader(transformer)
 
 		return ch, nil
 	case channel.TypeOpencodeGo:

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -17,6 +17,7 @@ import (
 	"github.com/looplj/axonhub/internal/tracing"
 	"github.com/looplj/axonhub/llm/transformer/anthropic/claudecode"
 	"github.com/looplj/axonhub/llm/transformer/openai/codex"
+	"github.com/looplj/axonhub/llm/transformer/opencode"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
@@ -206,9 +207,9 @@ func tryExtractTraceIDFromClaudeCodeRequest(c *gin.Context, config tracing.Confi
 	return traceID, nil
 }
 
-// tryExtractTraceIDFromOpenCodeRequest extracts the trace ID from the OpenCode session affinity header.
+// tryExtractTraceIDFromOpenCodeRequest extracts the trace ID from OpenCode session headers.
 func tryExtractTraceIDFromOpenCodeRequest(c *gin.Context) string {
-	traceID := c.GetHeader("x-session-affinity")
+	traceID := opencode.GetSessionIDFromHeaders(c.Request.Header)
 	if traceID == "" {
 		return ""
 	}

--- a/internal/server/middleware/trace_test.go
+++ b/internal/server/middleware/trace_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/looplj/axonhub/internal/tracing"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer/anthropic/claudecode"
+	"github.com/looplj/axonhub/llm/transformer/opencode"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
@@ -374,6 +375,50 @@ func TestWithTrace_OpenCodeDisabled(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.False(t, hasTrace)
+}
+
+func TestTryExtractTraceIDFromOpenCodeRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  http.Header
+		expected string
+	}{
+		{
+			name:     "OpenCode session header",
+			headers:  http.Header{opencode.SessionHeader: []string{"opencode-session"}},
+			expected: "opencode-session",
+		},
+		{
+			name:     "session ID header",
+			headers:  http.Header{opencode.SessionIDHeader: []string{"session-id"}},
+			expected: "session-id",
+		},
+		{
+			name:     "legacy session affinity header",
+			headers:  http.Header{opencode.SessionAffinityHeader: []string{"affinity-session"}},
+			expected: "affinity-session",
+		},
+		{
+			name: "current header takes priority",
+			headers: http.Header{
+				opencode.SessionHeader:         []string{"opencode-session"},
+				opencode.SessionIDHeader:       []string{"session-id"},
+				opencode.SessionAffinityHeader: []string{"affinity-session"},
+			},
+			expected: "opencode-session",
+		},
+		{name: "missing header", headers: http.Header{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			c.Request.Header = tt.headers
+
+			require.Equal(t, tt.expected, tryExtractTraceIDFromOpenCodeRequest(c))
+		})
+	}
 }
 
 func TestWithTrace_OpenCodeHeaderSetsTrace(t *testing.T) {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -39,15 +39,15 @@ type Config struct {
 	ExtraTraceBodyFields []string `conf:"extra_trace_body_fields" yaml:"extra_trace_body_fields" json:"extra_trace_body_fields"`
 
 	// ClaudeCodeTraceEnabled enables extracting trace IDs from Claude Code request metadata.
-	// Default to false.
+	// Default to true.
 	ClaudeCodeTraceEnabled bool `conf:"claude_code_trace_enabled" yaml:"claude_code_trace_enabled" json:"claude_code_trace_enabled"`
 
 	// CodexTraceEnabled enables extracting trace IDs from Codex request headers.
-	// Default to false.
+	// Default to true.
 	CodexTraceEnabled bool `conf:"codex_trace_enabled" yaml:"codex_trace_enabled" json:"codex_trace_enabled"`
 
 	// OpenCodeTraceEnabled enables extracting trace IDs from OpenCode request headers.
-	// Default to false.
+	// Default to true.
 	OpenCodeTraceEnabled bool `conf:"opencode_trace_enabled" yaml:"opencode_trace_enabled" json:"opencode_trace_enabled"`
 }
 

--- a/llm/transformer/opencode/headers.go
+++ b/llm/transformer/opencode/headers.go
@@ -1,0 +1,26 @@
+package opencode
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	// SessionHeader is the current OpenCode conversation identifier header.
+	SessionHeader = "X-Opencode-Session"
+	// SessionIDHeader is used by OpenCode clients that expose their session ID directly.
+	SessionIDHeader = "X-Session-Id"
+	// SessionAffinityHeader is the legacy OpenCode session affinity header.
+	SessionAffinityHeader = "X-Session-Affinity"
+)
+
+// GetSessionIDFromHeaders returns the first non-empty OpenCode session identifier.
+func GetSessionIDFromHeaders(headers http.Header) string {
+	for _, header := range []string{SessionHeader, SessionIDHeader, SessionAffinityHeader} {
+		if sessionID := strings.TrimSpace(headers.Get(header)); sessionID != "" {
+			return sessionID
+		}
+	}
+
+	return ""
+}

--- a/llm/transformer/opencode/outbound.go
+++ b/llm/transformer/opencode/outbound.go
@@ -3,7 +3,10 @@ package opencode
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
@@ -14,6 +17,7 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/deepseek"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // route identifies which upstream protocol an OpenCode Go model family speaks.
@@ -56,6 +60,21 @@ type OutboundTransformer struct {
 	deepseek  transformer.Outbound
 	responses transformer.Outbound
 	anthropic transformer.Outbound
+}
+
+// sessionHeaderOutbound adds the OpenCode Go session header to a protocol-specific
+// outbound transformer. It is used by the legacy Anthropic-only channel.
+type sessionHeaderOutbound struct {
+	transformer.Outbound
+}
+
+// WithSessionHeader decorates an outbound transformer with OpenCode Go session affinity.
+func WithSessionHeader(outbound transformer.Outbound) transformer.Outbound {
+	if outbound == nil {
+		return nil
+	}
+
+	return &sessionHeaderOutbound{Outbound: outbound}
 }
 
 // NewOutboundTransformer creates a new OpenCode Go OutboundTransformer with legacy parameters.
@@ -186,8 +205,48 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		httpReq.TransformerMetadata = map[string]any{}
 	}
 	httpReq.TransformerMetadata[routeMetadataKey] = string(r)
+	setSessionHeader(ctx, llmReq, httpReq)
 
 	return httpReq, nil
+}
+
+func (t *sessionHeaderOutbound) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
+	httpReq, err := t.Outbound.TransformRequest(ctx, llmReq)
+	if err != nil {
+		return nil, err
+	}
+
+	setSessionHeader(ctx, llmReq, httpReq)
+
+	return httpReq, nil
+}
+
+func setSessionHeader(ctx context.Context, llmReq *llm.Request, httpReq *httpclient.Request) {
+	if httpReq == nil {
+		return
+	}
+
+	if httpReq.Headers == nil {
+		httpReq.Headers = make(http.Header)
+	}
+
+	httpReq.Headers.Set(SessionHeader, resolveSessionID(ctx, llmReq))
+}
+
+func resolveSessionID(ctx context.Context, llmReq *llm.Request) string {
+	if llmReq != nil && llmReq.RawRequest != nil {
+		if sessionID := GetSessionIDFromHeaders(llmReq.RawRequest.Headers); sessionID != "" {
+			return sessionID
+		}
+	}
+
+	if sessionID, ok := shared.GetSessionID(ctx); ok {
+		if sessionID = strings.TrimSpace(sessionID); sessionID != "" {
+			return sessionID
+		}
+	}
+
+	return uuid.NewString()
 }
 
 // TransformResponse dispatches to the sub-transformer recorded on the request.

--- a/llm/transformer/opencode/outbound_test.go
+++ b/llm/transformer/opencode/outbound_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer/anthropic"
 	"github.com/looplj/axonhub/llm/transformer/deepseek"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 func newTestTransformer(t *testing.T) *OutboundTransformer {
@@ -105,7 +107,8 @@ func TestOutboundTransformer_TransformRequest_RoutesByModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			httpReq, err := tr.TransformRequest(context.Background(), &llm.Request{
+			ctx := shared.WithSessionID(context.Background(), "session-123")
+			httpReq, err := tr.TransformRequest(ctx, &llm.Request{
 				Model: tt.model,
 				Messages: []llm.Message{
 					{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
@@ -114,6 +117,7 @@ func TestOutboundTransformer_TransformRequest_RoutesByModel(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedURL, httpReq.URL)
 			assert.Equal(t, http.MethodPost, httpReq.Method)
+			assert.Equal(t, "session-123", httpReq.Headers.Get(SessionHeader))
 
 			// The route must be recorded for response routing.
 			require.NotNil(t, httpReq.TransformerMetadata)
@@ -122,6 +126,92 @@ func TestOutboundTransformer_TransformRequest_RoutesByModel(t *testing.T) {
 			assert.Equal(t, string(routeForModel(tt.model)), r)
 		})
 	}
+}
+
+func TestOutboundTransformer_TransformRequest_SessionHeaderPrecedence(t *testing.T) {
+	tr := newTestTransformer(t)
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		headers    http.Header
+		expectedID string
+	}{
+		{
+			name:       "explicit OpenCode session header",
+			ctx:        shared.WithSessionID(context.Background(), "context-session"),
+			headers:    http.Header{SessionHeader: []string{"explicit-session"}},
+			expectedID: "explicit-session",
+		},
+		{
+			name:       "OpenCode session affinity header",
+			ctx:        shared.WithSessionID(context.Background(), "context-session"),
+			headers:    http.Header{SessionAffinityHeader: []string{"affinity-session"}},
+			expectedID: "affinity-session",
+		},
+		{
+			name:       "OpenCode session ID header",
+			ctx:        shared.WithSessionID(context.Background(), "context-session"),
+			headers:    http.Header{SessionIDHeader: []string{"session-id"}},
+			expectedID: "session-id",
+		},
+		{
+			name:       "shared session context",
+			ctx:        shared.WithSessionID(context.Background(), "context-session"),
+			expectedID: "context-session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &llm.Request{
+				Model: "glm-5.2",
+				Messages: []llm.Message{
+					{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+				},
+			}
+			if tt.headers != nil {
+				request.RawRequest = &httpclient.Request{Headers: tt.headers}
+			}
+
+			httpReq, err := tr.TransformRequest(tt.ctx, request)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedID, httpReq.Headers.Get(SessionHeader))
+		})
+	}
+}
+
+func TestOutboundTransformer_TransformRequest_GeneratesSessionHeader(t *testing.T) {
+	tr := newTestTransformer(t)
+
+	httpReq, err := tr.TransformRequest(context.Background(), &llm.Request{
+		Model: "glm-5.2",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, httpReq.Headers.Get(SessionHeader))
+}
+
+func TestWithSessionHeader_AnthropicOutbound(t *testing.T) {
+	base, err := anthropic.NewOutboundTransformerWithConfig(&anthropic.Config{
+		Type:           anthropic.PlatformDirect,
+		BaseURL:        "https://opencode.ai/zen/go",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
+	})
+	require.NoError(t, err)
+
+	tr := WithSessionHeader(base)
+	ctx := shared.WithSessionID(context.Background(), "legacy-anthropic-session")
+	httpReq, err := tr.TransformRequest(ctx, &llm.Request{
+		Model: "minimax-m3",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-anthropic-session", httpReq.Headers.Get(SessionHeader))
 }
 
 func TestOutboundTransformer_TransformRequest_DeepSeekThinking(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode trace extraction is now enabled by default.
  * OpenCode session IDs are recognized from current and legacy session headers, with defined priority handling.
  * Session IDs are consistently propagated on outgoing OpenCode requests, with automatic generation when unavailable.

* **Documentation**
  * Updated English and Chinese configuration documentation, examples, and environment variable references.

* **Tests**
  * Added coverage for default trace settings, session-header extraction, precedence, propagation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->