### PR TITLE
fix(frontend): preserve channel form focus and onboarding dismissal

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -1250,7 +1250,9 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
     try {
       if (values.credentials?.apiKeys) {
-        values.credentials.apiKeys = [...new Set(values.credentials.apiKeys.filter((k) => k.trim().length > 0))];
+        values.credentials.apiKeys = [
+          ...new Set(values.credentials.apiKeys.map((key) => key.trim()).filter((key) => key.length > 0)),
+        ];
       }
 
       const retryableStatusCodes = parseRetryableStatusCodesInput(retryableStatusCodesText);
@@ -2358,17 +2360,8 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                               const keys = e.target.value.split('\n');
                                               field.onChange(keys);
                                             }}
-                                            onBlur={(e) => {
+                                            onBlur={() => {
                                               if (!showApiKey) return;
-                                              const keys = [
-                                                ...new Set(
-                                                  e.target.value
-                                                    .split('\n')
-                                                    .map((k) => k.trim())
-                                                    .filter((k) => k.length > 0)
-                                                ),
-                                              ];
-                                              field.onChange(keys);
                                               field.onBlur();
                                             }}
                                             readOnly={!showApiKey}
@@ -2441,18 +2434,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                           const keys = e.target.value.split('\n');
                                           field.onChange(keys);
                                         }}
-                                        onBlur={(e) => {
-                                          const keys = [
-                                            ...new Set(
-                                              e.target.value
-                                                .split('\n')
-                                                .map((k) => k.trim())
-                                                .filter((k) => k.length > 0)
-                                            ),
-                                          ];
-                                          field.onChange(keys);
-                                          field.onBlur();
-                                        }}
+                                        onBlur={() => field.onBlur()}
                                         placeholder={t('channels.dialogs.fields.apiKey.placeholder')}
                                         className='min-h-[80px] resize-y font-mono text-sm md:col-span-6'
                                         autoComplete='new-password'

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -1535,7 +1535,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
 
       // Fall back to apiKeys array if no OAuth token
       if (!firstApiKey && apiKeys?.length) {
-        firstApiKey = apiKeys.find((key) => key.trim().length > 0) || '';
+        firstApiKey = apiKeys.find((key) => key.trim().length > 0)?.trim() || '';
       }
 
       const result = await fetchModels.mutateAsync({
@@ -1705,15 +1705,17 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
   const removeApiKeys = useCallback(
     (keysToRemove: string[]) => {
       const currentKeys = form.getValues('credentials.apiKeys') || [];
-      const nextKeys = currentKeys.filter((k) => !keysToRemove.includes(k));
-      const validNextKeys = nextKeys.filter((k) => k.trim().length > 0);
+      const keysToRemoveSet = new Set(keysToRemove.map((key) => key.trim()));
+      const validNextKeys = currentKeys
+        .map((key) => key.trim())
+        .filter((key) => key.length > 0 && !keysToRemoveSet.has(key));
       if (validNextKeys.length === 0) {
         toast.error(t('channels.dialogs.fields.apiKey.mustKeepOne'));
         setConfirmRemoveSelectedOpen(false);
         setConfirmRemoveKey(null);
         return;
       }
-      form.setValue('credentials.apiKeys', nextKeys, { shouldDirty: true, shouldTouch: true });
+      form.setValue('credentials.apiKeys', validNextKeys, { shouldDirty: true, shouldTouch: true });
       setSelectedKeysToRemove(new Set());
       setConfirmRemoveSelectedOpen(false);
       setConfirmRemoveKey(null);
@@ -3102,7 +3104,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                 <ScrollArea className='min-h-0 flex-1' type='always'>
                   <div className='space-y-1 pr-3'>
                     {(() => {
-                      const validKeys = (apiKeys || []).map((k) => k.trim()).filter((k) => k.length > 0);
+                      const validKeys = [...new Set((apiKeys || []).map((key) => key.trim()).filter((key) => key.length > 0))];
                       const isLastKey = validKeys.length <= 1;
                       const enabledKeysCount = validKeys.filter((k) => savedAPIKeySet.has(k) && !disabledKeySet.has(k)).length;
                       return validKeys

--- a/frontend/src/features/onboarding/auto-disable-channel-onboarding-flow.tsx
+++ b/frontend/src/features/onboarding/auto-disable-channel-onboarding-flow.tsx
@@ -41,10 +41,11 @@ export function AutoDisableChannelOnboardingFlow({ onComplete }: AutoDisableChan
       onSuccess: () => {
         onComplete?.();
       },
-      onError: () => {
-        completedRef.current = false;
-        toast.error(t('common.errors.onboardingFailed'));
-      },
+        onError: () => {
+          completedRef.current = false;
+          setShowPrompt(true);
+          toast.error(t('common.errors.onboardingFailed'));
+        },
     });
   }, [completeOnboarding, onComplete, t]);
 
@@ -94,8 +95,8 @@ export function AutoDisableChannelOnboardingFlow({ onComplete }: AutoDisableChan
 
   const skipOnboarding = useCallback(() => {
     setShowPrompt(false);
-    markComplete();
-  }, [markComplete]);
+    markComplete(onComplete);
+  }, [markComplete, onComplete]);
 
   if (showPrompt === false) {
     return null;

--- a/frontend/src/features/onboarding/auto-disable-channel-onboarding-flow.tsx
+++ b/frontend/src/features/onboarding/auto-disable-channel-onboarding-flow.tsx
@@ -41,11 +41,11 @@ export function AutoDisableChannelOnboardingFlow({ onComplete }: AutoDisableChan
       onSuccess: () => {
         onComplete?.();
       },
-        onError: () => {
-          completedRef.current = false;
-          setShowPrompt(true);
-          toast.error(t('common.errors.onboardingFailed'));
-        },
+      onError: () => {
+        completedRef.current = false;
+        setShowPrompt(true);
+        toast.error(t('common.errors.onboardingFailed'));
+      },
     });
   }, [completeOnboarding, onComplete, t]);
 
@@ -95,8 +95,8 @@ export function AutoDisableChannelOnboardingFlow({ onComplete }: AutoDisableChan
 
   const skipOnboarding = useCallback(() => {
     setShowPrompt(false);
-    markComplete(onComplete);
-  }, [markComplete, onComplete]);
+    markComplete();
+  }, [markComplete]);
 
   if (showPrompt === false) {
     return null;

--- a/frontend/src/features/onboarding/onboarding-flow.tsx
+++ b/frontend/src/features/onboarding/onboarding-flow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { driver } from 'driver.js';
 import 'driver.js/dist/driver.css';
@@ -19,6 +19,7 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const navigate = useNavigate();
   const completeOnboarding = useCompleteOnboarding();
   const [showPrompt, setShowPrompt] = useState(true);
+  const completedRef = useRef(false);
 
   useEffect(() => {
     // Prevent body scroll when modal is open
@@ -33,6 +34,26 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
       document.body.style.overflow = '';
     };
   }, [showPrompt]);
+
+  const markComplete = useCallback(
+    (onSuccess?: () => void) => {
+      if (completedRef.current || completeOnboarding.isPending) return;
+      completedRef.current = true;
+
+      completeOnboarding.mutate(undefined, {
+        onSuccess: () => {
+          toast.success(t('system.onboarding.completeTour'));
+          onSuccess?.();
+        },
+        onError: () => {
+          completedRef.current = false;
+          setShowPrompt(true);
+          toast.error(t('common.errors.onboardingFailed'));
+        },
+      });
+    },
+    [completeOnboarding, t],
+  );
 
   const startOnboarding = useCallback(() => {
     setShowPrompt(false);
@@ -230,26 +251,15 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
                 align: 'start',
               },
               onHighlighted: () => {
-                // Mark onboarding as completed
-                completeOnboarding.mutate(undefined, {
-                  onSuccess: () => {
-                    toast.success(t('system.onboarding.completeTour'));
-                    onComplete?.();
-                    // Navigate to data storages page
-                    navigate({ to: '/data-storages' });
-                  },
+                markComplete(() => {
+                  onComplete?.();
+                  navigate({ to: '/data-storages' });
                 });
               },
             },
           ],
           onDestroyStarted: () => {
-            // Complete onboarding when user closes the tour
-            completeOnboarding.mutate(undefined, {
-              onSuccess: () => {
-                toast.success(t('system.onboarding.completeTour'));
-                onComplete?.();
-              },
-            });
+            markComplete(onComplete);
             driverObj.destroy();
           },
         });
@@ -257,16 +267,12 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         driverObj.drive();
       }, 500); // Wait a bit for the page to render
     });
-  }, [completeOnboarding, navigate, t]);
+  }, [markComplete, navigate, onComplete, t]);
 
   const skipOnboarding = useCallback(() => {
     setShowPrompt(false);
-    completeOnboarding.mutate(undefined, {
-      onSuccess: () => {
-        onComplete?.();
-      },
-    });
-  }, [completeOnboarding, onComplete]);
+    markComplete(onComplete);
+  }, [markComplete, onComplete]);
 
   if (showPrompt === false) {
     return null;

--- a/frontend/src/features/onboarding/onboarding-provider.tsx
+++ b/frontend/src/features/onboarding/onboarding-provider.tsx
@@ -29,6 +29,8 @@ export function OnboardingProvider({ children, showOnboarding = true, onComplete
       } else {
         setMode('none');
       }
+    } else if (!showOnboarding || !isOwner) {
+      setMode('none');
     }
   }, [onboardingInfo, isLoading, showOnboarding, isOwner]);
 

--- a/frontend/tests/channels.spec.ts
+++ b/frontend/tests/channels.spec.ts
@@ -42,7 +42,9 @@ test.describe('Admin Channels Management', () => {
 
     // Fill in API Key
     const apiKeyInput = createDialog.getByTestId('channel-api-key-input')
-    await apiKeyInput.fill('sk-test-key-' + uniqueSuffix)
+    await apiKeyInput.fill('  sk-test-key-' + uniqueSuffix + '  ')
+    await createDialog.getByTestId('channel-name-input').click()
+    await expect(createDialog.getByTestId('channel-name-input')).toBeFocused()
 
     // Add at least one supported model (required to enable Create button)
     // Wait for Quick Add Models section to appear and click on gpt-4o badge


### PR DESCRIPTION
## Summary
- Prevent synchronous API-key blur normalization from stealing focus between channel form inputs.
- Preserve trim, blank filtering, and deduplication at submit time.
- Close onboarding overlays immediately while retaining retry behavior when completion persistence fails.
- Add a channel form focus regression assertion.

## Validation
- TypeScript check passed.
- Changed-file ESLint passed.
- Browser smoke test passed for onboarding dismissal and repeated API-key-to-name focus transfer.
- Full frontend lint has pre-existing failures in unrelated files (163 errors, 92 warnings).

## Deployment
- The earlier deployed Cloud Run revision used the pre-review image; this PR contains the corrected follow-up changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API keys are now trimmed and duplicate entries are removed when saving channel credentials.
  * Prevented onboarding from completing multiple times through overlapping actions.
  * Failed onboarding completion now restores the prompt and keeps users on the current step.
  * Onboarding mode now resets when onboarding is disabled or access requirements are no longer met.
  * Navigation to data storage settings occurs only after onboarding completes successfully.

* **Tests**
  * Added coverage for trimming whitespace from channel API keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->