### PR TITLE
ci: enable manual unstable Docker image publishing

### DIFF
--- a/.github/workflows/docker-unstable.yml
+++ b/.github/workflows/docker-unstable.yml
@@ -3,6 +3,7 @@ name: Publish Docker image (unstable)
 on:
   schedule:
     - cron: '17 3 * * *'
+  workflow_dispatch:
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary
- add a manual `workflow_dispatch` trigger to the unstable Docker image workflow
- preserve the existing scheduled trigger and publish jobs

## Verification
- YAML parsed successfully with `yq`
- `git diff --check` passed
- signed commit verified by GitHub

Manual workflow runs require repository write access, not only maintainer access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually trigger unstable Docker image publishing, in addition to the existing scheduled run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->