### PR TITLE
fix(api): suppress stream errors after terminal events, close #2318

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ run:
 linters:
   default: all
   disable:
+    # Protocol strings may require British spelling (e.g. cancelled).
+    - misspell
     - prealloc
     - exhaustive
     - containedctx
@@ -157,11 +159,6 @@ linters:
       line-length: 180
       # tab width in spaces. Default to 1.
       tab-width: 1
-    misspell:
-      # Correct spellings using locale preferences for US or UK.
-      # Default is to use a neutral variety of English.
-      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-      locale: US
     nakedret:
       # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
       max-func-lines: 30

--- a/internal/server/api/chat.go
+++ b/internal/server/api/chat.go
@@ -362,6 +362,10 @@ func writeSSEStreamEnd(
 ) {
 	switch {
 	case terminalSeen:
+		if streamErr != nil {
+			log.Warn(ctx, "Stream error after terminal event was delivered, suppressing trailing error event",
+				log.Cause(streamErr))
+		}
 	case errors.Is(ctx.Err(), context.Canceled):
 		*clientDisconnected = true
 

--- a/internal/server/api/chat_test.go
+++ b/internal/server/api/chat_test.go
@@ -1193,6 +1193,44 @@ func TestWriteSSEStream_TerminalEventWinsDeadlineRace(t *testing.T) {
 	require.NotContains(t, w.Body.String(), "event:error")
 }
 
+func TestWriteSSEStream_ResponsesErrorAfterTerminalIsSuppressed(t *testing.T) {
+	tests := []struct {
+		name      string
+		keepAlive SSEKeepAliveConfig
+	}{
+		{name: "without heartbeat"},
+		{
+			name: "with heartbeat",
+			keepAlive: SSEKeepAliveConfig{
+				Enabled:  true,
+				Interval: time.Hour,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+			stream := &errorAfterStream{
+				items: []*httpclient.StreamEvent{
+					{Type: "response.created", Data: []byte(`{"type":"response.created"}`)},
+					{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"status":"completed"}}`)},
+				},
+				err: fmt.Errorf("read body: %w", io.ErrUnexpectedEOF),
+			}
+
+			writeSSEStream(c, stream, FormatStreamError, tt.keepAlive, sseHeartbeatOpenAI)
+
+			body := w.Body.String()
+			require.Contains(t, body, "response.completed")
+			require.NotContains(t, body, "event:error")
+			require.NotContains(t, body, io.ErrUnexpectedEOF.Error())
+		})
+	}
+}
+
 func TestWriteSSEStream_RefreshesWriteDeadline(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -1276,4 +1314,44 @@ func TestUpstreamErrorStream_PassthroughClassifiesTransportError(t *testing.T) {
 	stream = newUpstreamErrorStream(ctx, &errorAfterStream{err: plain}, systemService)
 	require.False(t, stream.Next())
 	assert.Equal(t, plain, stream.Err())
+}
+
+func TestWriteSSEStream_StandaloneErrorIsTerminal(t *testing.T) {
+	for _, event := range []*httpclient.StreamEvent{
+		{Type: "error", Data: []byte(`{"error":{"message":"provider failed"}}`)},
+		{Data: []byte(`{"type":"error","error":{"message":"provider failed"}}`)},
+	} {
+		name := "json_type"
+		if event.Type != "" {
+			name = "sse_type"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, heartbeat := range []bool{false, true} {
+				name := "without_heartbeat"
+				if heartbeat {
+					name = "with_heartbeat"
+				}
+				t.Run(name, func(t *testing.T) {
+					for _, streamErr := range []error{nil, io.ErrUnexpectedEOF} {
+						name := "clean_eof"
+						if streamErr != nil {
+							name = "transport_error"
+						}
+						t.Run(name, func(t *testing.T) {
+							w := httptest.NewRecorder()
+							c, _ := gin.CreateTestContext(w)
+							c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+							stream := &errorAfterStream{items: []*httpclient.StreamEvent{event}, err: streamErr}
+							writeSSEStream(c, stream, FormatStreamError, SSEKeepAliveConfig{Enabled: heartbeat, Interval: time.Hour}, sseHeartbeatOpenAI)
+							body := w.Body.String()
+							require.Equal(t, 1, strings.Count(body, "data:"))
+							require.Contains(t, body, string(event.Data))
+							require.NotContains(t, body, orchestrator.ErrStreamIncomplete.Error())
+							require.NotContains(t, body, io.ErrUnexpectedEOF.Error())
+						})
+					}
+				})
+			}
+		})
+	}
 }

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -456,10 +456,11 @@ type LatencyMetrics struct {
 	ReasoningDurationMs *int64
 }
 
-// UpdateRequestCompleted updates request status to completed with response body.
-func (s *RequestService) UpdateRequestCompleted(
+// UpdateRequestFinalized persists a terminal response and its final request status.
+func (s *RequestService) UpdateRequestFinalized(
 	ctx context.Context,
 	requestID int,
+	status request.Status,
 	externalId string,
 	responseBody any,
 	metrics *LatencyMetrics,
@@ -491,7 +492,7 @@ func (s *RequestService) UpdateRequestCompleted(
 	}
 
 	upd := client.Request.UpdateOneID(requestID).
-		SetStatus(request.StatusCompleted).
+		SetStatus(status).
 		SetExternalID(externalId)
 
 	// Set latency metrics if provided
@@ -744,10 +745,12 @@ func (s *RequestService) UpdateRequestStatusExternalIDAndResponseBody(
 	return nil
 }
 
-// UpdateRequestExecutionCompleted updates request execution status to completed with response body.
-func (s *RequestService) UpdateRequestExecutionCompleted(
+// UpdateRequestExecutionFinalized persists a terminal response and its final execution status.
+func (s *RequestService) UpdateRequestExecutionFinalized(
 	ctx context.Context,
 	executionID int,
+	status requestexecution.Status,
+	errorMessage string,
 	externalId string,
 	responseBody any,
 	metrics *LatencyMetrics,
@@ -779,8 +782,11 @@ func (s *RequestService) UpdateRequestExecutionCompleted(
 	}
 
 	upd := client.RequestExecution.UpdateOneID(executionID).
-		SetStatus(requestexecution.StatusCompleted).
+		SetStatus(status).
 		SetExternalID(externalId)
+	if errorMessage != "" {
+		upd = upd.SetErrorMessage(errorMessage)
+	}
 
 	// Set latency metrics if provided
 	if metrics != nil {
@@ -826,7 +832,7 @@ func (s *RequestService) UpdateRequestExecutionCompleted(
 	_, err = upd.Save(ctx)
 	if err != nil {
 		s.rollbackExternalPayload(ctx, dataStorage, savedExternalKey)
-		log.Error(ctx, "Failed to update request execution status to completed", log.Cause(err))
+		log.Error(ctx, "Failed to update finalized request execution", log.Cause(err), log.Any("status", status))
 		return err
 	}
 

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/dumper"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
@@ -21,6 +22,16 @@ import (
 // event and without an aggregated complete response. The same value is persisted
 // on the request and delivered to the client, so both sides agree on the reason.
 var ErrStreamIncomplete = errors.New("stream ended without terminal event or completed response")
+
+type streamTerminalState string
+
+const (
+	streamTerminalNone       streamTerminalState = ""
+	streamTerminalCompleted  streamTerminalState = "completed"
+	streamTerminalFailed     streamTerminalState = "failed"
+	streamTerminalIncomplete streamTerminalState = "incomplete"
+	streamTerminalCanceled   streamTerminalState = "canceled"
+)
 
 // InboundPersistentStream wraps a stream and tracks all responses for final saving to database.
 // It implements the streams.Stream interface and handles persistence in the Close method.
@@ -35,6 +46,7 @@ type InboundPersistentStream struct {
 	transformer    transformer.Inbound
 	perf           *biz.PerformanceRecord
 	responseChunks []*httpclient.StreamEvent
+	terminalState  streamTerminalState
 	closed         bool
 	state          *PersistenceState
 }
@@ -77,18 +89,22 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
-		if IsTerminalStreamEvent(event) {
-			ts.state.StreamCompleted = true
+		if ts.terminalState == streamTerminalNone {
+			ts.terminalState = classifyStreamTerminalEvent(event)
+			if ts.terminalState != streamTerminalNone {
+				ts.terminalState = ts.finalTerminalState()
+				ts.state.StreamCompleted = ts.terminalState == streamTerminalCompleted
+			}
 		}
 	}
 
 	return event
 }
 
-// IsTerminalStreamEvent checks both SSE metadata and JSON data for a successful
-// protocol-level or semantic completion marker. The SSE writers use it to decide
-// whether the client actually received a completion marker, so this must stay the
-// single source of truth for "the stream ended properly".
+// IsTerminalStreamEvent checks both SSE metadata and JSON data for a
+// protocol-level terminal marker. The SSE writers use it to decide whether the
+// client already received the stream outcome, so this must stay the single source
+// of truth for "the stream ended properly".
 func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	if event == nil {
 		return false
@@ -96,8 +112,8 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 
 	// For chat completions, check for [DONE] event
 	if bytes.Equal(event.Data, llm.DoneStreamEvent.Data) ||
-		// For Responses API, check for response.completed event
-		event.Type == "response.completed" ||
+		// For Responses API, check for all terminal response events
+		isResponsesTerminalEvent(event.Type) ||
 		// For Anthropic Messages API, check for message_stop event
 		event.Type == "message_stop" ||
 		// For OpenAI audio APIs (TTS sse / STT stream) which have no [DONE] sentinel:
@@ -115,7 +131,10 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	// the trailing [DONE] marker is read by the server.
 	eventType := gjson.GetBytes(event.Data, "type").String()
 	switch eventType {
-	case "response.completed", "message_stop", "speech.audio.done", "transcript.text.done":
+	case "message_stop", "speech.audio.done", "transcript.text.done":
+		return true
+	}
+	if isResponsesTerminalEvent(eventType) {
 		return true
 	}
 
@@ -127,6 +146,61 @@ func IsTerminalStreamEvent(event *httpclient.StreamEvent) bool {
 	// Gemini generateContent streams have no [DONE] sentinel. Completion is
 	// signaled by candidates[].finishReason (e.g. STOP, MAX_TOKENS, SAFETY).
 	return hasNonEmptyJSONStringField(event.Data, "candidates", "finishReason")
+}
+
+func isResponsesTerminalEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.incomplete", "response.cancelled", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func classifyStreamTerminalEvent(event *httpclient.StreamEvent) streamTerminalState {
+	if !IsTerminalStreamEvent(event) {
+		return streamTerminalNone
+	}
+	const responseStatusCanceledBritish = "cancelled" //nolint:misspell // OpenAI protocol spelling.
+
+	eventType := event.Type
+	jsonEventType := gjson.GetBytes(event.Data, "type").String()
+	responseStatus := gjson.GetBytes(event.Data, "response.status").String()
+
+	// Standalone errors can arrive before response.created and have no response status.
+	if eventType == "error" || jsonEventType == "error" {
+		return streamTerminalFailed
+	}
+
+	if eventType == "response.cancelled" || jsonEventType == "response.cancelled" ||
+		responseStatus == responseStatusCanceledBritish || responseStatus == "canceled" {
+		return streamTerminalCanceled
+	}
+	if eventType == "response.failed" || jsonEventType == "response.failed" || responseStatus == "failed" {
+		return streamTerminalFailed
+	}
+	if eventType == "response.incomplete" || jsonEventType == "response.incomplete" || responseStatus == "incomplete" {
+		return streamTerminalIncomplete
+	}
+
+	return streamTerminalCompleted
+}
+
+// streamTerminalErrorMessage is called for a non-successful terminal event.
+func streamTerminalErrorMessage(event *httpclient.StreamEvent, state streamTerminalState) string {
+	for _, path := range []string{
+		"response.error.message",
+		"error.message",
+		"response.incomplete_details.reason",
+	} {
+		if message := gjson.GetBytes(event.Data, path).String(); message != "" {
+			return message
+		}
+	}
+
+	// Compatible providers may use response.completed for abnormal outcomes.
+	// Report the classified outcome rather than a misleading event type.
+	return string(state)
 }
 
 func hasNonEmptyJSONStringField(data []byte, arrayPath, field string) bool {
@@ -150,6 +224,19 @@ func (ts *InboundPersistentStream) Err() error {
 	return ts.stream.Err()
 }
 
+func (ts *InboundPersistentStream) finalTerminalState() streamTerminalState {
+	// Generic finish_reason/message_stop events can lose the provider's failure
+	// or cancellation. Preserve that outcome even if the client disconnects
+	// before the converted terminal event is consumed. A successful provider
+	// outcome must not hide a downstream transformation failure.
+	switch ts.state.OutboundStreamTerminal {
+	case streamTerminalFailed, streamTerminalIncomplete, streamTerminalCanceled:
+		return ts.state.OutboundStreamTerminal
+	default:
+		return ts.terminalState
+	}
+}
+
 func (ts *InboundPersistentStream) Close() error {
 	if ts.closed {
 		return nil
@@ -162,13 +249,13 @@ func (ts *InboundPersistentStream) Close() error {
 
 	streamErr := ts.stream.Err()
 	ctxErr := ctx.Err()
+	ts.terminalState = ts.finalTerminalState()
 
-	// If we received the [DONE] event, treat the stream as successfully completed
-	// even if there's a context cancellation error. This handles the case where
-	// the client disconnects immediately after receiving the last chunk.
-	if ts.state.StreamCompleted {
-		// Stream completed successfully - perform final persistence
-		log.Debug(ctx, "Stream completed successfully (received terminal event), performing final persistence")
+	// A terminal event carries the final stream outcome. Persist its structured
+	// response even if a transport or context error arrives afterward.
+	if ts.terminalState != streamTerminalNone {
+		log.Debug(ctx, "Stream terminal event received, performing final persistence",
+			log.String("terminal_state", string(ts.terminalState)))
 		ts.persistResponseChunks(ctx)
 
 		return ts.stream.Close()
@@ -314,14 +401,26 @@ func (ts *InboundPersistentStream) _persistResponse(ctx context.Context, respons
 		}
 	}
 
-	err := ts.requestService.UpdateRequestCompleted(ctx, ts.request.ID, meta.ID, responseBody, metrics)
+	status := ts.terminalState.requestStatus()
+	err := ts.requestService.UpdateRequestFinalized(ctx, ts.request.ID, status, meta.ID, responseBody, metrics)
 	if err != nil {
-		log.Warn(ctx, "Failed to update request status to completed", log.Cause(err))
+		log.Warn(ctx, "Failed to update finalized request", log.Cause(err), log.Any("status", status))
 	}
 
 	// Save all response chunks at once
 	if err := ts.requestService.SaveRequestChunks(ctx, ts.request.ID, ts.responseChunks); err != nil {
 		log.Warn(ctx, "Failed to save request chunks", log.Cause(err))
+	}
+}
+
+func (s streamTerminalState) requestStatus() request.Status {
+	switch s {
+	case streamTerminalFailed, streamTerminalIncomplete:
+		return request.StatusFailed
+	case streamTerminalCanceled:
+		return request.StatusCanceled
+	default:
+		return request.StatusCompleted
 	}
 }
 

--- a/internal/server/orchestrator/inbound_test.go
+++ b/internal/server/orchestrator/inbound_test.go
@@ -3,15 +3,18 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/enttest"
 	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
@@ -229,6 +232,165 @@ func TestInboundPersistentStream_Close_WithTerminalEvent(t *testing.T) {
 	assert.True(t, mockStream.closed, "Stream should be closed")
 }
 
+func TestInboundPersistentStream_Close_ErrorAfterTerminalKeepsRequestCompleted(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+	project := createTestProject(t, ctx, client)
+	ch := createTestChannel(t, ctx, client)
+	_, requestService, _, _ := setupTestServices(t, client)
+	req, err := client.Request.Create().
+		SetProjectID(project.ID).
+		SetChannelID(ch.ID).
+		SetModelID("gpt-5").
+		SetStatus(request.StatusProcessing).
+		SetRequestBody([]byte(`{"stream":true}`)).
+		SetStream(true).
+		Save(ctx)
+	require.NoError(t, err)
+
+	completed := &httpclient.StreamEvent{
+		Type: "response.completed",
+		Data: []byte(`{"type":"response.completed","response":{"id":"resp_123","status":"completed","output":[]}}`),
+	}
+	mockStream := &mockStream{
+		events: []*httpclient.StreamEvent{completed},
+		err:    io.ErrUnexpectedEOF,
+	}
+	mockTransformer := &mockInboundTransformer{
+		aggregateResponseBody: []byte(`{"id":"resp_123","status":"completed","output":[]}`),
+		aggregateMeta:         llm.ResponseMeta{ID: "resp_123"},
+	}
+	state := &PersistenceState{}
+	stream := NewInboundPersistentStream(
+		ctx,
+		mockStream,
+		req,
+		&ent.RequestExecution{ID: 1},
+		requestService,
+		mockTransformer,
+		nil,
+		state,
+	)
+
+	require.True(t, stream.Next())
+	_ = stream.Current()
+	require.False(t, stream.Next())
+	require.ErrorIs(t, stream.Err(), io.ErrUnexpectedEOF)
+	require.NoError(t, stream.Close())
+	require.True(t, state.StreamCompleted)
+
+	dbReq, err := client.Request.Get(ctx, req.ID)
+	require.NoError(t, err)
+	require.Equal(t, request.StatusCompleted, dbReq.Status)
+}
+
+func TestInboundPersistentStream_Close_ResponsesFailureTerminalPersistsOutcome(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventType      string
+		responseBody   string
+		expectedStatus request.Status
+	}{
+		{
+			name:      "failed",
+			eventType: "response.failed",
+			responseBody: `{"id":"resp_failed","status":"failed","output":[],` +
+				`"error":{"type":"server_error","code":"provider_error","message":"provider failed"},` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus: request.StatusFailed,
+		},
+		{
+			name:      "incomplete",
+			eventType: "response.incomplete",
+			responseBody: `{"id":"resp_incomplete","status":"incomplete","output":[],` +
+				`"incomplete_details":{"reason":"max_output_tokens"},` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus: request.StatusFailed,
+		},
+		{
+			name:      "canceled",
+			eventType: "response.cancelled",
+			responseBody: `{"id":"resp_canceled","status":"canceled","output":[],` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus: request.StatusCanceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+
+			ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+			project := createTestProject(t, ctx, client)
+			ch := createTestChannel(t, ctx, client)
+			_, requestService, systemService, _ := setupTestServices(t, client)
+			require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+				StoreChunks:       true,
+				StoreRequestBody:  true,
+				StoreResponseBody: true,
+			}))
+
+			req, err := client.Request.Create().
+				SetProjectID(project.ID).
+				SetChannelID(ch.ID).
+				SetModelID("gpt-5").
+				SetStatus(request.StatusProcessing).
+				SetRequestBody([]byte(`{"stream":true}`)).
+				SetStream(true).
+				Save(ctx)
+			require.NoError(t, err)
+
+			event := &httpclient.StreamEvent{
+				Type: tt.eventType,
+				Data: []byte(`{"type":"` + tt.eventType + `","response":` + tt.responseBody + `}`),
+			}
+			stream := &mockStream{
+				events: []*httpclient.StreamEvent{event},
+				err:    io.ErrUnexpectedEOF,
+			}
+			responseID := gjson.Get(tt.responseBody, "id").String()
+			mockTransformer := &mockInboundTransformer{
+				aggregateResponseBody: []byte(tt.responseBody),
+				aggregateMeta: llm.ResponseMeta{
+					ID: responseID,
+					Usage: &llm.Usage{
+						PromptTokens:     10,
+						CompletionTokens: 2,
+						TotalTokens:      12,
+					},
+				},
+			}
+			state := &PersistenceState{}
+			persistentStream := NewInboundPersistentStream(
+				ctx,
+				stream,
+				req,
+				&ent.RequestExecution{ID: 1},
+				requestService,
+				mockTransformer,
+				nil,
+				state,
+			)
+
+			require.True(t, persistentStream.Next())
+			require.Equal(t, event, persistentStream.Current())
+			require.False(t, persistentStream.Next())
+			require.NoError(t, persistentStream.Close())
+			require.False(t, state.StreamCompleted)
+
+			dbReq, err := client.Request.Get(ctx, req.ID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, dbReq.Status)
+			require.Equal(t, responseID, dbReq.ExternalID)
+			require.JSONEq(t, tt.responseBody, string(dbReq.ResponseBody))
+			require.NotEmpty(t, dbReq.ResponseChunks)
+		})
+	}
+}
+
 // TestInboundPersistentStream_Close_WithAggregationError tests the error path:
 // aggregation fails but fallback behavior still works (persistResponseChunks called in final block).
 func TestInboundPersistentStream_Close_WithAggregationError(t *testing.T) {
@@ -398,6 +560,91 @@ func TestIsTerminalStreamEvent_SemanticCompletionInData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, IsTerminalStreamEvent(tt.event))
+		})
+	}
+}
+
+func TestIsTerminalStreamEvent_ResponsesTerminalEvents(t *testing.T) {
+	terminalTypes := []string{
+		"response.completed",
+		"response.failed",
+		"response.incomplete",
+		"response.cancelled",
+	}
+
+	for _, eventType := range terminalTypes {
+		t.Run(eventType+" in SSE metadata", func(t *testing.T) {
+			require.True(t, IsTerminalStreamEvent(&httpclient.StreamEvent{Type: eventType}))
+		})
+		t.Run(eventType+" in JSON data", func(t *testing.T) {
+			require.True(t, IsTerminalStreamEvent(&httpclient.StreamEvent{
+				Data: []byte(`{"type":"` + eventType + `"}`),
+			}))
+		})
+	}
+}
+
+func TestPersistentStreams_StandaloneErrorPersistsFailure(t *testing.T) {
+	for _, event := range []*httpclient.StreamEvent{
+		{Type: "error", Data: []byte(`{"error":{"message":"provider failed"}}`)},
+		{Data: []byte(`{"type":"error","error":{"message":"provider failed"}}`)},
+	} {
+		name := "json_type"
+		if event.Type != "" {
+			name = "sse_type"
+		}
+		t.Run(name, func(t *testing.T) {
+			require.True(t, IsTerminalStreamEvent(event))
+			require.Equal(t, streamTerminalFailed, classifyStreamTerminalEvent(event))
+			for _, aggregationFails := range []bool{false, true} {
+				name := "aggregation_succeeds"
+				if aggregationFails {
+					name = "aggregation_fails"
+				}
+				t.Run(name, func(t *testing.T) {
+					client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+					defer client.Close()
+					ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+					project := createTestProject(t, ctx, client)
+					channel := createTestChannel(t, ctx, client)
+					_, service, systemService, usageService := setupTestServices(t, client)
+					require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{StoreChunks: true, StoreResponseBody: true}))
+					req, err := client.Request.Create().SetProjectID(project.ID).SetChannelID(channel.ID).
+						SetModelID("gpt-5").SetStatus(request.StatusProcessing).
+						SetRequestBody([]byte(`{"stream":true}`)).SetStream(true).Save(ctx)
+					require.NoError(t, err)
+					execution, err := client.RequestExecution.Create().SetRequestID(req.ID).
+						SetProjectID(project.ID).SetChannelID(channel.ID).SetModelID("gpt-5").
+						SetFormat(llm.APIFormatOpenAIResponse.String()).SetStatus(requestexecution.StatusProcessing).
+						SetRequestBody([]byte(`{"stream":true}`)).SetStream(true).Save(ctx)
+					require.NoError(t, err)
+					var aggregateErr error
+					if aggregationFails {
+						aggregateErr = errors.New("no response created")
+					}
+					state := &PersistenceState{}
+					outbound := NewOutboundPersistentStream(ctx, &mockStream{events: []*httpclient.StreamEvent{event}},
+						req, execution, service, usageService, &mockTransformer{aggregatedErr: aggregateErr}, nil, state)
+					inbound := NewInboundPersistentStream(ctx, outbound, req, execution, service,
+						&mockInboundTransformer{aggregateErr: aggregateErr}, nil, state)
+					require.True(t, inbound.Next())
+					require.Equal(t, event, inbound.Current())
+					require.False(t, inbound.Next())
+					require.NoError(t, inbound.Err())
+					require.NoError(t, inbound.Close())
+					require.False(t, state.StreamCompleted)
+					require.Equal(t, streamTerminalFailed, state.OutboundStreamTerminal)
+					savedRequest, err := client.Request.Get(ctx, req.ID)
+					require.NoError(t, err)
+					require.Equal(t, request.StatusFailed, savedRequest.Status)
+					require.Len(t, savedRequest.ResponseChunks, 1)
+					savedExecution, err := client.RequestExecution.Get(ctx, execution.ID)
+					require.NoError(t, err)
+					require.Equal(t, requestexecution.StatusFailed, savedExecution.Status)
+					require.Equal(t, "provider failed", savedExecution.ErrorMessage)
+					require.Len(t, savedExecution.ResponseChunks, 1)
+				})
+			}
 		})
 	}
 }

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xcontext"
@@ -38,6 +39,8 @@ type OutboundPersistentStream struct {
 	transformer    transformer.Outbound
 	perf           *biz.PerformanceRecord
 	responseChunks []*httpclient.StreamEvent
+	terminalState  streamTerminalState
+	terminalError  string
 	closed         bool
 	state          *PersistenceState
 }
@@ -82,12 +85,16 @@ func (ts *OutboundPersistentStream) Current() *httpclient.StreamEvent {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
-		// Check if this is a terminal event, which indicates the stream completed successfully.
-		// For Chat Completions API this is the raw [DONE] event; for Responses API this is
-		// response.completed; for Anthropic Messages API this is message_stop.
-		if IsTerminalStreamEvent(event) {
-			ts.state.StreamCompleted = true
-			ts.markPerformanceCompleted()
+		if ts.terminalState == streamTerminalNone {
+			ts.terminalState = classifyStreamTerminalEvent(event)
+			if ts.terminalState != streamTerminalNone {
+				ts.state.OutboundStreamTerminal = ts.terminalState
+				if ts.terminalState != streamTerminalCompleted {
+					ts.terminalError = streamTerminalErrorMessage(event, ts.terminalState)
+				}
+				ts.state.StreamCompleted = ts.terminalState == streamTerminalCompleted
+				ts.markPerformanceTerminal(ts.terminalState, ts.terminalError)
+			}
 		}
 	}
 
@@ -111,13 +118,13 @@ func (ts *OutboundPersistentStream) Close() error {
 	streamErr := ts.stream.Err()
 	ctxErr := ctx.Err()
 
-	// If we received the [DONE] event, treat the stream as successfully completed
-	// even if there's a context cancellation error. This handles the case where
-	// the client disconnects immediately after receiving the last chunk.
-	if ts.state.StreamCompleted {
-		ts.logFinalizationDecision(ctx, "terminal_event_completed", streamErr, ctxErr, true, nil)
-		// Stream completed successfully - perform final persistence
-		log.Debug(ctx, "Stream completed successfully (received [DONE]), performing final persistence")
+	// A terminal event carries the final stream outcome. Persist its structured
+	// response even if a transport or context error arrives afterward.
+	if ts.terminalState != streamTerminalNone {
+		ts.logFinalizationDecision(ctx, "terminal_event_received", streamErr, ctxErr,
+			ts.terminalState == streamTerminalCompleted, nil)
+		log.Debug(ctx, "Stream terminal event received, performing final persistence",
+			log.String("terminal_state", string(ts.terminalState)))
 		ts.persistResponseChunks(ctx)
 
 		return ts.stream.Close()
@@ -150,7 +157,7 @@ func (ts *OutboundPersistentStream) Close() error {
 		if aggregatedCompleted {
 			log.Debug(ctx, "Stream has valid complete response without terminal event, treating as completed")
 			ts.state.StreamCompleted = true
-			ts.markPerformanceCompleted()
+			ts.markPerformanceTerminal(streamTerminalCompleted, "")
 			enqueueCompletedPerformance(ts.ctx, ts.state)
 		}
 	} else {
@@ -211,18 +218,28 @@ func (ts *OutboundPersistentStream) Close() error {
 	return ts.stream.Close()
 }
 
-func (ts *OutboundPersistentStream) markPerformanceCompleted() {
+func (ts *OutboundPersistentStream) markPerformanceTerminal(state streamTerminalState, message string) {
 	if ts.perf == nil || ts.perf.RequestCompleted {
 		return
 	}
 
-	ts.perf.MarkSuccess()
+	switch state {
+	case streamTerminalCompleted, streamTerminalIncomplete:
+		// Token limits and content filtering end a response without indicating
+		// a channel fault. Keep them out of failure counts and auto-disable rules.
+		ts.perf.MarkSuccess()
+	case streamTerminalCanceled:
+		ts.perf.MarkCanceled()
+	case streamTerminalFailed:
+		ts.perf.MarkFailedWithMessage(500, message)
+	case streamTerminalNone:
+	}
 }
 
 func (ts *OutboundPersistentStream) logFinalizationDecision(ctx context.Context, decision string, streamErr error, ctxErr error, aggregatedCompleted bool, aggregatedErr error) {
 	fields := []log.Field{
 		log.String("decision", decision),
-		log.Bool("terminal_event_seen", ts.state.StreamCompleted),
+		log.Bool("terminal_event_seen", ts.terminalState != streamTerminalNone),
 		log.Int("chunk_count", len(ts.responseChunks)),
 		log.String("api_format", string(ts.transformer.APIFormat())),
 		log.Bool("aggregated_completed", aggregatedCompleted),
@@ -257,6 +274,17 @@ func (ts *OutboundPersistentStream) persistResponseChunks(ctx context.Context) {
 		responseBody, meta, err := ts.transformer.AggregateStreamChunks(persistCtx, ts.state.RawProviderRequest, ts.responseChunks)
 		if err != nil {
 			log.Warn(persistCtx, "Failed to aggregate chunks using transformer", log.Cause(err))
+			// Aggregation failure must not discard a known terminal outcome or
+			// overwrite it with a local processing error. Persist status separately
+			// without trusting any partial response or usage returned with the error.
+			status := ts.terminalState.executionStatus()
+			if updateErr := ts.RequestService.UpdateRequestExecutionStatusWithMetrics(
+				persistCtx, ts.requestExec.ID, status, ts.terminalError, nil, ts.failureLatencyMetrics(),
+			); updateErr != nil {
+				log.Warn(persistCtx, "Failed to update terminal execution after aggregation failure",
+					log.Cause(updateErr), log.Any("status", status))
+			}
+			ts.persistFailureChunks(persistCtx)
 			return
 		}
 
@@ -340,9 +368,12 @@ func (ts *OutboundPersistentStream) persistAggregatedResponse(ctx context.Contex
 		}
 	}
 
-	err := ts.RequestService.UpdateRequestExecutionCompleted(
+	status := ts.terminalState.executionStatus()
+	err := ts.RequestService.UpdateRequestExecutionFinalized(
 		ctx,
 		ts.requestExec.ID,
+		status,
+		ts.terminalError,
 		meta.ID,
 		responseBody,
 		metrics,
@@ -350,14 +381,26 @@ func (ts *OutboundPersistentStream) persistAggregatedResponse(ctx context.Contex
 	if err != nil {
 		log.Warn(
 			ctx,
-			"Failed to update request execution with chunks, trying basic completion",
+			"Failed to update finalized request execution",
 			log.Cause(err),
+			log.Any("status", status),
 		)
 	}
 
 	// Save all response chunks at once
 	if err := ts.RequestService.SaveRequestExecutionChunks(ctx, ts.requestExec.ID, ts.responseChunks); err != nil {
 		log.Warn(ctx, "Failed to save request execution chunks", log.Cause(err))
+	}
+}
+
+func (s streamTerminalState) executionStatus() requestexecution.Status {
+	switch s {
+	case streamTerminalFailed, streamTerminalIncomplete:
+		return requestexecution.StatusFailed
+	case streamTerminalCanceled:
+		return requestexecution.StatusCanceled
+	default:
+		return requestexecution.StatusCompleted
 	}
 }
 
@@ -466,6 +509,7 @@ func (p *PersistentOutboundTransformer) TransformRequest(ctx context.Context, ll
 
 	p.state.CurrentCandidate = candidate
 	p.state.StreamCompleted = false
+	p.state.OutboundStreamTerminal = streamTerminalNone
 	p.refreshCandidateAPIFormat(ctx, candidate, p.state.CurrentModelIndex, llmRequest)
 
 	p.wrapped = selectOutboundForCandidate(candidate)

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -663,7 +663,8 @@ func TestPersistentOutboundTransformer_TransformRequest_ResetsStreamCompletedFor
 	processor := &PersistentOutboundTransformer{
 		wrapped: &mockTransformer{},
 		state: &PersistenceState{
-			StreamCompleted: true,
+			StreamCompleted:        true,
+			OutboundStreamTerminal: streamTerminalFailed,
 			ChannelModelsCandidates: []*ChannelModelsCandidate{
 				{Channel: channel, Priority: 0, Models: []biz.ChannelModelEntry{{RequestModel: "gpt-4", ActualModel: "gpt-4"}}},
 			},
@@ -686,6 +687,7 @@ func TestPersistentOutboundTransformer_TransformRequest_ResetsStreamCompletedFor
 	_, err := processor.TransformRequest(ctx, llmRequest)
 	require.NoError(t, err)
 	require.False(t, processor.state.StreamCompleted)
+	require.Equal(t, streamTerminalNone, processor.state.OutboundStreamTerminal)
 }
 
 func TestPersistentOutboundTransformer_CanRetry(t *testing.T) {
@@ -1161,6 +1163,276 @@ func TestOutboundPersistentStream_Close_AggregatedResponsesCompletionHandling(t 
 		require.Empty(t, dbExec.ErrorMessage)
 		require.JSONEq(t, string(aggregated), string(dbExec.ResponseBody))
 	})
+}
+
+func TestOutboundPersistentStream_Close_ResponsesTerminalPersistsOutcome(t *testing.T) {
+	tests := []struct {
+		name             string
+		eventType        string
+		responseBody     string
+		expectedStatus   requestexecution.Status
+		expectedError    string
+		channelSuccess   bool
+		channelCanceled  bool
+		channelErrorCode int
+	}{
+		{
+			name:      "failed",
+			eventType: "response.failed",
+			responseBody: `{"id":"resp_failed","status":"failed","output":[],` +
+				`"error":{"type":"server_error","code":"provider_error","message":"provider failed"},` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus:   requestexecution.StatusFailed,
+			expectedError:    "provider failed",
+			channelErrorCode: 500,
+		},
+		{
+			name:      "incomplete",
+			eventType: "response.incomplete",
+			responseBody: `{"id":"resp_incomplete","status":"incomplete","output":[],` +
+				`"incomplete_details":{"reason":"max_output_tokens"},` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus: requestexecution.StatusFailed,
+			expectedError:  "max_output_tokens",
+			channelSuccess: true,
+		},
+		{
+			name:      "content filter",
+			eventType: "response.incomplete",
+			responseBody: `{"id":"resp_filtered","status":"incomplete","output":[],` +
+				`"incomplete_details":{"reason":"content_filter"}}`,
+			expectedStatus: requestexecution.StatusFailed,
+			expectedError:  "content_filter",
+			channelSuccess: true,
+		},
+		{
+			name:      "completed event with incomplete status",
+			eventType: "response.completed",
+			responseBody: `{"id":"resp_incomplete_status","status":"incomplete","output":[],` +
+				`"incomplete_details":{"reason":"max_output_tokens"}}`,
+			expectedStatus: requestexecution.StatusFailed,
+			expectedError:  "max_output_tokens",
+			channelSuccess: true,
+		},
+		{
+			name:      "canceled",
+			eventType: "response.cancelled",
+			responseBody: `{"id":"resp_canceled","status":"canceled","output":[],` +
+				`"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}`,
+			expectedStatus:  requestexecution.StatusCanceled,
+			expectedError:   "canceled",
+			channelCanceled: true,
+		},
+		{
+			name:            "completed event with canceled status and no details",
+			eventType:       "response.completed",
+			responseBody:    `{"id":"resp_canceled_status","status":"canceled","output":[]}`,
+			expectedStatus:  requestexecution.StatusCanceled,
+			expectedError:   "canceled",
+			channelCanceled: true,
+		},
+		{
+			name:           "completed event with incomplete status and no details",
+			eventType:      "response.completed",
+			responseBody:   `{"id":"resp_incomplete_status","status":"incomplete","output":[]}`,
+			expectedStatus: requestexecution.StatusFailed,
+			expectedError:  "incomplete",
+			channelSuccess: true,
+		},
+		{
+			name:             "completed event with failed status and no details",
+			eventType:        "response.completed",
+			responseBody:     `{"id":"resp_failed_status","status":"failed","output":[]}`,
+			expectedStatus:   requestexecution.StatusFailed,
+			expectedError:    "failed",
+			channelErrorCode: 500,
+		},
+		{
+			name:            "canceled status with provider error message",
+			eventType:       "response.completed",
+			responseBody:    `{"id":"resp_canceled_message","status":"canceled","output":[],"error":{"message":"canceled by provider"}}`,
+			expectedStatus:  requestexecution.StatusCanceled,
+			expectedError:   "canceled by provider",
+			channelCanceled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+
+			ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+			project := createTestProject(t, ctx, client)
+			ch := createTestChannel(t, ctx, client)
+			_, requestService, systemService, usageLogService := setupTestServices(t, client)
+			require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+				StoreChunks:       true,
+				StoreRequestBody:  true,
+				StoreResponseBody: true,
+			}))
+
+			req, err := client.Request.Create().
+				SetProjectID(project.ID).
+				SetChannelID(ch.ID).
+				SetModelID("gpt-5").
+				SetStatus(request.StatusProcessing).
+				SetRequestBody([]byte(`{"stream":true}`)).
+				SetStream(true).
+				Save(ctx)
+			require.NoError(t, err)
+			exec, err := client.RequestExecution.Create().
+				SetRequestID(req.ID).
+				SetProjectID(project.ID).
+				SetChannelID(ch.ID).
+				SetModelID("gpt-5").
+				SetFormat(llm.APIFormatOpenAIResponse.String()).
+				SetStatus(requestexecution.StatusProcessing).
+				SetRequestBody([]byte(`{"stream":true}`)).
+				SetStream(true).
+				Save(ctx)
+			require.NoError(t, err)
+
+			event := &httpclient.StreamEvent{
+				Type: tt.eventType,
+				Data: []byte(`{"type":"` + tt.eventType + `","response":` + tt.responseBody + `}`),
+			}
+			stream := &sliceEventStream{
+				events: []*httpclient.StreamEvent{event},
+				err:    io.ErrUnexpectedEOF,
+			}
+			responseID := gjson.Get(tt.responseBody, "id").String()
+			transformer := &mockTransformer{
+				apiFormat:          llm.APIFormatOpenAIResponse,
+				aggregatedResponse: []byte(tt.responseBody),
+				aggregatedMeta: llm.ResponseMeta{
+					ID: responseID,
+					Usage: &llm.Usage{
+						PromptTokens:     10,
+						CompletionTokens: 2,
+						TotalTokens:      12,
+					},
+				},
+			}
+			perf := &biz.PerformanceRecord{StartTime: time.Now(), Stream: true}
+			state := &PersistenceState{Perf: perf}
+			persistentStream := NewOutboundPersistentStream(
+				ctx,
+				stream,
+				req,
+				exec,
+				requestService,
+				usageLogService,
+				transformer,
+				perf,
+				state,
+			)
+
+			require.True(t, persistentStream.Next())
+			require.Equal(t, event, persistentStream.Current())
+			require.False(t, persistentStream.Next())
+			require.NoError(t, persistentStream.Close())
+			require.False(t, state.StreamCompleted)
+			require.True(t, perf.RequestCompleted)
+			require.Equal(t, tt.channelSuccess, perf.Success)
+			require.Equal(t, tt.channelCanceled, perf.Canceled)
+			require.Equal(t, tt.channelErrorCode, perf.ResponseStatusCode)
+			if tt.channelErrorCode == 0 {
+				require.Empty(t, perf.ErrorMessage)
+			} else {
+				require.Equal(t, tt.expectedError, perf.ErrorMessage)
+			}
+
+			dbExec, err := client.RequestExecution.Get(ctx, exec.ID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, dbExec.Status)
+			require.Equal(t, tt.expectedError, dbExec.ErrorMessage)
+			require.Equal(t, responseID, dbExec.ExternalID)
+			require.JSONEq(t, tt.responseBody, string(dbExec.ResponseBody))
+			require.NotEmpty(t, dbExec.ResponseChunks)
+		})
+	}
+}
+
+func TestOutboundPersistentStream_Close_AggregationErrorPreservesTerminal(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventType      string
+		details        string
+		expectedStatus requestexecution.Status
+		expectedError  string
+	}{
+		{"completed", "response.completed", "", requestexecution.StatusCompleted, ""},
+		{"failed", "response.failed", `,"error":{"message":"provider failed"}`, requestexecution.StatusFailed, "provider failed"},
+		{"incomplete", "response.incomplete", `,"incomplete_details":{"reason":"max_output_tokens"}`, requestexecution.StatusFailed, "max_output_tokens"},
+		{"canceled", "response.cancelled", "", requestexecution.StatusCanceled, "canceled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+			ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+			streamCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			project := createTestProject(t, ctx, client)
+			channel := createTestChannel(t, ctx, client)
+			_, requestService, systemService, usageLogService := setupTestServices(t, client)
+			require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+				StoreChunks: true, StoreRequestBody: true, StoreResponseBody: true,
+			}))
+			req, err := client.Request.Create().
+				SetProjectID(project.ID).SetChannelID(channel.ID).SetModelID("gpt-5").
+				SetStatus(request.StatusProcessing).SetRequestBody([]byte(`{"stream":true}`)).
+				SetStream(true).Save(ctx)
+			require.NoError(t, err)
+			execution, err := client.RequestExecution.Create().
+				SetRequestID(req.ID).SetProjectID(project.ID).SetChannelID(channel.ID).SetModelID("gpt-5").
+				SetFormat(llm.APIFormatOpenAIResponse.String()).SetStatus(requestexecution.StatusProcessing).
+				SetRequestBody([]byte(`{"stream":true}`)).SetExternalID("resp_existing").
+				SetResponseBody([]byte(`{"existing":true}`)).SetStream(true).Save(ctx)
+			require.NoError(t, err)
+
+			event := &httpclient.StreamEvent{
+				Type: tt.eventType,
+				Data: []byte(`{"type":"` + tt.eventType + `","response":{"id":"resp_existing"` + tt.details + `}}`),
+			}
+			// A failed aggregation may return partial data. Do not persist it or
+			// charge usage from it; the raw chunks remain available for diagnosis.
+			transformer := &mockTransformer{
+				aggregatedErr:      fmt.Errorf("cannot aggregate response"),
+				aggregatedResponse: []byte(`{"partial":true}`),
+				aggregatedMeta: llm.ResponseMeta{
+					ID: "partial-id", Usage: &llm.Usage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12},
+				},
+			}
+			perf := &biz.PerformanceRecord{
+				StartTime: time.Now().Add(-time.Second), FirstTokenTime: lo.ToPtr(time.Now().Add(-500 * time.Millisecond)), Stream: true,
+			}
+			stream := NewOutboundPersistentStream(streamCtx, &sliceEventStream{
+				events: []*httpclient.StreamEvent{event}, err: io.ErrUnexpectedEOF,
+			}, req, execution, requestService, usageLogService, transformer, perf, &PersistenceState{})
+			require.True(t, stream.Next())
+			stream.Current()
+			require.False(t, stream.Next())
+			cancel()
+			require.NoError(t, stream.Close())
+
+			saved, err := client.RequestExecution.Get(ctx, execution.ID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, saved.Status)
+			require.Equal(t, tt.expectedError, saved.ErrorMessage)
+			require.Equal(t, "resp_existing", saved.ExternalID)
+			require.JSONEq(t, `{"existing":true}`, string(saved.ResponseBody))
+			require.NotEmpty(t, saved.ResponseChunks)
+			require.NotNil(t, saved.MetricsLatencyMs)
+			require.Positive(t, *saved.MetricsLatencyMs)
+			require.NotNil(t, saved.MetricsFirstTokenLatencyMs)
+			require.Positive(t, *saved.MetricsFirstTokenLatencyMs)
+			usageCount, err := client.UsageLog.Query().Count(ctx)
+			require.NoError(t, err)
+			require.Zero(t, usageCount)
+		})
+	}
 }
 
 func TestPersistentOutboundTransformer_TransformRequest_WithPrepopulatedState(t *testing.T) {

--- a/internal/server/orchestrator/request.go
+++ b/internal/server/orchestrator/request.go
@@ -224,7 +224,7 @@ func (m *persistRequestMiddleware) OnInboundRawResponse(ctx context.Context, htt
 	// STT text/srt/vtt responses are non-JSON; wrap them so the JSON response_body column accepts them.
 	respBody := audioSafeResponseBody(llmResp.RequestType, httpResp.Headers.Get("Content-Type"), httpResp.Body)
 
-	err := state.RequestService.UpdateRequestCompleted(persistCtx, state.Request.ID, llmResp.ID, respBody, metrics)
+	err := state.RequestService.UpdateRequestFinalized(persistCtx, state.Request.ID, request.StatusCompleted, llmResp.ID, respBody, metrics)
 	if err != nil {
 		log.Warn(persistCtx, "Failed to update request status to completed", log.Cause(err))
 	}

--- a/internal/server/orchestrator/request_execution.go
+++ b/internal/server/orchestrator/request_execution.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/log"
 	"github.com/looplj/axonhub/internal/pkg/xcontext"
 	"github.com/looplj/axonhub/internal/pkg/xerrors"
@@ -172,9 +173,11 @@ func (m *persistRequestExecutionMiddleware) OnOutboundLlmResponse(ctx context.Co
 	// before persisting into the JSON response_body column.
 	respBody := audioSafeResponseBody(llmResp.RequestType, m.rawResponse.Headers.Get("Content-Type"), m.rawResponse.Body)
 
-	err := state.RequestService.UpdateRequestExecutionCompleted(
+	err := state.RequestService.UpdateRequestExecutionFinalized(
 		persistCtx,
 		state.RequestExec.ID,
+		requestexecution.StatusCompleted,
+		"",
 		llmResp.ID,
 		respBody,
 		metrics,

--- a/internal/server/orchestrator/state.go
+++ b/internal/server/orchestrator/state.go
@@ -52,14 +52,23 @@ type PersistenceState struct {
 	// CurrentModelIndex is the current model index in CurrentCandidate.Models
 	CurrentModelIndex int
 
-	// Perf is the performance record for the current request.
+	// Perf records channel health and latency for the current request. For stream
+	// terminals, incomplete (token limit or content filtering) counts as channel
+	// success: it must not trigger channel failure counts or auto-disable rules.
 	Perf *biz.PerformanceRecord
 
-	// StreamCompleted tracks whether the stream has response successfully completed.
-	// This is used to distinguish between a stream that was canceled mid-way
-	// versus a stream that completed successfully but the client disconnected
-	// immediately after receiving the last chunk.
+	// StreamCompleted tracks a successful generation outcome, not channel health.
+	// A recognized incomplete terminal keeps this false and is persisted as Failed
+	// on both request and execution, even though Perf.Success is true. This does
+	// not turn a valid protocol response (such as finish_reason=length) into an
+	// HTTP/stream error for the client.
 	StreamCompleted bool
+
+	// OutboundStreamTerminal preserves the provider outcome across protocol
+	// conversion, which may replace an abnormal terminal event with a generic stop.
+	// Request/execution status and channel health intentionally interpret this
+	// outcome differently, as described by StreamCompleted and Perf above.
+	OutboundStreamTerminal streamTerminalState
 
 	// RawProviderResponse stores the raw provider response for non-stream response pass-through.
 	RawProviderResponse *httpclient.Response

--- a/internal/server/orchestrator/terminal_stream_test.go
+++ b/internal/server/orchestrator/terminal_stream_test.go
@@ -1,0 +1,170 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/streams"
+	"github.com/looplj/axonhub/llm/transformer"
+	"github.com/looplj/axonhub/llm/transformer/anthropic"
+	"github.com/looplj/axonhub/llm/transformer/openai"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+func TestPersistentStreams_ResponsesTerminalSurvivesProtocolConversion(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventType      string
+		status         string
+		details        string
+		expectedStatus request.Status
+	}{
+		{"completed", "response.completed", "completed", "", request.StatusCompleted},
+		{"failed", "response.failed", "failed", `,"error":{"message":"provider failed"}`, request.StatusFailed},
+		{"incomplete", "response.incomplete", "incomplete", `,"incomplete_details":{"reason":"max_output_tokens"}`, request.StatusFailed},
+		{"content filter", "response.incomplete", "incomplete", `,"incomplete_details":{"reason":"content_filter"}`, request.StatusFailed},
+		{"canceled", "response.cancelled", "canceled", "", request.StatusCanceled},
+		{"completed with failed status", "response.completed", "failed", `,"error":{"message":"provider failed"}`, request.StatusFailed},
+		{"completed with incomplete status", "response.completed", "incomplete", `,"incomplete_details":{"reason":"content_filter"}`, request.StatusFailed},
+		{"completed with canceled status", "response.completed", "canceled", "", request.StatusCanceled},
+	}
+	inbounds := []struct {
+		transformer.Inbound
+
+		name string
+	}{
+		{Inbound: openai.NewInboundTransformer(), name: "chat completions"},
+		{Inbound: anthropic.NewInboundTransformer(), name: "anthropic"},
+		{Inbound: responses.NewInboundTransformer(), name: "responses"},
+	}
+
+	for _, inbound := range inbounds {
+		for _, tt := range tests {
+			t.Run(inbound.name+"/"+tt.name, func(t *testing.T) {
+				client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+				defer client.Close()
+				ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+				streamCtx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				project := createTestProject(t, ctx, client)
+				channel := createTestChannel(t, ctx, client)
+				_, requestService, systemService, usageLogService := setupTestServices(t, client)
+				require.NoError(t, systemService.SetStoragePolicy(ctx, &biz.StoragePolicy{
+					StoreChunks: true, StoreRequestBody: true, StoreResponseBody: true,
+				}))
+				req, err := client.Request.Create().
+					SetProjectID(project.ID).SetChannelID(channel.ID).SetModelID("gpt-5").
+					SetStatus(request.StatusProcessing).SetRequestBody([]byte(`{"stream":true}`)).
+					SetStream(true).Save(ctx)
+				require.NoError(t, err)
+				execution, err := client.RequestExecution.Create().
+					SetRequestID(req.ID).SetProjectID(project.ID).SetChannelID(channel.ID).SetModelID("gpt-5").
+					SetFormat(llm.APIFormatOpenAIResponse.String()).SetStatus(requestexecution.StatusProcessing).
+					SetRequestBody([]byte(`{"stream":true}`)).SetStream(true).Save(ctx)
+				require.NoError(t, err)
+
+				events := []*httpclient.StreamEvent{
+					{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_terminal","model":"gpt-5","status":"in_progress","output":[]}}`)},
+					{Type: tt.eventType, Data: []byte(`{"type":"` + tt.eventType + `","response":{"id":"resp_terminal","status":"` + tt.status + `","output":[],"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}` + tt.details + `}}`)},
+				}
+				outbound, err := responses.NewOutboundTransformer("https://example.test", "test-key")
+				require.NoError(t, err)
+				state := &PersistenceState{}
+				raw := NewOutboundPersistentStream(streamCtx, streams.SliceStream(events), req, execution,
+					requestService, usageLogService, outbound, nil, state)
+				normalized, err := outbound.TransformStream(streamCtx, nil, raw)
+				require.NoError(t, err)
+				converted, err := inbound.TransformStream(streamCtx, normalized)
+				require.NoError(t, err)
+				stream := NewInboundPersistentStream(streamCtx, converted, req, execution, requestService, inbound, nil, state)
+				var lastEvent *httpclient.StreamEvent
+				for stream.Next() {
+					lastEvent = stream.Current()
+				}
+				require.NoError(t, stream.Err())
+				if inbound.name == "responses" && (tt.status == "failed" || tt.status == "incomplete") {
+					require.NotNil(t, lastEvent)
+					require.Equal(t, "response."+tt.status, lastEvent.Type)
+				}
+				// Persistence must retain the terminal outcome after client disconnect.
+				cancel()
+				require.NoError(t, stream.Close())
+
+				savedRequest, err := client.Request.Get(ctx, req.ID)
+				require.NoError(t, err)
+				savedExecution, err := client.RequestExecution.Get(ctx, execution.ID)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedStatus, savedRequest.Status)
+				require.Equal(t, string(tt.expectedStatus), string(savedExecution.Status))
+				require.Equal(t, tt.expectedStatus == request.StatusCompleted, state.StreamCompleted)
+				require.Equal(t, tt.status, gjson.GetBytes(savedExecution.ResponseBody, "status").String())
+				require.Equal(t, "resp_terminal", savedExecution.ExternalID)
+				require.NotEmpty(t, savedRequest.ResponseChunks)
+				require.NotEmpty(t, savedExecution.ResponseChunks)
+				if inbound.name == "responses" {
+					require.Equal(t, gjson.GetBytes(events[1].Data, "response.error.message").String(),
+						gjson.GetBytes(savedRequest.ResponseBody, "error.message").String())
+					require.Equal(t, gjson.GetBytes(events[1].Data, "response.incomplete_details.reason").String(),
+						gjson.GetBytes(savedRequest.ResponseBody, "incomplete_details.reason").String())
+				}
+			})
+		}
+	}
+}
+
+func TestInboundPersistentStream_ProviderSuccessDoesNotHideConversionFailure(t *testing.T) {
+	state := &PersistenceState{OutboundStreamTerminal: streamTerminalCompleted}
+	stream := NewInboundPersistentStream(t.Context(), streams.SliceStream([]*httpclient.StreamEvent{
+		{Type: "response.failed", Data: []byte(`{"type":"response.failed","response":{"status":"failed"}}`)},
+	}), nil, nil, nil, nil, nil, state)
+	require.True(t, stream.Next())
+	stream.Current()
+	require.Equal(t, request.StatusFailed, stream.finalTerminalState().requestStatus())
+	require.False(t, state.StreamCompleted)
+}
+
+func TestPersistentStreams_DisconnectBeforeConvertedTerminal(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	events := []*httpclient.StreamEvent{
+		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_canceled","model":"gpt-5","status":"in_progress","output":[]}}`)},
+		{Type: "response.output_text.delta", Data: []byte(`{"type":"response.output_text.delta","delta":"partial output"}`)},
+		{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":{"id":"resp_canceled","status":"canceled","output":[],"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}`)},
+	}
+	outbound, err := responses.NewOutboundTransformer("https://example.test", "test-key")
+	require.NoError(t, err)
+	state := &PersistenceState{}
+	raw := NewOutboundPersistentStream(ctx, streams.SliceStream(events), nil, nil, nil, nil, outbound, nil, state)
+	normalized, err := outbound.TransformStream(ctx, nil, raw)
+	require.NoError(t, err)
+	inbound := responses.NewInboundTransformer()
+	converted, err := inbound.TransformStream(ctx, normalized)
+	require.NoError(t, err)
+	stream := NewInboundPersistentStream(ctx, converted, nil, nil, nil, inbound, nil, state)
+	for stream.Next() {
+		event := stream.Current()
+		if state.OutboundStreamTerminal != streamTerminalNone {
+			// The converter first emits output_text.done; the client has not
+			// consumed the converted response terminal event yet.
+			require.False(t, IsTerminalStreamEvent(event))
+			break
+		}
+	}
+	require.Equal(t, streamTerminalCanceled, state.OutboundStreamTerminal)
+	require.Equal(t, streamTerminalNone, stream.terminalState)
+	cancel()
+	require.NoError(t, stream.Close())
+	require.Equal(t, streamTerminalCanceled, stream.terminalState)
+	require.False(t, state.StreamCompleted)
+}

--- a/llm/pipeline/responses_terminal_test.go
+++ b/llm/pipeline/responses_terminal_test.go
@@ -1,0 +1,196 @@
+package pipeline_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/pipeline"
+	"github.com/looplj/axonhub/llm/streams"
+	responsestransformer "github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+type responsesErrorAfterEventsStream struct {
+	events []*httpclient.StreamEvent
+	index  int
+	err    error
+}
+
+func (s *responsesErrorAfterEventsStream) Next() bool {
+	return s.index < len(s.events)
+}
+
+func (s *responsesErrorAfterEventsStream) Current() *httpclient.StreamEvent {
+	event := s.events[s.index]
+	s.index++
+
+	return event
+}
+
+func (s *responsesErrorAfterEventsStream) Err() error {
+	return s.err
+}
+
+func (s *responsesErrorAfterEventsStream) Close() error {
+	return nil
+}
+
+func TestPipeline_ResponsesDisconnectAfterTerminalPreservesOutcome(t *testing.T) {
+	tests := []struct {
+		name             string
+		eventType        string
+		status           string
+		expectedType     responsestransformer.StreamEventType
+		incompleteReason string
+		errorDetail      *responsestransformer.Error
+	}{
+		{name: "completed", eventType: "response.completed", status: "completed", expectedType: responsestransformer.StreamEventTypeResponseCompleted},
+		{name: "token limit", eventType: "response.incomplete", status: "incomplete", expectedType: responsestransformer.StreamEventTypeResponseIncomplete, incompleteReason: "max_output_tokens"},
+		{name: "content filter", eventType: "response.incomplete", status: "incomplete", expectedType: responsestransformer.StreamEventTypeResponseIncomplete, incompleteReason: "content_filter"},
+		{name: "provider reason", eventType: "response.incomplete", status: "incomplete", expectedType: responsestransformer.StreamEventTypeResponseIncomplete, incompleteReason: "provider_limit"},
+		{
+			name: "failed", eventType: "response.failed", status: "failed", expectedType: responsestransformer.StreamEventTypeResponseFailed,
+			errorDetail: &responsestransformer.Error{Type: "server_error", Code: "provider_error", Message: "provider failed", Param: "model"},
+		},
+		// Cancellation remains compatible with the existing downstream format.
+		{name: "cancelled", eventType: "response.cancelled", status: "cancelled", expectedType: responsestransformer.StreamEventTypeResponseCompleted},
+		{
+			name: "completed with failed status", eventType: "response.completed", status: "failed", expectedType: responsestransformer.StreamEventTypeResponseFailed,
+			errorDetail: &responsestransformer.Error{Code: "provider_error", Message: "provider failed"},
+		},
+		{name: "completed with incomplete status", eventType: "response.completed", status: "incomplete", expectedType: responsestransformer.StreamEventTypeResponseIncomplete, incompleteReason: "content_filter"},
+	}
+	for _, tt := range tests {
+		for _, withUsage := range []bool{false, true} {
+			for _, sourceError := range []struct {
+				name string
+				err  error
+			}{
+				{"clean EOF", nil},
+				{"unexpected EOF", fmt.Errorf("read body: %w", io.ErrUnexpectedEOF)},
+				{"canceled", context.Canceled},
+				{"deadline", context.DeadlineExceeded},
+			} {
+				t.Run(fmt.Sprintf("%s/usage=%t/%s", tt.name, withUsage, sourceError.name), func(t *testing.T) {
+					response := map[string]any{
+						"id": "resp_disconnect", "object": "response", "created_at": 1700000000,
+						"model": "gpt-5", "status": tt.status, "output": []any{},
+					}
+					if tt.incompleteReason != "" {
+						response["incomplete_details"] = map[string]string{"reason": tt.incompleteReason}
+					}
+					if tt.errorDetail != nil {
+						response["error"] = tt.errorDetail
+					}
+					if withUsage {
+						response["usage"] = map[string]int{"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+					}
+					terminalData, err := json.Marshal(map[string]any{"type": tt.eventType, "response": response})
+					require.NoError(t, err)
+					inbound := responsestransformer.NewInboundTransformer()
+					outbound, err := responsestransformer.NewOutboundTransformer("https://api.openai.com", "test-api-key")
+					require.NoError(t, err)
+
+					streamEvents := []*httpclient.StreamEvent{
+						{
+							Type: "response.created",
+							Data: []byte(`{"type":"response.created","response":{` +
+								`"id":"resp_disconnect","object":"response","created_at":1700000000,` +
+								`"model":"gpt-5","status":"in_progress","output":[]}}`),
+						},
+						{
+							Type: "response.output_item.added",
+							Data: []byte(`{"type":"response.output_item.added","output_index":0,` +
+								`"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"enc_1"}}`),
+						},
+						{
+							Type: "response.output_item.done",
+							Data: []byte(`{"type":"response.output_item.done","output_index":0,` +
+								`"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"enc_1"}}`),
+						},
+						{
+							Type: tt.eventType,
+							Data: terminalData,
+						},
+					}
+
+					executor := &mockExecutor{doStreamFunc: func(
+						ctx context.Context,
+						request *httpclient.Request,
+					) (streams.Stream[*httpclient.StreamEvent], error) {
+						return &responsesErrorAfterEventsStream{
+							events: streamEvents,
+							err:    sourceError.err,
+						}, nil
+					}}
+
+					pipe := pipeline.NewFactory(executor).Pipeline(inbound, outbound)
+					body, err := json.Marshal(map[string]any{
+						"model":  "gpt-5",
+						"stream": true,
+						"input":  "hello",
+					})
+					require.NoError(t, err)
+
+					result, err := pipe.Process(context.Background(), &httpclient.Request{
+						Method:      http.MethodPost,
+						URL:         "/v1/responses",
+						ContentType: "application/json",
+						Headers:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:        body,
+					})
+					require.NoError(t, err)
+					require.NotNil(t, result)
+					require.True(t, result.Stream)
+
+					var eventTypes []responsestransformer.StreamEventType
+					var terminal *responsestransformer.Response
+					terminalCount := 0
+					for result.EventStream.Next() {
+						var event responsestransformer.StreamEvent
+						require.NoError(t, json.Unmarshal(result.EventStream.Current().Data, &event))
+						eventTypes = append(eventTypes, event.Type)
+						switch event.Type {
+						case responsestransformer.StreamEventTypeResponseCompleted,
+							responsestransformer.StreamEventTypeResponseFailed,
+							responsestransformer.StreamEventTypeResponseIncomplete,
+							responsestransformer.StreamEventTypeResponseCancelled:
+							require.Equal(t, tt.expectedType, event.Type)
+							terminal = event.Response
+							terminalCount++
+						}
+					}
+
+					require.NoError(t, result.EventStream.Err())
+					require.Contains(t, eventTypes, tt.expectedType)
+					require.Equal(t, 1, terminalCount)
+					require.NotNil(t, terminal)
+					require.Equal(t, tt.status, lo.FromPtr(terminal.Status))
+					require.Equal(t, tt.errorDetail, terminal.Error)
+					if tt.incompleteReason != "" {
+						require.NotNil(t, terminal.IncompleteDetails)
+						require.Equal(t, tt.incompleteReason, terminal.IncompleteDetails.Reason)
+					} else {
+						require.Nil(t, terminal.IncompleteDetails)
+					}
+					if withUsage {
+						require.NotNil(t, terminal.Usage)
+						require.EqualValues(t, 100, terminal.Usage.InputTokens)
+						require.EqualValues(t, 50, terminal.Usage.OutputTokens)
+					} else {
+						require.Nil(t, terminal.Usage)
+					}
+					require.NotContains(t, eventTypes, responsestransformer.StreamEventTypeError)
+					require.NoError(t, result.EventStream.Close())
+				})
+			}
+		}
+	}
+}

--- a/llm/transformer/openai/responses/aggregator.go
+++ b/llm/transformer/openai/responses/aggregator.go
@@ -579,12 +579,11 @@ func (a *streamAggregator) processEvent(ev *StreamEvent) {
 		}
 
 	case StreamEventTypeResponseCompleted:
-		a.status = "completed"
-		if ev.Response != nil {
-			a.previousResponseID = ev.Response.PreviousResponseID
-			if ev.Response.Usage != nil {
-				a.usage = ev.Response.Usage
-			}
+		a.applyResponseSnapshot(ev.Response)
+		// The terminal event wins over a missing or stale in-progress status,
+		// while explicit failed, incomplete, and canceled outcomes are preserved.
+		if ev.Response == nil || ev.Response.Status == nil || a.status == "" || a.status == "in_progress" {
+			a.status = "completed"
 		}
 
 	case StreamEventTypeResponseFailed:

--- a/llm/transformer/openai/responses/aggregator_test.go
+++ b/llm/transformer/openai/responses/aggregator_test.go
@@ -54,6 +54,47 @@ func TestAggregateStreamChunks_CancelledFallbackUsesCanonicalStatus(t *testing.T
 	require.Equal(t, "canceled", *body.Status)
 }
 
+func TestAggregateStreamChunks_CompletedEventPreservesResponseSnapshot(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields string
+		status string
+	}{
+		{"no status", "", "completed"},
+		{"empty status", `,"status":""`, "completed"},
+		{"stale in-progress status", `,"status":"in_progress"`, "completed"},
+		{"completed", `,"status":"completed"`, "completed"},
+		{"incomplete", `,"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}`, "incomplete"},
+		{"content filter", `,"status":"incomplete","incomplete_details":{"reason":"content_filter"}`, "incomplete"},
+		{"failed", `,"status":"failed","error":{"type":"server_error","code":"provider_error","message":"provider failed"}`, "failed"},
+		{"canceled", `,"status":"canceled"`, "canceled"},
+		{"canceled", `,"status":"canceled"`, "canceled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := `{"id":"resp_terminal","model":"gpt-5","created_at":1700000001,"previous_response_id":"resp_previous","output":[],"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}` + tt.fields + `}`
+			body, meta, err := AggregateStreamChunks(t.Context(), []*httpclient.StreamEvent{
+				{Type: "response.completed", Data: []byte(`{"type":"response.completed","response":` + snapshot + `}`)},
+			})
+			require.NoError(t, err)
+			var expected, actual Response
+			require.NoError(t, json.Unmarshal([]byte(snapshot), &expected))
+			require.NoError(t, json.Unmarshal(body, &actual))
+			require.NotNil(t, actual.Status)
+			require.Equal(t, tt.status, *actual.Status)
+			require.Equal(t, expected.ID, actual.ID)
+			require.Equal(t, expected.Model, actual.Model)
+			require.Equal(t, expected.CreatedAt, actual.CreatedAt)
+			require.Equal(t, expected.PreviousResponseID, actual.PreviousResponseID)
+			require.Equal(t, expected.Error, actual.Error)
+			require.Equal(t, expected.IncompleteDetails, actual.IncompleteDetails)
+			require.Equal(t, expected.Usage, actual.Usage)
+			require.Equal(t, expected.ID, meta.ID)
+			require.Equal(t, expected.Usage.ToUsage(), meta.Usage)
+		})
+	}
+}
+
 func TestAggregateStreamChunks_CancelledSnapshotPreservesStatus(t *testing.T) {
 	resultBytes, _, err := AggregateStreamChunks(t.Context(), []*httpclient.StreamEvent{
 		{Type: "response.created", Data: []byte(`{"type":"response.created","response":{"id":"resp_canceled","object":"response","created_at":1700000000,"model":"gpt-5","status":"in_progress","output":[]}}`)},

--- a/llm/transformer/openai/responses/inbound_stream.go
+++ b/llm/transformer/openai/responses/inbound_stream.go
@@ -121,35 +121,23 @@ func (s *responsesInboundStream) Next() bool {
 		return true
 	}
 
+	// Once a terminal outcome is emitted, do not convert a later source error
+	// into a second terminal event.
+	if s.responseCompleted {
+		return false
+	}
+
 	// Clear the queue and reset index for new events
 	s.eventQueue = nil
 	s.queueIndex = 0
 
 	// Try to get the next chunk from source
 	if !s.source.Next() {
-		if s.err == nil && !s.errorEventEmitted && s.source.Err() == nil && s.hasFinished && !s.responseCompleted {
-			s.responseCompleted = true
-			// Only fall back to completed when no terminal status was mapped
-			// from a finish_reason (incomplete/failed/cancelled).
-			if s.aggregator.status == "" || s.aggregator.status == "in_progress" {
-				s.aggregator.status = "completed"
-			}
-			response := s.aggregator.buildResponse()
-			if s.usage != nil {
-				response.Usage = ConvertLLMUsageToResponsesUsage(s.usage)
-			}
-			if calls := getResponseWebSearchCallsFromMetadata(s.transformerMetadata); len(calls) > 0 {
-				response.Output = append(append([]Item(nil), calls...), response.Output...)
-			}
-
-			if err := s.enqueueEvent(&StreamEvent{
-				Type:     StreamEventTypeResponseCompleted,
-				Response: response,
-			}); err != nil {
-				s.err = fmt.Errorf("failed to enqueue response.completed event: %w", err)
+		if s.err == nil && !s.errorEventEmitted && s.source.Err() == nil && s.hasFinished {
+			if err := s.enqueueTerminalResponse(); err != nil {
+				s.err = err
 				return false
 			}
-
 			return s.Next()
 		}
 
@@ -299,9 +287,7 @@ func (s *responsesInboundStream) Next() bool {
 		if choice.FinishReason != nil && !s.hasFinished {
 			s.hasFinished = true
 
-			// Map the Chat Completions finish_reason onto the Responses status so
-			// the final response.completed event reports abnormal termination
-			// (truncation, content rejection, failure) instead of always claiming success.
+			// Map the finish_reason to the final Responses status and event type.
 			switch *choice.FinishReason {
 			case "length":
 				s.aggregator.status = "incomplete"
@@ -334,29 +320,10 @@ func (s *responsesInboundStream) Next() bool {
 		}
 	}
 
-	// Handle final usage chunk and complete response
+	// Usage follows the finish_reason; emit the final outcome once both arrive.
 	if chunk.Usage != nil && s.hasFinished && !s.responseCompleted {
-		s.responseCompleted = true
-		s.usage = chunk.Usage
-
-		// Build final response using aggregator
-		// A mapped terminal status (incomplete/failed/cancelled) must win over
-		// the default; only fall back to completed when still in_progress.
-		if s.aggregator.status == "" || s.aggregator.status == "in_progress" {
-			s.aggregator.status = "completed"
-		}
-		response := s.aggregator.buildResponse()
-		response.Usage = ConvertLLMUsageToResponsesUsage(s.usage)
-		if calls := getResponseWebSearchCallsFromMetadata(s.transformerMetadata); len(calls) > 0 {
-			response.Output = append(append([]Item(nil), calls...), response.Output...)
-		}
-
-		err := s.enqueueEvent(&StreamEvent{
-			Type:     StreamEventTypeResponseCompleted,
-			Response: response,
-		})
-		if err != nil {
-			s.err = fmt.Errorf("failed to enqueue response.completed event: %w", err)
+		if err := s.enqueueTerminalResponse(); err != nil {
+			s.err = err
 			return false
 		}
 	}
@@ -365,9 +332,59 @@ func (s *responsesInboundStream) Next() bool {
 	return s.Next()
 }
 
+// enqueueTerminalResponse serves both the final usage chunk and clean stream end.
+func (s *responsesInboundStream) enqueueTerminalResponse() error {
+	if s.aggregator.status == "" || s.aggregator.status == "in_progress" {
+		s.aggregator.status = "completed"
+	}
+	response := s.aggregator.buildResponse()
+	if s.usage != nil {
+		response.Usage = ConvertLLMUsageToResponsesUsage(s.usage)
+	}
+	if calls := getResponseWebSearchCallsFromMetadata(s.transformerMetadata); len(calls) > 0 {
+		response.Output = append(append([]Item(nil), calls...), response.Output...)
+	}
+
+	if raw, ok := s.transformerMetadata[responsesTerminalDetailsTransformerMetadataKey]; ok {
+		// Metadata may have crossed a JSON serialization boundary.
+		data, err := json.Marshal(raw)
+		if err != nil {
+			return fmt.Errorf("failed to encode terminal details: %w", err)
+		}
+		var details responsesTerminalDetails
+		if err := json.Unmarshal(data, &details); err != nil {
+			return fmt.Errorf("failed to decode terminal details: %w", err)
+		}
+		if details.Error != nil {
+			response.Error = details.Error
+		}
+		if details.IncompleteDetails != nil {
+			response.IncompleteDetails = details.IncompleteDetails
+		}
+	}
+
+	eventType := StreamEventTypeResponseCompleted
+	switch s.aggregator.status {
+	case "failed":
+		eventType = StreamEventTypeResponseFailed
+	case "incomplete":
+		eventType = StreamEventTypeResponseIncomplete
+	}
+	// Cancellation keeps the existing response.completed compatibility format.
+	if err := s.enqueueEvent(&StreamEvent{Type: eventType, Response: response}); err != nil {
+		return fmt.Errorf("failed to enqueue terminal response: %w", err)
+	}
+	s.responseCompleted = true
+	return nil
+}
+
 func (s *responsesInboundStream) mergeTransformerMetadata(metadata map[string]any) {
 	if len(metadata) == 0 {
 		return
+	}
+
+	if details, ok := metadata[responsesTerminalDetailsTransformerMetadataKey]; ok {
+		s.transformerMetadata[responsesTerminalDetailsTransformerMetadataKey] = details
 	}
 
 	if calls := getResponseWebSearchCallsFromMetadata(metadata); len(calls) > 0 {
@@ -1214,7 +1231,7 @@ func classifyStreamError(err error) (code, message string) {
 	code = "stream_error"
 	message = err.Error()
 
-	if errors.Is(err, io.EOF) {
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 		code = "upstream_eof"
 		message = "upstream connection closed unexpectedly"
 		return code, message
@@ -1294,6 +1311,11 @@ func (s *responsesInboundStream) Err() error {
 
 	if s.err != nil {
 		return s.err
+	}
+
+	// A source error after a terminal response must not become a second outcome.
+	if s.responseCompleted {
+		return nil
 	}
 
 	return s.source.Err()

--- a/llm/transformer/openai/responses/inbound_stream_test.go
+++ b/llm/transformer/openai/responses/inbound_stream_test.go
@@ -3,6 +3,8 @@ package responses
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,6 +15,26 @@ import (
 	"github.com/looplj/axonhub/llm/internal/pkg/xtest"
 	"github.com/looplj/axonhub/llm/streams"
 )
+
+func TestClassifyStreamError_UpstreamEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "wrapped unexpected EOF", err: fmt.Errorf("read body: %w", io.ErrUnexpectedEOF)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, message := classifyStreamError(tt.err)
+
+			require.Equal(t, "upstream_eof", code)
+			require.Equal(t, "upstream connection closed unexpectedly", message)
+		})
+	}
+}
 
 // Compare each event.
 var ignoreFields = cmp.FilterPath(func(p cmp.Path) bool {
@@ -488,6 +510,52 @@ func TestInboundTransformer_TransformStream_EmitsUpstreamErrorEvents(t *testing.
 	}
 }
 
+func TestInboundTransformer_TransformStream_DoesNotEmitFailureAfterCompleted(t *testing.T) {
+	transformedStream, err := NewInboundTransformer().TransformStream(t.Context(), &errorResponseStream{
+		items: []*llm.Response{
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Choices: []llm.Choice{{Index: 0, Delta: &llm.Message{Role: "assistant"}}},
+			},
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Choices: []llm.Choice{{
+					Index:        0,
+					Delta:        &llm.Message{},
+					FinishReason: lo.ToPtr("stop"),
+				}},
+			},
+			{
+				Object:  "chat.completion.chunk",
+				ID:      "resp_completed_before_error",
+				Created: 1700000000,
+				Model:   "gpt-5",
+				Usage:   &llm.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			},
+		},
+		err: fmt.Errorf("read body: %w", io.ErrUnexpectedEOF),
+	})
+	require.NoError(t, err)
+
+	var eventTypes []StreamEventType
+	for transformedStream.Next() {
+		var event StreamEvent
+		require.NoError(t, json.Unmarshal(transformedStream.Current().Data, &event))
+		eventTypes = append(eventTypes, event.Type)
+	}
+
+	require.NoError(t, transformedStream.Err())
+	require.Contains(t, eventTypes, StreamEventTypeResponseCompleted)
+	require.NotContains(t, eventTypes, StreamEventTypeResponseFailed)
+	require.NotContains(t, eventTypes, StreamEventTypeError)
+}
+
 type errorResponseStream struct {
 	items []*llm.Response
 	index int
@@ -524,23 +592,23 @@ func (s *errorResponseStream) Close() error {
 }
 
 // Chat Completions finish_reason must be propagated onto the Responses
-// response.completed status: truncation and failure are otherwise silently
-// reported as a successful completion downstream.
-func TestInboundTransformer_TransformStream_MapsFinishReasonToCompletedStatus(t *testing.T) {
+// terminal event and status, including truncation and provider failure.
+func TestInboundTransformer_TransformStream_MapsFinishReasonToTerminalEvent(t *testing.T) {
 	tests := []struct {
-		name                 string
-		finishReason         string
-		expectedStatus       string
-		expectedIncomplete   *ResponseIncompleteDetails
+		name               string
+		finishReason       string
+		expectedStatus     string
+		expectedType       StreamEventType
+		expectedIncomplete *ResponseIncompleteDetails
 	}{
-		{name: "length maps to incomplete", finishReason: "length", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "max_output_tokens"}},
-		{name: "content_filter maps to incomplete", finishReason: "content_filter", expectedStatus: "incomplete", expectedIncomplete: &ResponseIncompleteDetails{Reason: "content_filter"}},
-		{name: "error maps to failed", finishReason: "error", expectedStatus: "failed"},
-		{name: "cancelled maps to cancelled", finishReason: "cancelled", expectedStatus: "cancelled"},
-		{name: "canceled (US spelling) maps to cancelled", finishReason: "canceled", expectedStatus: "cancelled"},
-		{name: "unknown finish reason stays completed", finishReason: "bogus", expectedStatus: "completed"},
-		{name: "stop stays completed", finishReason: "stop", expectedStatus: "completed"},
-		{name: "tool_calls stays completed", finishReason: "tool_calls", expectedStatus: "completed"},
+		{name: "length maps to incomplete", finishReason: "length", expectedStatus: "incomplete", expectedType: StreamEventTypeResponseIncomplete, expectedIncomplete: &ResponseIncompleteDetails{Reason: "max_output_tokens"}},
+		{name: "content_filter maps to incomplete", finishReason: "content_filter", expectedStatus: "incomplete", expectedType: StreamEventTypeResponseIncomplete, expectedIncomplete: &ResponseIncompleteDetails{Reason: "content_filter"}},
+		{name: "error maps to failed", finishReason: "error", expectedStatus: "failed", expectedType: StreamEventTypeResponseFailed},
+		{name: "cancelled maps to cancelled", finishReason: "cancelled", expectedStatus: "cancelled", expectedType: StreamEventTypeResponseCompleted},
+		{name: "canceled (US spelling) maps to cancelled", finishReason: "canceled", expectedStatus: "cancelled", expectedType: StreamEventTypeResponseCompleted},
+		{name: "unknown finish reason stays completed", finishReason: "bogus", expectedStatus: "completed", expectedType: StreamEventTypeResponseCompleted},
+		{name: "stop stays completed", finishReason: "stop", expectedStatus: "completed", expectedType: StreamEventTypeResponseCompleted},
+		{name: "tool_calls stays completed", finishReason: "tool_calls", expectedStatus: "completed", expectedType: StreamEventTypeResponseCompleted},
 	}
 
 	for _, tt := range tests {
@@ -569,24 +637,25 @@ func TestInboundTransformer_TransformStream_MapsFinishReasonToCompletedStatus(t 
 			}))
 			require.NoError(t, err)
 
-			var completed *Response
+			var terminal *StreamEvent
 			for stream.Next() {
 				var ev StreamEvent
 				require.NoError(t, json.Unmarshal(stream.Current().Data, &ev))
-				if ev.Type == StreamEventTypeResponseCompleted && ev.Response != nil {
-					completed = ev.Response
+				if ev.Response != nil {
+					terminal = &ev
 				}
 			}
 			require.NoError(t, stream.Err())
 
-			require.NotNil(t, completed)
-			require.NotNil(t, completed.Status)
-			require.Equal(t, tt.expectedStatus, *completed.Status)
+			require.NotNil(t, terminal)
+			require.Equal(t, tt.expectedType, terminal.Type)
+			require.NotNil(t, terminal.Response.Status)
+			require.Equal(t, tt.expectedStatus, *terminal.Response.Status)
 			if tt.expectedIncomplete != nil {
-				require.NotNil(t, completed.IncompleteDetails)
-				require.Equal(t, tt.expectedIncomplete.Reason, completed.IncompleteDetails.Reason)
+				require.NotNil(t, terminal.Response.IncompleteDetails)
+				require.Equal(t, tt.expectedIncomplete.Reason, terminal.Response.IncompleteDetails.Reason)
 			} else {
-				require.Nil(t, completed.IncompleteDetails)
+				require.Nil(t, terminal.Response.IncompleteDetails)
 			}
 		})
 	}
@@ -632,7 +701,7 @@ func TestInboundTransformer_TransformStream_UsageBeforeFinishReasonKeepsMappedSt
 	for stream.Next() {
 		var ev StreamEvent
 		require.NoError(t, json.Unmarshal(stream.Current().Data, &ev))
-		if ev.Type == StreamEventTypeResponseCompleted && ev.Response != nil {
+		if ev.Type == StreamEventTypeResponseIncomplete && ev.Response != nil {
 			completed = ev.Response
 		}
 	}

--- a/llm/transformer/openai/responses/model.go
+++ b/llm/transformer/openai/responses/model.go
@@ -431,6 +431,13 @@ type URLCitation struct {
 
 const responsesWebSearchCallsTransformerMetadataKey = "openai_responses_web_search_calls"
 const responsesReasoningItemTransformerMetadataKey = "openai_responses_reasoning_item"
+const responsesTerminalDetailsTransformerMetadataKey = "openai_responses_terminal_details"
+
+// Preserve details that cannot be represented by a Chat Completions finish_reason.
+type responsesTerminalDetails struct {
+	Error             *Error                     `json:"error,omitempty"`
+	IncompleteDetails *ResponseIncompleteDetails `json:"incomplete_details,omitempty"`
+}
 
 type responsesReasoningItemMetadata struct {
 	ID   string `json:"id,omitempty"`

--- a/llm/transformer/openai/responses/outbound_stream.go
+++ b/llm/transformer/openai/responses/outbound_stream.go
@@ -102,16 +102,21 @@ func (s *responsesOutboundStream) Next() bool {
 	s.eventQueue = nil
 	s.queueIndex = 0
 
+	// The terminal event contains the final outcome and any usage. Once its
+	// queued chunks are drained, finish without reading a later transport error.
+	if s.responseCompleted {
+		if !s.doneEmitted {
+			s.doneEmitted = true
+			s.enqueue(llm.DoneResponse)
+			return true
+		}
+		return false
+	}
+
 	// Try to get the next chunk from source
 	if !s.stream.Next() {
 		if s.err == nil && s.stream.Err() == nil {
-			if !s.responseCompleted {
-				s.err = ErrStreamIncomplete
-			} else if !s.doneEmitted {
-				s.doneEmitted = true
-				s.enqueue(llm.DoneResponse)
-				return true
-			}
+			s.err = ErrStreamIncomplete
 		}
 		return false
 	}
@@ -596,11 +601,8 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			s.state.transformerMetadataEmitted = true
 		}
 
-		// The Responses API signals abnormal completion via response.completed
-		// with a status other than "completed" (incomplete/failed/cancelled) - it
-		// does not emit separate events for those cases. Map the status onto the
-		// Chat Completions finish_reason; fall back to the tool_calls/stop
-		// inference only when the status is absent or plain "completed".
+		// Some compatible providers report abnormal outcomes in response.completed
+		// instead of a separate terminal event. Preserve those statuses too.
 		finishReason := ""
 		if streamEvent.Response != nil && streamEvent.Response.Status != nil {
 			switch *streamEvent.Response.Status {
@@ -640,25 +642,6 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 			},
 		}
 
-		// Second event: usage (if available)
-		if streamEvent.Response != nil && streamEvent.Response.Usage != nil {
-			s.state.usage = streamEvent.Response.Usage.ToUsage()
-			usageResp := &llm.Response{
-				Object:             "chat.completion.chunk",
-				ID:                 s.state.responseID,
-				Model:              s.state.responseModel,
-				Created:            s.state.created,
-				PreviousResponseID: s.state.previousResponseID,
-				Choices:            []llm.Choice{},
-				Usage:              s.state.usage,
-			}
-
-			s.enqueue(resp)
-			s.enqueue(usageResp)
-
-			return nil
-		}
-
 	case StreamEventTypeResponseFailed:
 		if s.responseCompleted {
 			return nil
@@ -680,6 +663,10 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		// Response incomplete (e.g., max tokens)
 		s.responseCompleted = true
 		finishReason := "length"
+		if streamEvent.Response != nil && streamEvent.Response.IncompleteDetails != nil &&
+			streamEvent.Response.IncompleteDetails.Reason == "content_filter" {
+			finishReason = "content_filter"
+		}
 		resp.Choices = []llm.Choice{
 			{
 				Index:        0,
@@ -765,7 +752,32 @@ func (s *responsesOutboundStream) transformStreamChunk(event *httpclient.StreamE
 		return nil // Intentionally skip this event
 	}
 
+	if s.responseCompleted && streamEvent.Response != nil &&
+		(streamEvent.Response.Error != nil || streamEvent.Response.IncompleteDetails != nil) {
+		if resp.TransformerMetadata == nil {
+			resp.TransformerMetadata = make(map[string]any)
+		}
+		resp.TransformerMetadata[responsesTerminalDetailsTransformerMetadataKey] = responsesTerminalDetails{
+			Error:             streamEvent.Response.Error,
+			IncompleteDetails: streamEvent.Response.IncompleteDetails,
+		}
+	}
+
 	s.enqueue(resp)
+
+	// Preserve usage on every terminal outcome, after its finish_reason chunk.
+	if s.responseCompleted && streamEvent.Response != nil && streamEvent.Response.Usage != nil {
+		s.state.usage = streamEvent.Response.Usage.ToUsage()
+		s.enqueue(&llm.Response{
+			Object:             "chat.completion.chunk",
+			ID:                 s.state.responseID,
+			Model:              s.state.responseModel,
+			Created:            s.state.created,
+			PreviousResponseID: s.state.previousResponseID,
+			Choices:            []llm.Choice{},
+			Usage:              s.state.usage,
+		})
+	}
 
 	return nil
 }
@@ -817,6 +829,10 @@ func (s *responsesOutboundStream) Current() *llm.Response {
 func (s *responsesOutboundStream) Err() error {
 	if s.err != nil {
 		return s.err
+	}
+
+	if s.responseCompleted {
+		return nil
 	}
 
 	return s.stream.Err()

--- a/llm/transformer/openai/responses/outbound_stream_test.go
+++ b/llm/transformer/openai/responses/outbound_stream_test.go
@@ -247,7 +247,7 @@ func TestOutboundTransformer_TransformStream_DuplicateProviderDoneEmitsOnce(t *t
 	require.Equal(t, 1, countDoneResponses(responses))
 }
 
-func TestOutboundTransformer_TransformStream_ProviderDoneBeforeSourceErrorDoesNotEmitDone(t *testing.T) {
+func TestOutboundTransformer_TransformStream_SemanticTerminalWinsOverLateSourceError(t *testing.T) {
 	trans, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)
 
@@ -262,8 +262,9 @@ func TestOutboundTransformer_TransformStream_ProviderDoneBeforeSourceErrorDoesNo
 	require.NoError(t, err)
 
 	responses, err := streams.All(stream)
-	require.ErrorIs(t, err, sourceErr)
-	require.Equal(t, 0, countDoneResponses(responses))
+	require.NoError(t, err)
+	require.Equal(t, 1, countDoneResponses(responses))
+	require.Equal(t, 1, source.index, "Do not read the source after its semantic terminal")
 }
 
 type responsesErrorAfterStream struct {
@@ -1138,9 +1139,8 @@ func TestOutboundTransformer_TransformStream_PreservesPreviousResponseID(t *test
 	require.Equal(t, llm.DoneResponse, actual[3])
 }
 
-// The Responses API signals truncation/failure through response.completed with
-// status "incomplete"/"failed" rather than a dedicated event; the Chat
-// Completions finish_reason must reflect that instead of defaulting to stop.
+// Compatible providers may report abnormal statuses in response.completed.
+// The finish_reason must preserve those outcomes instead of defaulting to stop.
 func TestOutboundTransformer_TransformStream_MapsCompletedStatusToFinishReason(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -1203,6 +1203,33 @@ func TestOutboundTransformer_TransformStream_MapsCompletedStatusToFinishReason(t
 			}
 
 			require.Equal(t, []string{tt.expectedReason}, finishReasons)
+		})
+	}
+}
+
+func TestOutboundTransformer_TransformStream_MapsIncompleteReasonToFinishReason(t *testing.T) {
+	for _, tt := range []struct {
+		reason string
+		finish string
+	}{
+		{"max_output_tokens", "length"},
+		{"content_filter", "content_filter"},
+		{"provider_limit", "length"},
+	} {
+		t.Run(tt.reason, func(t *testing.T) {
+			trans, err := NewOutboundTransformer("https://example.test", "test-key")
+			require.NoError(t, err)
+			stream, err := trans.TransformStream(t.Context(), nil, streams.SliceStream([]*httpclient.StreamEvent{
+				{Type: "response.incomplete", Data: []byte(fmt.Sprintf(
+					`{"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":%q}}}`, tt.reason))},
+			}))
+			require.NoError(t, err)
+			chunks, err := streams.All(stream)
+			require.NoError(t, err)
+			require.Len(t, chunks, 2)
+			require.Len(t, chunks[0].Choices, 1)
+			require.Equal(t, tt.finish, lo.FromPtr(chunks[0].Choices[0].FinishReason))
+			require.Equal(t, llm.DoneResponse, chunks[1])
 		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious stream errors when a terminal response is followed by an unexpected disconnect.
  * Preserved completed response data and terminal details across connection closures.
  * Consistently handled completed, failed, incomplete, canceled, and standalone error responses.
  * Prevented duplicate terminal events from being emitted.
  * Retained final status and error details even when response aggregation encounters an error.
  * Improved upstream connection error classification and incomplete-response reason mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->