### PR TITLE
fix(openai): merge multiple system messages for strict upstreams

### DIFF
--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -56,6 +56,13 @@ func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField Reasonin
 		return MessageFromLLMWithConfig(m, reasoningField)
 	})
 
+	// Chat Completions accepts a single system message; strict OpenAI-compatible
+	// upstreams (notably domestic model gateways) reject the multiples that
+	// Claude Code produces when it sends the system prompt as an array. Merge
+	// them, mirroring the Responses outbound which folds system messages into a
+	// single `instructions` string.
+	req.Messages = mergeSystemMessages(req.Messages)
+
 	// Convert Stop
 	if r.Stop != nil {
 		req.Stop = &Stop{
@@ -106,6 +113,64 @@ func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField Reasonin
 	}
 
 	return req
+}
+
+// mergeSystemMessages collapses all system-role messages into one at the
+// position of the first, dropping the rest. The Chat Completions spec allows
+// a single system message, and strict OpenAI-compatible upstreams reject
+// extras with "System message must be at the beginning".
+func mergeSystemMessages(msgs []Message) []Message {
+	var (
+		systemCount int
+		firstSystem = -1
+		systemText  strings.Builder
+	)
+
+	for i, m := range msgs {
+		if m.Role != "system" {
+			continue
+		}
+		if firstSystem == -1 {
+			firstSystem = i
+		}
+		systemCount++
+		for _, text := range messageTextParts(m) {
+			if systemText.Len() > 0 {
+				systemText.WriteString("\n\n")
+			}
+			systemText.WriteString(text)
+		}
+	}
+
+	if systemCount < 2 {
+		return msgs
+	}
+
+	merged := make([]Message, 0, len(msgs)-systemCount+1)
+	for i, m := range msgs {
+		if i == firstSystem {
+			m.Content = MessageContent{Content: lo.ToPtr(systemText.String())}
+			merged = append(merged, m)
+		} else if m.Role != "system" {
+			merged = append(merged, m)
+		}
+	}
+	return merged
+}
+
+// messageTextParts extracts the text segments of a message from its string or
+// part-based content.
+func messageTextParts(m Message) []string {
+	var parts []string
+	if m.Content.Content != nil {
+		parts = append(parts, *m.Content.Content)
+	}
+	for _, p := range m.Content.MultipleContent {
+		if p.Type == "text" && p.Text != nil {
+			parts = append(parts, *p.Text)
+		}
+	}
+	return parts
 }
 
 // MessageFromLLM creates OpenAI Message from unified llm.Message.

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -158,19 +158,25 @@ func mergeSystemMessages(msgs []Message) []Message {
 	return merged
 }
 
-// messageTextParts extracts the text segments of a message from its string or
-// part-based content.
+// messageTextParts extracts the text segments of a message. MultipleContent
+// takes precedence over the scalar Content (matching MessageContent.MarshalJSON
+// and the documented mutual-exclusivity rule); the scalar is read only when
+// there are no parts, so a message carrying both representations is not
+// double-counted.
 func messageTextParts(m Message) []string {
-	var parts []string
-	if m.Content.Content != nil {
-		parts = append(parts, *m.Content.Content)
-	}
-	for _, p := range m.Content.MultipleContent {
-		if p.Type == "text" && p.Text != nil {
-			parts = append(parts, *p.Text)
+	if len(m.Content.MultipleContent) > 0 {
+		parts := make([]string, 0, len(m.Content.MultipleContent))
+		for _, p := range m.Content.MultipleContent {
+			if p.Type == "text" && p.Text != nil {
+				parts = append(parts, *p.Text)
+			}
 		}
+		return parts
 	}
-	return parts
+	if m.Content.Content != nil {
+		return []string{*m.Content.Content}
+	}
+	return nil
 }
 
 // MessageFromLLM creates OpenAI Message from unified llm.Message.

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -142,16 +142,18 @@ func mergeSystemMessages(msgs []Message) []Message {
 		}
 	}
 
-	if systemCount < 2 {
+	if systemCount == 0 {
 		return msgs
 	}
 
 	merged := make([]Message, 0, len(msgs)-systemCount+1)
-	for i, m := range msgs {
-		if i == firstSystem {
-			m.Content = MessageContent{Content: lo.ToPtr(systemText.String())}
-			merged = append(merged, m)
-		} else if m.Role != "system" {
+	mergedSystem := msgs[firstSystem]
+	if systemCount > 1 {
+		mergedSystem.Content = MessageContent{Content: lo.ToPtr(systemText.String())}
+	}
+	merged = append(merged, mergedSystem)
+	for _, m := range msgs {
+		if m.Role != "system" {
 			merged = append(merged, m)
 		}
 	}

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -853,3 +853,39 @@ func TestRequestFromLLM_KeepsSingleSystemMessage(t *testing.T) {
 	require.Equal(t, "system", req.Messages[0].Role)
 	require.Equal(t, "You are a coding agent.", *req.Messages[0].Content.Content)
 }
+
+// When a message carries both scalar Content and MultipleContent (both layers
+// treat MultipleContent as authoritative on marshal), merging must emit only
+// the MultipleContent text and not duplicate the scalar.
+func TestRequestFromLLM_MergesSystemMessages_MultipleContentPrecedence(t *testing.T) {
+	req := RequestFromLLM(context.Background(), &llm.Request{
+		Model: "qwen-max",
+		Messages: []llm.Message{
+			{
+				Role: "system",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("STALE SCALAR — must not appear"),
+					MultipleContent: []llm.MessageContentPart{
+						{Type: "text", Text: lo.ToPtr("You are a coding agent.")},
+						{Type: "text", Text: lo.ToPtr("Use rg for searches.")},
+					},
+				},
+			},
+			{
+				Role: "system",
+				Content: llm.MessageContent{
+					Content: lo.ToPtr("Second scalar"),
+				},
+			},
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}, ReasoningFieldNone)
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 2)
+	require.Equal(t, "system", req.Messages[0].Role)
+	merged := *req.Messages[0].Content.Content
+	require.Equal(t, "You are a coding agent.\n\nUse rg for searches.\n\nSecond scalar", merged)
+	require.NotContains(t, merged, "STALE SCALAR")
+	require.Equal(t, "user", req.Messages[1].Role)
+}

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -817,3 +817,39 @@ func TestRequestFromLLM_NormalizesTextPartTypesInMessages(t *testing.T) {
 	require.Equal(t, "text", req.Messages[0].Content.MultipleContent[0].Type)
 	require.Equal(t, "image_url", req.Messages[0].Content.MultipleContent[1].Type)
 }
+
+func TestRequestFromLLM_MergesMultipleSystemMessages(t *testing.T) {
+	req := RequestFromLLM(context.Background(), &llm.Request{
+		Model: "qwen-max",
+		Messages: []llm.Message{
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("You are a coding agent.")}},
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("Use rg for searches.")}},
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("Keep answers short.")}},
+		},
+	}, ReasoningFieldNone)
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 2)
+	require.Equal(t, "system", req.Messages[0].Role)
+	require.Equal(t,
+		"You are a coding agent.\n\nUse rg for searches.\n\nKeep answers short.",
+		*req.Messages[0].Content.Content)
+	require.Equal(t, "user", req.Messages[1].Role)
+	require.Equal(t, "Hello", *req.Messages[1].Content.Content)
+}
+
+func TestRequestFromLLM_KeepsSingleSystemMessage(t *testing.T) {
+	req := RequestFromLLM(context.Background(), &llm.Request{
+		Model: "qwen-max",
+		Messages: []llm.Message{
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("You are a coding agent.")}},
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}, ReasoningFieldNone)
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 2)
+	require.Equal(t, "system", req.Messages[0].Role)
+	require.Equal(t, "You are a coding agent.", *req.Messages[0].Content.Content)
+}

--- a/llm/transformer/openai/outbound_convert_test.go
+++ b/llm/transformer/openai/outbound_convert_test.go
@@ -839,6 +839,22 @@ func TestRequestFromLLM_MergesMultipleSystemMessages(t *testing.T) {
 	require.Equal(t, "Hello", *req.Messages[1].Content.Content)
 }
 
+func TestRequestFromLLM_MovesSingleLateSystemMessageToBeginning(t *testing.T) {
+	req := RequestFromLLM(context.Background(), &llm.Request{
+		Model: "qwen-max",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+			{Role: "system", Content: llm.MessageContent{Content: lo.ToPtr("Use concise answers.")}},
+		},
+	}, ReasoningFieldNone)
+
+	require.NotNil(t, req)
+	require.Len(t, req.Messages, 2)
+	require.Equal(t, "system", req.Messages[0].Role)
+	require.Equal(t, "Use concise answers.", *req.Messages[0].Content.Content)
+	require.Equal(t, "user", req.Messages[1].Role)
+}
+
 func TestRequestFromLLM_KeepsSingleSystemMessage(t *testing.T) {
 	req := RequestFromLLM(context.Background(), &llm.Request{
 		Model: "qwen-max",


### PR DESCRIPTION
## Problem

When a Claude Code client (Anthropic format) is routed through AxonHub to a domestic OpenAI-compatible model, the request intermittently fails with:

> System message must be at the beginning.

## Root cause

Claude Code sends the system prompt as an array (`system.multiple_prompts`). The Anthropic inbound transformer splits this into **multiple `system`-role messages** in the unified `llm.Request`:

- `llm/transformer/anthropic/inbound_convert.go` (the `MultiplePrompts` branch)

The Chat Completions outbound transformer then forwarded those multiple system messages to the upstream verbatim. The OpenAI Chat Completions spec allows a single system message, and strict OpenAI-compatible upstreams (notably domestic model gateways) reject extras with "System message must be at the beginning".

The Responses API outbound already folds system messages into a single `instructions` string (`convertInstructionsFromMessages`), so it was unaffected — only the Chat Completions path had the gap.

## Fix

Collapse all `system`-role messages into a single leading system message in the OpenAI Chat Completions outbound (`llm/transformer/openai/outbound_convert.go`), joining content parts with blank lines (`\n\n`). This mirrors the Anthropic semantics (array of system parts = one system prompt) and the existing Responses-outbound behavior.

Unconditional merging is safe: the Chat Completions spec permits only one system message, and this outbound does not emit `cache_control`, so nothing is lost.

## Tests

Added `TestRequestFromLLM_MergesMultipleSystemMessages` and `TestRequestFromLLM_KeepsSingleSystemMessage` to `llm/transformer/openai/outbound_convert_test.go`. Full package `go test ./transformer/openai/` passes.

## Scope note

This covers OpenAI-format channels (the common case). Anthropic-compatible channels (`*_anthropic`, e.g. `deepseek_anthropic`) still emit `system` as a `multiple_prompts` array, which a downstream relay may internally convert to OpenAI format and hit the same error. Those need a per-channel merge toggle (the array is required for cache breakpoints on real Anthropic), intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI-compatible chat services by consolidating multiple system messages into one.
  * Combined system-message text in its original order, separating each message with a blank line.
  * Ensured system messages appear before non-system messages, including when a single system message was provided later.
  * Corrected content handling so structured text takes precedence over scalar content when both are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->