### PR TITLE
feat: fire webhook when api key disabled, close #2380

### DIFF
--- a/internal/server/biz/channel_apikey.go
+++ b/internal/server/biz/channel_apikey.go
@@ -86,10 +86,16 @@ func (svc *ChannelService) DisableAPIKey(
 
 	// 如果没有可用 key 了，禁用整个 channel
 	channelDisabled := len(enabledKeys) == 0
+	var (
+		autoDisabledAt     time.Time
+		autoDisabledReason string
+	)
 	if channelDisabled {
+		autoDisabledAt = time.Now()
+		autoDisabledReason = fmt.Sprintf("%s (last error: %d)", allKeysDisabledErrorPrefix, errorCode)
 		update.SetStatus(channel.StatusDisabled)
-		update.SetErrorMessage(fmt.Sprintf("%s (last error: %d)", allKeysDisabledErrorPrefix, errorCode))
-		update.SetAutoDisabledAt(time.Now())
+		update.SetErrorMessage(autoDisabledReason)
+		update.SetAutoDisabledAt(autoDisabledAt)
 		log.Warn(ctx, "Channel disabled because all API keys are disabled",
 			log.Int("channel_id", channelID),
 			log.String("channel_name", ch.Name),
@@ -106,6 +112,17 @@ func (svc *ChannelService) DisableAPIKey(
 	)
 
 	if channelDisabled {
+		svc.asyncNotifyChannelAutoDisabled(ctx, ChannelAutoDisabledEvent{
+			ChannelID:       ch.ID,
+			ChannelName:     ch.Name,
+			ChannelProvider: ch.Type.String(),
+			ChannelBaseURL:  ch.BaseURL,
+			ChannelStatus:   channel.StatusDisabled.String(),
+			StatusCode:      errorCode,
+			Reason:          autoDisabledReason,
+			OccurredAt:      autoDisabledAt,
+		})
+
 		// Synchronously reload the local cache to immediately stop selecting this channel.
 		// This matches the behavior of markChannelUnavailable.
 		reloadCtx, cancel := xcontext.DetachWithTimeout(ctx, 10*time.Second)

--- a/internal/server/biz/channel_auto_disable.go
+++ b/internal/server/biz/channel_auto_disable.go
@@ -77,8 +77,7 @@ func (svc *ChannelService) markChannelUnavailable(ctx context.Context, channelID
 			log.Cause(err),
 		)
 	} else {
-		notifyCtx := context.WithoutCancel(ctx)
-		go svc.WebhookNotifier.NotifyChannelAutoDisabled(notifyCtx, ChannelAutoDisabledEvent{
+		svc.asyncNotifyChannelAutoDisabled(ctx, ChannelAutoDisabledEvent{
 			ChannelID:       updatedChannel.ID,
 			ChannelName:     updatedChannel.Name,
 			ChannelProvider: updatedChannel.Type.String(),
@@ -103,6 +102,20 @@ func (svc *ChannelService) markChannelUnavailable(ctx context.Context, channelID
 
 	// Also notify other instances via the watcher for cross-instance cache invalidation.
 	svc.asyncReloadChannels()
+}
+
+func (svc *ChannelService) asyncNotifyChannelAutoDisabled(ctx context.Context, event ChannelAutoDisabledEvent) {
+	notifyCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error(notifyCtx, "channel auto-disabled webhook notification panicked", log.Any("panic", r))
+			}
+		}()
+
+		svc.WebhookNotifier.NotifyChannelAutoDisabled(notifyCtx, event)
+	}()
 }
 
 // resolveAutoDisableStatuses returns the global auto-disable thresholds, which

--- a/internal/server/biz/channel_auto_disable_test.go
+++ b/internal/server/biz/channel_auto_disable_test.go
@@ -2,6 +2,10 @@ package biz
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -406,6 +410,75 @@ func TestChannelService_DisableAllAPIKeysDisablesChannel(t *testing.T) {
 	require.Equal(t, channel.StatusDisabled, updatedCh.Status)
 	require.Len(t, updatedCh.DisabledAPIKeys, 2)
 	require.NotNil(t, updatedCh.ErrorMessage)
+}
+
+func TestChannelService_DisableAllAPIKeysNotifiesWebhook(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	type webhookRequest struct {
+		body string
+		err  error
+	}
+	notifications := make(chan webhookRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		notifications <- webhookRequest{body: string(body), err: err}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := WebhookNotifierConfig{
+		Targets: []WebhookTarget{
+			{
+				Name:      "default",
+				Enabled:   true,
+				URL:       server.URL,
+				TimeoutMs: 1000,
+				Body:      `{"event":"{{.Event}}","channel_id":{{.Channel.ID}},"channel_name":"{{.Channel.Name}}","provider":"{{.Channel.Provider}}","base_url":"{{.Channel.BaseURL}}","status":"{{.Channel.Status}}","status_code":{{.Trigger.StatusCode}},"reason":"{{.Trigger.Reason}}"}`,
+			},
+		},
+		Subscriptions: []WebhookSubscription{
+			{Event: EventChannelAutoDisabled, TargetNames: []string{"default"}},
+		},
+	}
+
+	svc := newTestChannelService(client)
+	svc.SystemService = newTestSystemServiceWithWebhookConfig(t, client, cfg)
+	svc.WebhookNotifier = NewWebhookNotifier(svc.SystemService, httpclient.NewHttpClient())
+
+	ch := createTestChannelWithAPIKeys(t, client, ctx, "test-channel-webhook", []string{"key1", "key2"})
+
+	require.NoError(t, svc.DisableAPIKey(ctx, ch.ID, "key1", 500, "first key failed"))
+
+	select {
+	case notification := <-notifications:
+		t.Fatalf("received webhook before channel was disabled: %s", notification.body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(t, svc.DisableAPIKey(ctx, ch.ID, "key2", 500, "second key failed"))
+
+	select {
+	case notification := <-notifications:
+		require.NoError(t, notification.err)
+		require.JSONEq(t, fmt.Sprintf(`{
+			"event": "channel.auto_disabled",
+			"channel_id": %d,
+			"channel_name": "test-channel-webhook",
+			"provider": "openai",
+			"base_url": "https://api.openai.com",
+			"status": "disabled",
+			"status_code": 500,
+			"reason": "All API keys disabled (last error: 500)"
+		}`, ch.ID), notification.body)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel auto-disabled webhook")
+	}
 }
 
 func TestChannelService_SuccessClearsErrorCounts(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added webhook notifications when a channel is automatically disabled after all of its API keys are exhausted.
  - Notifications include the channel’s automatic-disable timestamp and reason.
  - Webhook delivery continues independently of the request that triggered the channel disablement, improving notification reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->