### PR TITLE
fix(bailian): preserve enable_thinking from OpenAI requests

### DIFF
--- a/llm/transformer/bailian/outbound.go
+++ b/llm/transformer/bailian/outbound.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -62,7 +65,26 @@ func NewOutboundTransformerWithConfig(config *Config) (transformer.Outbound, err
 func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.Request) (*httpclient.Request, error) {
 	llmReq = mergeConsecutiveToolCallMessages(llmReq)
 
-	return t.Outbound.TransformRequest(ctx, llmReq)
+	httpReq, err := t.Outbound.TransformRequest(ctx, llmReq)
+	if err != nil {
+		return nil, err
+	}
+
+	if llmReq == nil || llmReq.APIFormat != llm.APIFormatOpenAIChatCompletion || llmReq.RawRequest == nil {
+		return httpReq, nil
+	}
+
+	enableThinking := gjson.GetBytes(llmReq.RawRequest.Body, "enable_thinking")
+	if enableThinking.Type != gjson.True && enableThinking.Type != gjson.False {
+		return httpReq, nil
+	}
+
+	httpReq.Body, err = sjson.SetBytes(httpReq.Body, "enable_thinking", enableThinking.Bool())
+	if err != nil {
+		return nil, fmt.Errorf("failed to preserve Bailian enable_thinking: %w", err)
+	}
+
+	return httpReq, nil
 }
 
 func mergeConsecutiveToolCallMessages(req *llm.Request) *llm.Request {

--- a/llm/transformer/bailian/outbound_test.go
+++ b/llm/transformer/bailian/outbound_test.go
@@ -9,8 +9,86 @@ import (
 
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/auth"
+	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 )
+
+func TestBailianTransformRequest_PreservesOpenAIEnableThinking(t *testing.T) {
+	transformer, err := NewOutboundTransformerWithConfig(&Config{
+		BaseURL:        "https://example.com",
+		APIKeyProvider: auth.NewStaticKeyProvider("test-key"),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		apiFormat llm.APIFormat
+		rawBody   string
+		expected  string
+	}{
+		{
+			name:      "false",
+			apiFormat: llm.APIFormatOpenAIChatCompletion,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}],"enable_thinking":false}`,
+			expected:  `false`,
+		},
+		{
+			name:      "true",
+			apiFormat: llm.APIFormatOpenAIChatCompletion,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}],"enable_thinking":true}`,
+			expected:  `true`,
+		},
+		{
+			name:      "omitted",
+			apiFormat: llm.APIFormatOpenAIChatCompletion,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:      "null",
+			apiFormat: llm.APIFormatOpenAIChatCompletion,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}],"enable_thinking":null}`,
+		},
+		{
+			name:      "string",
+			apiFormat: llm.APIFormatOpenAIChatCompletion,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}],"enable_thinking":"false"}`,
+		},
+		{
+			name:      "non OpenAI inbound",
+			apiFormat: llm.APIFormatAnthropicMessage,
+			rawBody:   `{"model":"qwen-max","messages":[{"role":"user","content":"hi"}],"enable_thinking":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userContent := "hi"
+			req := &llm.Request{
+				Model:     "qwen-max",
+				APIFormat: tt.apiFormat,
+				Messages: []llm.Message{
+					{Role: "user", Content: llm.MessageContent{Content: &userContent}},
+				},
+				RawRequest: &httpclient.Request{Body: []byte(tt.rawBody)},
+			}
+
+			httpReq, err := transformer.TransformRequest(context.Background(), req)
+			require.NoError(t, err)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(httpReq.Body, &body))
+
+			enableThinking, ok := body["enable_thinking"]
+			if tt.expected == "" {
+				require.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			require.JSONEq(t, tt.expected, string(enableThinking))
+		})
+	}
+}
 
 func TestBailianTransformRequest_MergeConsecutiveToolCalls(t *testing.T) {
 	transformer, err := NewOutboundTransformerWithConfig(&Config{


### PR DESCRIPTION
## Summary

- preserve Bailian's top-level `enable_thinking` option during OpenAI Chat request transformation
- forward only explicit JSON booleans, preserving both `false` and `true`
- keep the field absent when omitted, null, non-boolean, or received through another API format

## Context

OpenAI-compatible clients can pass Bailian-specific options through `extra_body`, which serializes `enable_thinking` at the top level. During non-passthrough transformation, the generic OpenAI request model drops this unknown field, so Bailian never receives an explicit `false`.

## Tests

- `go test ./transformer/bailian -count=1`

Fixes #2115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the `enable_thinking` setting when sending supported OpenAI chat-completion requests through the Bailian provider.
  * Maintained existing behavior for unsupported request formats and omitted or non-boolean values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->