### PR TITLE
fix(requests): keep API key filter visible without results

### DIFF
--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+﻿import { useMemo, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Table } from '@tanstack/react-table';
 import { Filter, GripVertical, X } from 'lucide-react';
@@ -65,6 +65,9 @@ interface RequestFilterControlsProps {
   onCloseAfterAction?: () => void;
 }
 
+/**
+ * Renders request filters for desktop and mobile layouts, including empty API key results.
+ */
 function RequestFilterControls({
   table,
   dateRange,

--- a/frontend/src/features/requests/components/data-table-toolbar.tsx
+++ b/frontend/src/features/requests/components/data-table-toolbar.tsx
@@ -147,7 +147,7 @@ function RequestFilterControls({
           footer={channelFooter}
         />
       )}
-      {canViewApiKeys && table.getColumn('caller') && (apiKeyOptions.length > 0 || isFetchingApiKeys) && (
+      {canViewApiKeys && table.getColumn('caller') && (
         <DataTableFacetedFilter
           column={table.getColumn('caller')}
           title={t('requests.filters.apiKey')}


### PR DESCRIPTION
## 问题描述

请求列表页面中的 API Key 筛选器会在搜索结果为空时被错误隐藏。

当用户在 API Key 筛选器中输入一个不存在的 API Key 或无法匹配任何结果的关键词时，API 返回空的选项列表。原有渲染逻辑将“选项为空且请求已完成”视为不需要显示筛选器，导致 API Key 筛选器从工具栏中消失。

这会带来以下问题：

- 用户无法确认筛选器是否正常工作；
- 筛选器消失后，无法直接清空或修改当前搜索条件；
- 工具栏布局会发生变化，影响页面使用体验；
- 用户可能误以为没有 API Key 筛选权限，或认为页面加载失败。

## 复现步骤

1. 进入请求列表页面。
2. 找到 API Key（Caller）筛选器。
3. 输入一个不存在的 API Key，或输入一个不会匹配任何 API Key 的关键词。
4. 等待 API Key 选项请求完成。
5. 观察请求列表工具栏。

### 实际结果

API Key 筛选器从工具栏中消失，用户无法继续在该筛选器中清空输入或修改搜索条件。

### 预期结果

API Key 筛选器应继续显示。没有匹配结果时，应由筛选器内部展示空状态，同时允许用户清空搜索条件或重新输入关键词。

## 问题原因

API Key 筛选器原先依赖 API Key 选项列表和加载状态进行条件渲染：只有在存在选项或正在加载时才显示筛选器。

这种判断无法区分两种情况：

1. 用户没有权限使用 API Key 筛选器；
2. 用户有权限使用筛选器，但当前搜索条件没有匹配结果。

当第二种情况发生时，空的选项列表被错误地当成了筛选器不可用，最终导致组件被卸载。

## 解决方案

本次修改调整 API Key 筛选器的显示逻辑，不再根据选项列表是否为空或请求是否正在加载来决定是否渲染筛选器。

筛选器是否显示仅由以下条件决定：

- 当前用户是否拥有查看 API Key 的权限；
- 请求列表中是否存在 Caller/API Key 列。

当 API Key 查询返回空结果时，筛选器仍然保持显示，并将空数据交由筛选器组件自身处理。这样用户可以继续清空输入、修改关键词或重新选择 API Key。

## 修改内容

- 调整 `frontend/src/features/requests/components/data-table-toolbar.tsx` 中 API Key 筛选器的条件渲染逻辑；
- 移除对 API Key 选项数量的依赖；
- 移除对 API Key 加载状态的依赖；
- 保留权限控制和 Caller 列可用性判断；
- 确保无匹配结果时筛选器不会从工具栏中消失；
- 补充相关说明。

## 修复后的行为

- 有匹配结果时：API Key 筛选器正常显示并可选择结果；
- 无匹配结果时：筛选器继续显示，并展示空状态；
- 用户可以清空当前输入或修改搜索关键词；
- 用户无权限或 Caller 列不可用时：筛选器仍按原有逻辑隐藏。

## 验证

已针对请求列表工具栏的条件渲染逻辑进行检查，确认 API Key 选项为空时不会再导致筛选器组件被移除。

按照仓库约定，未执行 build 或 lint 命令。