### PR TITLE
fix: include hy4 models in Tencent catalog

### DIFF
--- a/internal/server/biz/catalog_filter.go
+++ b/internal/server/biz/catalog_filter.go
@@ -278,7 +278,7 @@ func mergeTencentPlans(data catalogFile, filtered *catalogFile) {
 			return
 		}
 		if requireFamily {
-			if normalized != "hy3" && !strings.HasPrefix(normalized, "hy3-") && !strings.HasPrefix(normalized, "hunyuan-") {
+			if normalized != "hy3" && normalized != "hy4" && !strings.HasPrefix(normalized, "hy3-") && !strings.HasPrefix(normalized, "hy4-") && !strings.HasPrefix(normalized, "hunyuan-") {
 				return
 			}
 		}

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -410,7 +410,9 @@ function filterProviders(data, allowedIds) {
 					: id;
 				const isTencentModel =
 					normalizedId === "hy3" ||
+					normalizedId === "hy4" ||
 					normalizedId.startsWith("hy3-") ||
+					normalizedId.startsWith("hy4-") ||
 					normalizedId.startsWith("hunyuan-");
 
 				if (!isTencentModel || mergedModels.has(normalizedId)) continue;

--- a/scripts/sync/sync-model-developers.js
+++ b/scripts/sync/sync-model-developers.js
@@ -429,7 +429,7 @@ function filterProviders(data, allowedIds) {
 				models: Array.from(mergedModels.values()),
 			};
 			console.log(
-				`Merged ${mergedModels.size} Hy3/Hunyuan models into Tencent developer`,
+				`Merged ${mergedModels.size} Hy3/Hy4/Hunyuan models into Tencent developer`,
 			);
 		}
 	}


### PR DESCRIPTION
include hy4 models in Tencent Family Model catalog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing Tencent Hunyuan HY4 model identifiers, including `hy4` and `hy4-*` formats.
  - HY4 models are now correctly grouped with other Tencent Hunyuan models during catalog and developer synchronization.
  - Synchronization logs now clearly identify merged HY3, HY4, and Hunyuan model families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->