### PR TITLE
fix(requests): keep API key filter visible without results

### DIFF
--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -65,6 +65,9 @@ interface RequestFilterControlsProps {
   onCloseAfterAction?: () => void;
 }
 
+/**
+ * Renders the request filters available to the current user.
+ */
 function RequestFilterControls({
   table,
   dateRange,
@@ -147,7 +150,7 @@ function RequestFilterControls({
           footer={channelFooter}
         />
       )}
-      {canViewApiKeys && table.getColumn('caller') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+      {canViewApiKeys && table.getColumn('caller') && (
         <DataTableFacetedFilter
           column={table.getColumn('caller')}
           title={t('requests.filters.apiKey')}


### PR DESCRIPTION
## Summary

- Keep the API key filter control mounted when a search returns no matching options.
- Allow the empty state to be displayed inside the filter instead of removing the control.

## Validation

- Not run (build and lint were not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The caller/API-key filter now remains visible for authorized users whenever the corresponding table column is available, including while options are loading or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->