### PR TITLE
fix(openai): do not invent prompt_cache_key for compatible gateways

### DIFF
--- a/llm/transformer/openai/outbound.go
+++ b/llm/transformer/openai/outbound.go
@@ -194,6 +194,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 
 	// Convert to OpenAI Request format (this strips helper fields)
 	oaiReq := RequestFromLLM(ctx, llmReq, reasoningField)
+	applyPromptCacheKeyFallback(ctx, oaiReq, t.config.BaseURL)
 	//nolint:exhaustive // Checked.
 	switch t.config.PlatformType {
 	case PlatformOpenAI:

--- a/llm/transformer/openai/outbound_convert.go
+++ b/llm/transformer/openai/outbound_convert.go
@@ -13,8 +13,11 @@ import (
 )
 
 // RequestFromLLM creates an OpenAI Request from unified llm.Request with reasoning
-// field configuration. When the request has no explicit prompt cache key, ctx's
-// session ID is used as a fallback when available.
+// field configuration. It copies an explicit prompt cache key when the inbound
+// request already has one; it does not invent a session-derived fallback.
+// Official OpenAI Chat Completions hosts apply that fallback in
+// applyPromptCacheKeyFallback, because NVIDIA NIM and other strict
+// OpenAI-compatible gateways reject unknown `prompt_cache_key`.
 func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField ReasoningField) *Request {
 	if r == nil {
 		return nil
@@ -43,12 +46,6 @@ func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField Reasonin
 		Stream:              r.Stream,
 		ParallelToolCalls:   r.ParallelToolCalls,
 		Verbosity:           r.Verbosity,
-	}
-
-	if ctx != nil && lo.FromPtr(req.PromptCacheKey) == "" {
-		if sessionID, ok := shared.GetSessionID(ctx); ok && sessionID != "" {
-			req.PromptCacheKey = lo.ToPtr(sessionID)
-		}
 	}
 
 	// Convert messages
@@ -113,6 +110,25 @@ func RequestFromLLM(ctx context.Context, r *llm.Request, reasoningField Reasonin
 	}
 
 	return req
+}
+
+// applyPromptCacheKeyFallback fills prompt_cache_key from the request session ID
+// only for hosts that accept the field. Explicit inbound keys are left as-is.
+func applyPromptCacheKeyFallback(ctx context.Context, req *Request, baseURL string) {
+	if req == nil || !shared.SupportsPromptCacheKey(baseURL) {
+		return
+	}
+	if lo.FromPtr(req.PromptCacheKey) != "" {
+		return
+	}
+	if ctx == nil {
+		return
+	}
+	sessionID, ok := shared.GetSessionID(ctx)
+	if !ok || sessionID == "" {
+		return
+	}
+	req.PromptCacheKey = lo.ToPtr(sessionID)
 }
 
 // mergeSystemMessages collapses all system-role messages into one at the

--- a/llm/transformer/openai/outbound_test.go
+++ b/llm/transformer/openai/outbound_test.go
@@ -257,6 +257,38 @@ func TestOutboundTransformer_TransformRequest_PromptCacheKeyFallback(t *testing.
 	})
 }
 
+func TestOutboundTransformer_TransformRequest_PromptCacheKeyFallback_SkipsStrictCompatHosts(t *testing.T) {
+	tr, err := NewOutboundTransformer("https://integrate.api.nvidia.com/v1", "test-api-key")
+	require.NoError(t, err)
+
+	request := &llm.Request{
+		Model: "moonshotai/kimi-k3",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	ctx := shared.WithSessionID(t.Context(), "02351f25-5398-4576-80a5-0e29cb79904d")
+	httpReq, err := tr.TransformRequest(ctx, request)
+	require.NoError(t, err)
+
+	var payload Request
+	require.NoError(t, json.Unmarshal(httpReq.Body, &payload))
+	assert.Nil(t, payload.PromptCacheKey)
+}
+
+func TestRequestFromLLM_DoesNotInventPromptCacheKey(t *testing.T) {
+	ctx := shared.WithSessionID(t.Context(), "session-123")
+	req := RequestFromLLM(ctx, &llm.Request{
+		Model: "gpt-4",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}, ReasoningFieldNone)
+	require.NotNil(t, req)
+	assert.Nil(t, req.PromptCacheKey)
+}
+
 func TestOutboundTransformer_TransformRequest_StripsUnsupportedToolCallExtraContentForOpenAI(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/llm/transformer/openai/responses/outbound.go
+++ b/llm/transformer/openai/responses/outbound.go
@@ -290,7 +290,7 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		Truncation:           xmap.GetStringPtr(llmReq.TransformerMetadata, "truncation"),
 	}
 
-	if lo.FromPtr(payload.PromptCacheKey) == "" {
+	if lo.FromPtr(payload.PromptCacheKey) == "" && shared.SupportsPromptCacheKey(t.config.BaseURL) {
 		if sessionID, ok := shared.GetSessionID(ctx); ok {
 			// A session may multiplex several concurrent conversations
 			// (e.g. Claude Code subagents); scope the cache key to the

--- a/llm/transformer/openai/responses/outbound_test.go
+++ b/llm/transformer/openai/responses/outbound_test.go
@@ -1137,6 +1137,27 @@ func TestOutboundTransformer_TransformRequest_UsesSharedSessionIDAsPromptCacheKe
 	require.Equal(t, "shared-session-123-"+conversationAnchor(req.Messages), *payload.PromptCacheKey)
 }
 
+func TestOutboundTransformer_TransformRequest_PromptCacheKeyFallback_SkipsStrictCompatHosts(t *testing.T) {
+	transformer, err := NewOutboundTransformer("https://integrate.api.nvidia.com/v1", "test-api-key")
+	require.NoError(t, err)
+
+	ctx := shared.WithSessionID(context.Background(), "shared-session-123")
+	req := &llm.Request{
+		Model: "moonshotai/kimi-k3",
+		Messages: []llm.Message{
+			{Role: "user", Content: llm.MessageContent{Content: lo.ToPtr("Hello")}},
+		},
+	}
+
+	httpReq, err := transformer.TransformRequest(ctx, req)
+	require.NoError(t, err)
+
+	var payload Request
+	err = json.Unmarshal(httpReq.Body, &payload)
+	require.NoError(t, err)
+	require.Nil(t, payload.PromptCacheKey)
+}
+
 func TestOutboundTransformer_TransformRequest_PromptCacheKeyScopedPerConversation(t *testing.T) {
 	transformer, err := NewOutboundTransformer("https://api.openai.com", "test-api-key")
 	require.NoError(t, err)

--- a/llm/transformer/shared/openai.go
+++ b/llm/transformer/shared/openai.go
@@ -1,5 +1,10 @@
 package shared
 
+import (
+	"net/url"
+	"strings"
+)
+
 // EncodeOpenAIEncryptedContent encodes raw OpenAI encrypted content for storage.
 // OpenAI encrypted_content is already base64-encoded, so this is a passthrough.
 func EncodeOpenAIEncryptedContent(content *string) *string {
@@ -23,4 +28,23 @@ func DecodeOpenAIEncryptedContent(content *string) *string {
 	}
 
 	return content
+}
+
+// SupportsPromptCacheKey reports whether the OpenAI-protocol host documents
+// prompt_cache_key. Official OpenAI Chat Completions and Responses do;
+// NVIDIA NIM and many OpenAI-compatible gateways reject the field.
+func SupportsPromptCacheKey(baseURL string) bool {
+	raw := strings.TrimSpace(baseURL)
+	if raw == "" {
+		return false
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "api.openai.com" || strings.HasSuffix(host, ".api.openai.com")
 }

--- a/llm/transformer/shared/openai_test.go
+++ b/llm/transformer/shared/openai_test.go
@@ -88,6 +88,27 @@ func TestEncodeOpenAIEncryptedContent(t *testing.T) {
 	}
 }
 
+func TestSupportsPromptCacheKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{name: "official chat", baseURL: "https://api.openai.com/v1", want: true},
+		{name: "official responses", baseURL: "https://api.openai.com", want: true},
+		{name: "official subdomain", baseURL: "https://us.api.openai.com/v1", want: true},
+		{name: "host only", baseURL: "api.openai.com", want: true},
+		{name: "nvidia nim", baseURL: "https://integrate.api.nvidia.com/v1", want: false},
+		{name: "openai-compatible proxy", baseURL: "https://openai.example.com/v1", want: false},
+		{name: "empty", baseURL: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, SupportsPromptCacheKey(tt.baseURL))
+		})
+	}
+}
+
 func TestOpenAIEncodeDecodeRoundTrip(t *testing.T) {
 	original := new("gAAAAABpg2hk4yLqQUPBKlNLPwYE5lSfBmhv0")
 


### PR DESCRIPTION
## Summary
- Anthropic inbound (Claude Code) always stores the session/trace id via `shared.WithSessionID`.
- `RequestFromLLM` then copied that id into Chat Completions `prompt_cache_key` for **every** OpenAI-compatible upstream.
- NVIDIA NIM (`integrate.api.nvidia.com`) rejects unknown `prompt_cache_key` with HTTP 400, so Claude Code saw empty/400 output while playground (AI SDK, no session fallback) succeeded on the same `kimi-k3` channel.

## Change
- `RequestFromLLM` no longer invents a cache key.
- Session fallback runs only for official `api.openai.com` hosts (Chat Completions and Responses).
- Explicit inbound `prompt_cache_key` is still forwarded.

## Test plan
- [x] `cd llm && go test ./transformer/shared/ ./transformer/openai/ ./transformer/openai/responses/`
- NVIDIA / other strict gateways: session present, no `prompt_cache_key` on the wire
- Official OpenAI: session fallback still applied

Related production incident: Claude Code session `02351f25-5398-4576-80a5-0e29cb79904d` → NVIDIA `Unsupported parameter(s): prompt_cache_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt cache keys are now automatically applied only when supported by the target OpenAI host.
  * Strict compatibility endpoints no longer receive unsupported prompt cache keys.
  * Explicitly provided prompt cache keys remain unchanged.

* **Tests**
  * Added coverage for supported OpenAI endpoints and compatibility hosts.
  * Verified that session IDs do not create prompt cache keys for unsupported endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->