### PR TITLE
fix(openai): prevent zero-status errors from returning HTTP 200

### DIFF
--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -194,6 +194,15 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
+	llmErr, isLLMError := errors.AsType[*llm.ResponseError](rawErr)
+	if isLLMError && llmErr == nil {
+		return &httpclient.Error{
+			StatusCode: http.StatusInternalServerError,
+			Status:     http.StatusText(http.StatusInternalServerError),
+			Body:       xjson.MustMarshal(&OpenAIError{Detail: llm.ErrorDetail{Message: "An unexpected error occurred", Type: "unexpected_error"}}),
+		}
+	}
+
 	if errors.Is(rawErr, transformer.ErrInvalidModel) {
 		return &httpclient.Error{
 			StatusCode: http.StatusUnprocessableEntity,
@@ -223,7 +232,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		}
 	}
 
-	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
+	if isLLMError {
 		statusCode := llmErr.StatusCode
 		if statusCode == 0 && llmErr.Detail.Code == "context_length_exceeded" {
 			statusCode = http.StatusBadRequest

--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -202,7 +202,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 	}
 
 	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
-		return httpErr
+		return normalizeHTTPErrorStatus(httpErr)
 	}
 
 	// Handle validation errors
@@ -215,9 +215,14 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 	}
 
 	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
+		statusCode := llmErr.StatusCode
+		if statusCode < http.StatusBadRequest || statusCode > 599 {
+			statusCode = http.StatusBadGateway
+		}
+
 		return &httpclient.Error{
-			StatusCode: llmErr.StatusCode,
-			Status:     http.StatusText(llmErr.StatusCode),
+			StatusCode: statusCode,
+			Status:     http.StatusText(statusCode),
 			Body:       xjson.MustMarshal(&OpenAIError{Detail: llmErr.Detail}),
 		}
 	}
@@ -227,4 +232,16 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 		Status:     http.StatusText(http.StatusInternalServerError),
 		Body:       xjson.MustMarshal(&OpenAIError{Detail: llm.ErrorDetail{Message: rawErr.Error(), Type: "internal_server_error"}}),
 	}
+}
+
+func normalizeHTTPErrorStatus(httpErr *httpclient.Error) *httpclient.Error {
+	if httpErr.StatusCode >= http.StatusBadRequest && httpErr.StatusCode <= 599 {
+		return httpErr
+	}
+
+	normalized := *httpErr
+	normalized.StatusCode = http.StatusBadGateway
+	normalized.Status = http.StatusText(http.StatusBadGateway)
+
+	return &normalized
 }

--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/looplj/axonhub/llm"
@@ -185,7 +186,7 @@ func (t *InboundTransformer) AggregateStreamChunks(
 
 // TransformError transforms LLM error response to HTTP error response.
 func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *httpclient.Error {
-	if rawErr == nil {
+	if rawErr == nil || (reflect.ValueOf(rawErr).Kind() == reflect.Ptr && reflect.ValueOf(rawErr).IsNil()) {
 		return &httpclient.Error{
 			StatusCode: http.StatusInternalServerError,
 			Status:     http.StatusText(http.StatusInternalServerError),
@@ -234,6 +235,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 	}
 }
 
+// normalizeHTTPErrorStatus maps invalid error statuses to an upstream failure.
 func normalizeHTTPErrorStatus(httpErr *httpclient.Error) *httpclient.Error {
 	if httpErr.StatusCode >= http.StatusBadRequest && httpErr.StatusCode <= 599 {
 		return httpErr

--- a/llm/transformer/openai/inbound.go
+++ b/llm/transformer/openai/inbound.go
@@ -203,6 +203,14 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 	}
 
 	if httpErr, ok := errors.AsType[*httpclient.Error](rawErr); ok {
+		if httpErr == nil {
+			return &httpclient.Error{
+				StatusCode: http.StatusInternalServerError,
+				Status:     http.StatusText(http.StatusInternalServerError),
+				Body:       xjson.MustMarshal(&OpenAIError{Detail: llm.ErrorDetail{Message: "An unexpected error occurred", Type: "unexpected_error"}}),
+			}
+		}
+
 		return normalizeHTTPErrorStatus(httpErr)
 	}
 
@@ -217,7 +225,9 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 
 	if llmErr, ok := errors.AsType[*llm.ResponseError](rawErr); ok {
 		statusCode := llmErr.StatusCode
-		if statusCode < http.StatusBadRequest || statusCode > 599 {
+		if statusCode == 0 && llmErr.Detail.Code == "context_length_exceeded" {
+			statusCode = http.StatusBadRequest
+		} else if statusCode < http.StatusBadRequest || statusCode > 599 {
 			statusCode = http.StatusBadGateway
 		}
 

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -709,6 +709,7 @@ func mustMarshal(v any) []byte {
 
 func TestInboundTransformer_TransformError(t *testing.T) {
 	transformer := NewInboundTransformer()
+	var nilHTTPError *httpclient.Error
 
 	tests := []struct {
 		name          string
@@ -733,6 +734,14 @@ func TestInboundTransformer_TransformError(t *testing.T) {
 		{
 			name: "nil error",
 			err:  nil,
+			expectedError: &httpclient.Error{
+				StatusCode: http.StatusInternalServerError,
+				Body:       []byte(`{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`),
+			},
+		},
+		{
+			name: "typed nil http error",
+			err:  nilHTTPError,
 			expectedError: &httpclient.Error{
 				StatusCode: http.StatusInternalServerError,
 				Body:       []byte(`{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`),

--- a/llm/transformer/openai/inbound_test.go
+++ b/llm/transformer/openai/inbound_test.go
@@ -738,6 +738,29 @@ func TestInboundTransformer_TransformError(t *testing.T) {
 				Body:       []byte(`{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`),
 			},
 		},
+		{
+			name: "response error without status code",
+			err: &llm.ResponseError{
+				Detail: llm.ErrorDetail{
+					Message: "provider temporarily unavailable",
+					Type:    "provider_unavailable",
+				},
+			},
+			expectedError: &httpclient.Error{
+				StatusCode: http.StatusBadGateway,
+				Body:       []byte(`{"error":{"message":"provider temporarily unavailable","type":"provider_unavailable"}}`),
+			},
+		},
+		{
+			name: "http error without status code",
+			err: &httpclient.Error{
+				Body: []byte(`{"error":{"message":"provider temporarily unavailable","type":"provider_unavailable"}}`),
+			},
+			expectedError: &httpclient.Error{
+				StatusCode: http.StatusBadGateway,
+				Body:       []byte(`{"error":{"message":"provider temporarily unavailable","type":"provider_unavailable"}}`),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/llm/transformer/openai/transform_error_test.go
+++ b/llm/transformer/openai/transform_error_test.go
@@ -1,0 +1,111 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestInboundTransformer_TransformError_WrappedTypedNilReturnsInternalServerError(t *testing.T) {
+	transformer := NewInboundTransformer()
+	var typedNil *httpclient.Error
+	wrapped := fmt.Errorf("wrap: %w", typedNil)
+
+	result := transformer.TransformError(context.Background(), wrapped)
+
+	require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	require.Equal(t, http.StatusText(http.StatusInternalServerError), result.Status)
+	require.JSONEq(t, `{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`, string(result.Body))
+}
+
+func TestInboundTransformer_TransformError_StatuslessContextLengthExceededReturnsBadRequest(t *testing.T) {
+	transformer := NewInboundTransformer()
+	detail := llm.ErrorDetail{
+		Code:    "context_length_exceeded",
+		Message: "maximum context length exceeded",
+		Type:    "invalid_request_error",
+		Param:   "messages",
+	}
+
+	result := transformer.TransformError(context.Background(), &llm.ResponseError{Detail: detail})
+
+	require.Equal(t, http.StatusBadRequest, result.StatusCode)
+	require.Equal(t, http.StatusText(http.StatusBadRequest), result.Status)
+	var body OpenAIError
+	require.NoError(t, json.Unmarshal(result.Body, &body))
+	require.Equal(t, detail, body.Detail)
+}
+
+func TestInboundTransformer_TransformError_NormalizesStatusCodes(t *testing.T) {
+	httpBadRequest := &httpclient.Error{StatusCode: http.StatusBadRequest, Status: "client error"}
+	httpServiceUnavailable := &httpclient.Error{StatusCode: http.StatusServiceUnavailable, Status: "server error"}
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantSame   *httpclient.Error
+	}{
+		{
+			name:       "httpclient error preserves valid 4xx",
+			err:        httpBadRequest,
+			wantStatus: http.StatusBadRequest,
+			wantSame:   httpBadRequest,
+		},
+		{
+			name:       "httpclient error preserves valid 5xx",
+			err:        httpServiceUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantSame:   httpServiceUnavailable,
+		},
+		{
+			name:       "response error preserves valid 4xx",
+			err:        &llm.ResponseError{StatusCode: http.StatusBadRequest},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "response error preserves valid 5xx",
+			err:        &llm.ResponseError{StatusCode: http.StatusServiceUnavailable},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "httpclient error maps status 200 to bad gateway",
+			err:        &httpclient.Error{StatusCode: http.StatusOK},
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "httpclient error maps status 600 to bad gateway",
+			err:        &httpclient.Error{StatusCode: 600},
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "response error maps status 200 to bad gateway",
+			err:        &llm.ResponseError{StatusCode: http.StatusOK},
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "response error maps status 600 to bad gateway",
+			err:        &llm.ResponseError{StatusCode: 600},
+			wantStatus: http.StatusBadGateway,
+		},
+	}
+
+	transformer := NewInboundTransformer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transformer.TransformError(context.Background(), tt.err)
+
+			require.Equal(t, tt.wantStatus, result.StatusCode)
+			if tt.wantSame != nil {
+				require.Same(t, tt.wantSame, result)
+			}
+		})
+	}
+}

--- a/llm/transformer/openai/transform_error_test.go
+++ b/llm/transformer/openai/transform_error_test.go
@@ -25,6 +25,18 @@ func TestInboundTransformer_TransformError_WrappedTypedNilReturnsInternalServerE
 	require.JSONEq(t, `{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`, string(result.Body))
 }
 
+func TestInboundTransformer_TransformError_WrappedTypedNilResponseErrorReturnsInternalServerError(t *testing.T) {
+	transformer := NewInboundTransformer()
+	var typedNil *llm.ResponseError
+	wrapped := fmt.Errorf("wrap: %w", typedNil)
+
+	result := transformer.TransformError(context.Background(), wrapped)
+
+	require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	require.Equal(t, http.StatusText(http.StatusInternalServerError), result.Status)
+	require.JSONEq(t, `{"error":{"message":"An unexpected error occurred","type":"unexpected_error"}}`, string(result.Body))
+}
+
 func TestInboundTransformer_TransformError_StatuslessContextLengthExceededReturnsBadRequest(t *testing.T) {
 	transformer := NewInboundTransformer()
 	detail := llm.ErrorDetail{


### PR DESCRIPTION
## Summary

- normalize OpenAI inbound `httpclient.Error` values whose status is missing or outside the HTTP error range
- map status-less `llm.ResponseError` values to `502 Bad Gateway` while preserving the provider error body
- add regression coverage for both error paths

A provider can report a top-level stream error without an HTTP status. Passing status `0` to Gin leaves its default `200 OK`, so OpenAI-compatible streaming clients select the SSE parser and then see an empty stream instead of the JSON provider error. The fallback is `502` because these errors originate from an upstream provider. Existing valid 4xx/5xx statuses remain unchanged.

Fixes #2083

## Tests

- `cd llm && go test ./transformer/openai -run ^'TestInboundTransformer_TransformError$' -count=1`\n- `cd llm && go test ./transformer/openai -count=1`\n- `cd llm && go test ./... -count=1`\n- `go test ./internal/server/api -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized invalid or missing HTTP error status codes to **502 Bad Gateway**.
  * Preserved original error response bodies while ensuring errors use valid HTTP status ranges.
  * Correctly handles nil and typed-nil errors, returning a **500 Internal Server Error** response.
  * Maps `context_length_exceeded` errors without a status code to **400 Bad Request**.
  * Preserves valid 4xx and 5xx error statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->