### PR TITLE
fix(trace): stop persisting traces for embedding requests

### DIFF
--- a/internal/server/biz/trace.go
+++ b/internal/server/biz/trace.go
@@ -674,16 +674,18 @@ func requestToSegment(ctx context.Context, req *ent.Request) (*Segment, error) {
 
 			inbound, err := getInboundTransformer(apiFormat)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get inbound transformer: %w", err)
-			}
+				// Format has no message-shaped request body (e.g. embeddings);
+				// skip it instead of failing the whole trace.
+				log.Warn(ctx, "No inbound transformer for format, skipping request spans", log.Cause(err), log.Int("request_id", req.ID))
+			} else {
+				llmReq, err := inbound.TransformRequest(ctx, httpReq)
+				if err != nil {
+					log.Warn(ctx, "Failed to transform request body", log.Cause(err), log.Int("request_id", req.ID))
+					return segment, nil
+				}
 
-			llmReq, err := inbound.TransformRequest(ctx, httpReq)
-			if err != nil {
-				log.Warn(ctx, "Failed to transform request body", log.Cause(err), log.Int("request_id", req.ID))
-				return segment, nil
+				requestSpans = append(requestSpans, extractSpansFromMessages(llmReq.Messages, fmt.Sprintf("request-%d", req.ID))...)
 			}
-
-			requestSpans = append(requestSpans, extractSpansFromMessages(llmReq.Messages, fmt.Sprintf("request-%d", req.ID))...)
 		}
 	}
 
@@ -710,26 +712,28 @@ func requestToSegment(ctx context.Context, req *ent.Request) (*Segment, error) {
 		} else {
 			outbound, err := getOutboundTransformer(apiFormat)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get outbound transformer: %w", err)
-			}
+				// Format has no message-shaped response body (e.g. embeddings);
+				// skip it instead of failing the whole trace.
+				log.Warn(ctx, "No outbound transformer for format, skipping response spans", log.Cause(err), log.Int("request_id", req.ID))
+			} else {
+				httpResp := &httpclient.Response{
+					Body:       req.ResponseBody,
+					StatusCode: http.StatusOK,
+					Headers: http.Header{
+						"Content-Type": {"application/json"},
+					},
+				}
 
-			httpResp := &httpclient.Response{
-				Body:       req.ResponseBody,
-				StatusCode: http.StatusOK,
-				Headers: http.Header{
-					"Content-Type": {"application/json"},
-				},
-			}
+				unifiedResp, err := outbound.TransformResponse(ctx, httpResp)
+				if err != nil {
+					log.Warn(ctx, "Failed to transform response body", log.Cause(err), log.Int("request_id", req.ID))
+					return segment, nil
+				}
 
-			unifiedResp, err := outbound.TransformResponse(ctx, httpResp)
-			if err != nil {
-				log.Warn(ctx, "Failed to transform response body", log.Cause(err), log.Int("request_id", req.ID))
-				return segment, nil
-			}
-
-			segment.Metadata = extractMetadataFromResponse(unifiedResp)
-			if len(unifiedResp.Choices) > 0 && unifiedResp.Choices[0].Message != nil {
-				responseSpans = append(responseSpans, extractSpansFromMessage(unifiedResp.Choices[0].Message, fmt.Sprintf("response-%d", req.ID))...)
+				segment.Metadata = extractMetadataFromResponse(unifiedResp)
+				if len(unifiedResp.Choices) > 0 && unifiedResp.Choices[0].Message != nil {
+					responseSpans = append(responseSpans, extractSpansFromMessage(unifiedResp.Choices[0].Message, fmt.Sprintf("response-%d", req.ID))...)
+				}
 			}
 		}
 	}

--- a/internal/server/biz/trace_embedding_test.go
+++ b/internal/server/biz/trace_embedding_test.go
@@ -1,0 +1,50 @@
+package biz
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/llm"
+)
+
+func TestRequestToSegment_EmbeddingFormatSkipsSpans(t *testing.T) {
+	now := time.Now()
+
+	reqBody, err := json.Marshal(map[string]any{
+		"model": "text-embedding-3-small",
+		"input": "hello world",
+	})
+	require.NoError(t, err)
+
+	respBody, err := json.Marshal(map[string]any{
+		"object": "list",
+		"data": []map[string]any{
+			{"object": "embedding", "index": 0, "embedding": []float64{0.1, 0.2}},
+		},
+		"usage": map[string]any{"prompt_tokens": 3, "total_tokens": 3},
+	})
+	require.NoError(t, err)
+
+	req := &ent.Request{
+		ID:           42,
+		ModelID:      "text-embedding-3-small",
+		Format:       string(llm.APIFormatOpenAIEmbedding),
+		Status:       request.StatusCompleted,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		RequestBody:  reqBody,
+		ResponseBody: respBody,
+	}
+
+	segment, err := requestToSegment(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, segment)
+	require.Empty(t, segment.RequestSpans)
+	require.Empty(t, segment.ResponseSpans)
+}

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -116,14 +116,6 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 			return
 		}
 
-		// Tool endpoints such as embeddings carry a trace ID header from generic API
-		// clients but are not conversation turns, so they never get a persisted trace.
-		if isNonMessageEndpoint(c.Request.URL.Path) {
-			c.Next()
-
-			return
-		}
-
 		// The trace middleware can resolve a more specific ID from fallback headers
 		// or request bodies. Keep the request context in sync with that final value.
 		c.Request = c.Request.WithContext(tracing.WithTraceID(c.Request.Context(), traceID))
@@ -138,6 +130,15 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 		projectID, ok := contexts.GetProjectID(c.Request.Context())
 		if !ok {
 			c.Next()
+			return
+		}
+
+		// Tool endpoints such as embeddings carry a trace ID header from generic API
+		// clients but are not conversation turns: keep the resolved trace ID and
+		// response headers for client correlation, but never persist a trace for them.
+		if isNonMessageEndpoint(c.Request.URL.Path) {
+			c.Next()
+
 			return
 		}
 

--- a/internal/server/middleware/trace.go
+++ b/internal/server/middleware/trace.go
@@ -116,6 +116,14 @@ func WithTrace(config tracing.Config, traceService *biz.TraceService) gin.Handle
 			return
 		}
 
+		// Tool endpoints such as embeddings carry a trace ID header from generic API
+		// clients but are not conversation turns, so they never get a persisted trace.
+		if isNonMessageEndpoint(c.Request.URL.Path) {
+			c.Next()
+
+			return
+		}
+
 		// The trace middleware can resolve a more specific ID from fallback headers
 		// or request bodies. Keep the request context in sync with that final value.
 		c.Request = c.Request.WithContext(tracing.WithTraceID(c.Request.Context(), traceID))
@@ -233,4 +241,18 @@ func tryExtractTraceIDFromCodexRequest(c *gin.Context) string {
 	log.Debug(c.Request.Context(), "Extracted trace ID from "+traceSource, log.String("trace_id", traceID))
 
 	return traceID
+}
+
+// isNonMessageEndpoint reports whether the request targets an endpoint whose
+// payload is not message-shaped (e.g. /v1/embeddings). Such requests may carry
+// a trace ID header from generic API clients, but must not create a persisted
+// trace: they are tool calls rather than conversation turns and have no
+// displayable content in the trace UI.
+func isNonMessageEndpoint(path string) bool {
+	if strings.HasSuffix(path, "/embeddings") {
+		return true
+	}
+
+	// Gemini serves embeddings through model actions instead of an /embeddings path.
+	return strings.Contains(path, ":embedContent") || strings.Contains(path, ":batchEmbedContents")
 }

--- a/internal/server/middleware/trace_test.go
+++ b/internal/server/middleware/trace_test.go
@@ -1450,6 +1450,114 @@ func TestWithTrace_WritesResponseAliasesForExplicitTraceWithoutProject(t *testin
 	require.Equal(t, "client-trace-123", w.Header().Get("X-Oneapi-Request-Id"))
 }
 
+func TestWithTrace_SkipsPersistedTraceForEmbeddingEndpoint(t *testing.T) {
+	config := tracing.Config{
+		TraceHeader: "AH-Trace-Id",
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(func(c *gin.Context) {
+		ctx := authz.WithTestBypass(c.Request.Context())
+		ctx = ent.NewContext(ctx, client)
+		ctx = contexts.WithProjectID(ctx, testProject.ID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	router.POST("/v1/embeddings", func(c *gin.Context) {
+		_, ok := contexts.GetTrace(c.Request.Context())
+		require.False(t, ok, "embeddings requests must not carry a persisted trace")
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader([]byte(`{"model":"text-embedding-3-small","input":"hello"}`)))
+	req.Header.Set("Ah-Trace-Id", "client-trace-123")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	traceCount, err := client.Trace.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, traceCount, "embedding requests must not create persisted traces")
+}
+
+func TestWithTrace_PersistsTraceForChatEndpoint(t *testing.T) {
+	config := tracing.Config{
+		TraceHeader: "AH-Trace-Id",
+	}
+
+	router, client, traceService := setupTestTraceMiddleware(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(httptest.NewRequest(http.MethodGet, "/", nil).Context())
+	ctx = ent.NewContext(ctx, client)
+
+	testProject, err := client.Project.Create().
+		SetName("test-project").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router.Use(func(c *gin.Context) {
+		ctx := authz.WithTestBypass(c.Request.Context())
+		ctx = ent.NewContext(ctx, client)
+		ctx = contexts.WithProjectID(ctx, testProject.ID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.Use(WithTrace(config, traceService))
+
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		trace, ok := contexts.GetTrace(c.Request.Context())
+		require.True(t, ok)
+		require.Equal(t, "client-trace-123", trace.TraceID)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)))
+	req.Header.Set("Ah-Trace-Id", "client-trace-123")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	storedTrace, err := client.Trace.Query().Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "client-trace-123", storedTrace.TraceID)
+}
+
+func TestIsNonMessageEndpoint(t *testing.T) {
+	testCases := []struct {
+		path string
+		want bool
+	}{
+		{path: "/v1/embeddings", want: true},
+		{path: "/jina/v1/embeddings", want: true},
+		{path: "/gemini/v1beta/models/text-embedding-004:embedContent", want: true},
+		{path: "/gemini/v1beta/models/text-embedding-004:batchEmbedContents", want: true},
+		{path: "/v1/chat/completions", want: false},
+		{path: "/anthropic/v1/messages", want: false},
+		{path: "/v1/responses", want: false},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, isNonMessageEndpoint(tc.path), tc.path)
+	}
+}
+
 func TestWithTrace_WritesResponseAliasesWhenTracePersistenceFails(t *testing.T) {
 	config := tracing.Config{
 		TraceHeader:          "AH-Trace-Id",

--- a/internal/server/middleware/trace_test.go
+++ b/internal/server/middleware/trace_test.go
@@ -1452,7 +1452,8 @@ func TestWithTrace_WritesResponseAliasesForExplicitTraceWithoutProject(t *testin
 
 func TestWithTrace_SkipsPersistedTraceForEmbeddingEndpoint(t *testing.T) {
 	config := tracing.Config{
-		TraceHeader: "AH-Trace-Id",
+		TraceHeader:          "AH-Trace-Id",
+		ResponseTraceHeaders: []string{"AH-Trace-Id"},
 	}
 
 	router, client, traceService := setupTestTraceMiddleware(t)
@@ -1479,6 +1480,10 @@ func TestWithTrace_SkipsPersistedTraceForEmbeddingEndpoint(t *testing.T) {
 	router.POST("/v1/embeddings", func(c *gin.Context) {
 		_, ok := contexts.GetTrace(c.Request.Context())
 		require.False(t, ok, "embeddings requests must not carry a persisted trace")
+
+		traceID, ok := tracing.GetTraceID(c.Request.Context())
+		require.True(t, ok)
+		require.Equal(t, "client-trace-123", traceID)
 		c.Status(http.StatusOK)
 	})
 
@@ -1489,6 +1494,7 @@ func TestWithTrace_SkipsPersistedTraceForEmbeddingEndpoint(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "client-trace-123", w.Header().Get("Ah-Trace-Id"))
 	traceCount, err := client.Trace.Query().Count(ctx)
 	require.NoError(t, err)
 	require.Zero(t, traceCount, "embedding requests must not create persisted traces")


### PR DESCRIPTION
## Problem

The `/project/traces` page returned "内部服务器错误" (internal server error) when any persisted trace had an `openai/embeddings` request as its first completed request.

Root causes:

1. `requestToSegment` hard-failed on formats that have no registered transformer (`openai/embeddings`, `openai/completions`, rerank, ...). The error propagated through the `firstUserQuery` resolver and took down the entire traces page with a 500.
2. Embedding requests (tool calls with no conversation content) were persisted as standalone traces whenever the API client sent a trace ID header, polluting the traces list.

## Changes

- `internal/server/biz/trace.go` — `requestToSegment` now logs and skips request/response bodies whose format has no inbound/outbound transformer instead of returning an error, so a single non-message request can never fail the whole trace. Existing embedding traces now render as `-` instead of crashing the page.
- `internal/server/middleware/trace.go` — `WithTrace` no longer creates persisted traces for non-message endpoints (`/embeddings` suffix, Gemini `:embedContent` / `:batchEmbedContents`). Requests still execute and usage is recorded as before; they simply carry no `trace_id`.
- Tests added for both behaviors, plus a regression test asserting chat endpoints still get traced.

## Notes

Existing embedding-only traces already in the database are left untouched (they no longer cause errors); the filter only prevents new ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embedding and other non-message requests no longer prevent trace segments from being created when span transformation is unavailable.
  * Non-message endpoints no longer create persisted traces, even when a trace ID is provided.
  * Trace IDs remain available for request correlation, and configured response trace headers are still returned.
  * Message-based endpoints continue to persist traces as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->