### PR TITLE
fix(openai): complete cross-format request conversion

### DIFF
--- a/internal/server/biz/channel_endpoint.go
+++ b/internal/server/biz/channel_endpoint.go
@@ -58,8 +58,8 @@ func ValidateEndpoints(endpoints []objects.ChannelEndpoint) error {
 			return fmt.Errorf("endpoint[%d]: unsupported transport %q", i, ep.Transport)
 		}
 
-		if ep.Transport == objects.ChannelEndpointTransportWebSocket && !supportsWebSocketTransport(ep.APIFormat) {
-			return fmt.Errorf("endpoint[%d]: websocket transport only supports api_format %q or %q", i, llm.APIFormatOpenAIResponse.String(), llm.APIFormatOpenAIResponseCompact.String())
+		if endpointTransport(ep) == objects.ChannelEndpointTransportWebSocket && !supportsWebSocketTransport(ep.APIFormat) {
+			return fmt.Errorf("endpoint[%d]: websocket transport only supports api_format %q", i, llm.APIFormatOpenAIResponse.String())
 		}
 
 		if ep.Path != "" {
@@ -77,7 +77,7 @@ func ValidateEndpoints(endpoints []objects.ChannelEndpoint) error {
 }
 
 func supportsWebSocketTransport(apiFormat string) bool {
-	return apiFormat == llm.APIFormatOpenAIResponse.String() || apiFormat == llm.APIFormatOpenAIResponseCompact.String()
+	return apiFormat == llm.APIFormatOpenAIResponse.String()
 }
 
 // ValidateModelProtocols validates the channel settings' per-model protocol overrides.

--- a/internal/server/biz/channel_endpoint_mapping_test.go
+++ b/internal/server/biz/channel_endpoint_mapping_test.go
@@ -246,11 +246,20 @@ func TestValidateEndpoints(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("websocket compact responses endpoint passes validation", func(t *testing.T) {
+	t.Run("websocket compact responses endpoint returns error", func(t *testing.T) {
 		err := ValidateEndpoints([]objects.ChannelEndpoint{
 			{APIFormat: llm.APIFormatOpenAIResponseCompact.String(), Transport: objects.ChannelEndpointTransportWebSocket},
 		})
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "websocket transport only supports")
+	})
+
+	t.Run("websocket compact responses base url returns error", func(t *testing.T) {
+		err := ValidateEndpoints([]objects.ChannelEndpoint{
+			{APIFormat: llm.APIFormatOpenAIResponseCompact.String(), BaseURL: "wss://api.openai.com/v1"},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "websocket transport only supports")
 	})
 
 	t.Run("valid endpoints pass validation", func(t *testing.T) {

--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -374,6 +374,9 @@ func (svc *ChannelService) buildNonDefaultEndpointOutbound(
 	} else {
 		ep.BaseURL = baseURL
 	}
+	if endpointTransport(ep) == objects.ChannelEndpointTransportWebSocket && !supportsWebSocketTransport(ep.APIFormat) {
+		return nil, fmt.Errorf("websocket transport only supports api_format %q", llm.APIFormatOpenAIResponse.String())
+	}
 
 	switch ep.APIFormat {
 	case llm.APIFormatOpenAIChatCompletion.String():

--- a/internal/server/biz/channel_llm_openai_compatible_test.go
+++ b/internal/server/biz/channel_llm_openai_compatible_test.go
@@ -144,6 +144,27 @@ func TestOpenAIResponsesEndpoint_InheritsWebSocketTransportFromBaseURL(t *testin
 	require.True(t, ok)
 }
 
+func TestOpenAIResponsesCompactEndpoint_RejectsInheritedWebSocketTransport(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:compact_websocket?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(context.Background())
+	entChannel := client.Channel.Create().
+		SetName("Responses Compact WebSocket Channel").
+		SetType(channel.TypeOpenaiResponses).
+		SetBaseURL("wss://api.openai.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-5"}).
+		SetDefaultTestModel("gpt-5").
+		SetEndpoints([]objects.ChannelEndpoint{{
+			APIFormat: llm.APIFormatOpenAIResponseCompact.String(),
+		}}).
+		SaveX(ctx)
+
+	_, err := NewChannelServiceForTest(client).buildChannelWithOutbounds(entChannel)
+	require.ErrorContains(t, err, "websocket transport only supports api_format \"openai/responses\"")
+}
+
 func TestCodexOAuthWebSocketEndpointBuildsWithoutAPIKey(t *testing.T) {
 	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
 	defer client.Close()

--- a/llm/model.go
+++ b/llm/model.go
@@ -589,6 +589,10 @@ type VideoURL struct {
 type DocumentURL struct {
 	// URL is the URL of the document (data URL or regular URL).
 	URL string `json:"url"`
+	// FileID is the provider file identifier when the document was uploaded separately.
+	FileID string `json:"file_id,omitempty"`
+	// Filename is the document name used for inline file data.
+	Filename string `json:"filename,omitempty"`
 
 	// MIMEType is the MIME type of the document.
 	// e.g. "application/pdf", "application/msword"

--- a/llm/transformer/gemini/inbound_convert.go
+++ b/llm/transformer/gemini/inbound_convert.go
@@ -97,15 +97,9 @@ func convertGeminiToLLMRequest(geminiReq *GenerateContentRequest) (*llm.Request,
 
 		// Convert ResponseSchema/ResponseJsonSchema to ResponseFormat json_schema
 		if len(gc.ResponseJsonSchema) > 0 {
-			chatReq.ResponseFormat = &llm.ResponseFormat{
-				Type:       "json_schema",
-				JSONSchema: gc.ResponseJsonSchema,
-			}
+			chatReq.ResponseFormat = geminiJSONSchemaResponseFormat(gc.ResponseJsonSchema)
 		} else if len(gc.ResponseSchema) > 0 {
-			chatReq.ResponseFormat = &llm.ResponseFormat{
-				Type:       "json_schema",
-				JSONSchema: gc.ResponseSchema,
-			}
+			chatReq.ResponseFormat = geminiJSONSchemaResponseFormat(gc.ResponseSchema)
 		} else if gc.ResponseMIMEType == "application/json" {
 			// If only ResponseMIMEType is set to JSON, use json_object
 			chatReq.ResponseFormat = &llm.ResponseFormat{
@@ -131,14 +125,11 @@ func convertGeminiToLLMRequest(geminiReq *GenerateContentRequest) (*llm.Request,
 
 	// Convert contents to messages
 	for i, content := range geminiReq.Contents {
-		msg, err := convertGeminiContentToLLMMessage(content, geminiReq.Contents[:i])
+		converted, err := convertGeminiContentToLLMMessages(content, geminiReq.Contents[:i])
 		if err != nil {
 			return nil, err
 		}
-
-		if msg != nil {
-			messages = append(messages, *msg)
-		}
+		messages = append(messages, converted...)
 	}
 
 	chatReq.Messages = messages
@@ -253,6 +244,84 @@ func convertGeminiToLLMRequest(geminiReq *GenerateContentRequest) (*llm.Request,
 	}
 
 	return chatReq, nil
+}
+
+func convertGeminiContentToLLMMessages(content *Content, previousContents []*Content) ([]llm.Message, error) {
+	if content == nil {
+		return nil, nil
+	}
+
+	hasFunctionResponse := false
+	for _, part := range content.Parts {
+		if part != nil && part.FunctionResponse != nil {
+			hasFunctionResponse = true
+			break
+		}
+	}
+	if !hasFunctionResponse || len(content.Parts) == 1 {
+		msg, err := convertGeminiContentToLLMMessage(content, previousContents)
+		if err != nil || msg == nil {
+			return nil, err
+		}
+		return []llm.Message{*msg}, nil
+	}
+
+	messages := make([]llm.Message, 0, len(content.Parts))
+	regularParts := make([]*Part, 0, len(content.Parts))
+	flushRegularParts := func() error {
+		if len(regularParts) == 0 {
+			return nil
+		}
+		msg, err := convertGeminiContentToLLMMessage(&Content{Role: content.Role, Parts: regularParts}, previousContents)
+		if err != nil {
+			return err
+		}
+		if msg != nil {
+			messages = append(messages, *msg)
+		}
+		regularParts = nil
+		return nil
+	}
+
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		if part.FunctionResponse == nil {
+			regularParts = append(regularParts, part)
+			continue
+		}
+		if err := flushRegularParts(); err != nil {
+			return nil, err
+		}
+		msg, err := convertGeminiContentToLLMMessage(&Content{Role: content.Role, Parts: []*Part{part}}, previousContents)
+		if err != nil {
+			return nil, err
+		}
+		if msg != nil {
+			messages = append(messages, *msg)
+		}
+	}
+	if err := flushRegularParts(); err != nil {
+		return nil, err
+	}
+
+	return messages, nil
+}
+
+func geminiJSONSchemaResponseFormat(schema json.RawMessage) *llm.ResponseFormat {
+	wrapper, _ := json.Marshal(struct {
+		Name   string          `json:"name"`
+		Schema json.RawMessage `json:"schema"`
+	}{
+		Name:   "gemini_response",
+		Schema: schema,
+	})
+
+	return &llm.ResponseFormat{
+		Type:       "json_schema",
+		JSONSchema: wrapper,
+	}
 }
 
 func convertGeminiThinkingConfigToGeminiOpenAIExtraBody(thinkingConfig *ThinkingConfig) (json.RawMessage, error) {

--- a/llm/transformer/gemini/inbound_convert_test.go
+++ b/llm/transformer/gemini/inbound_convert_test.go
@@ -445,8 +445,38 @@ func TestConvertGeminiToLLMRequest_ResponseFormat(t *testing.T) {
 				require.NotNil(t, result.ResponseFormat)
 				require.Equal(t, "json_schema", result.ResponseFormat.Type)
 				require.NotNil(t, result.ResponseFormat.JSONSchema)
-				require.Contains(t, string(result.ResponseFormat.JSONSchema), "name")
-				require.Contains(t, string(result.ResponseFormat.JSONSchema), "age")
+
+				var wrapper struct {
+					Name   string          `json:"name"`
+					Schema json.RawMessage `json:"schema"`
+				}
+				require.NoError(t, json.Unmarshal(result.ResponseFormat.JSONSchema, &wrapper))
+				require.Equal(t, "gemini_response", wrapper.Name)
+				require.JSONEq(t, `{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}}`, string(wrapper.Schema))
+			},
+		},
+		{
+			name: "request with ResponseJsonSchema adds OpenAI schema name",
+			input: &GenerateContentRequest{
+				Contents: []*Content{{
+					Role:  "user",
+					Parts: []*Part{{Text: "Generate JSON"}},
+				}},
+				GenerationConfig: &GenerationConfig{
+					ResponseJsonSchema: json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}}}`),
+				},
+			},
+			validate: func(t *testing.T, result *llm.Request) {
+				t.Helper()
+				require.NotNil(t, result.ResponseFormat)
+
+				var wrapper struct {
+					Name   string          `json:"name"`
+					Schema json.RawMessage `json:"schema"`
+				}
+				require.NoError(t, json.Unmarshal(result.ResponseFormat.JSONSchema, &wrapper))
+				require.Equal(t, "gemini_response", wrapper.Name)
+				require.JSONEq(t, `{"type":"object","properties":{"answer":{"type":"string"}}}`, string(wrapper.Schema))
 			},
 		},
 		{
@@ -975,6 +1005,39 @@ func TestConvertGeminiContentToLLMMessage(t *testing.T) {
 			tt.validate(t, result)
 		})
 	}
+}
+
+func TestConvertGeminiContentToLLMMessages_MultipleFunctionResponses(t *testing.T) {
+	messages, err := convertGeminiContentToLLMMessages(&Content{
+		Role: "user",
+		Parts: []*Part{
+			{Text: "Tool results:"},
+			{FunctionResponse: &FunctionResponse{
+				ID:       "call_alpha",
+				Name:     "tool_alpha",
+				Response: map[string]any{"value": 1},
+			}},
+			{FunctionResponse: &FunctionResponse{
+				ID:       "call_beta",
+				Name:     "tool_beta",
+				Response: map[string]any{"value": 2},
+			}},
+			{Text: "Continue."},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, messages, 4)
+
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, "Tool results:", lo.FromPtr(messages[0].Content.Content))
+	require.Equal(t, "tool", messages[1].Role)
+	require.Equal(t, "call_alpha", lo.FromPtr(messages[1].ToolCallID))
+	require.JSONEq(t, `{"value":1}`, lo.FromPtr(messages[1].Content.Content))
+	require.Equal(t, "tool", messages[2].Role)
+	require.Equal(t, "call_beta", lo.FromPtr(messages[2].ToolCallID))
+	require.JSONEq(t, `{"value":2}`, lo.FromPtr(messages[2].Content.Content))
+	require.Equal(t, "user", messages[3].Role)
+	require.Equal(t, "Continue.", lo.FromPtr(messages[3].Content.Content))
 }
 
 func TestConvertGeminiContentToLLMMessage_ThoughtSignature(t *testing.T) {

--- a/llm/transformer/openai/inbound_convert.go
+++ b/llm/transformer/openai/inbound_convert.go
@@ -241,6 +241,15 @@ func (p MessageContentPart) ToLLMPart() llm.MessageContentPart {
 		}
 	}
 
+	if p.File != nil {
+		part.Type = "document"
+		part.Document = &llm.DocumentURL{
+			URL:      p.File.FileData,
+			FileID:   p.File.FileID,
+			Filename: p.File.Filename,
+		}
+	}
+
 	return part
 }
 

--- a/llm/transformer/openai/model.go
+++ b/llm/transformer/openai/model.go
@@ -264,6 +264,13 @@ type MessageContentPart struct {
 	ImageURL   *ImageURL   `json:"image_url,omitempty"`
 	VideoURL   *VideoURL   `json:"video_url,omitempty"`
 	InputAudio *InputAudio `json:"input_audio,omitempty"`
+	File       *File       `json:"file,omitempty"`
+}
+
+type File struct {
+	FileData string `json:"file_data,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
+	Filename string `json:"filename,omitempty"`
 }
 
 // ImageURL represents an image URL with optional detail level.

--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -176,6 +176,9 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 	if len(llmReq.Messages) == 0 {
 		return nil, fmt.Errorf("%w: messages are required", transformer.ErrInvalidRequest)
 	}
+	if err := validateChatDocumentParts(llmReq.Messages); err != nil {
+		return nil, err
+	}
 
 	// Determine which reasoning field to use, default to ReasoningFieldContent.
 	// reasoning_content is the standard field used by most providers (OpenAI o-series,

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -265,6 +265,18 @@ func MessageContentPartFromLLM(p llm.MessageContentPart) MessageContentPart {
 		}
 	}
 
+	if p.Document != nil {
+		part.Type = "file"
+		part.File = &File{
+			FileData: p.Document.URL,
+			FileID:   p.Document.FileID,
+			Filename: p.Document.Filename,
+		}
+		if part.File.Filename == "" && p.Document.MIMEType == "application/pdf" {
+			part.File.Filename = "document.pdf"
+		}
+	}
+
 	return part
 }
 

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -2,10 +2,13 @@ package openai
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
@@ -268,9 +271,11 @@ func MessageContentPartFromLLM(p llm.MessageContentPart) MessageContentPart {
 	if p.Document != nil {
 		part.Type = "file"
 		part.File = &File{
-			FileData: p.Document.URL,
 			FileID:   p.Document.FileID,
 			Filename: p.Document.Filename,
+		}
+		if strings.HasPrefix(p.Document.URL, "data:") {
+			part.File.FileData = p.Document.URL
 		}
 		if part.File.Filename == "" && p.Document.MIMEType == "application/pdf" {
 			part.File.Filename = "document.pdf"
@@ -278,6 +283,21 @@ func MessageContentPartFromLLM(p llm.MessageContentPart) MessageContentPart {
 	}
 
 	return part
+}
+
+func validateChatDocumentParts(messages []llm.Message) error {
+	for _, message := range messages {
+		for _, part := range message.Content.MultipleContent {
+			if part.Type != "document" || part.Document == nil {
+				continue
+			}
+			if part.Document.FileID == "" && part.Document.URL != "" && !strings.HasPrefix(part.Document.URL, "data:") {
+				return fmt.Errorf("%w: OpenAI Chat file inputs require file_id or a data URL in file_data", transformer.ErrInvalidRequest)
+			}
+		}
+	}
+
+	return nil
 }
 
 // normalizeContentPartType maps Responses-only text part types onto the plain

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -148,6 +148,21 @@ func TestMessageContentPartFileRoundTrip(t *testing.T) {
 	require.Equal(t, part.Document.URL, roundTrip.Document.URL)
 }
 
+func TestMessageContentPartFromLLMDoesNotMapRegularFileURLToFileData(t *testing.T) {
+	part := MessageContentPartFromLLM(llm.MessageContentPart{
+		Type: "document",
+		Document: &llm.DocumentURL{
+			URL:      "https://example.com/report.pdf",
+			MIMEType: "application/pdf",
+		},
+	})
+
+	require.Equal(t, "file", part.Type)
+	require.NotNil(t, part.File)
+	require.Empty(t, part.File.FileData)
+	require.Empty(t, part.File.FileID)
+}
+
 func TestMessageContentFromLLM_IgnoresCompactionParts(t *testing.T) {
 	content := MessageContentFromLLM(llm.MessageContent{
 		MultipleContent: []llm.MessageContentPart{

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -125,6 +125,29 @@ func TestMessageContentPartAudioRoundTrip(t *testing.T) {
 	require.Equal(t, "audio-base64", roundTrip.InputAudio.Data)
 }
 
+func TestMessageContentPartFileRoundTrip(t *testing.T) {
+	part := llm.MessageContentPart{
+		Type: "document",
+		Document: &llm.DocumentURL{
+			URL:      "data:application/pdf;base64,JVBERi0xLjQK",
+			MIMEType: "application/pdf",
+			Filename: "report.pdf",
+		},
+	}
+
+	oaiPart := MessageContentPartFromLLM(part)
+	require.Equal(t, "file", oaiPart.Type)
+	require.NotNil(t, oaiPart.File)
+	require.Equal(t, "report.pdf", oaiPart.File.Filename)
+	require.Equal(t, part.Document.URL, oaiPart.File.FileData)
+
+	roundTrip := oaiPart.ToLLMPart()
+	require.Equal(t, "document", roundTrip.Type)
+	require.NotNil(t, roundTrip.Document)
+	require.Equal(t, "report.pdf", roundTrip.Document.Filename)
+	require.Equal(t, part.Document.URL, roundTrip.Document.URL)
+}
+
 func TestMessageContentFromLLM_IgnoresCompactionParts(t *testing.T) {
 	content := MessageContentFromLLM(llm.MessageContent{
 		MultipleContent: []llm.MessageContentPart{

--- a/llm/transformer/openai/outbound_test.go
+++ b/llm/transformer/openai/outbound_test.go
@@ -192,6 +192,24 @@ func TestOutboundTransformer_TransformRequest(t *testing.T) {
 	}
 }
 
+func TestOutboundTransformer_RejectsRegularChatFileURL(t *testing.T) {
+	transformerInterface, err := NewOutboundTransformer("https://api.openai.com/v1", "test-key")
+	require.NoError(t, err)
+
+	_, err = transformerInterface.TransformRequest(context.Background(), &llm.Request{
+		Model: "gpt-5.6",
+		Messages: []llm.Message{{
+			Role: "user",
+			Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{
+				Type:     "document",
+				Document: &llm.DocumentURL{URL: "https://example.com/report.pdf"},
+			}}},
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "require file_id or a data URL")
+}
+
 func TestOutboundTransformer_TransformRequest_PromptCacheKeyFallback(t *testing.T) {
 	tr, err := NewOutboundTransformer("https://api.openai.com/v1", "test-api-key")
 	require.NoError(t, err)

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/tidwall/gjson"
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -42,6 +43,16 @@ func (t *InboundTransformer) TransformRequest(ctx context.Context, httpReq *http
 
 	if len(httpReq.Body) == 0 {
 		return nil, fmt.Errorf("%w: request body is empty", transformer.ErrInvalidRequest)
+	}
+	if gjson.GetBytes(httpReq.Body, "stream_id").Exists() {
+		return nil, &llm.ResponseError{
+			StatusCode: http.StatusBadRequest,
+			Detail: llm.ErrorDetail{
+				Message: "Unsupported parameter: stream_id",
+				Type:    "invalid_request_error",
+				Param:   "stream_id",
+			},
+		}
 	}
 
 	// Check content type
@@ -95,6 +106,7 @@ type ResponseErrorDetail struct {
 	Message string `json:"message"`
 	Type    string `json:"type"`
 	Code    string `json:"code,omitempty"`
+	Param   string `json:"param,omitempty"`
 }
 
 // TransformError transforms LLM error response to HTTP error response in Responses API format.
@@ -121,6 +133,7 @@ func (t *InboundTransformer) TransformError(ctx context.Context, rawErr error) *
 				Message: llmErr.Detail.Message,
 				Type:    llmErr.Detail.Type,
 				Code:    llmErr.Detail.Code,
+				Param:   llmErr.Detail.Param,
 			},
 		}
 

--- a/llm/transformer/openai/responses/inbound.go
+++ b/llm/transformer/openai/responses/inbound.go
@@ -567,6 +567,8 @@ func convertItemToMessage(item *Item) (*llm.Message, error) {
 		}
 
 		return nil, nil
+	case "input_file":
+		return responseInputFileMessage(item), nil
 
 	case "function_call":
 		// Function call from assistant - convert to tool call
@@ -750,11 +752,45 @@ func convertContentItemToPart(item *Item) (*llm.MessageContentPart, error) {
 
 		return nil, nil
 
+	case "input_file":
+		message := responseInputFileMessage(item)
+		if message == nil || len(message.Content.MultipleContent) == 0 {
+			return nil, nil
+		}
+		return &message.Content.MultipleContent[0], nil
+
 	case "compaction", "compaction_summary":
 		return compactionContentPartFromItem(item, item.Type), nil
 
 	default:
 		return nil, nil
+	}
+}
+
+func responseInputFileMessage(item *Item) *llm.Message {
+	document := &llm.DocumentURL{
+		FileID:   lo.FromPtr(item.FileID),
+		Filename: lo.FromPtr(item.Filename),
+	}
+	if item.FileData != nil {
+		document.URL = *item.FileData
+	} else if item.FileURL != nil {
+		document.URL = *item.FileURL
+	}
+	if parsed := xurl.ParseDataURL(document.URL); parsed != nil {
+		document.MIMEType = parsed.MediaType
+	}
+	if document.URL == "" && document.FileID == "" {
+		return nil
+	}
+
+	return &llm.Message{
+		Role: lo.Ternary(item.Role != "", item.Role, "user"),
+		Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{{
+			ID:       item.ID,
+			Type:     "document",
+			Document: document,
+		}}},
 	}
 }
 

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -775,6 +775,30 @@ func TestInboundTransformer_TransformRequest_GroupsConsecutiveFunctionCalls(t *t
 	require.Equal(t, "call_b", lo.FromPtr(result.Messages[3].ToolCallID))
 }
 
+func TestInboundTransformer_TransformRequest_PreservesInputFiles(t *testing.T) {
+	trans := NewInboundTransformer()
+	result, err := trans.TransformRequest(t.Context(), &httpclient.Request{
+		Body: []byte(`{
+			"model":"gpt-5.6",
+			"input":[{"role":"user","content":[
+				{"type":"input_file","filename":"inline.pdf","file_data":"data:application/pdf;base64,JVBERi0xLjQK"},
+				{"type":"input_file","filename":"remote.pdf","file_url":"https://example.com/remote.pdf"},
+				{"type":"input_file","file_id":"file_123"}
+			]}]
+		}`),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 1)
+	require.Len(t, result.Messages[0].Content.MultipleContent, 3)
+	require.Equal(t, "data:application/pdf;base64,JVBERi0xLjQK", result.Messages[0].Content.MultipleContent[0].Document.URL)
+	require.Equal(t, "application/pdf", result.Messages[0].Content.MultipleContent[0].Document.MIMEType)
+	require.Equal(t, "inline.pdf", result.Messages[0].Content.MultipleContent[0].Document.Filename)
+	require.Equal(t, "https://example.com/remote.pdf", result.Messages[0].Content.MultipleContent[1].Document.URL)
+	require.Equal(t, "remote.pdf", result.Messages[0].Content.MultipleContent[1].Document.Filename)
+	require.Equal(t, "file_123", result.Messages[0].Content.MultipleContent[2].Document.FileID)
+}
+
 func TestInboundTransformer_TransformResponse(t *testing.T) {
 	trans := NewInboundTransformer()
 

--- a/llm/transformer/openai/responses/inbound_test.go
+++ b/llm/transformer/openai/responses/inbound_test.go
@@ -56,6 +56,13 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "stream_id is websocket only",
+			httpReq: &httpclient.Request{
+				Body: []byte(`{"model":"gpt-4o","input":"Hello","stream_id":"main"}`),
+			},
+			expectError: true,
+		},
+		{
 			name: "simple text input",
 			httpReq: &httpclient.Request{
 				Body: []byte(`{
@@ -551,6 +558,25 @@ func TestInboundTransformer_TransformRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInboundTransformer_TransformRequest_RejectsHTTPStreamIDWithParam(t *testing.T) {
+	trans := NewInboundTransformer()
+
+	_, err := trans.TransformRequest(t.Context(), &httpclient.Request{
+		Body: []byte(`{"model":"gpt-4o","input":"Hello","stream_id":"main"}`),
+	})
+	require.Error(t, err)
+
+	httpErr := trans.TransformError(t.Context(), err)
+	require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	require.JSONEq(t, `{
+		"error":{
+			"message":"Unsupported parameter: stream_id",
+			"type":"invalid_request_error",
+			"param":"stream_id"
+		}
+	}`, string(httpErr.Body))
 }
 
 func TestInboundTransformer_TransformRequest_PreservesWebSearchTools(t *testing.T) {

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -546,6 +546,11 @@ type Item struct {
 
 	// The detail of the image. high, low, or auto, for input_image type.
 	Detail *string `json:"detail,omitempty"`
+	// File fields for input_file content.
+	FileData *string `json:"file_data,omitempty"`
+	FileID   *string `json:"file_id,omitempty"`
+	FileURL  *string `json:"file_url,omitempty"`
+	Filename *string `json:"filename,omitempty"`
 
 	// Text for output_text/input_text type.
 	Text *string `json:"text,omitempty"`

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -1059,6 +1059,7 @@ type Error struct {
 	Type    string `json:"type,omitempty"`
 	Code    string `json:"code,omitempty"`
 	Message string `json:"message"`
+	Param   string `json:"param,omitempty"`
 }
 
 type rawJSONSchema struct {

--- a/llm/transformer/openai/responses/outbound_convert.go
+++ b/llm/transformer/openai/responses/outbound_convert.go
@@ -175,6 +175,10 @@ func convertUserMessage(msg llm.Message) Item {
 						Detail:   p.ImageURL.Detail,
 					})
 				}
+			case "document":
+				if p.Document != nil {
+					contentItems = append(contentItems, responseInputFile(p.Document))
+				}
 			case "compaction", "compaction_summary":
 				if p.Compact != nil {
 					contentItems = append(contentItems, compactionItemFromPart(p, p.Type))
@@ -188,6 +192,29 @@ func convertUserMessage(msg llm.Message) Item {
 		Role:    msg.Role,
 		Content: &Input{Items: contentItems},
 	}
+}
+
+func responseInputFile(document *llm.DocumentURL) Item {
+	item := Item{
+		Type: "input_file",
+	}
+	if document.FileID != "" {
+		item.FileID = &document.FileID
+	}
+	if document.Filename != "" {
+		item.Filename = &document.Filename
+	} else if document.MIMEType == "application/pdf" {
+		item.Filename = lo.ToPtr("document.pdf")
+	}
+	if document.URL != "" {
+		if strings.HasPrefix(document.URL, "data:") {
+			item.FileData = &document.URL
+		} else {
+			item.FileURL = &document.URL
+		}
+	}
+
+	return item
 }
 
 // convertAssistantMessage converts an assistant message to Responses API Item(s) format.

--- a/llm/transformer/openai/responses/outbound_convert_test.go
+++ b/llm/transformer/openai/responses/outbound_convert_test.go
@@ -382,6 +382,39 @@ func TestConvertToolMessage(t *testing.T) {
 	}
 }
 
+func TestConvertUserMessagePreservesInputFiles(t *testing.T) {
+	input := convertInputFromMessages([]llm.Message{{
+		Role: "user",
+		Content: llm.MessageContent{MultipleContent: []llm.MessageContentPart{
+			{
+				Type: "document",
+				Document: &llm.DocumentURL{
+					URL:      "data:application/pdf;base64,JVBERi0xLjQK",
+					MIMEType: "application/pdf",
+				},
+			},
+			{
+				Type:     "document",
+				Document: &llm.DocumentURL{URL: "https://example.com/report.pdf", Filename: "report.pdf"},
+			},
+			{
+				Type:     "document",
+				Document: &llm.DocumentURL{FileID: "file_123"},
+			},
+		}},
+	}}, llm.TransformOptions{})
+
+	require.Len(t, input.Items, 1)
+	require.NotNil(t, input.Items[0].Content)
+	require.Len(t, input.Items[0].Content.Items, 3)
+	require.Equal(t, "input_file", input.Items[0].Content.Items[0].Type)
+	require.Equal(t, "document.pdf", lo.FromPtr(input.Items[0].Content.Items[0].Filename))
+	require.Equal(t, "data:application/pdf;base64,JVBERi0xLjQK", lo.FromPtr(input.Items[0].Content.Items[0].FileData))
+	require.Equal(t, "https://example.com/report.pdf", lo.FromPtr(input.Items[0].Content.Items[1].FileURL))
+	require.Equal(t, "report.pdf", lo.FromPtr(input.Items[0].Content.Items[1].Filename))
+	require.Equal(t, "file_123", lo.FromPtr(input.Items[0].Content.Items[2].FileID))
+}
+
 // The wire shape matters as much as the struct: a tool result carrying an image
 // has to serialise as an output array of content parts, not as a string.
 func TestConvertToolMessageImageSerializesAsOutputArray(t *testing.T) {

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -702,12 +702,29 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		}
 
 	case StreamEventTypeError:
+		detail := llm.ErrorDetail{
+			Code:    streamEvent.Code,
+			Message: streamEvent.Message,
+			Type:    string(streamEvent.Type),
+			Param:   lo.FromPtr(streamEvent.Param),
+		}
+		if streamEvent.Error != nil {
+			if streamEvent.Error.Type != "" {
+				detail.Type = streamEvent.Error.Type
+			}
+			if streamEvent.Error.Code != "" {
+				detail.Code = streamEvent.Error.Code
+			}
+			if streamEvent.Error.Message != "" {
+				detail.Message = streamEvent.Error.Message
+			}
+			if streamEvent.Error.Param != "" {
+				detail.Param = streamEvent.Error.Param
+			}
+		}
 		return &llm.ResponseError{
-			Detail: llm.ErrorDetail{
-				Code:    streamEvent.Code,
-				Message: streamEvent.Message,
-				Param:   lo.FromPtr(streamEvent.Param),
-			},
+			StatusCode: streamEvent.Status,
+			Detail:     detail,
 		}
 
 	case StreamEventTypeImageGenerationPartialImage,

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -1264,3 +1264,71 @@ func TestOutboundTransformer_TransformStream_CreatedAtCompatibility(t *testing.T
 		})
 	}
 }
+
+func TestOutboundTransformer_TransformStream_PreservesOfficialWebSocketError(t *testing.T) {
+	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		data     string
+		wantType string
+	}{
+		{
+			name:     "official nested error",
+			wantType: "invalid_request_error",
+			data: `{
+				"type":"error",
+				"status":400,
+				"error":{
+					"type":"invalid_request_error",
+					"code":"invalid_value",
+					"message":"invalid websocket request",
+					"param":"input"
+				}
+			}`,
+		},
+		{
+			name:     "partial nested error retains flattened fields",
+			wantType: "invalid_request_error",
+			data: `{
+				"type":"error",
+				"status":400,
+				"code":"invalid_value",
+				"message":"invalid websocket request",
+				"param":"input",
+				"error":{"type":"invalid_request_error"}
+			}`,
+		},
+		{
+			name:     "legacy flattened error has a type",
+			wantType: "error",
+			data: `{
+				"type":"error",
+				"status":400,
+				"code":"invalid_value",
+				"message":"invalid websocket request",
+				"param":"input"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream([]*httpclient.StreamEvent{{
+				Type: "error",
+				Data: []byte(tt.data),
+			}}))
+			require.NoError(t, err)
+			require.False(t, stream.Next())
+
+			var responseErr *llm.ResponseError
+			require.ErrorAs(t, stream.Err(), &responseErr)
+			require.Equal(t, 400, responseErr.StatusCode)
+			require.Equal(t, tt.wantType, responseErr.Detail.Type)
+			require.Equal(t, "invalid_value", responseErr.Detail.Code)
+			require.Equal(t, "invalid websocket request", responseErr.Detail.Message)
+			require.Equal(t, "input", responseErr.Detail.Param)
+		})
+	}
+}

--- a/llm/transformer/openai/responses/stream_event.go
+++ b/llm/transformer/openai/responses/stream_event.go
@@ -66,6 +66,8 @@ type StreamEvent struct {
 	// Common fields
 	Type           StreamEventType `json:"type"`
 	SequenceNumber int             `json:"sequence_number"`
+	Status         int             `json:"status,omitempty"`
+	Error          *Error          `json:"error,omitempty"`
 
 	// For response.* events
 	Response *Response `json:"response,omitempty"`

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -139,9 +139,55 @@ func TopLevelWebSocketError(chunks []*httpclient.StreamEvent) error {
 			continue
 		}
 
-		var event StreamEvent
+		var event struct {
+			Status  int             `json:"status"`
+			Code    string          `json:"code"`
+			Message string          `json:"message"`
+			Param   string          `json:"param"`
+			Error   json.RawMessage `json:"error"`
+		}
 		if err := json.Unmarshal(chunk.Data, &event); err != nil {
 			return fmt.Errorf("websocket error event")
+		}
+		if event.Status >= http.StatusBadRequest && event.Status <= 599 {
+			detail := map[string]any{}
+			if event.Message != "" {
+				detail["message"] = event.Message
+			}
+			if event.Code != "" {
+				detail["type"] = event.Code
+				detail["code"] = event.Code
+			}
+			if event.Param != "" {
+				detail["param"] = event.Param
+			}
+			if len(event.Error) > 0 && string(event.Error) != "null" {
+				var nested map[string]any
+				if err := json.Unmarshal(event.Error, &nested); err != nil {
+					return fmt.Errorf("failed to decode websocket error detail: %w", err)
+				}
+				for key, value := range nested {
+					if value == nil {
+						continue
+					}
+					if text, ok := value.(string); ok && text == "" {
+						continue
+					}
+					detail[key] = value
+				}
+			}
+			body, err := json.Marshal(struct {
+				Error map[string]any `json:"error"`
+			}{Error: detail})
+			if err != nil {
+				return fmt.Errorf("failed to encode websocket error response: %w", err)
+			}
+
+			return &httpclient.Error{
+				StatusCode: event.Status,
+				Status:     http.StatusText(event.Status),
+				Body:       body,
+			}
 		}
 		if event.Code != "" && event.Message != "" {
 			return fmt.Errorf("websocket error event: %s: %s", event.Code, event.Message)

--- a/llm/transformer/openai/responses/websocket_executor.go
+++ b/llm/transformer/openai/responses/websocket_executor.go
@@ -1284,13 +1284,19 @@ func normalizeWebSocketEvent(raw []byte) []byte {
 	if !ok {
 		return append([]byte(nil), raw...)
 	}
-	if value, ok := errorValue["code"]; ok {
-		payload["code"] = value
-	} else if value, ok := errorValue["type"]; ok {
-		payload["code"] = value
+	if jsonValueIsEmpty(payload["code"]) {
+		if value, ok := errorValue["code"]; ok {
+			payload["code"] = value
+		} else if value, ok := errorValue["type"]; ok {
+			payload["code"] = value
+		}
 	}
 	for _, key := range []string{"message", "param"} {
-		if value, ok := errorValue[key]; ok {
+		if jsonValueIsEmpty(payload[key]) {
+			value, ok := errorValue[key]
+			if !ok {
+				continue
+			}
 			payload[key] = value
 		}
 	}
@@ -1299,4 +1305,12 @@ func normalizeWebSocketEvent(raw []byte) []byte {
 		return append([]byte(nil), raw...)
 	}
 	return body
+}
+
+func jsonValueIsEmpty(value any) bool {
+	if value == nil {
+		return true
+	}
+	text, ok := value.(string)
+	return ok && text == ""
 }

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -1428,6 +1428,17 @@ func TestNormalizeWebSocketEventFlattensNestedError(t *testing.T) {
 	require.Equal(t, "model", payload["param"])
 }
 
+func TestNormalizeWebSocketEventPreservesFlattenedFields(t *testing.T) {
+	raw := []byte(`{"type":"error","status":400,"code":"invalid_value","message":"flat message","error":{"type":"invalid_request_error","message":"nested message"}}`)
+
+	normalized := normalizeWebSocketEvent(raw)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(normalized, &payload))
+	require.Equal(t, "invalid_value", payload["code"])
+	require.Equal(t, "flat message", payload["message"])
+}
+
 func TestToWebSocketURL(t *testing.T) {
 	got, err := toWebSocketURL("https://api.openai.com/v1/responses")
 	require.NoError(t, err)

--- a/llm/transformer/openai/responses/websocket_executor_test.go
+++ b/llm/transformer/openai/responses/websocket_executor_test.go
@@ -254,6 +254,88 @@ func TestWebSocketExecutorDoReturnsErrorForTopLevelErrorEvent(t *testing.T) {
 	require.ErrorContains(t, err, "bad_request: invalid websocket request")
 }
 
+func TestTopLevelWebSocketErrorPreservesOfficialErrorStatusAndBody(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "official nested error",
+			data: `{
+				"type":"error",
+				"status":400,
+				"error":{
+					"type":"invalid_request_error",
+					"code":"invalid_value",
+					"message":"invalid websocket request",
+					"param":"input"
+				}
+			}`,
+			want: `{
+				"error":{
+					"type":"invalid_request_error",
+					"code":"invalid_value",
+					"message":"invalid websocket request",
+					"param":"input"
+				}
+			}`,
+		},
+		{
+			name: "legacy flattened error",
+			data: `{
+				"type":"error",
+				"status":400,
+				"code":"invalid_value",
+				"message":"invalid websocket request",
+				"param":"input"
+			}`,
+			want: `{
+				"error":{
+					"type":"invalid_value",
+					"code":"invalid_value",
+					"message":"invalid websocket request",
+					"param":"input"
+				}
+			}`,
+		},
+		{
+			name: "partial nested error retains flattened fields",
+			data: `{
+				"type":"error",
+				"status":400,
+				"code":"invalid_value",
+				"message":"invalid websocket request",
+				"param":"input",
+				"error":{"type":"invalid_request_error","request_id":"req_123"}
+			}`,
+			want: `{
+				"error":{
+					"type":"invalid_request_error",
+					"code":"invalid_value",
+					"message":"invalid websocket request",
+					"param":"input",
+					"request_id":"req_123"
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := TopLevelWebSocketError([]*httpclient.StreamEvent{{
+				Type: "error",
+				Data: []byte(tt.data),
+			}})
+
+			var httpErr *httpclient.Error
+			require.ErrorAs(t, err, &httpErr)
+			require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+			require.JSONEq(t, tt.want, string(httpErr.Body))
+		})
+	}
+}
+
 func TestWebSocketExecutorDoAggregatesFailedResponseEvent(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 目标

本 PR 针对 OpenAI-compatible 多协议转换和 Responses WebSocket 传输做真实上游验证，并修复验证中发现的转换问题。测试使用临时渠道，凭据不写入仓库，真实域名全部脱敏。

## 脱敏约定

| 标识 | PR 中显示的值 | 含义 |
| --- | --- | --- |
| <DOWNSTREAM_BASE> | http://axonhub.example | AxonHub 下游地址，实际地址省略 |
| <UPSTREAM_HTTPS> | https://upstream-gateway.example/v1 | 实际 OpenAI-compatible HTTPS base URL 已脱敏 |
| <UPSTREAM_WSS> | wss://upstream-gateway.example/v1 | 实际 Responses WSS base URL 已脱敏 |
| TEST_KEY | <redacted> | 下游测试 key，不展示 |

临时渠道只在测试期间启用：matrix-chat（OpenAI Chat HTTPS）、matrix-responses-http（OpenAI Responses HTTPS）、matrix-responses-wss（OpenAI Responses WSS）。测试结束后渠道已软归档，正式服务已恢复。

## 传输与转换矩阵

| 下游请求 | 上游渠道/URL（脱敏） | 上游请求形式 | 下游响应形式 | 转换路径 | 结果 |
| --- | --- | --- | --- | --- | --- |
| POST /v1/chat/completions | matrix-chat → <UPSTREAM_HTTPS>/chat/completions | Chat messages | chat.completion 或 Chat SSE chunks | OpenAI Chat 入站 → llm.Request(chat) → OpenAI Chat outbound | 通过 |
| POST /v1/responses | matrix-chat → <UPSTREAM_HTTPS>/chat/completions | Responses input | Responses response 或 typed SSE | Responses 入站 → llm.Request(chat) → Chat outbound → Responses 响应转换 | 通过 |
| GET /v1/responses WebSocket | matrix-chat → <UPSTREAM_HTTPS>/chat/completions | response.create，服务端转为 Chat 流 | WebSocket response.* 事件 | Responses WS envelope → Responses HTTP request → Chat outbound → Responses stream inbound → WS envelope | 通过 |
| POST /v1/chat/completions | matrix-responses-http → <UPSTREAM_HTTPS>/responses | Chat messages | chat.completion 或 Chat SSE | Chat 入站 → llm.Request(chat) → Responses outbound → Chat 响应转换 | 通过 |
| POST /v1/responses | matrix-responses-http → <UPSTREAM_HTTPS>/responses | Responses input | Responses response 或 typed SSE | Responses 入站 → llm.Request(chat) → Responses outbound（HTTPS） | 通过 |
| GET /v1/responses WebSocket | matrix-responses-http → <UPSTREAM_HTTPS>/responses | response.create | WebSocket response.* 事件 | Responses WS → Responses HTTP outbound → Responses stream inbound → WS | 通过 |
| POST /v1/chat/completions | matrix-responses-wss → <UPSTREAM_WSS>/responses | Chat messages | chat.completion 或 Chat SSE | Chat 入站 → llm.Request(chat) → Responses WSS outbound → Chat 响应转换 | 通过 |
| POST /v1/responses | matrix-responses-wss → <UPSTREAM_WSS>/responses | Responses input | Responses response 或 typed SSE | Responses 入站 → llm.Request(chat) → Responses WSS outbound | 通过 |
| GET /v1/responses WebSocket | matrix-responses-wss → <UPSTREAM_WSS>/responses | response.create | WebSocket response.* 事件 | Responses WS → Responses WSS outbound → Responses stream inbound → WS | 通过 |
| POST /v1/messages | 三个 OpenAI 上游渠道 | Anthropic Messages | Anthropic JSON/SSE | Anthropic 入站 → llm.Request(chat) → OpenAI outbound → Anthropic 响应转换 | 通过 |
| POST /gemini/v1beta/models/{model}:generateContent | 三个 OpenAI 上游渠道 | Gemini contents | Gemini JSON/SSE | Gemini 入站 → llm.Request(chat) → OpenAI outbound → Gemini 响应转换 | 通过 |

## 详细测试用例

下面的请求示例只保留协议相关字段，model 使用下游别名，所有凭据和真实域名均省略。

| 用例 | 请求关键内容 | 响应关键内容 | 验证项 | 涉及路径 | 结果 |
| --- | --- | --- | --- | --- | --- |
| 基础文本 | Chat：{"model":"matrix-*","messages":[{"role":"user","content":"Reply exactly PONG"}]}；Responses：{"model":"matrix-*","input":"Reply exactly PONG","store":false} | Chat：object=chat.completion；Responses：object=response，文本为 PONG | HTTP 200、非空文本、响应 object 与下游协议匹配 | Chat/Responses 入站 → unified chat → Chat 或 Responses outbound | 通过 |
| Chat SSE | stream=true，用户内容为 Reply exactly STREAM_OK | text/event-stream；存在 chat.completion.chunk 和 [DONE] | chunk 可解析、收到 [DONE]、文本包含 STREAM_OK | Chat 入站 → provider stream → Chat stream inbound | 通过 |
| Responses SSE | stream=true，用户内容为 Reply exactly STREAM_OK | response.created、response.in_progress、response.output_text.delta、response.completed | typed event 可消费，终态为 response.completed | Responses 入站 → provider SSE/WSS → Responses stream inbound | 通过 |
| Anthropic SSE | POST /v1/messages，stream=true，内容为 STREAM_OK | message_start、content_block_delta、message_delta、message_stop | 文本增量拼接正确，终态为 message_stop | Anthropic inbound → unified chat → OpenAI outbound → Anthropic stream writer | 通过 |
| Gemini SSE | streamGenerateContent?alt=sse，内容为 STREAM_OK | Gemini candidates 增量，finishReason=STOP | 文本拼接正确，STOP 被识别为正常结束 | Gemini inbound → unified chat → OpenAI outbound → Gemini stream writer | 通过 |
| 工具调用 | Chat/Anthropic：function tool get_temperature(city)；Responses：同名 function tool；Gemini：functionDeclarations | 首轮返回 tool call；回传 21°C 后最终文本包含 21 | 工具名、参数、call id、tool result 关联正确 | 各协议 tool schema → llm.Tool/ToolCall → OpenAI function tool → 结果反向转换 | 通过 |
| 并行双工具 | Gemini 一轮要求 tool_alpha(value=1)、tool_beta(value=2)，同一 contents 回传两个 functionResponse | 最终 200，文本确认两个工具结果 | 两个 function call 和两个 function response 均保留；无 No tool output found | Gemini content 拆分 → 两条 unified tool message → Responses/Chat tool output | 修复后通过 |
| 结构化输出 | Chat：response_format.type=json_schema；Responses：text.format.type=json_schema；Gemini：responseMimeType=application/json + responseJsonSchema | {"answer":"PONG","count":7} | JSON 可解析、字段符合 schema；Gemini 转 Responses 自动补 text.format.name=gemini_response | Schema 入站 → unified ResponseFormat → OpenAI Chat/Responses schema outbound | 修复后通过 |
| 图片输入 | 使用有效 JPEG data URL（测试素材为本地正常 JPEG，bytes 不展示） | 文本为 IMAGE_OK | Chat、Responses、Gemini 三种输入形态均可传递；HTTP 200 | image content → unified image_url → provider image input → response conversion | 通过 |
| PDF 文件输入 | Responses：input_file(file_data="data:application/pdf;base64,...")；Chat：file.file_data；Gemini：inlineData(mimeType=application/pdf) | Responses HTTPS/WSS 返回 DOCUMENT-642 | 文件内容真实被上游读取，不只是检查状态码 | Chat file / Gemini inlineData / Responses input_file → unified DocumentURL → Responses input_file | 修复后通过 |
| 普通文件 URL | Chat 输入只有 file.file_data=https://... | 400 invalid_request_error | 不把普通 URL 伪装成 Chat file_data；Responses 仍支持 file_url | unified DocumentURL → Chat outbound 校验；Responses outbound 保留 file_url | 修复后通过 |
| Anthropic 多轮 | 首轮：The reference token is CYAN-247. Reply ACK.；第二轮携带 assistant content，询问 token | 非流和 SSE 均返回 CYAN-247 | 历史 assistant content 保留、SSE 终态正确 | Anthropic messages → unified history → OpenAI Chat/Responses → Anthropic response | 通过 |
| Gemini 多轮 | 首轮：The reference token is TEAL-935. Reply ACK.；第二轮携带 model content，询问 token | 非流和 SSE 均返回 TEAL-935 | user → model → user 顺序保留 | Gemini contents → unified history → OpenAI Chat/Responses/WSS → Gemini response | 通过 |
| Responses previous_response_id | 首轮保存 response id；下一轮只带 previous_response_id 和新 input | 200、上下文答案正确 | HTTP、同 WS 连接、跨 WS 重连均验证 | Responses session store → full input reconstruction → provider outbound | 通过 |
| store=false 重连 | 首轮/第二轮使用 store=false；关闭连接后以第二轮 response id 新连接继续 | 三类上游均返回正确 codeword | 不依赖 provider 持久化；验证 AxonHub session cache 恢复 | downstream WS → Responses session store → new upstream connection | 通过 |
| WS warmup | response.create with generate=false，再用 warmup id + 新 input | warmup 返回 response id；后续返回上下文答案 | warmup 不生成模型输出，但可继续对话 | WS envelope state → continuation merge → provider request | 通过 |
| WS 命名 lane | stream_id=parallel-a、parallel-b 同连接并发发送 | 两 lane 事件交错但各自终态和文本正确 | 每个事件带正确 lane id；不同 lane 并发 | WS dispatcher → per-lane FIFO/session → provider WSS | 通过 |
| WS 同 lane FIFO | 同一 stream_id=fifo 连续发送 FIRST、SECOND | 两个 response.completed，无重叠 | 同 lane 不并发、按发送顺序完成 | WS dispatcher lane queue → provider WSS | 通过 |
| WS fork | 先完成 fork-root，两个新 lane 携带同一 previous_response_id，分别询问 +1/+2 | fork-one=11、fork-two=12 | 父响应可跨 lane fork，事件路由不串线 | WS stream_id lane + previous_response_id lineage | 通过 |
| 错误后恢复 | 发送非法图片或非法 WS stream_id，随后发送正常 RECOVERED | 错误为 400，后续正常请求仍 200 | 连接不被错误请求拖死；错误 code/param/status 保留 | provider error → outbound stream error → WS/HTTP error writer | 修复后通过 |
| Thinking | Anthropic thinking.type=adaptive；Gemini thinkingConfig | 200，答案 42；若上游未返回 thought block，仅验证结果和请求不报错 | reasoning 参数可跨协议转换；不把 provider 未返回 thought 误判为失败 | Anthropic/Gemini reasoning config → unified reasoning → OpenAI request | 通过 |

## 真实执行统计

| 测试批次 | 配置 | 总数 | 通过 | 失败/说明 |
| --- | --- | ---: | ---: | --- |
| OpenAI HTTP/Chat/Responses 交叉矩阵 | passThroughBody=true | 34 | 34 | 0 |
| OpenAI Responses WebSocket 交叉矩阵 | passThroughBody=true | 20 | 20 | 0 |
| Anthropic/Gemini → OpenAI Chat/Responses/WSS 矩阵 | passThroughBody=true | 57 | 57 | 0 |
| OpenAI HTTP/Chat/Responses 交叉矩阵 | passThroughBody=false | 34 | 34 | 0 |
| OpenAI Responses WebSocket 交叉矩阵 | passThroughBody=false | 20 | 20 | 0 |
| Anthropic/Gemini → OpenAI Chat/Responses/WSS 矩阵 | passThroughBody=false | 57 | 57 | 0 |
| 补充真实用例 | 非透传：PDF、并行工具、多轮 SSE、store=false 重连、WSS fork | — | 全部通过 | 目标 Chat 上游读取 PDF 的 3 条属于上游能力限制 |

SQLite request_executions 中保留了真实执行记录；本轮累计 334 条记录，其中 306 条 completed，28 条为修复前故障探针、故意负向请求或上游能力限制探针。所有修复后的正向矩阵均通过，失败记录没有被隐藏或删除。

## 独立 OpenAI 端点能力探针

这些端点不属于 Chat/Responses 的 RequestTypeChat 互转面，因此单独记录，不把上游能力缺失算作转换通过：

| 端点 | 直接上游响应 | 判定 |
| --- | --- | --- |
| /v1/completions | 400，completion is not supported | 临时上游未实现 legacy Completions |
| /v1/embeddings | 400，embedding is not supported | 临时上游未实现该模型能力 |
| /v1/moderations | 422，目标 moderation model 不存在 | 模型清单/上游能力限制 |
| /v1/images/generations | 403，image generation 未对该 group 开启 | 权限限制 |
| /v1/videos | 422，目标视频模型不存在 | 模型清单限制 |
| /v1/audio/speech | 400，speech is not supported | 临时上游未实现 TTS |
| /v1/audio/transcriptions、/v1/audio/translations | 422，目标模型不存在 | 模型清单限制 |
| /v1/responses/compact HTTPS | 502，Upstream request failed | 临时上游未提供 Compact 服务 |
| /v1/responses/compact WSS | 404，path not found | 官方 standalone Compact 是 HTTP；AxonHub 现拒绝 Compact WSS 配置 |

## 修复内容

| 文件/区域 | 修复 |
| --- | --- |
| llm/transformer/gemini/inbound_convert.go | Gemini responseSchema/responseJsonSchema 转统一 Responses schema 时补稳定名称 gemini_response；同一 content 中多个 functionResponse 拆成多条 tool message |
| llm/model.go、OpenAI/Responses models | 增加 DocumentURL.file_id、filename 及 Responses input_file 字段 |
| OpenAI Chat/Responses converters | 实现 Chat file、Responses input_file、Gemini document 与 unified document 的双向转换 |
| llm/transformer/openai/outbound.go | Chat 不支持普通 file_url 时在 outbound 明确返回 invalid request；仅允许 file_id 或 data URL file_data |
| internal/server/biz/channel_endpoint.go、channel_llm.go | standalone openai/responses_compact 不再允许 WebSocket transport |
| Responses WebSocket error path | 保留官方 status、nested error、flattened code/message/param；部分 nested error 不覆盖已有非空 flattened 字段 |

## 本地与 CI 验证

- cd llm && go test ./transformer/gemini ./transformer/openai ./transformer/openai/responses
- go test ./internal/server/biz ./internal/server/orchestrator
- PR CI：Build Backend、Build Frontend、test、lint、Test Frontend Unit、CodeRabbit、Greptile 全部通过
- 当前 head：8460e484，未执行 merge

官方协议参考：

- https://developers.openai.com/api/docs/guides/websocket-mode
- https://developers.openai.com/api/docs/guides/file-inputs

