### PR TITLE
fix: propagate OpenCode sessions to custom endpoints

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -241,6 +241,9 @@ func (svc *ChannelService) buildChannelWithOutbounds(c *ent.Channel, apiKeyOverr
 		if err != nil {
 			return nil, fmt.Errorf("failed to build outbound for api_format %q on channel %s: %w", ep.APIFormat, c.Name, err)
 		}
+		if c.Type == channel.TypeOpencodeGo || c.Type == channel.TypeOpencodeGoAnthropic {
+			out = opencode.WithSessionHeader(out)
+		}
 		outbounds[ep.APIFormat] = out
 	}
 

--- a/internal/server/biz/channel_llm_endpoint_routing_test.go
+++ b/internal/server/biz/channel_llm_endpoint_routing_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/transformer"
+	"github.com/looplj/axonhub/llm/transformer/opencode"
+	"github.com/looplj/axonhub/llm/transformer/shared"
 )
 
 // TestBuildChannelWithOutbounds_FamilyRoutingOnCustomChatEndpoints asserts that
@@ -120,4 +124,50 @@ func TestBuildChannelWithOutbounds_FamilyRoutingOnCustomChatEndpoints(t *testing
 		// Generic openai normalization appends /v1, which is correct for v1 APIs.
 		require.Equal(t, "https://api.example.com/v1/chat/completions", url)
 	})
+}
+
+func TestBuildChannelWithOutbounds_OpenCodeCustomEndpointsCarrySessionHeader(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:opencode_endpoint_session?mode=memory&_fk=0")
+	t.Cleanup(func() { client.Close() })
+
+	svc := NewChannelServiceForTest(client)
+	ctx := shared.WithSessionID(context.Background(), "session-123")
+	c := &ent.Channel{
+		ID:          1,
+		Name:        "OpenCode",
+		Type:        channel.TypeOpencodeGo,
+		BaseURL:     "https://upstream.example.com",
+		Credentials: objects.ChannelCredentials{APIKey: "test-key"},
+		Endpoints: []objects.ChannelEndpoint{
+			{APIFormat: llm.APIFormatOpenAIChatCompletion.String()},
+			{APIFormat: llm.APIFormatOpenAIResponse.String()},
+			{APIFormat: llm.APIFormatAnthropicMessage.String()},
+		},
+	}
+
+	ch, err := svc.buildChannelWithOutbounds(c)
+	require.NoError(t, err)
+
+	for _, apiFormat := range []string{
+		llm.APIFormatOpenAIChatCompletion.String(),
+		llm.APIFormatOpenAIResponse.String(),
+		llm.APIFormatAnthropicMessage.String(),
+	} {
+		outbound := ch.Outbounds[apiFormat]
+		require.NotNil(t, outbound)
+
+		httpReq, err := outbound.TransformRequest(ctx, &llm.Request{
+			Model: "test-model",
+			Messages: []llm.Message{
+				{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "session-123", httpReq.Headers.Get(opencode.SessionHeader))
+	}
+
+	responsesOutbound := ch.Outbounds[llm.APIFormatOpenAIResponse.String()]
+	require.Implements(t, (*pipeline.ChannelCustomizedExecutor)(nil), responsesOutbound)
+	require.Implements(t, (*transformer.TransportRequestFinalizer)(nil), responsesOutbound)
+	require.Implements(t, (*stoppableOutbound)(nil), responsesOutbound)
 }

--- a/llm/transformer/opencode/outbound.go
+++ b/llm/transformer/opencode/outbound.go
@@ -11,6 +11,7 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
 	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/anthropic"
@@ -62,10 +63,17 @@ type OutboundTransformer struct {
 	anthropic transformer.Outbound
 }
 
-// sessionHeaderOutbound adds the OpenCode Go session header to a protocol-specific
-// outbound transformer. It is used by the legacy Anthropic-only channel.
+// sessionHeaderOutbound adds OpenCode session affinity to an outbound.
 type sessionHeaderOutbound struct {
 	transformer.Outbound
+}
+
+// sessionHeaderCustomizedOutbound preserves customized executor behavior for
+// outbounds such as OpenAI Responses while adding OpenCode session affinity.
+type sessionHeaderCustomizedOutbound struct {
+	*sessionHeaderOutbound
+
+	customizer pipeline.ChannelCustomizedExecutor
 }
 
 // WithSessionHeader decorates an outbound transformer with OpenCode Go session affinity.
@@ -74,7 +82,15 @@ func WithSessionHeader(outbound transformer.Outbound) transformer.Outbound {
 		return nil
 	}
 
-	return &sessionHeaderOutbound{Outbound: outbound}
+	wrapped := &sessionHeaderOutbound{Outbound: outbound}
+	if customizer, ok := outbound.(pipeline.ChannelCustomizedExecutor); ok {
+		return &sessionHeaderCustomizedOutbound{
+			sessionHeaderOutbound: wrapped,
+			customizer:            customizer,
+		}
+	}
+
+	return wrapped
 }
 
 // NewOutboundTransformer creates a new OpenCode Go OutboundTransformer with legacy parameters.
@@ -219,6 +235,27 @@ func (t *sessionHeaderOutbound) TransformRequest(ctx context.Context, llmReq *ll
 	setSessionHeader(ctx, llmReq, httpReq)
 
 	return httpReq, nil
+}
+
+// CustomizeExecutor forwards executor customization to the wrapped outbound.
+func (t *sessionHeaderCustomizedOutbound) CustomizeExecutor(executor pipeline.Executor) pipeline.Executor {
+	return t.customizer.CustomizeExecutor(executor)
+}
+
+// FinalizeTransportRequest forwards transport cleanup when supported.
+func (t *sessionHeaderCustomizedOutbound) FinalizeTransportRequest(request *httpclient.Request) *httpclient.Request {
+	if finalizer, ok := t.Outbound.(transformer.TransportRequestFinalizer); ok {
+		return finalizer.FinalizeTransportRequest(request)
+	}
+
+	return request
+}
+
+// Stop releases resources owned by the wrapped outbound when supported.
+func (t *sessionHeaderCustomizedOutbound) Stop() {
+	if stoppable, ok := t.Outbound.(interface{ Stop() }); ok {
+		stoppable.Stop()
+	}
 }
 
 func setSessionHeader(ctx context.Context, llmReq *llm.Request, httpReq *httpclient.Request) {

--- a/llm/transformer/opencode/outbound_test.go
+++ b/llm/transformer/opencode/outbound_test.go
@@ -13,11 +13,18 @@ import (
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
 	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer"
 	"github.com/looplj/axonhub/llm/transformer/anthropic"
 	"github.com/looplj/axonhub/llm/transformer/deepseek"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 	"github.com/looplj/axonhub/llm/transformer/shared"
 )
+
+type stoppableOutbound interface {
+	Stop()
+}
 
 func newTestTransformer(t *testing.T) *OutboundTransformer {
 	t.Helper()
@@ -192,6 +199,19 @@ func TestOutboundTransformer_TransformRequest_GeneratesSessionHeader(t *testing.
 	})
 	require.NoError(t, err)
 	assert.NotEmpty(t, httpReq.Headers.Get(SessionHeader))
+}
+
+func TestWithSessionHeader_PreservesCustomizedOutboundCapabilities(t *testing.T) {
+	base, err := responses.NewOutboundTransformerWithConfig(&responses.Config{
+		BaseURL:        "https://opencode.ai/zen/go",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-api-key"),
+	})
+	require.NoError(t, err)
+
+	wrapped := WithSessionHeader(base)
+	require.Implements(t, (*pipeline.ChannelCustomizedExecutor)(nil), wrapped)
+	require.Implements(t, (*transformer.TransportRequestFinalizer)(nil), wrapped)
+	require.Implements(t, (*stoppableOutbound)(nil), wrapped)
 }
 
 func TestWithSessionHeader_AnthropicOutbound(t *testing.T) {


### PR DESCRIPTION
修复自定义端口配置导致的OpenCode Session标头缺失问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OpenCode requests now consistently include the active session identifier when using OpenAI Chat, OpenAI Responses, or Anthropic endpoints.
  - Existing endpoint capabilities, including specialized request handling and graceful stopping, continue to work when session tracking is enabled.
  - Session-header handling remains limited to supported OpenCode channel types; other channel behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->