### PR TITLE
fix(frontend): handle empty channel error messages

### DIFF
--- a/frontend/src/features/channels/components/channels-bulk-test-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-bulk-test-dialog.tsx
@@ -87,7 +87,7 @@ export function ChannelsBulkTestDialog() {
   const recoverableChannels = useMemo(() => {
     return selectedChannels.filter((channel) => {
       const result = results[channel.id];
-      return result?.status === 'success' && (channel.status === 'disabled' || !!channel.errorMessage);
+      return result?.status === 'success' && (channel.status === 'disabled' || channel.errorMessage != null);
     });
   }, [results, selectedChannels]);
 

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -95,7 +95,7 @@ const ActionCell = memo(({ row }: { row: Row<Channel> }) => {
   const { channelPermissions } = usePermissions();
   const testChannel = useTestChannel();
   const isArchived = channel.status === 'archived';
-  const hasError = !!channel.errorMessage;
+  const hasError = channel.errorMessage != null;
   const hasDisabledAPIKeys = channelPermissions.canWrite && (channel.disabledAPIKeys?.length ?? 0) > 0;
 
   const handleDefaultTest = async () => {
@@ -341,7 +341,7 @@ function getProxyURLSummary(proxyURL: string): { label: string; detail?: string 
 const NameCell = memo(({ row }: { row: Row<Channel> }) => {
   const { t } = useTranslation();
   const channel = row.original;
-  const hasError = !!channel.errorMessage;
+  const hasError = channel.errorMessage != null;
   const disabledKeysCount = channel.disabledAPIKeys?.length ?? 0;
   const hasDisabledKeys = disabledKeysCount > 0;
   const websiteURL = getChannelWebsiteURL(channel.baseURL);

--- a/frontend/src/features/channels/components/channels-error-resolved-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-error-resolved-dialog.tsx
@@ -33,7 +33,7 @@ export function ChannelsErrorResolvedDialog({ open, onOpenChange }: ChannelsErro
     onOpenChange(false);
   };
 
-  if (!currentRow || !currentRow.errorMessage) {
+  if (!currentRow || currentRow.errorMessage == null) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- treat non-null channel error messages as unresolved, including legacy empty strings
- allow empty-string errors to open the resolution dialog and be cleared
- align bulk recovery eligibility with the same non-null semantics

## Verification
- `git diff --check`
- manually exercised null vs empty-string decision logic
- no matching frontend test covers channel error resolution, so no test was modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel error-state handling across bulk testing and channel views.
  * Channels with an error state are now consistently recognized as recoverable or requiring attention, even when the associated error message is empty.
  * The resolved-error dialog now displays correctly for channels whose error state lacks message text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->