### PR TITLE
fix(gql): return channel model entries in deterministic order

### DIFF
--- a/internal/server/gql/axonhub.resolvers.go
+++ b/internal/server/gql/axonhub.resolvers.go
@@ -49,7 +49,7 @@ func (r *channelResolver) DefaultEndpoints(ctx context.Context, obj *ent.Channel
 func (r *channelResolver) AllModelEntries(ctx context.Context, obj *ent.Channel) ([]*biz.ChannelModelEntry, error) {
 	ch := biz.Channel{Channel: obj}
 	entries := ch.GetModelEntries()
-	result := lo.Values(entries)
+	result := sortChannelModelEntries(lo.Values(entries))
 
 	return lo.ToSlicePtr(result), nil
 }

--- a/internal/server/gql/channel_model_entries.go
+++ b/internal/server/gql/channel_model_entries.go
@@ -1,0 +1,21 @@
+package gql
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/looplj/axonhub/internal/server/biz"
+)
+
+// sortChannelModelEntries returns a new slice with the entries sorted by
+// RequestModel in ascending order. The sort is stable, so entries sharing the
+// same RequestModel keep their relative input order, making the output
+// deterministic for a given input.
+func sortChannelModelEntries(entries []biz.ChannelModelEntry) []biz.ChannelModelEntry {
+	sorted := slices.Clone(entries)
+	slices.SortStableFunc(sorted, func(a, b biz.ChannelModelEntry) int {
+		return strings.Compare(a.RequestModel, b.RequestModel)
+	})
+
+	return sorted
+}

--- a/internal/server/gql/channel_model_entries_test.go
+++ b/internal/server/gql/channel_model_entries_test.go
@@ -1,0 +1,87 @@
+package gql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz"
+)
+
+func TestSortChannelModelEntries_SortsByRequestModelAscending(t *testing.T) {
+	entries := []biz.ChannelModelEntry{
+		{RequestModel: "gpt-4o", ActualModel: "gpt-4o", Source: "direct"},
+		{RequestModel: "claude-sonnet-4", ActualModel: "claude-sonnet-4", Source: "direct"},
+		{RequestModel: "deepseek-chat", ActualModel: "deepseek-v3", Source: "mapping"},
+		{RequestModel: "kimi-k3", ActualModel: "moonshot-v1", Source: "auto_trim"},
+	}
+
+	sorted := sortChannelModelEntries(entries)
+
+	got := make([]string, 0, len(sorted))
+	for _, entry := range sorted {
+		got = append(got, entry.RequestModel)
+	}
+
+	require.Equal(t, []string{"claude-sonnet-4", "deepseek-chat", "gpt-4o", "kimi-k3"}, got)
+}
+
+func TestSortChannelModelEntries_EmptyInput(t *testing.T) {
+	require.Empty(t, sortChannelModelEntries(nil))
+	require.Empty(t, sortChannelModelEntries([]biz.ChannelModelEntry{}))
+}
+
+func TestSortChannelModelEntries_DuplicateRequestModelStable(t *testing.T) {
+	entries := []biz.ChannelModelEntry{
+		{RequestModel: "gpt-4o", ActualModel: "gpt-4o", Source: "direct"},
+		{RequestModel: "gpt-4o", ActualModel: "ft:gpt-4o", Source: "mapping"},
+		{RequestModel: "claude-sonnet-4", ActualModel: "claude-sonnet-4", Source: "direct"},
+	}
+
+	first := sortChannelModelEntries(entries)
+
+	// Same input always produces the same output.
+	for range 20 {
+		require.Equal(t, first, sortChannelModelEntries(entries))
+	}
+
+	// Entries sharing a RequestModel keep their relative input order.
+	require.Equal(t, []biz.ChannelModelEntry{
+		{RequestModel: "claude-sonnet-4", ActualModel: "claude-sonnet-4", Source: "direct"},
+		{RequestModel: "gpt-4o", ActualModel: "gpt-4o", Source: "direct"},
+		{RequestModel: "gpt-4o", ActualModel: "ft:gpt-4o", Source: "mapping"},
+	}, first)
+}
+
+func TestChannelResolver_AllModelEntries_ReturnsSortedEntries(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=1")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+
+	channelEntity, err := client.Channel.Create().
+		SetName("Unordered models").
+		SetType(channel.TypeOpenai).
+		SetStatus(channel.StatusEnabled).
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"gpt-4o", "claude-sonnet-4", "deepseek-chat", "kimi-k3"}).
+		SetDefaultTestModel("gpt-4o").
+		Save(ctx)
+	require.NoError(t, err)
+
+	resolver := &channelResolver{&Resolver{}}
+	entries, err := resolver.AllModelEntries(ctx, channelEntity)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		got = append(got, entry.RequestModel)
+	}
+
+	require.Equal(t, []string{"claude-sonnet-4", "deepseek-chat", "gpt-4o", "kimi-k3"}, got)
+}


### PR DESCRIPTION
## Summary

- `Channel.allModelEntries` now returns entries sorted by `RequestModel` in ascending order, so every consumer gets a stable, deterministic list instead of a randomly ordered one.

## Problem

`Channel.GetModelEntries()` returns a Go `map[string]ChannelModelEntry`, and the `AllModelEntries` resolver passed `lo.Values(entries)` straight through to GraphQL. Go deliberately randomizes map iteration order, so the same channel returned a different model list order on every request.

The frontend Playground channel mode renders `allModelEntries` directly and uses `allModelEntries[0].requestModel` as the default selection, so both the list order and the preselected model drifted on every refresh. Other consumers of `allModelEntries` (models association dialog, analytics filter bar) were affected the same way.

## Implementation

- Added a small package-level helper `sortChannelModelEntries` (`internal/server/gql/channel_model_entries.go`) that stable-sorts a `[]biz.ChannelModelEntry` by `RequestModel` (`slices.SortStableFunc` + `strings.Compare`, plain lexicographic order).
- The `AllModelEntries` resolver now pipes `lo.Values(entries)` through that helper. Only the resolver layer changed — `biz`, `ent` generated code, and the GraphQL schema are untouched, and all GraphQL consumers of `allModelEntries` get the ordering fix at once.
- Stable sort was chosen so entries sharing a `RequestModel` keep their relative input order, keeping the output fully deterministic. No natural-sort or case-folding tricks; model ids are compared as-is.

## Tests

- `go test ./internal/server/gql/ -run 'TestSortChannelModelEntries|TestChannelResolver_AllModelEntries'` — 4 new tests, all passing:
  - `TestSortChannelModelEntries_SortsByRequestModelAscending` — shuffled input comes back strictly ascending by `RequestModel`.
  - `TestSortChannelModelEntries_EmptyInput` — nil / empty slice input.
  - `TestSortChannelModelEntries_DuplicateRequestModelStable` — duplicate `RequestModel` with different `Source`: repeated runs produce identical output and equal keys keep their relative input order.
  - `TestChannelResolver_AllModelEntries_ReturnsSortedEntries` — resolver-level test against a real channel entity with out-of-order supported models.
- Full `go test ./internal/server/gql/` package passes.

## Risk

- Only the response ordering of `allModelEntries` changes; the returned set of entries is identical.
- No known consumer depends on the previous (random) order; the Playground Model Gateway mode already queries models with explicit `orderBy: { field: 'NAME', direction: 'ASC' }` and is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Channel model entries are now displayed in ascending alphabetical order.
  * Entries with identical model names retain their original order.
  * Empty model lists continue to return correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->