### PR TITLE
fix(frontend): remove table row hover scale causing scrollbar flicker

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -535,11 +535,13 @@
 
 /* 表格行悬浮效果 */
 .table-row-hover {
-  transition: all 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
 .table-row-hover:hover {
   background-color: var(--accent) !important;
-  transform: scale(1.005);
   box-shadow: var(--shadow-sm);
   border-color: var(--primary);
   z-index: 10;


### PR DESCRIPTION
## Summary

Table rows using the global `table-row-hover` class no longer scale on hover, so moving the mouse across any data table (channels, models, apikeys, users, roles, projects, prompts, etc.) no longer makes the horizontal scrollbar flash and the container height jitter. All other hover feedback (background, shadow, border color, z-index, border radius) is preserved.

## Problem

`.table-row-hover:hover` in `frontend/src/index.css` applied `transform: scale(1.005)` to the hovered row:

1. The scaled row becomes 0.5% wider than its `overflow-auto` scroll container, so a horizontal scrollbar appears.
2. Moving the pointer off the row removes the scale, so the scrollbar disappears again.
3. On browsers where scrollbars take layout space, the appearing/disappearing horizontal scrollbar also changes the container's client height, shifting the vertical scrollbar and the content above it.

Net effect: sweeping the mouse across any of the 12 tables using this class makes the scrollbars flicker and the page "jitter". `transition: all` also animated the layout-affecting properties instead of only the visual ones.

## Implementation

In `frontend/src/index.css` (`.table-row-hover` block):

- Removed `transform: scale(1.005)` from `.table-row-hover:hover` (root cause).
- Narrowed `transition: all 0.2s ease` to `transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease` — exactly the properties that still change.

Unchanged: background color, box shadow, border color, `z-index`, `position: relative`, `border-radius`, and the `.table-row-hover:hover > *` child rule.

## Tests

Pure CSS change with no build-time or runtime logic impact; Build/Lint/Test will run automatically in CI. Focused checks performed locally:

- `git diff --check` — clean.
- `prettier --check src/index.css` — the diff block itself is format-clean. Note: the file as a whole fails this check both before and after this PR due to pre-existing `oklch(0.2 …)` vs `oklch(0.20 …)` spacing differences with prettier 3.8.1, unrelated to this change.
- Verified no other `scale(` usage was touched (`.hover-card` and keyframe animations untouched).
- Diff contains only the two rule changes above.

## Risk

Low. The only visual change is dropping the 0.5% hover zoom; every other hover cue remains identical, and no table component or class consumer (12 table views) is modified. Rows are back to exactly 100% width, so `overflow-auto` behavior returns to the no-scale baseline.

Side note (no code change): `.hover-card` still uses `transform: scale(1.02)` on hover. It targets floating cards rather than rows inside scroll containers, so it does not trigger this scrollbar flicker today, but it would if ever placed inside an `overflow-auto` container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined table row hover transitions for background, shadow, and border changes.
  - Hovered table rows no longer scale in size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->