### PR TITLE
feat(codex): support gpt-6-astra

### DIFF
--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -126,7 +126,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
   codex: {
     channelType: 'codex',
     baseURL: 'https://chatgpt.com/backend-api/codex#',
-    defaultModels: ['gpt-5.2', 'gpt-5.2-codex'],
+    defaultModels: ['gpt-5.2', 'gpt-5.2-codex', 'gpt-6-astra'],
     apiFormat: OPENAI_RESPONSES,
     color: 'bg-[#32746D] text-white border-[#32746D]',
     icon: OpenAI,

--- a/llm/transformer/openai/codex/constants.go
+++ b/llm/transformer/openai/codex/constants.go
@@ -23,6 +23,7 @@ func DefaultModels() []string {
 		"gpt-5.6-sol",
 		"gpt-5.6-terra",
 		"gpt-5.6-luna",
+		"gpt-6-astra",
 	}
 }
 
@@ -37,7 +38,7 @@ const (
 	RedirectURI = "http://localhost:1455/auth/callback"
 	Scopes      = "openid profile email offline_access"
 
-	codexDefaultVersion = "0.144.1"
+	codexDefaultVersion = "0.153.4"
 
 	// fabricatedBetaFeatures mirrors the X-Codex-Beta-Features value the current
 	// Codex CLI sends, used when a non-Codex inbound client omits the header.


### PR DESCRIPTION
## Summary\n- Add gpt-6-astra to the Codex channel default model list.\n- Register gpt-6-astra in the Codex transformer model list.\n- Update the fabricated Codex Version header to 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the GPT-6 Astra model in Codex channels.
  * Updated the Codex model configuration to recognize the latest default version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->