### PR TITLE
fix(openai): tolerate object-shaped usage cost

### DIFF
--- a/llm/transformer/openai/usage.go
+++ b/llm/transformer/openai/usage.go
@@ -1,6 +1,10 @@
 package openai
 
-import "github.com/looplj/axonhub/llm"
+import (
+	"encoding/json"
+
+	"github.com/looplj/axonhub/llm"
+)
 
 // PromptTokensDetails Breakdown of tokens used in the prompt.
 type PromptTokensDetails struct {
@@ -40,6 +44,42 @@ type Usage struct {
 	// Cost is the request cost calculated by AxonHub from channel model prices.
 	// Omitted when no matching price is configured.
 	Cost *float64 `json:"cost,omitempty"`
+}
+
+// UnmarshalJSON tolerates provider-specific usage.cost values. AxonHub does not
+// trust or propagate upstream cost values, and some compatible providers encode
+// cost as an object instead of a number. Preserve numeric values for JSON
+// round-trips, but ignore other valid JSON shapes without dropping the usage
+// token counts.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	type usageAlias Usage
+
+	decoded := struct {
+		*usageAlias
+
+		Cost json.RawMessage `json:"cost"`
+	}{
+		usageAlias: (*usageAlias)(u),
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	if len(decoded.Cost) == 0 {
+		return nil
+	}
+
+	// A present null or non-number cost is an upstream extension that should not
+	// affect usage parsing. ToLLMUsage intentionally does not propagate it.
+	u.Cost = nil
+
+	var cost float64
+	if err := json.Unmarshal(decoded.Cost, &cost); err == nil {
+		u.Cost = &cost
+	}
+
+	return nil
 }
 
 func (u *Usage) ToLLMUsage() *llm.Usage {

--- a/llm/transformer/openai/usage_cost_test.go
+++ b/llm/transformer/openai/usage_cost_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 )
 
 func TestUsage_CostJSON(t *testing.T) {
@@ -63,6 +64,61 @@ func TestUsage_CostJSON(t *testing.T) {
 		require.NotNil(t, usage)
 		require.Nil(t, usage.Cost)
 	})
+
+	t.Run("object-shaped upstream cost is ignored", func(t *testing.T) {
+		var decoded Usage
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"prompt_tokens": 15102,
+			"completion_tokens": 282,
+			"total_tokens": 15384,
+			"cost": {
+				"usd": 0.00701712,
+				"hypercredits": 0.1403424
+			}
+		}`), &decoded))
+		require.Nil(t, decoded.Cost)
+		require.Equal(t, int64(15102), decoded.PromptTokens)
+		require.Equal(t, int64(282), decoded.CompletionTokens)
+		require.Equal(t, int64(15384), decoded.TotalTokens)
+	})
+}
+
+func TestAggregateStreamChunks_ObjectShapedUsageCost(t *testing.T) {
+	chunks := []*httpclient.StreamEvent{
+		{Data: []byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion.chunk",
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"delta": {"content": "ok"},
+				"finish_reason": "stop"
+			}]
+		}`)},
+		{Data: []byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion.chunk",
+			"model": "test-model",
+			"choices": [],
+			"usage": {
+				"prompt_tokens": 15102,
+				"completion_tokens": 282,
+				"total_tokens": 15384,
+				"cost": {
+					"usd": 0.00701712,
+					"hypercredits": 0.1403424
+				}
+			}
+		}`)},
+	}
+
+	_, meta, err := AggregateStreamChunks(t.Context(), chunks, DefaultTransformChunk)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Usage)
+	require.Equal(t, int64(15102), meta.Usage.PromptTokens)
+	require.Equal(t, int64(282), meta.Usage.CompletionTokens)
+	require.Equal(t, int64(15384), meta.Usage.TotalTokens)
+	require.Nil(t, meta.Usage.Cost)
 }
 
 func TestCompletionUsage_CostJSON(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of usage data when cost information arrives in an unsupported object format.
  * Token counts are now preserved even when cost values are non-numeric or null.
  * Numeric cost values continue to round-trip correctly during processing.
  * Streaming usage aggregation now remains available with token counts when cost data cannot be interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->