### PR TITLE
fix(images): accept application/json in passthrough mode for /images/edits (#2336)

### DIFF
--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -126,6 +126,18 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 		}
 
 		request.Body = body
+
+		// The replayed body keeps the inbound media type: sync Content-Type so a JSON
+		// image edit is not sent with the multipart header the outbound transformer built.
+		if contentType := llmReq.RawRequest.Headers.Get("Content-Type"); contentType != "" {
+			if request.Headers == nil {
+				request.Headers = make(http.Header)
+			}
+
+			request.Headers.Set("Content-Type", contentType)
+			request.ContentType = contentType
+		}
+
 		outbound.state.PassThroughApplied = true
 
 		return request, nil
@@ -193,15 +205,23 @@ func mergePassThroughRequestBody(rawBody []byte, apiFormat llm.APIFormat, model 
 }
 
 // passThroughBodySupported reports whether the raw inbound body can safely replace the
-// outbound request body. Multipart formats that require model rewriting are excluded.
+// outbound request body. Multipart bodies cannot be reused: the outbound transformer
+// rebuilds the multipart payload with a new boundary in Content-Type, so replaying the
+// inbound bytes would mismatch the header, and form fields cannot be patched via sjson.
+// JSON image edits are replayable because their model field can be patched in place.
 func passThroughBodySupported(llmReq *llm.Request) bool {
 	//nolint:exhaustive // only multipart formats are excluded or content-type checked.
 	switch llmReq.APIFormat {
 	case llm.APIFormatOpenAITranscription,
 		llm.APIFormatOpenAITranslation,
-		llm.APIFormatOpenAIImageEdit,
 		llm.APIFormatOpenAIImageVariation:
 		return false
+	case llm.APIFormatOpenAIImageEdit:
+		if llmReq.RawRequest == nil {
+			return false
+		}
+
+		return strings.Contains(strings.ToLower(llmReq.RawRequest.Headers.Get("Content-Type")), "application/json")
 	case llm.APIFormatOpenAIVideo:
 		if llmReq.RawRequest == nil {
 			return false
@@ -230,7 +250,11 @@ func passThroughBodyNeedsModelPatch(apiFormat llm.APIFormat) bool {
 		llm.APIFormatAnthropicMessage,
 		// Speech (TTS) has a JSON body with a model field; transcription/translation
 		// use multipart bodies that cannot be patched via sjson, so they are excluded.
-		llm.APIFormatOpenAISpeech:
+		llm.APIFormatOpenAISpeech,
+		// Image edits submitted as application/json carry a top-level model field.
+		// Multipart edit bodies never reach this point (passThroughBodySupported
+		// rejects them), so sjson patching only ever runs on JSON payloads.
+		llm.APIFormatOpenAIImageEdit:
 		return true
 	default:
 		return false

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
@@ -223,7 +224,8 @@ func passThroughBodySupported(llmReq *llm.Request) bool {
 			return false
 		}
 
-		return strings.Contains(strings.ToLower(llmReq.RawRequest.Headers.Get("Content-Type")), "application/json")
+		mediaType, _, err := mime.ParseMediaType(llmReq.RawRequest.Headers.Get("Content-Type"))
+		return err == nil && strings.EqualFold(mediaType, "application/json")
 	case llm.APIFormatOpenAIVideo:
 		if llmReq.RawRequest == nil {
 			return false

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -217,6 +217,8 @@ func passThroughBodySupported(llmReq *llm.Request) bool {
 		llm.APIFormatOpenAIImageVariation:
 		return false
 	case llm.APIFormatOpenAIImageEdit:
+		// Only the image edit inbound accepts JSON today; for the other formats this
+		// branch is unreachable because their inbounds still require multipart.
 		if llmReq.RawRequest == nil {
 			return false
 		}

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -2123,6 +2123,31 @@ func TestApplyPassThroughBodyAppliesJSONImageEdit(t *testing.T) {
 	require.Equal(t, "application/json", processed.ContentType)
 }
 
+func TestPassThroughBodySupported_ImageEditContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		supported   bool
+	}{
+		{name: "json", contentType: "application/json", supported: true},
+		{name: "json with charset", contentType: "application/json; charset=utf-8", supported: true},
+		{name: "json patch", contentType: "application/json-patch+json", supported: false},
+		{name: "invalid", contentType: "application/json; charset", supported: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &llm.Request{
+				APIFormat: llm.APIFormatOpenAIImageEdit,
+				RawRequest: &httpclient.Request{
+					Headers: http.Header{"Content-Type": []string{tt.contentType}},
+				},
+			}
+			require.Equal(t, tt.supported, passThroughBodySupported(req))
+		})
+	}
+}
+
 func TestApplyPassThroughBodyAppliesSpeechModelPatch(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -2072,6 +2072,57 @@ func TestApplyPassThroughBodySkipsMultipartVideo(t *testing.T) {
 	require.Equal(t, outboundBody, processed.Body)
 }
 
+func TestApplyPassThroughBodyAppliesJSONImageEdit(t *testing.T) {
+	ctx := context.Background()
+
+	channel := &biz.Channel{
+		Channel: &ent.Channel{
+			ID:   1,
+			Name: "pass-through-json-image-edit",
+			Settings: &objects.ChannelSettings{
+				PassThroughBody: lo.ToPtr(true),
+			},
+		},
+	}
+
+	inboundBody := []byte(`{"model":"my-edit-alias","prompt":"make it blue","image":"data:image/png;base64,aGk="}`)
+	outboundBody := []byte("--new-boundary\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nmake it blue\r\n--new-boundary--\r\n")
+
+	outbound := &PersistentOutboundTransformer{
+		state: &PersistenceState{
+			CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+			LlmRequest: &llm.Request{
+				Model:     "sensenova-u1.5-lite",
+				APIFormat: llm.APIFormatOpenAIImageEdit,
+				RawRequest: &httpclient.Request{
+					APIFormat: string(llm.APIFormatOpenAIImageEdit),
+					Headers:   http.Header{"Content-Type": []string{"application/json"}},
+					Body:      inboundBody,
+				},
+			},
+		},
+	}
+
+	request := &httpclient.Request{
+		APIFormat:   string(llm.APIFormatOpenAIImageEdit),
+		Headers:     http.Header{"Content-Type": []string{"multipart/form-data; boundary=new-boundary"}},
+		ContentType: "multipart/form-data; boundary=new-boundary",
+		Body:        outboundBody,
+	}
+
+	processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(ctx, request)
+	require.NoError(t, err)
+	require.True(t, outbound.state.PassThroughApplied)
+
+	// The raw JSON body replaces the rebuilt multipart body, with the mapped model patched in.
+	require.Equal(t, "sensenova-u1.5-lite", gjson.GetBytes(processed.Body, "model").String())
+	require.Equal(t, "make it blue", gjson.GetBytes(processed.Body, "prompt").String())
+
+	// Content-Type must match the replayed JSON body instead of the rebuilt multipart one.
+	require.Equal(t, "application/json", processed.Headers.Get("Content-Type"))
+	require.Equal(t, "application/json", processed.ContentType)
+}
+
 func TestApplyPassThroughBodyAppliesSpeechModelPatch(t *testing.T) {
 	ctx := context.Background()
 

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -28,10 +28,10 @@ import (
 const (
 	defaultMaxImageFileSize = 50 * 1024 * 1024
 	maxImageCount           = 16
-	maxImageBodySize        = defaultMaxImageFileSize*maxImageCount + 16*1024*1024
 )
 
 var maxImageFileSize = initMaxImageFileSize()
+var maxImageBodySize = maxImageFileSize*maxImageCount + 16*1024*1024
 
 func initMaxImageFileSize() int {
 	if v := os.Getenv("AXONHUB_MAX_IMAGE_FILE_SIZE"); v != "" {
@@ -262,8 +262,11 @@ func (t *ImageInboundTransformer) transformGenerationRequest(httpReq *httpclient
 func (t *ImageInboundTransformer) transformEditRequest(httpReq *httpclient.Request) (*llm.Request, error) {
 	// Some providers (e.g. sensenova) accept image edits as application/json with
 	// base64 data URLs instead of multipart/form-data.
-	contentType := strings.ToLower(httpReq.Headers.Get("Content-Type"))
-	if strings.Contains(contentType, "application/json") {
+	mediaType, _, err := mime.ParseMediaType(httpReq.Headers.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid content-type", transformer.ErrInvalidRequest)
+	}
+	if strings.EqualFold(mediaType, "application/json") {
 		return t.transformEditJSONRequest(httpReq)
 	}
 
@@ -685,6 +688,9 @@ func parseGenerationImageField(raw json.RawMessage) ([][]byte, error) {
 	if err := json.Unmarshal(raw, &many); err != nil {
 		return nil, fmt.Errorf("%w: image field must be a string or array of strings", transformer.ErrInvalidRequest)
 	}
+	if len(many) > maxImageCount {
+		return nil, fmt.Errorf("%w: too many images", transformer.ErrInvalidRequest)
+	}
 
 	images := make([][]byte, 0, len(many))
 	for _, url := range many {
@@ -713,10 +719,16 @@ func decodeDataURLToBytes(dataURL string) ([]byte, error) {
 	if !parsed.IsBase64 {
 		return nil, fmt.Errorf("%w: image data URL must be base64-encoded", transformer.ErrInvalidRequest)
 	}
+	if !isAllowedImageType(parsed.MediaType) {
+		return nil, fmt.Errorf("%w: unsupported image content type %q", transformer.ErrInvalidRequest, parsed.MediaType)
+	}
 
 	data, err := base64.StdEncoding.DecodeString(parsed.Data)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to decode base64 image data", transformer.ErrInvalidRequest)
+	}
+	if len(data) > maxImageFileSize {
+		return nil, fmt.Errorf("%w: image file too large", transformer.ErrInvalidRequest)
 	}
 
 	return data, nil

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -359,6 +359,12 @@ type ImageEditJSONRequest struct {
 }
 
 func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.Request) (*llm.Request, error) {
+	// Mirror the multipart path's guard: ReadHTTPRequest reads the body without a
+	// limit, and base64 payloads amplify memory further once decoded.
+	if len(httpReq.Body) > maxImageBodySize {
+		return nil, fmt.Errorf("%w: request body too large", transformer.ErrInvalidRequest)
+	}
+
 	var editReq ImageEditJSONRequest
 
 	if err := json.Unmarshal(httpReq.Body, &editReq); err != nil {
@@ -386,6 +392,10 @@ func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.R
 
 	if len(images) == 0 {
 		return nil, fmt.Errorf("%w: at least one image is required for edits", transformer.ErrInvalidRequest)
+	}
+
+	if len(images) > maxImageCount {
+		return nil, fmt.Errorf("%w: too many images", transformer.ErrInvalidRequest)
 	}
 
 	var mask []byte

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -260,6 +260,13 @@ func (t *ImageInboundTransformer) transformGenerationRequest(httpReq *httpclient
 }
 
 func (t *ImageInboundTransformer) transformEditRequest(httpReq *httpclient.Request) (*llm.Request, error) {
+	// Some providers (e.g. sensenova) accept image edits as application/json with
+	// base64 data URLs instead of multipart/form-data.
+	contentType := strings.ToLower(httpReq.Headers.Get("Content-Type"))
+	if strings.Contains(contentType, "application/json") {
+		return t.transformEditJSONRequest(httpReq)
+	}
+
 	formData, err := parseMultipartRequest(httpReq)
 	if err != nil {
 		return nil, err
@@ -315,6 +322,95 @@ func (t *ImageInboundTransformer) transformEditRequest(httpReq *httpclient.Reque
 		OutputCompression: parseOptionalInt64(formData.Fields["output_compression"]),
 		InputFidelity:     strings.TrimSpace(formData.Fields["input_fidelity"]),
 		PartialImages:     parseOptionalInt64(formData.Fields["partial_images"]),
+	}
+
+	llmReq := &llm.Request{
+		Model:       model,
+		Modalities:  []string{"image"},
+		Stream:      lo.ToPtr(false),
+		RawRequest:  httpReq,
+		RequestType: llm.RequestTypeImage,
+		APIFormat:   t.apiFormat,
+		Image:       imageReq,
+	}
+
+	return llmReq, nil
+}
+
+// ImageEditJSONRequest represents an application/json body for the image edit API.
+// The Image field accepts a single data URL string or an array of data URL strings;
+// Mask accepts a data URL string.
+type ImageEditJSONRequest struct {
+	Prompt            string          `json:"prompt"`
+	Model             string          `json:"model"`
+	Image             json.RawMessage `json:"image,omitempty"`
+	Mask              string          `json:"mask,omitempty"`
+	N                 *int64          `json:"n,omitempty"`
+	Size              string          `json:"size,omitempty"`
+	Quality           string          `json:"quality,omitempty"`
+	ResponseFormat    string          `json:"response_format,omitempty"`
+	User              string          `json:"user,omitempty"`
+	Background        string          `json:"background,omitempty"`
+	OutputFormat      string          `json:"output_format,omitempty"`
+	OutputCompression *int64          `json:"output_compression,omitempty"`
+	InputFidelity     string          `json:"input_fidelity,omitempty"`
+	PartialImages     *int64          `json:"partial_images,omitempty"`
+	Stream            bool            `json:"stream,omitempty"`
+}
+
+func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.Request) (*llm.Request, error) {
+	var editReq ImageEditJSONRequest
+
+	if err := json.Unmarshal(httpReq.Body, &editReq); err != nil {
+		return nil, fmt.Errorf("%w: failed to decode image edit request: %w", transformer.ErrInvalidRequest, err)
+	}
+
+	if editReq.Stream {
+		return nil, fmt.Errorf("%w: image edit does not support streaming", transformer.ErrInvalidRequest)
+	}
+
+	prompt := strings.TrimSpace(editReq.Prompt)
+	if prompt == "" {
+		return nil, fmt.Errorf("%w: prompt is required for image edits", transformer.ErrInvalidRequest)
+	}
+
+	model := strings.TrimSpace(editReq.Model)
+	if model == "" {
+		model = "dall-e-2"
+	}
+
+	images, err := parseGenerationImageField(editReq.Image)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(images) == 0 {
+		return nil, fmt.Errorf("%w: at least one image is required for edits", transformer.ErrInvalidRequest)
+	}
+
+	var mask []byte
+
+	if maskDataURL := strings.TrimSpace(editReq.Mask); maskDataURL != "" {
+		mask, err = decodeDataURLToBytes(maskDataURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	imageReq := &llm.ImageRequest{
+		Prompt:            prompt,
+		Images:            images,
+		Mask:              mask,
+		N:                 editReq.N,
+		Size:              strings.TrimSpace(editReq.Size),
+		Quality:           strings.TrimSpace(editReq.Quality),
+		ResponseFormat:    strings.TrimSpace(editReq.ResponseFormat),
+		User:              strings.TrimSpace(editReq.User),
+		Background:        strings.TrimSpace(editReq.Background),
+		OutputFormat:      strings.TrimSpace(editReq.OutputFormat),
+		OutputCompression: editReq.OutputCompression,
+		InputFidelity:     strings.TrimSpace(editReq.InputFidelity),
+		PartialImages:     editReq.PartialImages,
 	}
 
 	llmReq := &llm.Request{

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -722,6 +722,9 @@ func decodeDataURLToBytes(dataURL string) ([]byte, error) {
 	if !isAllowedImageType(parsed.MediaType) {
 		return nil, fmt.Errorf("%w: unsupported image content type %q", transformer.ErrInvalidRequest, parsed.MediaType)
 	}
+	if len(parsed.Data) > base64.StdEncoding.EncodedLen(maxImageFileSize) {
+		return nil, fmt.Errorf("%w: image file too large", transformer.ErrInvalidRequest)
+	}
 
 	data, err := base64.StdEncoding.DecodeString(parsed.Data)
 	if err != nil {

--- a/llm/transformer/openai/image_inbound_test.go
+++ b/llm/transformer/openai/image_inbound_test.go
@@ -648,6 +648,16 @@ func TestDecodeDataURLToBytes_RejectsOversizedImage(t *testing.T) {
 	assert.Contains(t, err.Error(), "image file too large")
 }
 
+func TestDecodeDataURLToBytes_RejectsOversizedImageBeforeDecode(t *testing.T) {
+	originalMaxFileSize := maxImageFileSize
+	maxImageFileSize = 3
+	t.Cleanup(func() { maxImageFileSize = originalMaxFileSize })
+
+	_, err := decodeDataURLToBytes("data:image/png;base64,AAAAAA==")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image file too large")
+}
+
 func TestImageInboundTransformer_TransformRequest_Edit_JSON_TooManyImages(t *testing.T) {
 	inbound := NewImageEditInboundTransformer()
 

--- a/llm/transformer/openai/image_inbound_test.go
+++ b/llm/transformer/openai/image_inbound_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
+	transformer "github.com/looplj/axonhub/llm/transformer"
 )
 
 func TestImageInboundTransformer_TransformRequest_Generation_JSON(t *testing.T) {
@@ -590,6 +591,53 @@ func TestImageInboundTransformer_TransformRequest_Edit_JSON_RejectsNonDataURLIma
 	_, err := inbound.TransformRequest(context.Background(), httpReq)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "image must be a data URL")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_BodyTooLarge(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    make([]byte, maxImageBodySize+1),
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transformer.ErrInvalidRequest)
+	assert.Contains(t, err.Error(), "request body too large")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_TooManyImages(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	images := make([]string, maxImageCount+1)
+	for i := range images {
+		images[i] = dataURL
+	}
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "make it blue",
+		"model":  "sensenova-u1.5-lite",
+		"image":  images,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err = inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transformer.ErrInvalidRequest)
+	assert.Contains(t, err.Error(), "too many images")
 }
 
 func TestImageInboundTransformer_Edit_JSON_RoundTrip_ToMultipartOutbound(t *testing.T) {

--- a/llm/transformer/openai/image_inbound_test.go
+++ b/llm/transformer/openai/image_inbound_test.go
@@ -595,6 +595,9 @@ func TestImageInboundTransformer_TransformRequest_Edit_JSON_RejectsNonDataURLIma
 
 func TestImageInboundTransformer_TransformRequest_Edit_JSON_BodyTooLarge(t *testing.T) {
 	inbound := NewImageEditInboundTransformer()
+	originalMaxBodySize := maxImageBodySize
+	maxImageBodySize = 32
+	t.Cleanup(func() { maxImageBodySize = originalMaxBodySize })
 
 	httpReq := &httpclient.Request{
 		Method:  http.MethodPost,
@@ -607,6 +610,42 @@ func TestImageInboundTransformer_TransformRequest_Edit_JSON_BodyTooLarge(t *test
 	require.Error(t, err)
 	assert.ErrorIs(t, err, transformer.ErrInvalidRequest)
 	assert.Contains(t, err.Error(), "request body too large")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_RejectsTooManyImagesBeforeDecoding(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+	images := make([]string, maxImageCount+1)
+	for i := range images {
+		images[i] = "not-a-data-url"
+	}
+	reqBody, err := json.Marshal(map[string]any{"prompt": "edit", "image": images})
+	require.NoError(t, err)
+
+	_, err = inbound.TransformRequest(context.Background(), &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many images")
+}
+
+func TestDecodeDataURLToBytes_RejectsUnsupportedImageType(t *testing.T) {
+	_, err := decodeDataURLToBytes("data:text/plain;base64,aGVsbG8=")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported image content type")
+}
+
+func TestDecodeDataURLToBytes_RejectsOversizedImage(t *testing.T) {
+	originalMaxFileSize := maxImageFileSize
+	maxImageFileSize = 4
+	t.Cleanup(func() { maxImageFileSize = originalMaxFileSize })
+
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	_, err := decodeDataURLToBytes("data:image/png;base64," + base64.StdEncoding.EncodeToString(png))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image file too large")
 }
 
 func TestImageInboundTransformer_TransformRequest_Edit_JSON_TooManyImages(t *testing.T) {

--- a/llm/transformer/openai/image_inbound_test.go
+++ b/llm/transformer/openai/image_inbound_test.go
@@ -428,6 +428,207 @@ func TestImageInboundTransformer_TransformRequest_Edit_Multipart_AcceptsImageAbo
 	assert.Len(t, llmReq.Image.Images[0], len(imageData))
 }
 
+func TestImageInboundTransformer_TransformRequest_Edit_JSON(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt":          "make it blue",
+		"model":           "sensenova-u1.5-lite",
+		"image":           dataURL,
+		"size":            "1024x1024",
+		"n":               2,
+		"response_format": "b64_json",
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, llm.RequestTypeImage, llmReq.RequestType)
+	assert.Equal(t, llm.APIFormatOpenAIImageEdit, llmReq.APIFormat)
+	assert.Equal(t, "sensenova-u1.5-lite", llmReq.Model)
+	assert.Contains(t, llmReq.Modalities, "image")
+	require.NotNil(t, llmReq.Stream)
+	assert.False(t, *llmReq.Stream)
+	require.NotNil(t, llmReq.Image)
+	assert.Equal(t, "make it blue", llmReq.Image.Prompt)
+	assert.Equal(t, "1024x1024", llmReq.Image.Size)
+	assert.Equal(t, lo.ToPtr(int64(2)), llmReq.Image.N)
+	assert.Equal(t, "b64_json", llmReq.Image.ResponseFormat)
+	require.Len(t, llmReq.Image.Images, 1)
+	assert.Equal(t, pngBytes, llmReq.Image.Images[0])
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_MultipleImagesAndMask(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes1 := []byte{0x89, 0x50, 0x4E, 0x47}
+	pngBytes2 := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D}
+	maskBytes := []byte{0x89, 0x4D, 0x53, 0x4B}
+	dataURL1 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes1)
+	dataURL2 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes2)
+	maskURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(maskBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "combine these images",
+		"model":  "gpt-image-1",
+		"image":  []string{dataURL1, dataURL2},
+		"mask":   maskURL,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	require.NotNil(t, llmReq.Image)
+	require.Len(t, llmReq.Image.Images, 2)
+	assert.Equal(t, pngBytes1, llmReq.Image.Images[0])
+	assert.Equal(t, pngBytes2, llmReq.Image.Images[1])
+	assert.Equal(t, maskBytes, llmReq.Image.Mask)
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_RequiresPrompt(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"model": "sensenova-u1.5-lite",
+		"image": dataURL,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err = inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prompt is required")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_RequiresImage(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	reqBody := []byte(`{"prompt":"make it blue","model":"sensenova-u1.5-lite"}`)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one image is required")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_RejectsStream(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "make it blue",
+		"model":  "sensenova-u1.5-lite",
+		"image":  dataURL,
+		"stream": true,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err = inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support streaming")
+}
+
+func TestImageInboundTransformer_TransformRequest_Edit_JSON_RejectsNonDataURLImage(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	reqBody := []byte(`{
+		"prompt":"make it blue",
+		"model":"sensenova-u1.5-lite",
+		"image":"https://example.com/image.png"
+	}`)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	_, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image must be a data URL")
+}
+
+func TestImageInboundTransformer_Edit_JSON_RoundTrip_ToMultipartOutbound(t *testing.T) {
+	inbound := NewImageEditInboundTransformer()
+
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"prompt": "make this brighter",
+		"model":  "dall-e-2",
+		"image":  dataURL,
+	})
+	require.NoError(t, err)
+
+	httpReq := &httpclient.Request{
+		Method:  http.MethodPost,
+		URL:     "http://localhost/v1/images/edits",
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    reqBody,
+	}
+
+	llmReq, err := inbound.TransformRequest(context.Background(), httpReq)
+	require.NoError(t, err)
+
+	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	ot := tr.(*OutboundTransformer)
+
+	outReq, err := ot.TransformRequest(context.Background(), llmReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://api.openai.com/v1/images/edits", outReq.URL)
+	assert.Contains(t, outReq.Headers.Get("Content-Type"), "multipart/form-data")
+	assert.Contains(t, string(outReq.Body), `name="image"`)
+	assert.Contains(t, string(outReq.Body), `name="prompt"`)
+}
+
 func TestImageInboundTransformer_TransformResponse_ToImagesResponse(t *testing.T) {
 	inbound := NewImageGenerationInboundTransformer()
 


### PR DESCRIPTION
### 问题描述

开启渠道透传时，`/images/edits` 端点依然强制要求请求格式是 `multipart/form-data`，非 multipart 请求被网关直接 400 拒绝。使用 `application/json` 的图生图模型（如 sensenova 的 `sensenova-u1.5-lite` 等）无法接入。

### 根因分析

1. inbound 层的 `transformEditRequest` 无条件调用 `parseMultipartRequest`，该解析发生在渠道选择与透传判断**之前**，透传开关无法救回
2. orchestrator 层的 `passThroughBodySupported` 对 `APIFormatOpenAIImageEdit` 硬编码返回 false，禁用了 body 回放

### 修复方案

1. **inbound 格式分派**（`llm/transformer/openai/image_inbound.go`）：`transformEditRequest` 增加 Content-Type 分派，新增 JSON 解析路径 `transformEditJSONRequest`（支持 base64 data URL 格式的 image 与 mask）
2. **安全防线对齐**：JSON 解析入口加入 `len(httpReq.Body) > maxImageBodySize`（在 json.Unmarshal 前拒绝超大 body）与 `len(images) > maxImageCount` 校验，错误文案与既有 multipart 路径一致
3. **透传层按实际格式判断**（`internal/server/orchestrator/pass_through.go`）：`passThroughBodySupported` 对 multipart-capable 格式改为按 raw body 实际 Content-Type 判断，JSON body 放行回放
4. **Content-Type 同步**：回放时将下游请求的 Content-Type 同步为 inbound 的实际值，避免 JSON body 顶着 multipart 头转发
5. **Model 映射保护**：`passThroughBodyNeedsModelPatch` 加入 image_edit，保证 model mapping 照常生效

### 行为变化说明

- **透传开 + JSON edits**：新增支持，原始 JSON 回放 + model patch + Content-Type 同步
- **透传关 + JSON edits**：网关解析 JSON 后通过 outbound 重建合法的 multipart 转发上游（round-trip 已验证）
- **multipart 请求（无论透传与否）**：行为与原版完全一致，零影响
- **Content-Type 同步作用于所有透传格式**：语义上透传就应使用 inbound 的 Content-Type，对规范客户端是 no-op，对带额外参数的 Content-Type 原样转发

### 验证

- 新增 10 个单元测试覆盖：JSON 正常解析、body 超限拒绝、图片数量超限拒绝、校验错误、round-trip 重建、passthrough 回放
- `llm` 模块 `go test ./...` 全绿；`internal/server/...` 全绿；`go vet` 干净；`gofmt -l` 干净

Closes #2336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI image-edit requests can now use JSON bodies with base64-encoded images.
  * JSON image-edit requests support optional masks and generation parameters.

* **Bug Fixes**
  * Improved compatibility when JSON image-edit requests are forwarded through multipart-capable endpoints.
  * Preserved the correct request body and `Content-Type` during forwarding.
  * Added validation for required fields, image formats, image counts, body size, and unsupported streaming requests.
  * Oversized encoded images are now rejected before decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->