### PR TITLE
feat: archive personal api keys when delete user, close #2272

### DIFF
--- a/internal/server/biz/api_key.go
+++ b/internal/server/biz/api_key.go
@@ -574,6 +574,75 @@ func (s *APIKeyService) UpdateAPIKeyStatus(ctx context.Context, id int, status a
 	return apiKey, nil
 }
 
+func (s *APIKeyService) updatePersonalAPIKeyStatusByUser(
+	ctx context.Context,
+	userID int,
+	fromStatuses []apikey.Status,
+	toStatus apikey.Status,
+	action string,
+) error {
+	ctx = authz.WithSystemBypass(ctx, "update-user-personal-api-key-status")
+	client := s.entFromContext(ctx)
+	predicate := apikey.And(
+		apikey.UserIDEQ(userID),
+		apikey.TypeEQ(apikey.TypePersonal),
+		apikey.StatusIn(fromStatuses...),
+	)
+
+	apiKeys, err := client.APIKey.Query().
+		Where(predicate).
+		All(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to query user personal API keys: %w", err)
+	}
+
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	_, err = client.APIKey.Update().
+		Where(predicate).
+		SetStatus(toStatus).
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to %s user personal API keys: %w", action, err)
+	}
+
+	keys := lo.Map(apiKeys, func(apiKey *ent.APIKey, _ int) string { return apiKey.Key })
+	runAfterCommit(ctx, func(ctx context.Context) {
+		for _, key := range keys {
+			s.APIKeyCache.Invalidate(buildAPIKeyCacheKey(key))
+		}
+		s.invalidateAPIKeyCaches(ctx, keys...)
+	})
+
+	return nil
+}
+
+// archivePersonalAPIKeysByUser archives all non-archived personal API keys
+// created by a user.
+func (s *APIKeyService) archivePersonalAPIKeysByUser(ctx context.Context, userID int) error {
+	return s.updatePersonalAPIKeyStatusByUser(
+		ctx,
+		userID,
+		[]apikey.Status{apikey.StatusEnabled, apikey.StatusDisabled},
+		apikey.StatusArchived,
+		"archive",
+	)
+}
+
+// disablePersonalAPIKeysByUser disables all enabled personal API keys created
+// by a user.
+func (s *APIKeyService) disablePersonalAPIKeysByUser(ctx context.Context, userID int) error {
+	return s.updatePersonalAPIKeyStatusByUser(
+		ctx,
+		userID,
+		[]apikey.Status{apikey.StatusEnabled},
+		apikey.StatusDisabled,
+		"disable",
+	)
+}
+
 // UpdateAPIKeyProfiles updates the profiles of an API key.
 func (s *APIKeyService) UpdateAPIKeyProfiles(ctx context.Context, id int, profiles objects.APIKeyProfiles) (*ent.APIKey, error) {
 	client := s.entFromContext(ctx)

--- a/internal/server/biz/auth_test.go
+++ b/internal/server/biz/auth_test.go
@@ -112,6 +112,7 @@ func setupTestAuthService(t *testing.T, cacheConfig xcache.Config) (*AuthService
 		ProjectService: projectService,
 		KeyPrefix:      "ah",
 	})
+	userService.apiKeyService = apiKeyService
 
 	authService := &AuthService{
 		SystemService: systemService,

--- a/internal/server/biz/user.go
+++ b/internal/server/biz/user.go
@@ -23,14 +23,16 @@ import (
 type UserServiceParams struct {
 	fx.In
 
-	CacheConfig xcache.Config
-	Ent         *ent.Client
+	CacheConfig   xcache.Config
+	Ent           *ent.Client
+	APIKeyService *APIKeyService
 }
 
 type UserService struct {
 	*AbstractService
 
 	UserCache           xcache.Cache[ent.User]
+	apiKeyService       *APIKeyService
 	permissionValidator *PermissionValidator
 }
 
@@ -40,6 +42,7 @@ func NewUserService(params UserServiceParams) *UserService {
 			db: params.Ent,
 		},
 		UserCache:           xcache.NewFromConfig[ent.User](params.CacheConfig),
+		apiKeyService:       params.APIKeyService,
 		permissionValidator: NewPermissionValidator(),
 	}
 }
@@ -208,19 +211,36 @@ func (s *UserService) UpdateOwnProfile(ctx context.Context, input ent.UpdateUser
 
 // UpdateUserStatus updates the status of a user.
 func (s *UserService) UpdateUserStatus(ctx context.Context, id int, status user.Status) (*ent.User, error) {
-	client := s.entFromContext(ctx)
+	var updatedUser *ent.User
 
-	user, err := client.User.UpdateOneID(id).
-		SetStatus(status).
-		Save(ctx)
+	err := s.RunInTransaction(ctx, func(ctx context.Context) error {
+		client := s.entFromContext(ctx)
+
+		result, err := client.User.UpdateOneID(id).
+			SetStatus(status).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to update user status: %w", err)
+		}
+		updatedUser = result
+
+		if status == user.StatusDeactivated {
+			if err := s.apiKeyService.disablePersonalAPIKeysByUser(ctx, id); err != nil {
+				return fmt.Errorf("failed to disable user personal API keys: %w", err)
+			}
+		}
+
+		runAfterCommit(ctx, func(ctx context.Context) {
+			s.invalidateUserCache(ctx, id)
+		})
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update user status: %w", err)
+		return nil, err
 	}
 
-	// Invalidate cache
-	s.invalidateUserCache(ctx, id)
-
-	return user, nil
+	return updatedUser, nil
 }
 
 // GetUserByID gets a user by ID with caching.
@@ -564,8 +584,9 @@ func (s *UserService) UpdateProjectUser(ctx context.Context, userID, projectID i
 // 2. Checks if user is owner (cannot delete owner)
 // 3. Removes user from all projects (UserProject)
 // 4. Removes all user roles (UserRole)
-// 5. Soft deletes the user
-// 6. Invalidates user cache.
+// 5. Archives the user's personal API keys
+// 6. Soft deletes the user
+// 7. Invalidates user cache.
 func (s *UserService) DeleteUser(ctx context.Context, id int) error {
 	// Validate permissions before deleting
 	if err := s.permissionValidator.CanDeleteUser(ctx, id); err != nil {
@@ -602,13 +623,18 @@ func (s *UserService) DeleteUser(ctx context.Context, id int) error {
 			return fmt.Errorf("failed to delete user roles: %w", err)
 		}
 
-		// 3. Soft delete the user
+		// 3. Archive the user's personal API keys
+		if err = s.apiKeyService.archivePersonalAPIKeysByUser(ctx, id); err != nil {
+			return fmt.Errorf("failed to archive user personal API keys: %w", err)
+		}
+
+		// 4. Soft delete the user
 		err = client.User.DeleteOneID(id).Exec(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to delete user: %w", err)
 		}
 
-		// 4. Invalidate user cache
+		// 5. Invalidate user cache
 		s.invalidateUserCache(ctx, id)
 
 		return nil

--- a/internal/server/biz/user_test.go
+++ b/internal/server/biz/user_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/ent/role"
 	"github.com/looplj/axonhub/internal/ent/user"
@@ -27,6 +28,26 @@ func setupTestUserService(t *testing.T) (*UserService, *ent.Client) {
 	}
 
 	return userService, client
+}
+
+func setupTestUserAPIKeyService(t *testing.T, userService *UserService, client *ent.Client) *APIKeyService {
+	t.Helper()
+
+	cacheConfig := xcache.Config{Mode: xcache.ModeMemory}
+	projectService := NewProjectService(ProjectServiceParams{
+		CacheConfig: cacheConfig,
+		Ent:         client,
+	})
+	apiKeyService := NewAPIKeyService(APIKeyServiceParams{
+		CacheConfig:    cacheConfig,
+		Ent:            client,
+		ProjectService: projectService,
+		KeyPrefix:      "ah",
+	})
+	t.Cleanup(apiKeyService.Stop)
+	userService.apiKeyService = apiKeyService
+
+	return apiKeyService
 }
 
 // createOwnerUser creates an owner user for testing permission-protected operations.
@@ -1182,6 +1203,7 @@ func TestUpdateUser_CacheInvalidation(t *testing.T) {
 func TestUpdateUserStatus_CacheInvalidation(t *testing.T) {
 	userService, client := setupTestUserService(t)
 	defer client.Close()
+	setupTestUserAPIKeyService(t, userService, client)
 
 	ctx := context.Background()
 	ctx = ent.NewContext(ctx, client)
@@ -1211,6 +1233,85 @@ func TestUpdateUserStatus_CacheInvalidation(t *testing.T) {
 	// Verify cache was invalidated
 	_, err = userService.UserCache.Get(ctx, cacheKey)
 	require.Error(t, err, "User cache should be invalidated after status update")
+}
+
+func TestUpdateUserStatusDeactivatedDisablesOnlyPersonalAPIKeys(t *testing.T) {
+	userService, client := setupTestUserService(t)
+	defer client.Close()
+	apiKeyService := setupTestUserAPIKeyService(t, userService, client)
+
+	ctx := ent.NewContext(context.Background(), client)
+	ctx = authz.WithTestBypass(ctx)
+
+	testUser, err := client.User.Create().
+		SetEmail("deactivate@example.com").
+		SetPassword("password").
+		SetStatus(user.StatusActivated).
+		Save(ctx)
+	require.NoError(t, err)
+
+	project, err := client.Project.Create().
+		SetName("Deactivate User Project").
+		Save(ctx)
+	require.NoError(t, err)
+
+	personalKey, err := client.APIKey.Create().
+		SetKey("ah-deactivate-personal-key").
+		SetName("Deactivate Personal Key").
+		SetType(apikey.TypePersonal).
+		SetUser(testUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	userKey, err := client.APIKey.Create().
+		SetKey("ah-deactivate-user-key").
+		SetName("Deactivate User Key").
+		SetType(apikey.TypeUser).
+		SetUser(testUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	serviceKey, err := client.APIKey.Create().
+		SetKey("ah-deactivate-service-key").
+		SetName("Deactivate Service Key").
+		SetType(apikey.TypeServiceAccount).
+		SetUser(testUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	cachedKey, err := apiKeyService.GetAPIKey(ctx, personalKey.Key)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, cachedKey.Status)
+
+	updatedUser, err := userService.UpdateUserStatus(ctx, testUser.ID, user.StatusDeactivated)
+	require.NoError(t, err)
+	require.Equal(t, user.StatusDeactivated, updatedUser.Status)
+
+	disabledPersonalKey, err := client.APIKey.Get(ctx, personalKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusDisabled, disabledPersonalKey.Status)
+
+	unchangedUserKey, err := client.APIKey.Get(ctx, userKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, unchangedUserKey.Status)
+
+	unchangedServiceKey, err := client.APIKey.Get(ctx, serviceKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, unchangedServiceKey.Status)
+
+	refreshedKey, err := apiKeyService.GetAPIKey(ctx, personalKey.Key)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusDisabled, refreshedKey.Status)
+
+	// Reactivating the user must not silently re-enable revoked personal keys.
+	_, err = userService.UpdateUserStatus(ctx, testUser.ID, user.StatusActivated)
+	require.NoError(t, err)
+	personalKeyAfterReactivation, err := client.APIKey.Get(ctx, personalKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusDisabled, personalKeyAfterReactivation.Status)
 }
 
 func TestAddUserToProject_CacheInvalidation(t *testing.T) {
@@ -1472,4 +1573,113 @@ func TestUpdateProjectUser_UpdateIsOwner_PermissionDenied(t *testing.T) {
 		Only(ctx)
 	require.NoError(t, err)
 	require.False(t, userProject.IsOwner)
+}
+
+func TestDeleteUserArchivesOnlyPersonalAPIKeysAndInvalidatesCache(t *testing.T) {
+	userService, client := setupTestUserService(t)
+	defer client.Close()
+	apiKeyService := setupTestUserAPIKeyService(t, userService, client)
+
+	ctx := ent.NewContext(context.Background(), client)
+	ctx = authz.WithTestBypass(ctx)
+	owner := createOwnerUser(t, ctx, client)
+	ctx = contexts.WithUser(ctx, owner)
+
+	targetUser, err := client.User.Create().
+		SetEmail("target@example.com").
+		SetPassword("password").
+		Save(ctx)
+	require.NoError(t, err)
+
+	otherUser, err := client.User.Create().
+		SetEmail("other@example.com").
+		SetPassword("password").
+		Save(ctx)
+	require.NoError(t, err)
+
+	project, err := client.Project.Create().
+		SetName("Test Project").
+		Save(ctx)
+	require.NoError(t, err)
+
+	targetKey, err := client.APIKey.Create().
+		SetKey("ah-target-key").
+		SetName("Target Key").
+		SetType(apikey.TypePersonal).
+		SetUser(targetUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	disabledPersonalKey, err := client.APIKey.Create().
+		SetKey("ah-target-disabled-personal-key").
+		SetName("Target Disabled Personal Key").
+		SetType(apikey.TypePersonal).
+		SetStatus(apikey.StatusDisabled).
+		SetUser(targetUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	targetUserKey, err := client.APIKey.Create().
+		SetKey("ah-target-user-key").
+		SetName("Target User Key").
+		SetType(apikey.TypeUser).
+		SetUser(targetUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	targetServiceKey, err := client.APIKey.Create().
+		SetKey("ah-target-service-key").
+		SetName("Target Service Key").
+		SetType(apikey.TypeServiceAccount).
+		SetUser(targetUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	otherKey, err := client.APIKey.Create().
+		SetKey("ah-other-key").
+		SetName("Other Key").
+		SetUser(otherUser).
+		SetProject(project).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Prime the cache with the enabled value before deleting the user.
+	cachedKey, err := apiKeyService.GetAPIKey(ctx, targetKey.Key)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, cachedKey.Status)
+
+	require.NoError(t, userService.DeleteUser(ctx, targetUser.ID))
+
+	archivedKey, err := client.APIKey.Get(ctx, targetKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusArchived, archivedKey.Status)
+
+	archivedDisabledKey, err := client.APIKey.Get(ctx, disabledPersonalKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusArchived, archivedDisabledKey.Status)
+
+	userKey, err := client.APIKey.Get(ctx, targetUserKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, userKey.Status)
+
+	serviceKey, err := client.APIKey.Get(ctx, targetServiceKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, serviceKey.Status)
+
+	unrelatedKey, err := client.APIKey.Get(ctx, otherKey.ID)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusEnabled, unrelatedKey.Status)
+
+	// A read immediately after deletion must not return the stale enabled cache entry.
+	refreshedKey, err := apiKeyService.GetAPIKey(ctx, targetKey.Key)
+	require.NoError(t, err)
+	require.Equal(t, apikey.StatusArchived, refreshedKey.Status)
+
+	authService := &AuthService{APIKeyService: apiKeyService}
+	_, err = authService.AuthenticateAPIKey(ctx, targetKey.Key)
+	require.ErrorContains(t, err, "api key not enabled")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deactivating a user now disables their personal API keys.
  * Reactivating a user does not re-enable previously revoked personal keys.
  * Deleting a user now archives all of their personal API keys, including disabled keys.
  * API-key caches are refreshed after status changes and deletion, preventing archived or disabled keys from being used.
  * Keys belonging to other users, service accounts, and the user account itself remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->