### PR TITLE
fix(playground): honor aliases when a channel is specified

### DIFF
--- a/internal/server/biz/channel_llm.go
+++ b/internal/server/biz/channel_llm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"slices"
 	"strconv"
@@ -1422,13 +1423,13 @@ func (ch *Channel) GetModelEntries() map[string]ChannelModelEntry {
 	return entries
 }
 
-// GetDirectModelEntries returns the direct models this channel can handle.
-// This is used for testing purposes where we need to see all available models
-// regardless of the HideOriginalModels setting.
-// The difference from GetModelEntries is that this method does NOT filter out
-// direct models when HideOriginalModels is enabled.
+// GetDirectModelEntries returns the models a specified-channel flow
+// (playground, TestChannel) can send. It keeps every alias from
+// GetModelEntries and also re-adds the original SupportedModels names
+// when HideOriginalModels or HideMappedModels would hide them from the
+// public list, so a channel test can still target the provider model id.
 func (ch *Channel) GetDirectModelEntries() map[string]ChannelModelEntry {
-	entries := make(map[string]ChannelModelEntry)
+	entries := maps.Clone(ch.GetModelEntries())
 
 	for _, model := range ch.SupportedModels {
 		if _, exists := entries[model]; !exists {

--- a/internal/server/biz/channel_model_entry_test.go
+++ b/internal/server/biz/channel_model_entry_test.go
@@ -518,3 +518,34 @@ func TestChannel_GetUnifiedModels_LowercaseModelID(t *testing.T) {
 		})
 	}
 }
+
+func TestChannel_GetDirectModelEntries_IncludesAliasesAndHiddenOriginals(t *testing.T) {
+	ch := &Channel{
+		Channel: &ent.Channel{
+			Name:            "nv-api6",
+			SupportedModels: []string{"moonshotai/kimi-k3", "deepseek-ai/deepseek-v4-pro"},
+			Settings: &objects.ChannelSettings{
+				AutoTrimedModelPrefixes: []string{"moonshotai", "deepseek-ai"},
+				ModelMappings: []objects.ModelMapping{
+					{From: "deepseek-v4-flash", To: "deepseek-ai/deepseek-v4-pro"},
+				},
+				HideOriginalModels: true,
+			},
+		},
+	}
+
+	entries := ch.GetDirectModelEntries()
+
+	require.Equal(t, "moonshotai/kimi-k3", entries["kimi-k3"].ActualModel)
+	require.Equal(t, "auto_trim", entries["kimi-k3"].Source)
+	require.Equal(t, "deepseek-ai/deepseek-v4-pro", entries["deepseek-v4-pro"].ActualModel)
+	require.Equal(t, "deepseek-ai/deepseek-v4-pro", entries["deepseek-v4-flash"].ActualModel)
+	require.Equal(t, "mapping", entries["deepseek-v4-flash"].Source)
+	require.Equal(t, "moonshotai/kimi-k3", entries["moonshotai/kimi-k3"].ActualModel)
+	require.Equal(t, "direct", entries["moonshotai/kimi-k3"].Source)
+
+	public := ch.GetModelEntries()
+	_, hidden := public["moonshotai/kimi-k3"]
+	require.False(t, hidden, "HideOriginalModels should still hide provider ids from the public list")
+	require.Contains(t, public, "kimi-k3")
+}

--- a/internal/server/orchestrator/candidates_basic_test.go
+++ b/internal/server/orchestrator/candidates_basic_test.go
@@ -201,6 +201,37 @@ func TestSpecifiedChannelSelector_Select_ModelNotSupported(t *testing.T) {
 	require.Contains(t, err.Error(), "model gpt-4 not supported")
 }
 
+func TestSpecifiedChannelSelector_Select_AutoTrimAndMapping(t *testing.T) {
+	ctx, client := setupTest(t)
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("nv-api6").
+		SetBaseURL("https://integrate.api.nvidia.com/v1").
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"moonshotai/kimi-k3", "deepseek-ai/deepseek-v4-pro"}).
+		SetDefaultTestModel("moonshotai/kimi-k3").
+		SetSettings(&objects.ChannelSettings{
+			AutoTrimedModelPrefixes: []string{"moonshotai", "deepseek-ai"},
+			ModelMappings: []objects.ModelMapping{
+				{From: "deepseek-v4-pro", To: "deepseek-ai/deepseek-v4-pro"},
+			},
+			HideOriginalModels: true,
+		}).
+		SetStatus(channel.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	selector := NewSpecifiedChannelSelector(newTestChannelServiceForChannels(client), objects.GUID{ID: ch.ID})
+
+	for _, model := range []string{"kimi-k3", "moonshotai/kimi-k3", "deepseek-v4-pro"} {
+		result, err := selector.Select(ctx, &llm.Request{Model: model})
+		require.NoError(t, err, "model %s", model)
+		require.Len(t, result, 1)
+		require.Equal(t, model, result[0].Models[0].RequestModel)
+	}
+}
+
 // TestSpecifiedChannelSelector_Select_ChannelNotFound tests SpecifiedChannelSelector with non-existent channel.
 func TestSpecifiedChannelSelector_Select_ChannelNotFound(t *testing.T) {
 	ctx, client := setupTest(t)


### PR DESCRIPTION
## Summary
- Playground / TestChannel pin a channel via `SpecifiedChannelSelector`, which called `GetDirectModelEntries()`.
- That helper only kept `SupportedModels` ids, so auto-trim aliases (`kimi-k3`) and mappings (`deepseek-v4-pro`) were rejected even though the public model list (`allModelEntries`) showed them.
- Seen on `nv-api6` (`hideOriginalModels` + `autoTrimedModelPrefixes`) as `model kimi-k3 not supported in channel nv-api6`.

## Change
- `GetDirectModelEntries` now starts from `GetModelEntries()` (aliases included) and re-adds hidden original provider ids so channel tests can still target the upstream model name.

## Test plan
- [x] `go test ./internal/server/biz/ -run TestChannel_GetDirectModelEntries_IncludesAliasesAndHiddenOriginals`
- [x] `go test ./internal/server/orchestrator/ -run TestSpecifiedChannelSelector_Select`

🤖 Generated with [Claude Code](https://claude.com/claude-code)