### PR TITLE
fix(frontend): silence transient channel polling errors

### DIFF
--- a/frontend/src/features/channels/data/channel-query-error.test.mjs
+++ b/frontend/src/features/channels/data/channel-query-error.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+
+const source = readFileSync(join(import.meta.dirname, 'channel-query-error.ts'), 'utf8');
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2023,
+  },
+}).outputText;
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString('base64')}`;
+const { shouldNotifyChannelQueryError } = await import(moduleUrl);
+
+test('notifies when the initial channel query fails without data', () => {
+  assert.equal(shouldNotifyChannelQueryError(new Error('failed'), false, false), true);
+});
+
+test('notifies when a new query key fails with placeholder data', () => {
+  assert.equal(shouldNotifyChannelQueryError(new Error('failed'), true, true), true);
+});
+
+test('does not notify when a background refresh fails with settled data', () => {
+  assert.equal(shouldNotifyChannelQueryError(new Error('failed'), true, false), false);
+});

--- a/frontend/src/features/channels/data/channel-query-error.ts
+++ b/frontend/src/features/channels/data/channel-query-error.ts
@@ -1,0 +1,3 @@
+export function shouldNotifyChannelQueryError(error: unknown, hasData: boolean, isPlaceholderData: boolean): boolean {
+  return Boolean(error && (!hasData || isPlaceholderData));
+}

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { useEffect } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { graphqlRequest } from '@/gql/graphql';
 import { pageInfoSchema } from '@/gql/pagination';
@@ -1034,7 +1035,7 @@ export function useQueryChannels(
   const { handleError } = useErrorHandler();
   const { t } = useTranslation();
 
-  return useQuery({
+  const query = useQuery({
     enabled: !options?.disableAutoFetch,
     queryKey: [
       'channels',
@@ -1049,13 +1050,8 @@ export function useQueryChannels(
       variables?.before,
     ],
     queryFn: async () => {
-      try {
-        const data = await graphqlRequest<{ queryChannels: ChannelConnection }>(QUERY_CHANNELS_QUERY, { input: variables });
-        return channelConnectionSchema.parse(data?.queryChannels);
-      } catch (error) {
-        handleError(error, t('common.errors.internalServerError'));
-        throw error;
-      }
+      const data = await graphqlRequest<{ queryChannels: ChannelConnection }>(QUERY_CHANNELS_QUERY, { input: variables });
+      return channelConnectionSchema.parse(data?.queryChannels);
     },
     // Poll so the live limiter snapshot (in-flight / queue) stays roughly fresh.
     // 5s is light traffic; pause when the tab is hidden.
@@ -1065,6 +1061,14 @@ export function useQueryChannels(
     // so the component never renders with data = undefined and crashes.
     placeholderData: keepPreviousData,
   });
+
+  useEffect(() => {
+    if (query.error && query.data === undefined) {
+      handleError(query.error, t('common.errors.internalServerError'));
+    }
+  }, [handleError, query.data, query.error, t]);
+
+  return query;
 }
 
 export function useAllChannelNames(options?: { enabled?: boolean }) {

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -1067,7 +1067,7 @@ export function useQueryChannels(
     if (shouldNotifyChannelQueryError(query.error, query.data !== undefined, query.isPlaceholderData)) {
       handleError(query.error, t('common.errors.internalServerError'));
     }
-  }, [handleError, query.data, query.error, t]);
+  }, [handleError, query.data, query.error, query.isPlaceholderData, t]);
 
   return query;
 }

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { graphqlRequest } from '@/gql/graphql';
 import { pageInfoSchema } from '@/gql/pagination';
+import { shouldNotifyChannelQueryError } from './channel-query-error';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useErrorHandler } from '@/hooks/use-error-handler';
@@ -1063,7 +1064,7 @@ export function useQueryChannels(
   });
 
   useEffect(() => {
-    if (query.error && query.data === undefined) {
+    if (shouldNotifyChannelQueryError(query.error, query.data !== undefined, query.isPlaceholderData)) {
       handleError(query.error, t('common.errors.internalServerError'));
     }
   }, [handleError, query.data, query.error, t]);


### PR DESCRIPTION
## Summary
- keep existing channel data visible when a background refresh fails
- show the error toast only when the initial channel query has no data

## Verification
- frontend typecheck passed
- 44 frontend tests passed
- malformed JSON during a background refresh was verified not to produce a toast in Chromium QA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading channel data.
  * Initial-load errors are now reported only when no channel data has been retrieved.
  * Errors for new channel queries using placeholder data are reported appropriately.
  * Prevented background refresh errors from interrupting or replacing already loaded channel data.
  * Updated error handling as channel data transitions between placeholder and fully loaded states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->