### PR TITLE
fix(openai): preserve request contracts across transports

### DIFF
--- a/internal/server/api/responses_websocket.go
+++ b/internal/server/api/responses_websocket.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -29,6 +30,9 @@ const (
 	responsesWebSocketPingInterval     = responsesWebSocketIdleTimeout / 2
 	responsesWebSocketPingWriteTimeout = 10 * time.Second
 	responsesWebSocketWriteTimeout     = 10 * time.Second
+	responsesWebSocketMaxActive        = 16
+	responsesWebSocketMaxPending       = 64
+	responsesWebSocketMaxNamedStreams  = 32
 )
 
 type responsesWebSocketProcessFunc func(context.Context, *httpclient.Request) (orchestrator.ChatCompletionResult, error)
@@ -36,8 +40,6 @@ type responsesWebSocketProcessFunc func(context.Context, *httpclient.Request) (o
 type responsesWebSocketErrorFunc func(context.Context, error) *httpclient.Error
 
 // serveResponsesWebSocket implements the downstream Responses WebSocket mode.
-// Each response.create message is processed synchronously, which preserves the
-// protocol's single in-flight response per connection rule.
 func serveResponsesWebSocket(
 	c *gin.Context,
 	requestTimeout time.Duration,
@@ -49,7 +51,8 @@ func serveResponsesWebSocket(
 		return
 	}
 
-	ctx := shared.WithResponsesWebSocket(c.Request.Context())
+	ctx, cancelSession := context.WithCancel(shared.WithResponsesWebSocket(c.Request.Context()))
+	defer cancelSession()
 	if _, ok := shared.GetSessionID(ctx); !ok {
 		ctx = shared.WithSessionID(ctx, "responses-ws-"+uuid.NewString())
 	}
@@ -63,6 +66,7 @@ func serveResponsesWebSocket(
 		return
 	}
 	defer conn.Close()
+	writer := &responsesWebSocketWriter{conn: conn}
 
 	conn.SetReadLimit(responsesWebSocketMaxMessageSize)
 	if err := conn.SetReadDeadline(time.Now().Add(responsesWebSocketIdleTimeout)); err != nil {
@@ -77,7 +81,8 @@ func serveResponsesWebSocket(
 	defer close(pingDone)
 	go runResponsesWebSocketPings(ctx, conn, pingDone)
 
-	session := new(responsesWebSocketSession)
+	dispatcher := newResponsesWebSocketDispatcher(ctx, cancelSession, conn, writer, c.Request, requestTimeout, process, transformError)
+	defer dispatcher.wait()
 	for {
 		messageType, message, readErr := conn.ReadMessage()
 		if readErr != nil {
@@ -93,54 +98,194 @@ func serveResponsesWebSocket(
 		}
 
 		if messageType != websocket.TextMessage {
-			if err := writeResponsesWebSocketError(conn, invalidResponsesWebSocketRequest("response.create must be sent as a text message", "")); err != nil {
+			if err := writeResponsesWebSocketError(writer, invalidResponsesWebSocketRequest("response.create must be sent as a text message", ""), ""); err != nil {
 				return
 			}
 			continue
 		}
 
-		request, warmup, requestErr := session.prepareRequest(c.Request, message)
-		if requestErr != nil {
-			if err := writeResponsesWebSocketError(conn, requestErr); err != nil {
-				return
-			}
-			continue
-		}
-		if warmup != nil {
-			if err := writeResponsesWebSocketWarmup(conn, warmup); err != nil {
+		streamID, envelopeErr := responsesWebSocketEnvelopeStreamID(message)
+		if envelopeErr != nil {
+			if err := writeResponsesWebSocketError(writer, envelopeErr, ""); err != nil {
 				return
 			}
 			continue
 		}
 
-		requestCtx := ctx
-		cancel := func() {}
-		if requestTimeout > 0 {
-			requestCtx, cancel = context.WithTimeout(ctx, requestTimeout)
+		lane, laneErr := dispatcher.lane(streamID)
+		if laneErr != nil {
+			if err := writeResponsesWebSocketError(writer, laneErr, streamID); err != nil {
+				return
+			}
+			continue
 		}
-		if request.RawRequest != nil {
-			request.RawRequest = request.RawRequest.WithContext(requestCtx)
-		}
-
-		result, processErr := process(requestCtx, request)
-		if processErr != nil {
-			httpErr := transformResponsesWebSocketError(requestCtx, processErr, transformError)
-			cancel()
-			if err := writeResponsesWebSocketError(conn, httpErr); err != nil {
+		if !dispatcher.reserve() {
+			if err := writeResponsesWebSocketError(writer, responsesWebSocketQueueLimitError(), streamID); err != nil {
 				return
 			}
 			continue
 		}
 
-		writeErr := writeResponsesWebSocketResult(requestCtx, conn, result, transformError)
-		cancel()
-		if writeErr != nil {
-			if !errors.Is(writeErr, context.Canceled) && ctx.Err() == nil {
-				log.Warn(ctx, "Failed to write Responses WebSocket result", log.Cause(writeErr))
+		dispatcher.dispatch(lane, streamID, append([]byte(nil), message...))
+	}
+}
+
+type responsesWebSocketWriter struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+type responsesWebSocketLane struct {
+	session responsesWebSocketSession
+	tail    <-chan struct{}
+}
+
+type responsesWebSocketDispatcher struct {
+	ctx            context.Context
+	cancel         context.CancelFunc
+	conn           *websocket.Conn
+	writer         *responsesWebSocketWriter
+	rawRequest     *http.Request
+	requestTimeout time.Duration
+	process        responsesWebSocketProcessFunc
+	transformError responsesWebSocketErrorFunc
+	active         chan struct{}
+	pending        chan struct{}
+	lanes          map[string]*responsesWebSocketLane
+	namedStreams   int
+	wg             sync.WaitGroup
+	closeOnce      sync.Once
+}
+
+func newResponsesWebSocketDispatcher(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	conn *websocket.Conn,
+	writer *responsesWebSocketWriter,
+	rawRequest *http.Request,
+	requestTimeout time.Duration,
+	process responsesWebSocketProcessFunc,
+	transformError responsesWebSocketErrorFunc,
+) *responsesWebSocketDispatcher {
+	return &responsesWebSocketDispatcher{
+		ctx:            ctx,
+		cancel:         cancel,
+		conn:           conn,
+		writer:         writer,
+		rawRequest:     rawRequest,
+		requestTimeout: requestTimeout,
+		process:        process,
+		transformError: transformError,
+		active:         make(chan struct{}, responsesWebSocketMaxActive),
+		pending:        make(chan struct{}, responsesWebSocketMaxPending),
+		lanes:          make(map[string]*responsesWebSocketLane),
+	}
+}
+
+func (d *responsesWebSocketDispatcher) reserve() bool {
+	select {
+	case d.pending <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *responsesWebSocketDispatcher) lane(streamID string) (*responsesWebSocketLane, *httpclient.Error) {
+	if lane := d.lanes[streamID]; lane != nil {
+		return lane, nil
+	}
+	if streamID != "" && d.namedStreams >= responsesWebSocketMaxNamedStreams {
+		return nil, responsesWebSocketRequestError(
+			"This WebSocket connection has reached its maximum number of distinct stream IDs (32). Reuse an existing stream_id or open a new WebSocket connection.",
+			"stream_id",
+			"websocket_stream_limit_reached",
+		)
+	}
+
+	ready := make(chan struct{})
+	close(ready)
+	lane := &responsesWebSocketLane{tail: ready}
+	d.lanes[streamID] = lane
+	if streamID != "" {
+		d.namedStreams++
+	}
+
+	return lane, nil
+}
+
+func (d *responsesWebSocketDispatcher) dispatch(lane *responsesWebSocketLane, streamID string, message []byte) {
+	previous := lane.tail
+	done := make(chan struct{})
+	lane.tail = done
+	d.wg.Go(func() {
+		defer func() { <-d.pending }()
+		defer close(done)
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Error(d.ctx, "Panic while processing Responses WebSocket request", log.Any("panic", recovered))
+				d.closeOnce.Do(func() {
+					d.cancel()
+					_ = d.conn.Close()
+				})
 			}
+		}()
+
+		select {
+		case <-previous:
+		case <-d.ctx.Done():
 			return
 		}
+		select {
+		case d.active <- struct{}{}:
+			defer func() { <-d.active }()
+		case <-d.ctx.Done():
+			return
+		}
+
+		if err := d.processMessage(&lane.session, streamID, message); err != nil {
+			if !errors.Is(err, context.Canceled) && d.ctx.Err() == nil {
+				log.Warn(d.ctx, "Failed to write Responses WebSocket result", log.Cause(err))
+			}
+			d.closeOnce.Do(func() {
+				d.cancel()
+				_ = d.conn.Close()
+			})
+		}
+	})
+}
+
+func (d *responsesWebSocketDispatcher) processMessage(session *responsesWebSocketSession, streamID string, message []byte) error {
+	request, warmup, requestErr := session.prepareRequest(d.rawRequest, message)
+	if requestErr != nil {
+		return writeResponsesWebSocketError(d.writer, requestErr, streamID)
 	}
+	if warmup != nil {
+		return writeResponsesWebSocketWarmup(d.writer, warmup, streamID)
+	}
+
+	requestCtx := d.ctx
+	cancel := func() {}
+	if d.requestTimeout > 0 {
+		requestCtx, cancel = context.WithTimeout(d.ctx, d.requestTimeout)
+	}
+	defer cancel()
+	if request.RawRequest != nil {
+		request.RawRequest = request.RawRequest.WithContext(requestCtx)
+	}
+
+	result, processErr := d.process(requestCtx, request)
+	if processErr != nil {
+		httpErr := transformResponsesWebSocketError(requestCtx, processErr, d.transformError)
+		return writeResponsesWebSocketError(d.writer, httpErr, streamID)
+	}
+
+	return writeResponsesWebSocketResult(requestCtx, d.writer, result, d.transformError, streamID)
+}
+
+func (d *responsesWebSocketDispatcher) wait() {
+	d.cancel()
+	d.wg.Wait()
 }
 
 func runResponsesWebSocketPings(ctx context.Context, conn *websocket.Conn, done <-chan struct{}) {
@@ -166,6 +311,47 @@ func runResponsesWebSocketPings(ctx context.Context, conn *websocket.Conn, done 
 			return
 		}
 	}
+}
+
+func responsesWebSocketEnvelopeStreamID(message []byte) (string, *httpclient.Error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(message, &payload); err != nil || payload == nil {
+		return "", invalidResponsesWebSocketRequest("invalid response.create JSON payload", "")
+	}
+
+	var eventType string
+	if rawType, ok := payload["type"]; !ok || json.Unmarshal(rawType, &eventType) != nil || eventType != responseCreateWebSocketEventType {
+		return "", invalidResponsesWebSocketRequest("expected a response.create event", "type")
+	}
+
+	rawStreamID, ok := payload["stream_id"]
+	if !ok {
+		return "", nil
+	}
+	var streamID string
+	if json.Unmarshal(rawStreamID, &streamID) != nil || !validResponsesWebSocketStreamID(streamID) {
+		return "", responsesWebSocketRequestError(
+			"The 'stream_id' field must be a non-empty string with at most 256 characters and may only contain letters, numbers, underscores, hyphens, and periods.",
+			"stream_id",
+			"invalid_stream_id",
+		)
+	}
+
+	return streamID, nil
+}
+
+func validResponsesWebSocketStreamID(streamID string) bool {
+	if streamID == "" || len(streamID) > 256 {
+		return false
+	}
+	for _, char := range streamID {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' || char == '_' || char == '-' || char == '.' {
+			continue
+		}
+		return false
+	}
+
+	return true
 }
 
 type responsesWebSocketSession struct {
@@ -199,8 +385,8 @@ func (s *responsesWebSocketSession) prepareRequest(
 			return nil, nil, invalidResponsesWebSocketRequest("generate must be a boolean", "generate")
 		}
 	}
-	displayControls := make(map[string]json.RawMessage, 2)
-	for _, key := range []string{"generate", "background"} {
+	displayControls := make(map[string]json.RawMessage, 3)
+	for _, key := range []string{"generate", "background", "stream_id"} {
 		if value, ok := payload[key]; ok {
 			displayControls[key] = append(json.RawMessage(nil), value...)
 		}
@@ -209,6 +395,7 @@ func (s *responsesWebSocketSession) prepareRequest(
 	delete(payload, "type")
 	delete(payload, "generate")
 	delete(payload, "background")
+	delete(payload, "stream_id")
 
 	previousResponseID := responseWebSocketStringField(payload, "previous_response_id")
 	if s.warmupID != "" && previousResponseID == s.warmupID {
@@ -358,7 +545,7 @@ func responseWebSocketStringField(payload map[string]json.RawMessage, key string
 	return value
 }
 
-func writeResponsesWebSocketWarmup(conn *websocket.Conn, warmup *responsesWebSocketWarmup) error {
+func writeResponsesWebSocketWarmup(writer *responsesWebSocketWriter, warmup *responsesWebSocketWarmup, streamID string) error {
 	if warmup == nil {
 		return nil
 	}
@@ -376,27 +563,27 @@ func writeResponsesWebSocketWarmup(conn *websocket.Conn, warmup *responsesWebSoc
 		response["previous_response_id"] = warmup.PreviousResponseID
 	}
 
-	if err := writeResponsesWebSocketJSON(conn, gin.H{
+	if err := writeResponsesWebSocketJSON(writer, responsesWebSocketEvent(streamID, gin.H{
 		"type":            "response.created",
 		"sequence_number": 0,
 		"response":        response,
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
-	if err := writeResponsesWebSocketJSON(conn, gin.H{
+	if err := writeResponsesWebSocketJSON(writer, responsesWebSocketEvent(streamID, gin.H{
 		"type":            "response.in_progress",
 		"sequence_number": 1,
 		"response":        response,
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
 
 	response["status"] = "completed"
-	return writeResponsesWebSocketJSON(conn, gin.H{
+	return writeResponsesWebSocketJSON(writer, responsesWebSocketEvent(streamID, gin.H{
 		"type":            "response.completed",
 		"sequence_number": 2,
 		"response":        response,
-	})
+	}))
 }
 
 func responseWebSocketRequestHeaders(headers http.Header) http.Header {
@@ -416,9 +603,10 @@ func responseWebSocketRequestHeaders(headers http.Header) http.Header {
 
 func writeResponsesWebSocketResult(
 	ctx context.Context,
-	conn *websocket.Conn,
+	writer *responsesWebSocketWriter,
 	result orchestrator.ChatCompletionResult,
 	transformError responsesWebSocketErrorFunc,
+	streamID string,
 ) error {
 	if result.ChatCompletionStream != nil {
 		stream := result.ChatCompletionStream
@@ -433,13 +621,17 @@ func writeResponsesWebSocketResult(
 			if orchestrator.IsTerminalStreamEvent(event) {
 				terminalSeen = true
 			}
-			if err := writeResponsesWebSocketMessage(conn, websocket.TextMessage, event.Data); err != nil {
+			data, err := withResponsesWebSocketStreamID(event.Data, streamID)
+			if err != nil {
+				return err
+			}
+			if err := writeResponsesWebSocketMessage(writer, websocket.TextMessage, data); err != nil {
 				return err
 			}
 		}
 
 		if err := stream.Err(); err != nil && !terminalSeen {
-			return writeResponsesWebSocketError(conn, transformResponsesWebSocketError(ctx, err, transformError))
+			return writeResponsesWebSocketError(writer, transformResponsesWebSocketError(ctx, err, transformError), streamID)
 		}
 
 		return nil
@@ -448,18 +640,18 @@ func writeResponsesWebSocketResult(
 	if result.ChatCompletion != nil {
 		var response json.RawMessage
 		if !json.Valid(result.ChatCompletion.Body) {
-			return writeResponsesWebSocketError(conn, invalidResponsesWebSocketRequest("invalid Responses result", ""))
+			return writeResponsesWebSocketError(writer, invalidResponsesWebSocketRequest("invalid Responses result", ""), streamID)
 		}
 		response = result.ChatCompletion.Body
 
-		return writeResponsesWebSocketJSON(conn, gin.H{
+		return writeResponsesWebSocketJSON(writer, responsesWebSocketEvent(streamID, gin.H{
 			"type":            "response.completed",
 			"sequence_number": 0,
 			"response":        response,
-		})
+		}))
 	}
 
-	return writeResponsesWebSocketError(conn, invalidResponsesWebSocketRequest("Responses request returned no result", ""))
+	return writeResponsesWebSocketError(writer, invalidResponsesWebSocketRequest("Responses request returned no result", ""), streamID)
 }
 
 func transformResponsesWebSocketError(ctx context.Context, err error, transformError responsesWebSocketErrorFunc) *httpclient.Error {
@@ -480,10 +672,14 @@ func transformResponsesWebSocketError(ctx context.Context, err error, transformE
 }
 
 func invalidResponsesWebSocketRequest(message, param string) *httpclient.Error {
+	return responsesWebSocketRequestError(message, param, "invalid_request_error")
+}
+
+func responsesWebSocketRequestError(message, param, code string) *httpclient.Error {
 	detail := gin.H{
 		"message": message,
 		"type":    "invalid_request_error",
-		"code":    "invalid_request_error",
+		"code":    code,
 	}
 	if param != "" {
 		detail["param"] = param
@@ -500,7 +696,19 @@ func invalidResponsesWebSocketRequest(message, param string) *httpclient.Error {
 	}
 }
 
-func writeResponsesWebSocketError(conn *websocket.Conn, httpErr *httpclient.Error) error {
+func responsesWebSocketQueueLimitError() *httpclient.Error {
+	httpErr := responsesWebSocketRequestError(
+		"This WebSocket connection has reached its pending response limit (64). Wait for an active response to finish before sending more response.create events.",
+		"",
+		"websocket_queue_limit_reached",
+	)
+	httpErr.StatusCode = http.StatusTooManyRequests
+	httpErr.Status = http.StatusText(http.StatusTooManyRequests)
+
+	return httpErr
+}
+
+func writeResponsesWebSocketError(writer *responsesWebSocketWriter, httpErr *httpclient.Error, streamID string) error {
 	status := http.StatusInternalServerError
 	if httpErr != nil && httpErr.StatusCode != 0 {
 		status = httpErr.StatusCode
@@ -519,25 +727,55 @@ func writeResponsesWebSocketError(conn *websocket.Conn, httpErr *httpclient.Erro
 		}
 	}
 
-	return writeResponsesWebSocketJSON(conn, gin.H{
+	return writeResponsesWebSocketJSON(writer, responsesWebSocketEvent(streamID, gin.H{
 		"type":   "error",
 		"status": status,
 		"error":  detail,
-	})
+	}))
 }
 
-func writeResponsesWebSocketMessage(conn *websocket.Conn, messageType int, data []byte) error {
-	if err := conn.SetWriteDeadline(time.Now().Add(responsesWebSocketWriteTimeout)); err != nil {
+func responsesWebSocketEvent(streamID string, event gin.H) gin.H {
+	if streamID != "" {
+		event["stream_id"] = streamID
+	}
+
+	return event
+}
+
+func withResponsesWebSocketStreamID(data []byte, streamID string) ([]byte, error) {
+	if streamID == "" {
+		return data, nil
+	}
+
+	var event map[string]json.RawMessage
+	if err := json.Unmarshal(data, &event); err != nil {
+		return nil, fmt.Errorf("failed to decode Responses WebSocket event: %w", err)
+	}
+	encodedStreamID, err := json.Marshal(streamID)
+	if err != nil {
+		return nil, err
+	}
+	event["stream_id"] = encodedStreamID
+
+	return json.Marshal(event)
+}
+
+func writeResponsesWebSocketMessage(writer *responsesWebSocketWriter, messageType int, data []byte) error {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+
+	if err := writer.conn.SetWriteDeadline(time.Now().Add(responsesWebSocketWriteTimeout)); err != nil {
 		return err
 	}
 
-	return conn.WriteMessage(messageType, data)
+	return writer.conn.WriteMessage(messageType, data)
 }
 
-func writeResponsesWebSocketJSON(conn *websocket.Conn, value any) error {
-	if err := conn.SetWriteDeadline(time.Now().Add(responsesWebSocketWriteTimeout)); err != nil {
+func writeResponsesWebSocketJSON(writer *responsesWebSocketWriter, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
 		return err
 	}
 
-	return conn.WriteJSON(value)
+	return writeResponsesWebSocketMessage(writer, websocket.TextMessage, data)
 }

--- a/internal/server/api/responses_websocket_test.go
+++ b/internal/server/api/responses_websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -83,6 +84,260 @@ func TestResponsesWebSocketProcessesSequentialResponseCreateEvents(t *testing.T)
 	require.Equal(t, "resp_1", gjson.GetBytes(second.Body, "previous_response_id").String())
 	require.Equal(t, "response.create", gjson.GetBytes(second.JSONBody, "type").String())
 	require.False(t, gjson.GetBytes(second.JSONBody, "stream").Exists())
+}
+
+func TestResponsesWebSocketStreamIDIsClientOnlyAndReturnedOnEveryEvent(t *testing.T) {
+	requests := make(chan *httpclient.Request, 1)
+	process := func(_ context.Context, request *httpclient.Request) (orchestrator.ChatCompletionResult, error) {
+		requests <- request
+		return orchestrator.ChatCompletionResult{
+			ChatCompletionStream: streams.SliceStream([]*httpclient.StreamEvent{
+				{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_lane"}}`)},
+				{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_lane","status":"completed"}}`)},
+			}),
+		}, nil
+	}
+
+	server := newResponsesWebSocketTestServer(t, process, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane.alpha-1","model":"gpt-test","input":"hello"}`)))
+	for _, eventType := range []string{"response.created", "response.completed"} {
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, eventType, gjson.GetBytes(event, "type").String())
+		require.Equal(t, "lane.alpha-1", gjson.GetBytes(event, "stream_id").String())
+	}
+
+	request := <-requests
+	require.False(t, gjson.GetBytes(request.Body, "stream_id").Exists())
+	require.Equal(t, "lane.alpha-1", gjson.GetBytes(request.JSONBody, "stream_id").String())
+}
+
+func TestResponsesWebSocketRunsDifferentStreamsConcurrentlyAndSameStreamFIFO(t *testing.T) {
+	startedA1 := make(chan struct{})
+	startedA2 := make(chan struct{})
+	startedB := make(chan struct{})
+	releaseA1 := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseA1)
+		}
+	}()
+
+	process := func(_ context.Context, request *httpclient.Request) (orchestrator.ChatCompletionResult, error) {
+		input := gjson.GetBytes(request.Body, "input").String()
+		switch input {
+		case "a1":
+			close(startedA1)
+			<-releaseA1
+		case "a2":
+			close(startedA2)
+		case "b1":
+			close(startedB)
+		}
+
+		return orchestrator.ChatCompletionResult{
+			ChatCompletionStream: streams.SliceStream([]*httpclient.StreamEvent{{
+				Type: "response.completed",
+				Data: []byte(`{"type":"response.completed","response":{"id":"resp_` + input + `","status":"completed"}}`),
+			}}),
+		}, nil
+	}
+
+	server := newResponsesWebSocketTestServer(t, process, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-a","model":"gpt-test","input":"a1"}`)))
+	select {
+	case <-startedA1:
+	case <-time.After(time.Second):
+		t.Fatal("first lane-a request did not start")
+	}
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-a","model":"gpt-test","input":"a2"}`)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-b","model":"gpt-test","input":"b1"}`)))
+	select {
+	case <-startedB:
+	case <-time.After(time.Second):
+		t.Fatal("lane-b request did not run concurrently")
+	}
+	select {
+	case <-startedA2:
+		t.Fatal("second lane-a request started before the first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	_, eventB, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "lane-b", gjson.GetBytes(eventB, "stream_id").String())
+	require.Equal(t, "resp_b1", gjson.GetBytes(eventB, "response.id").String())
+
+	close(releaseA1)
+	released = true
+	select {
+	case <-startedA2:
+	case <-time.After(time.Second):
+		t.Fatal("second lane-a request did not start after the first completed")
+	}
+
+	for _, responseID := range []string{"resp_a1", "resp_a2"} {
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, "lane-a", gjson.GetBytes(event, "stream_id").String())
+		require.Equal(t, responseID, gjson.GetBytes(event, "response.id").String())
+	}
+}
+
+func TestResponsesWebSocketValidatesAndLimitsNamedStreams(t *testing.T) {
+	server := newResponsesWebSocketTestServer(t, nil, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"bad/lane","model":"gpt-test","generate":false}`)))
+	_, invalidEvent, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "error", gjson.GetBytes(invalidEvent, "type").String())
+	require.Equal(t, "invalid_stream_id", gjson.GetBytes(invalidEvent, "error.code").String())
+	require.False(t, gjson.GetBytes(invalidEvent, "stream_id").Exists())
+
+	for i := range responsesWebSocketMaxNamedStreams {
+		message := fmt.Sprintf(`{"type":"response.create","stream_id":"lane-%d","model":"gpt-test","generate":false}`, i)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(message)))
+	}
+
+	completed := make(map[string]struct{}, responsesWebSocketMaxNamedStreams)
+	for range responsesWebSocketMaxNamedStreams * 3 {
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		if gjson.GetBytes(event, "type").String() == "response.completed" {
+			completed[gjson.GetBytes(event, "stream_id").String()] = struct{}{}
+		}
+	}
+	require.Len(t, completed, responsesWebSocketMaxNamedStreams)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-over-limit","model":"gpt-test","generate":false}`)))
+	_, limitEvent, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "error", gjson.GetBytes(limitEvent, "type").String())
+	require.Equal(t, "websocket_stream_limit_reached", gjson.GetBytes(limitEvent, "error.code").String())
+	require.Equal(t, "lane-over-limit", gjson.GetBytes(limitEvent, "stream_id").String())
+}
+
+func TestResponsesWebSocketLimitsActiveResponsesPerConnection(t *testing.T) {
+	started := make(chan string, responsesWebSocketMaxActive+1)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	process := func(_ context.Context, request *httpclient.Request) (orchestrator.ChatCompletionResult, error) {
+		input := gjson.GetBytes(request.Body, "input").String()
+		started <- input
+		<-release
+		return orchestrator.ChatCompletionResult{
+			ChatCompletionStream: streams.SliceStream([]*httpclient.StreamEvent{{
+				Type: "response.completed",
+				Data: []byte(`{"type":"response.completed","response":{"id":"resp_` + input + `","status":"completed"}}`),
+			}}),
+		}, nil
+	}
+
+	server := newResponsesWebSocketTestServer(t, process, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	for i := range responsesWebSocketMaxActive + 1 {
+		message := fmt.Sprintf(`{"type":"response.create","stream_id":"active-%d","model":"gpt-test","input":"%d"}`, i, i)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(message)))
+	}
+	for range responsesWebSocketMaxActive {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("expected active response did not start")
+		}
+	}
+	select {
+	case value := <-started:
+		t.Fatalf("response %s exceeded the active response limit", value)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release <- struct{}{}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("queued response did not start after a slot became available")
+	}
+	close(release)
+	released = true
+
+	for range responsesWebSocketMaxActive + 1 {
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	}
+}
+
+func TestResponsesWebSocketBoundsPendingResponsesPerConnection(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	process := func(_ context.Context, _ *httpclient.Request) (orchestrator.ChatCompletionResult, error) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		return orchestrator.ChatCompletionResult{
+			ChatCompletionStream: streams.SliceStream([]*httpclient.StreamEvent{{
+				Type: "response.completed",
+				Data: []byte(`{"type":"response.completed","response":{"id":"resp_pending","status":"completed"}}`),
+			}}),
+		}, nil
+	}
+
+	server := newResponsesWebSocketTestServer(t, process, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	for i := range responsesWebSocketMaxPending + 1 {
+		message := fmt.Sprintf(`{"type":"response.create","model":"gpt-test","input":"%d"}`, i)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(message)))
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first pending response did not start")
+	}
+
+	_, limitEvent, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "error", gjson.GetBytes(limitEvent, "type").String())
+	require.Equal(t, int64(http.StatusTooManyRequests), gjson.GetBytes(limitEvent, "status").Int())
+	require.Equal(t, "websocket_queue_limit_reached", gjson.GetBytes(limitEvent, "error.code").String())
+
+	close(release)
+	released = true
+	for range responsesWebSocketMaxPending {
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	}
 }
 
 func TestResponsesWebSocketStreamsHTTPSSEResponseIncrementally(t *testing.T) {
@@ -205,18 +460,20 @@ func TestResponsesWebSocketWritesProtocolAndProcessingErrorsWithoutClosingConnec
 	require.Equal(t, int64(http.StatusBadRequest), gjson.GetBytes(invalidEvent, "status").Int())
 	require.Equal(t, "type", gjson.GetBytes(invalidEvent, "error.param").String())
 
-	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"fail","input":"hello"}`)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-errors","model":"fail","input":"hello"}`)))
 	_, processError, err := conn.ReadMessage()
 	require.NoError(t, err)
 	require.Equal(t, "error", gjson.GetBytes(processError, "type").String())
 	require.Equal(t, int64(http.StatusBadGateway), gjson.GetBytes(processError, "status").Int())
 	require.Equal(t, "provider_unavailable", gjson.GetBytes(processError, "error.code").String())
+	require.Equal(t, "lane-errors", gjson.GetBytes(processError, "stream_id").String())
 
-	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"ok","input":"hello"}`)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","stream_id":"lane-errors","model":"ok","input":"hello"}`)))
 	_, completed, err := conn.ReadMessage()
 	require.NoError(t, err)
 	require.Equal(t, "response.completed", gjson.GetBytes(completed, "type").String())
 	require.Equal(t, "resp_ok", gjson.GetBytes(completed, "response.id").String())
+	require.Equal(t, "lane-errors", gjson.GetBytes(completed, "stream_id").String())
 }
 
 func TestResponsesWebSocketWarmupReturnsIDAndMergesContinuation(t *testing.T) {
@@ -273,6 +530,57 @@ func TestResponsesWebSocketWarmupReturnsIDAndMergesContinuation(t *testing.T) {
 	require.Len(t, gjson.GetBytes(continuationRequest.Body, "input").Array(), 2)
 	require.Equal(t, "hello", gjson.GetBytes(continuationRequest.Body, "input.0.content").String())
 	require.Equal(t, "function_call_output", gjson.GetBytes(continuationRequest.Body, "input.1.type").String())
+}
+
+func TestResponsesWebSocketWarmupsAreIsolatedByStream(t *testing.T) {
+	requests := make(chan *httpclient.Request, 2)
+	process := func(_ context.Context, request *httpclient.Request) (orchestrator.ChatCompletionResult, error) {
+		requests <- request
+		return orchestrator.ChatCompletionResult{
+			ChatCompletionStream: streams.SliceStream([]*httpclient.StreamEvent{{
+				Type: "response.completed",
+				Data: []byte(`{"type":"response.completed","response":{"id":"resp_generated","status":"completed"}}`),
+			}}),
+		}, nil
+	}
+
+	server := newResponsesWebSocketTestServer(t, process, nil)
+	conn := dialResponsesWebSocket(t, server.URL, nil)
+	defer conn.Close()
+
+	warmupIDs := make(map[string]string, 2)
+	for _, streamID := range []string{"lane-a", "lane-b"} {
+		message := fmt.Sprintf(`{"type":"response.create","stream_id":%q,"model":"gpt-test","generate":false,"input":%q}`, streamID, streamID+"-base")
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(message)))
+		for i := range 3 {
+			_, event, err := conn.ReadMessage()
+			require.NoError(t, err)
+			require.Equal(t, streamID, gjson.GetBytes(event, "stream_id").String())
+			if i == 0 {
+				warmupIDs[streamID] = gjson.GetBytes(event, "response.id").String()
+			}
+		}
+	}
+
+	for _, streamID := range []string{"lane-a", "lane-b"} {
+		message := fmt.Sprintf(`{"type":"response.create","stream_id":%q,"model":"gpt-test","previous_response_id":%q,"input":%q}`, streamID, warmupIDs[streamID], streamID+"-next")
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(message)))
+		_, event, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, streamID, gjson.GetBytes(event, "stream_id").String())
+	}
+
+	seen := make(map[string][]string, 2)
+	for range 2 {
+		request := <-requests
+		items := gjson.GetBytes(request.Body, "input").Array()
+		require.Len(t, items, 2)
+		base := items[0].Get("content").String()
+		streamID := strings.TrimSuffix(base, "-base")
+		seen[streamID] = []string{base, items[1].Get("content").String()}
+	}
+	require.Equal(t, []string{"lane-a-base", "lane-a-next"}, seen["lane-a"])
+	require.Equal(t, []string{"lane-b-base", "lane-b-next"}, seen["lane-b"])
 }
 
 func TestResponsesWebSocketRejectsOversizedMessages(t *testing.T) {

--- a/internal/server/orchestrator/pass_through.go
+++ b/internal/server/orchestrator/pass_through.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/tidwall/sjson"
@@ -104,7 +105,7 @@ func applyPassThroughRequestBody(outbound *PersistentOutboundTransformer, system
 		// Multipart bodies cannot be reused: the outbound transformer rebuilds the
 		// multipart payload with a new boundary in Content-Type, so replaying the inbound
 		// bytes would mismatch the header, and form fields cannot be patched via sjson.
-		if !passThroughBodySupported(llmReq.APIFormat) {
+		if !passThroughBodySupported(llmReq) {
 			return request, nil
 		}
 
@@ -192,29 +193,38 @@ func mergePassThroughRequestBody(rawBody []byte, apiFormat llm.APIFormat, model 
 }
 
 // passThroughBodySupported reports whether the raw inbound body can safely replace the
-// outbound request body. Multipart formats are excluded.
-func passThroughBodySupported(apiFormat llm.APIFormat) bool {
-	//nolint:exhaustive // only multipart formats are excluded.
-	switch apiFormat {
+// outbound request body. Multipart formats that require model rewriting are excluded.
+func passThroughBodySupported(llmReq *llm.Request) bool {
+	//nolint:exhaustive // only multipart formats are excluded or content-type checked.
+	switch llmReq.APIFormat {
 	case llm.APIFormatOpenAITranscription,
 		llm.APIFormatOpenAITranslation,
 		llm.APIFormatOpenAIImageEdit,
 		llm.APIFormatOpenAIImageVariation:
 		return false
+	case llm.APIFormatOpenAIVideo:
+		if llmReq.RawRequest == nil {
+			return false
+		}
+
+		return !strings.HasPrefix(strings.ToLower(llmReq.RawRequest.Headers.Get("Content-Type")), "multipart/")
 	default:
 		return true
 	}
 }
 
 func passThroughBodyNeedsModelPatch(apiFormat llm.APIFormat) bool {
-	//nolint:exhaustive // ohter format do not need model field.
+	//nolint:exhaustive // other formats do not need a model field.
 	switch apiFormat {
 	case llm.APIFormatOpenAIChatCompletion,
+		llm.APIFormatOpenAICompletion,
 		llm.APIFormatOpenAIResponse,
 		llm.APIFormatOpenAIResponseCompact,
 		llm.APIFormatOpenAIEmbedding,
 		llm.APIFormatOpenAIModeration,
 		llm.APIFormatOpenAIAlphaSearch,
+		llm.APIFormatOpenAIImageGeneration,
+		llm.APIFormatOpenAIVideo,
 		llm.APIFormatJinaEmbedding,
 		llm.APIFormatJinaRerank,
 		llm.APIFormatAnthropicMessage,

--- a/internal/server/orchestrator/pass_through_test.go
+++ b/internal/server/orchestrator/pass_through_test.go
@@ -1393,6 +1393,153 @@ func TestApplyPassThroughBodyPreservesMappedModel(t *testing.T) {
 	require.Equal(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"temperature":0.4}`, string(outbound.state.LlmRequest.RawRequest.Body))
 }
 
+func TestOpenAIJSONRequestBodyRoutingContracts(t *testing.T) {
+	formats := []llm.APIFormat{
+		llm.APIFormatOpenAIChatCompletion,
+		llm.APIFormatOpenAICompletion,
+		llm.APIFormatOpenAIResponse,
+		llm.APIFormatOpenAIResponseCompact,
+		llm.APIFormatOpenAIEmbedding,
+		llm.APIFormatOpenAIModeration,
+		llm.APIFormatOpenAIAlphaSearch,
+		llm.APIFormatOpenAIImageGeneration,
+		llm.APIFormatOpenAIVideo,
+		llm.APIFormatOpenAISpeech,
+	}
+
+	for _, format := range formats {
+		t.Run(format.String()+" pass-through", func(t *testing.T) {
+			channel := &biz.Channel{Channel: &ent.Channel{
+				ID:   1,
+				Name: "openai-pass-through",
+				Settings: &objects.ChannelSettings{
+					PassThroughBody: lo.ToPtr(true),
+				},
+			}}
+			outbound := &PersistentOutboundTransformer{state: &PersistenceState{
+				CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+				LlmRequest: &llm.Request{
+					Model:     "provider-model",
+					APIFormat: format,
+					RawRequest: &httpclient.Request{
+						APIFormat: format.String(),
+						Body:      []byte(`{"model":"client-alias","official_future_field":{"enabled":true}}`),
+					},
+				},
+			}}
+			transformed := &httpclient.Request{
+				APIFormat: format.String(),
+				Body:      []byte(`{"model":"provider-model","converted_only":true}`),
+			}
+
+			processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(t.Context(), transformed)
+			require.NoError(t, err)
+			require.True(t, outbound.state.PassThroughApplied)
+			require.Equal(t, "provider-model", gjson.GetBytes(processed.Body, "model").String())
+			require.True(t, gjson.GetBytes(processed.Body, "official_future_field.enabled").Bool())
+			require.False(t, gjson.GetBytes(processed.Body, "converted_only").Exists())
+		})
+
+		t.Run(format.String()+" conversion", func(t *testing.T) {
+			channel := &biz.Channel{Channel: &ent.Channel{
+				ID:   1,
+				Name: "openai-conversion",
+				Settings: &objects.ChannelSettings{
+					PassThroughBody: lo.ToPtr(true),
+				},
+			}}
+			outbound := &PersistentOutboundTransformer{state: &PersistenceState{
+				CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+				LlmRequest: &llm.Request{
+					Model:     "provider-model",
+					APIFormat: format,
+					RawRequest: &httpclient.Request{
+						APIFormat: format.String(),
+						Body:      []byte(`{"model":"client-alias","original_only":true}`),
+					},
+				},
+			}}
+			transformed := &httpclient.Request{
+				APIFormat: llm.APIFormatAnthropicMessage.String(),
+				Body:      []byte(`{"model":"provider-model","converted_only":true}`),
+			}
+
+			processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(t.Context(), transformed)
+			require.NoError(t, err)
+			require.False(t, outbound.state.PassThroughApplied)
+			require.Equal(t, transformed, processed)
+			require.True(t, gjson.GetBytes(processed.Body, "converted_only").Bool())
+			require.False(t, gjson.GetBytes(processed.Body, "original_only").Exists())
+		})
+	}
+}
+
+func TestOpenAIResponseBodyRoutingContracts(t *testing.T) {
+	formats := []llm.APIFormat{
+		llm.APIFormatOpenAIChatCompletion,
+		llm.APIFormatOpenAICompletion,
+		llm.APIFormatOpenAIResponse,
+		llm.APIFormatOpenAIResponseCompact,
+		llm.APIFormatOpenAIEmbedding,
+		llm.APIFormatOpenAIModeration,
+		llm.APIFormatOpenAIAlphaSearch,
+		llm.APIFormatOpenAIImageGeneration,
+		llm.APIFormatOpenAIImageEdit,
+		llm.APIFormatOpenAIVideo,
+		llm.APIFormatOpenAISpeech,
+		llm.APIFormatOpenAITranscription,
+		llm.APIFormatOpenAITranslation,
+	}
+
+	for _, format := range formats {
+		t.Run(format.String()+" pass-through", func(t *testing.T) {
+			channel := &biz.Channel{Channel: &ent.Channel{
+				ID:   1,
+				Name: "openai-response-pass-through",
+				Settings: &objects.ChannelSettings{
+					PassThroughBody: lo.ToPtr(true),
+				},
+			}}
+			raw := &httpclient.Response{StatusCode: http.StatusOK, Body: []byte(`{"raw":true}`)}
+			outbound := &PersistentOutboundTransformer{state: &PersistenceState{
+				CurrentCandidate:    &ChannelModelsCandidate{Channel: channel},
+				LlmRequest:          &llm.Request{APIFormat: format},
+				RawProviderRequest:  &httpclient.Request{APIFormat: format.String()},
+				RawProviderResponse: raw,
+			}}
+			transformed := &httpclient.Response{StatusCode: http.StatusOK, Body: []byte(`{"transformed":true}`)}
+
+			processed, err := applyPassThroughResponse(outbound, nil).OnInboundRawResponse(t.Context(), transformed)
+			require.NoError(t, err)
+			require.Equal(t, raw, processed)
+		})
+
+		t.Run(format.String()+" conversion", func(t *testing.T) {
+			channel := &biz.Channel{Channel: &ent.Channel{
+				ID:   1,
+				Name: "openai-response-conversion",
+				Settings: &objects.ChannelSettings{
+					PassThroughBody: lo.ToPtr(true),
+				},
+			}}
+			outbound := &PersistentOutboundTransformer{state: &PersistenceState{
+				CurrentCandidate:   &ChannelModelsCandidate{Channel: channel},
+				LlmRequest:         &llm.Request{APIFormat: format},
+				RawProviderRequest: &httpclient.Request{APIFormat: llm.APIFormatAnthropicMessage.String()},
+				RawProviderResponse: &httpclient.Response{
+					StatusCode: http.StatusOK,
+					Body:       []byte(`{"raw":true}`),
+				},
+			}}
+			transformed := &httpclient.Response{StatusCode: http.StatusOK, Body: []byte(`{"transformed":true}`)}
+
+			processed, err := applyPassThroughResponse(outbound, nil).OnInboundRawResponse(t.Context(), transformed)
+			require.NoError(t, err)
+			require.Equal(t, transformed, processed)
+		})
+	}
+}
+
 func TestApplyPassThroughBodySkipsWhenOutboundPolicyRejects(t *testing.T) {
 	ctx := context.Background()
 
@@ -1889,6 +2036,40 @@ func TestApplyPassThroughBodySkipsMultipartFormats(t *testing.T) {
 			require.False(t, outbound.state.PassThroughApplied)
 		})
 	}
+}
+
+func TestApplyPassThroughBodySkipsMultipartVideo(t *testing.T) {
+	channel := &biz.Channel{Channel: &ent.Channel{
+		ID:   1,
+		Name: "pass-through-multipart-video",
+		Settings: &objects.ChannelSettings{
+			PassThroughBody: lo.ToPtr(true),
+		},
+	}}
+	inboundBody := []byte("--client-boundary\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nclient-alias\r\n--client-boundary--\r\n")
+	outboundBody := []byte("--provider-boundary\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nprovider-model\r\n--provider-boundary--\r\n")
+	outbound := &PersistentOutboundTransformer{state: &PersistenceState{
+		CurrentCandidate: &ChannelModelsCandidate{Channel: channel},
+		LlmRequest: &llm.Request{
+			Model:     "provider-model",
+			APIFormat: llm.APIFormatOpenAIVideo,
+			RawRequest: &httpclient.Request{
+				APIFormat: llm.APIFormatOpenAIVideo.String(),
+				Headers:   http.Header{"Content-Type": []string{"multipart/form-data; boundary=client-boundary"}},
+				Body:      inboundBody,
+			},
+		},
+	}}
+	request := &httpclient.Request{
+		APIFormat: llm.APIFormatOpenAIVideo.String(),
+		Headers:   http.Header{"Content-Type": []string{"multipart/form-data; boundary=provider-boundary"}},
+		Body:      outboundBody,
+	}
+
+	processed, err := applyPassThroughRequestBody(outbound, nil).OnOutboundRawRequest(t.Context(), request)
+	require.NoError(t, err)
+	require.False(t, outbound.state.PassThroughApplied)
+	require.Equal(t, outboundBody, processed.Body)
 }
 
 func TestApplyPassThroughBodyAppliesSpeechModelPatch(t *testing.T) {

--- a/llm/provider_extensions.go
+++ b/llm/provider_extensions.go
@@ -14,6 +14,7 @@ type OpenAIResponsesProviderExtensions struct {
 
 type OpenAIResponsesRequestExtensions struct {
 	ReasoningContext string                       `json:"-"`
+	RawFields        map[string]json.RawMessage   `json:"-"`
 	RawTools         []OpenAIResponsesRawFragment `json:"-"`
 	ToolSignatures   []string                     `json:"-"`
 	RawToolChoice    json.RawMessage              `json:"-"`
@@ -57,6 +58,7 @@ func CloneProviderExtensions(src *ProviderExtensions) *ProviderExtensions {
 		if src.OpenAIResponses.Request != nil {
 			cloned.OpenAIResponses.Request = &OpenAIResponsesRequestExtensions{
 				ReasoningContext: src.OpenAIResponses.Request.ReasoningContext,
+				RawFields:        cloneRawMessageMap(src.OpenAIResponses.Request.RawFields),
 				RawTools:         cloneOpenAIResponsesRawFragments(src.OpenAIResponses.Request.RawTools),
 				ToolSignatures:   append([]string(nil), src.OpenAIResponses.Request.ToolSignatures...),
 				RawToolChoice:    cloneRawMessage(src.OpenAIResponses.Request.RawToolChoice),
@@ -66,6 +68,19 @@ func CloneProviderExtensions(src *ProviderExtensions) *ProviderExtensions {
 	}
 
 	return cloned
+}
+
+func cloneRawMessageMap(src map[string]json.RawMessage) map[string]json.RawMessage {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]json.RawMessage, len(src))
+	for key, value := range src {
+		out[key] = cloneRawMessage(value)
+	}
+
+	return out
 }
 
 func cloneOpenAIResponsesRawFragments(src []OpenAIResponsesRawFragment) []OpenAIResponsesRawFragment {

--- a/llm/transformer/openai/responses/compact.go
+++ b/llm/transformer/openai/responses/compact.go
@@ -9,7 +9,7 @@ import (
 // CompactAPIRequest is the request body for POST /v1/responses/compact.
 type CompactAPIRequest struct {
 	Model        string `json:"model"`
-	Input        Input  `json:"input"`
+	Input        Input  `json:"input,omitzero"`
 	Instructions string `json:"instructions,omitempty"`
 	// PreviousResponseID string `json:"previous_response_id,omitempty"` // Not supported yet.
 	PromptCacheKey string `json:"prompt_cache_key,omitempty"`

--- a/llm/transformer/openai/responses/compact_inbound.go
+++ b/llm/transformer/openai/responses/compact_inbound.go
@@ -72,6 +72,7 @@ func (t *CompactInboundTransformer) TransformRequest(ctx context.Context, httpRe
 			PromptCacheKey: req.PromptCacheKey,
 		},
 	}
+	attachOpenAIResponsesRawRequestFields(llmReq, httpReq.Body, rawCompactRequestFields)
 
 	return llmReq, nil
 }

--- a/llm/transformer/openai/responses/compact_outbound.go
+++ b/llm/transformer/openai/responses/compact_outbound.go
@@ -33,7 +33,7 @@ func (t *OutboundTransformer) transformCompactRequest(
 		PromptCacheKey: llmReq.Compact.PromptCacheKey,
 	}
 
-	body, err := json.Marshal(payload)
+	body, err := marshalCompactRequestPayload(payload, llmReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal compact request: %w", err)
 	}

--- a/llm/transformer/openai/responses/compact_outbound_test.go
+++ b/llm/transformer/openai/responses/compact_outbound_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
@@ -135,6 +136,28 @@ func TestOutboundTransformer_TransformCompactRequest_AccountIdentity(t *testing.
 	require.NoError(t, err)
 	require.NotNil(t, httpReq)
 	require.Nil(t, httpReq.Metadata)
+}
+
+func TestCompactTransformRequest_PreservesOfficialOptionalFields(t *testing.T) {
+	inbound := NewCompactInboundTransformer()
+	outbound, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	body := []byte(`{"model":"gpt-5.6","previous_response_id":"resp_123","prompt_cache_options":{"mode":"implicit","ttl":"30m"},"prompt_cache_retention":"in_memory","service_tier":"auto"}`)
+	llmRequest, err := inbound.TransformRequest(t.Context(), &httpclient.Request{
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Body:    body,
+	})
+	require.NoError(t, err)
+
+	outboundRequest, err := outbound.TransformRequest(t.Context(), llmRequest)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(outboundRequest.Body, "input").Exists())
+	require.Equal(t, "resp_123", gjson.GetBytes(outboundRequest.Body, "previous_response_id").String())
+	require.Equal(t, "implicit", gjson.GetBytes(outboundRequest.Body, "prompt_cache_options.mode").String())
+	require.Equal(t, "30m", gjson.GetBytes(outboundRequest.Body, "prompt_cache_options.ttl").String())
+	require.Equal(t, "in_memory", gjson.GetBytes(outboundRequest.Body, "prompt_cache_retention").String())
+	require.Equal(t, "auto", gjson.GetBytes(outboundRequest.Body, "service_tier").String())
 }
 
 func TestOutboundTransformer_TransformCompactResponse(t *testing.T) {

--- a/llm/transformer/openai/responses/http_executor.go
+++ b/llm/transformer/openai/responses/http_executor.go
@@ -28,8 +28,7 @@ func (e *httpTransportExecutor) DoStream(ctx context.Context, request *httpclien
 
 // PrepareHTTPTransportRequest removes WebSocket-v2-only request metadata before
 // an HTTP/SSE attempt. Generic Responses HTTP requests retain a normal
-// previous_response_id unless the WebSocket beta marker proves it came from a
-// WebSocket continuation. Codex callers can force removal because their HTTP
+// previous_response_id. Codex callers can force removal because their HTTP
 // endpoint does not support that field.
 func PrepareHTTPTransportRequest(request *httpclient.Request, stripPreviousResponseID bool) *httpclient.Request {
 	if request == nil {
@@ -37,10 +36,6 @@ func PrepareHTTPTransportRequest(request *httpclient.Request, stripPreviousRespo
 	}
 
 	headers, webSocketBetaRemoved := withoutWebSocketBeta(request.Headers)
-	if webSocketBetaRemoved {
-		stripPreviousResponseID = true
-	}
-
 	body := request.Body
 	bodyChanged := false
 	if stripPreviousResponseID {

--- a/llm/transformer/openai/responses/http_executor_test.go
+++ b/llm/transformer/openai/responses/http_executor_test.go
@@ -27,7 +27,7 @@ func (e *httpTransportCaptureExecutor) DoStream(_ context.Context, request *http
 	return streams.SliceStream([]*httpclient.StreamEvent{}), nil
 }
 
-func TestHTTPTransportExecutorStripsWebSocketContinuation(t *testing.T) {
+func TestHTTPTransportExecutorStripsWebSocketMetadataAndKeepsContinuation(t *testing.T) {
 	outbound, err := NewOutboundTransformerWithConfig(&Config{
 		BaseURL:        "https://api.example.com/v1",
 		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
@@ -49,13 +49,25 @@ func TestHTTPTransportExecutorStripsWebSocketContinuation(t *testing.T) {
 	require.NoError(t, stream.Close())
 	require.NotNil(t, inner.request)
 	require.Equal(t, "other_beta=v1", inner.request.Headers.Get("OpenAI-Beta"))
-	require.False(t, gjson.GetBytes(inner.request.Body, "previous_response_id").Exists())
+	require.Equal(t, "resp_ws", gjson.GetBytes(inner.request.Body, "previous_response_id").String())
 	require.True(t, gjson.GetBytes(inner.request.Body, "stream").Bool())
 	require.Equal(t, "hello", gjson.GetBytes(inner.request.Body, "input").String())
 
 	// Transport cleanup must not mutate the request retained by the pipeline.
 	require.Equal(t, WebSocketBetaHeaderValue+", other_beta=v1", request.Headers.Get("OpenAI-Beta"))
 	require.Equal(t, "resp_ws", gjson.GetBytes(request.Body, "previous_response_id").String())
+}
+
+func TestPrepareHTTPTransportRequestKeepsContinuationWithoutInput(t *testing.T) {
+	request := &httpclient.Request{
+		Headers: http.Header{"Openai-Beta": {WebSocketBetaHeaderValue}},
+		Body:    []byte(`{"model":"gpt-5","previous_response_id":"resp_ws","stream":true}`),
+	}
+
+	prepared := PrepareHTTPTransportRequest(request, false)
+	require.Empty(t, prepared.Headers.Get("OpenAI-Beta"))
+	require.Equal(t, "resp_ws", gjson.GetBytes(prepared.Body, "previous_response_id").String())
+	require.False(t, gjson.GetBytes(prepared.Body, "input").Exists())
 }
 
 func TestHTTPTransportExecutorKeepsNormalHTTPContinuation(t *testing.T) {

--- a/llm/transformer/openai/responses/integration_test.go
+++ b/llm/transformer/openai/responses/integration_test.go
@@ -84,3 +84,57 @@ func TestTransformRequest_Integration(t *testing.T) {
 		})
 	}
 }
+
+func TestTransformRequest_PreservesOfficialRawTopLevelFields(t *testing.T) {
+	inboundTransformer := NewInboundTransformer()
+	outboundTransformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		body string
+		keys []string
+	}{
+		{
+			name: "prompt can provide the request content",
+			body: `{"model":"gpt-5.6","prompt":{"id":"pmpt_123","version":"2","variables":{"topic":"frogs"}}}`,
+			keys: []string{"prompt"},
+		},
+		{
+			name: "conversation can provide the request context",
+			body: `{"model":"gpt-5.6","conversation":{"id":"conv_123"}}`,
+			keys: []string{"conversation"},
+		},
+		{
+			name: "current optional request fields",
+			body: `{"model":"gpt-5.6","input":"hello","context_management":[{"type":"compaction","compact_threshold":12000}],"moderation":{"model":"omni-moderation-latest","policy":{"input":{"mode":"score"},"output":{"mode":"score"}}},"prompt_cache_options":{"mode":"implicit","ttl":"30m"}}`,
+			keys: []string{"context_management", "moderation", "prompt_cache_options"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inboundRequest := &httpclient.Request{
+				Headers: http.Header{"Content-Type": []string{"application/json"}},
+				Body:    []byte(tt.body),
+			}
+			llmRequest, err := inboundTransformer.TransformRequest(t.Context(), inboundRequest)
+			require.NoError(t, err)
+
+			outboundRequest, err := outboundTransformer.TransformRequest(t.Context(), llmRequest)
+			require.NoError(t, err)
+
+			var want map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(tt.body), &want))
+			var got map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(outboundRequest.Body, &got))
+			for _, key := range tt.keys {
+				require.JSONEq(t, string(want[key]), string(got[key]), key)
+			}
+			if _, hasInput := want["input"]; !hasInput {
+				_, gotHasInput := got["input"]
+				require.False(t, gotHasInput)
+			}
+		})
+	}
+}

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -103,7 +103,7 @@ type Request struct {
 	Temperature *float64 `json:"temperature,omitempty"`
 
 	// Input can be a string prompt or an array of input items.
-	Input Input `json:"input"`
+	Input Input `json:"input,omitzero"`
 	// Tools includes the function/image_generation/web_search/custom tools.
 	Tools []Tool `json:"tools,omitzero"`
 	// Parallel tool calls preference.

--- a/llm/transformer/openai/responses/request_extensions.go
+++ b/llm/transformer/openai/responses/request_extensions.go
@@ -6,6 +6,21 @@ import (
 	"github.com/looplj/axonhub/llm"
 )
 
+var rawCreateRequestFields = []string{
+	"context_management",
+	"conversation",
+	"moderation",
+	"prompt",
+	"prompt_cache_options",
+}
+
+var rawCompactRequestFields = []string{
+	"previous_response_id",
+	"prompt_cache_options",
+	"prompt_cache_retention",
+	"service_tier",
+}
+
 func attachOpenAIResponsesRequestExtensions(chatReq *llm.Request, req *Request, rawBody []byte) {
 	if chatReq == nil || req == nil {
 		return
@@ -18,13 +33,14 @@ func attachOpenAIResponsesRequestExtensions(chatReq *llm.Request, req *Request, 
 	}
 	requestExt := &llm.OpenAIResponsesRequestExtensions{
 		ReasoningContext: reasoningContext,
+		RawFields:        selectRawRequestFields(raw.Fields, rawCreateRequestFields),
 		RawTools:         buildRawOnlyToolFragments(req.Tools, raw.Tools),
 		ToolSignatures:   buildRepresentedToolSignatures(req.Tools),
 		RawToolChoice:    rawUnsupportedToolChoice(req.ToolChoice, raw.ToolChoice),
 		RawInputItems:    buildRawOnlyInputFragments(req.Input, raw.InputItems),
 	}
 
-	if requestExt.ReasoningContext == "" && len(requestExt.RawTools) == 0 && len(requestExt.RawToolChoice) == 0 && len(requestExt.RawInputItems) == 0 {
+	if requestExt.ReasoningContext == "" && len(requestExt.RawFields) == 0 && len(requestExt.RawTools) == 0 && len(requestExt.RawToolChoice) == 0 && len(requestExt.RawInputItems) == 0 {
 		return
 	}
 
@@ -36,6 +52,7 @@ func attachOpenAIResponsesRequestExtensions(chatReq *llm.Request, req *Request, 
 }
 
 type rawRequestFragments struct {
+	Fields     map[string]json.RawMessage
 	Tools      []json.RawMessage
 	ToolChoice json.RawMessage
 	InputItems []json.RawMessage
@@ -54,6 +71,10 @@ func parseRawRequestFragments(rawBody []byte) rawRequestFragments {
 	if err := json.Unmarshal(rawBody, &raw); err != nil {
 		return rawRequestFragments{}
 	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &fields); err != nil {
+		return rawRequestFragments{}
+	}
 
 	var inputItems []json.RawMessage
 	if len(raw.Input) > 0 && json.Unmarshal(raw.Input, &inputItems) != nil {
@@ -61,10 +82,58 @@ func parseRawRequestFragments(rawBody []byte) rawRequestFragments {
 	}
 
 	return rawRequestFragments{
+		Fields:     fields,
 		Tools:      raw.Tools,
 		ToolChoice: raw.ToolChoice,
 		InputItems: inputItems,
 	}
+}
+
+func attachOpenAIResponsesRawRequestFields(chatReq *llm.Request, rawBody []byte, fieldNames []string) {
+	if chatReq == nil || len(rawBody) == 0 {
+		return
+	}
+
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(rawBody, &fields) != nil {
+		return
+	}
+	rawFields := selectRawRequestFields(fields, fieldNames)
+	if len(rawFields) == 0 {
+		return
+	}
+
+	ext := llm.EnsureOpenAIResponsesProviderExtensions(chatReq)
+	if ext == nil {
+		return
+	}
+	if ext.Request == nil {
+		ext.Request = &llm.OpenAIResponsesRequestExtensions{}
+	}
+	if ext.Request.RawFields == nil {
+		ext.Request.RawFields = make(map[string]json.RawMessage, len(rawFields))
+	}
+	for key, value := range rawFields {
+		ext.Request.RawFields[key] = value
+	}
+}
+
+func selectRawRequestFields(fields map[string]json.RawMessage, fieldNames []string) map[string]json.RawMessage {
+	if len(fields) == 0 || len(fieldNames) == 0 {
+		return nil
+	}
+
+	selected := make(map[string]json.RawMessage, len(fieldNames))
+	for _, name := range fieldNames {
+		if value, ok := fields[name]; ok {
+			selected[name] = cloneRaw(value)
+		}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+
+	return selected
 }
 
 func buildRepresentedToolSignatures(tools []Tool) []string {
@@ -220,6 +289,7 @@ func marshalRequestPayload(payload Request, llmReq *llm.Request) ([]byte, error)
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
+	mergeRawRequestFields(obj, requestExt)
 
 	if tools, ok := mergeRawOnlyTools(obj["tools"], requestExt); ok {
 		toolsRaw, err := json.Marshal(tools)
@@ -240,6 +310,38 @@ func marshalRequestPayload(payload Request, llmReq *llm.Request) ([]byte, error)
 		}
 		obj["input"] = inputRaw
 	}
+
+	return json.Marshal(obj)
+}
+
+func mergeRawRequestFields(obj map[string]json.RawMessage, requestExt *llm.OpenAIResponsesRequestExtensions) {
+	if obj == nil || requestExt == nil {
+		return
+	}
+
+	for key, value := range requestExt.RawFields {
+		if _, exists := obj[key]; !exists && len(value) > 0 {
+			obj[key] = cloneRaw(value)
+		}
+	}
+}
+
+func marshalCompactRequestPayload(payload CompactAPIRequest, llmReq *llm.Request) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	requestExt := openAIResponsesRequestExtensions(llmReq)
+	if requestExt == nil || len(requestExt.RawFields) == 0 {
+		return body, nil
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, err
+	}
+	mergeRawRequestFields(obj, requestExt)
 
 	return json.Marshal(obj)
 }


### PR DESCRIPTION
## Summary

- keep previous_response_id when removing the Responses WebSocket beta header for generic HTTP/SSE upstreams
- preserve current official Responses and Responses Compact top-level fields through the non-pass-through transform path and omit input when the client did not provide it
- patch mapped models for all supported OpenAI JSON pass-through formats, while keeping multipart video requests on the transformed path
- support Responses WebSocket stream_id lanes: return stream_id on every lane event, keep it out of HTTP upstream bodies, run different lanes concurrently, preserve FIFO within one lane, cap active responses at 16, pending responses at 64, and named lanes at 32
- add request/response routing contract matrices across the supported OpenAI API formats

## Root cause

The HTTP transport cleanup treated the WebSocket beta marker as a reason to drop previous_response_id. A continuation frame without incremental input therefore reached the upstream without input, previous_response_id, prompt, or conversation. The Responses request model also did not retain several current official fields when body pass-through was disabled.

The downstream WebSocket handler also predated named stream lanes: it forwarded stream_id to HTTP upstreams, omitted it from returned events, and serialized the entire connection.

Reference:
- https://developers.openai.com/api/reference/resources/responses/methods/create
- https://developers.openai.com/api/docs/guides/websocket-mode

## Reproduction

Connect to the downstream WebSocket and send a named response:

    wscat -c ws://127.0.0.1:8090/v1/responses -H "Authorization: Bearer $AXONHUB_API_KEY"
    > {"type":"response.create","stream_id":"lane-a","model":"MODEL","input":"ping"}

Before this fix, returned events omitted stream_id and an HTTP Responses upstream received the WebSocket-only stream_id field. After this fix every event contains "stream_id":"lane-a" and the normalized HTTP request does not contain stream_id.

The original continuation regression is reproduced with:

    curl http://127.0.0.1:8090/v1/responses \
      -H "Authorization: Bearer $AXONHUB_API_KEY" \
      -H "Content-Type: application/json" \
      -H "OpenAI-Beta: responses_websockets=2026-02-06" \
      -d "{\"model\":\"MODEL\",\"previous_response_id\":\"resp_external\"}"

Before this fix the HTTP transport removed previous_response_id; after this fix it only removes the WebSocket beta marker.

## Validation

- cd llm && go test -count=1 ./transformer/openai/...
- go test -count=1 ./internal/server/api ./internal/server ./internal/server/orchestrator
- go test -race -count=1 ./internal/server/api -run TestResponsesWebSocket
- live HTTP/SSE matrix: 34/34 passed against observable OpenAI mock channels
- live Responses WebSocket matrix: 11/11 passed after the fix
- live OpenAI-to-Anthropic conversion: text, SSE, multi-turn, structured output, multimodal and tool-call flows passed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple named streams in Responses WebSocket sessions, with concurrent processing and ordered handling per stream.
  - Stream identifiers are returned with events, including errors and completion messages.
  - Added safeguards for active streams, named streams, and pending requests.

- **Bug Fixes**
  - Preserved additional OpenAI Responses request fields and continuation information.
  - Prevented empty `input` fields from being added to outgoing requests.
  - Improved pass-through handling across supported OpenAI formats.
  - Multipart video requests continue to use transformed handling rather than pass-through bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->