### PR TITLE
fix(channels): use reported Codex quota window durations

### DIFF
--- a/frontend/src/features/channels/components/channel-quota.test.mjs
+++ b/frontend/src/features/channels/components/channel-quota.test.mjs
@@ -17,6 +17,12 @@ const { outputText } = ts.transpileModule(helpers, {
 const { getQuotaLimits, quotaWindowLabel } = await import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`);
 const t = (key) => key;
 
+/**
+ * Create a persisted Codex channel fixture with independently configurable raw and normalized data.
+ * @param {object | undefined} rateLimit Raw provider windows, or undefined for legacy records.
+ * @param {object[]} limits Normalized quota entries, defaulting to a primary window with 52% used.
+ * @returns {object} Channel fixture consumed by the table's quota helpers.
+ */
 function codex(rateLimit, limits = [{ window: 'primary', usageRatio: 0.52 }]) {
   return {
     type: 'codex',

--- a/frontend/src/features/channels/components/channel-quota.test.mjs
+++ b/frontend/src/features/channels/components/channel-quota.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import ts from 'typescript';
+
+// Run the table's pure quota helpers without loading React or its providers.
+const source = readFileSync(new URL('./channels-columns.tsx', import.meta.url), 'utf8');
+const ast = ts.createSourceFile('channels-columns.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const helperNames = ['getQuotaLimits', 'codexWindowDuration', 'quotaWindowLabel'];
+const helpers = ast.statements
+  .filter((node) => ts.isFunctionDeclaration(node) && helperNames.includes(node.name?.text))
+  .map((node) => `export ${node.getText(ast)}`)
+  .join('\n');
+const { outputText } = ts.transpileModule(helpers, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2023 },
+});
+const { getQuotaLimits, quotaWindowLabel } = await import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`);
+const t = (key) => key;
+
+function codex(rateLimit, limits = [{ window: 'primary', usageRatio: 0.52 }]) {
+  return {
+    type: 'codex',
+    providerQuotaStatus: {
+      status: 'available',
+      quotaData: { _limits: limits, rate_limit: rateLimit },
+    },
+  };
+}
+
+test('weekly-only Codex primary quota is shown once as 7d, with its usage preserved', () => {
+  const channel = codex({ primary_window: { used_percent: 52, limit_window_seconds: 604800 }, secondary_window: null });
+  const limits = getQuotaLimits(channel);
+  assert.deepEqual(limits, [{ window: '7d', usageRatio: 0.52, status: 'available' }]);
+  assert.equal(quotaWindowLabel(limits[0].window, t), '7d');
+  assert.equal(Math.round(100 - limits[0].usageRatio * 100), 48);
+});
+
+test('Codex dual windows and other durations use reported lengths', () => {
+  for (const [seconds, label] of [[18000, '5h'], [86400, '1d'], [7200, '2h'], [5400, '90m'], [45, '45s']]) {
+    const limits = getQuotaLimits(codex({
+      primary_window: { used_percent: 20, limit_window_seconds: seconds },
+      secondary_window: { used_percent: 60, limit_window_seconds: 604800 },
+    }));
+    assert.deepEqual(limits.map((limit) => limit.window), [label, '7d']);
+    assert.deepEqual(limits.map((limit) => limit.usageRatio), [0.2, 0.6]);
+  }
+});
+
+test('absent windows do not inherit a synthetic normalized primary quota', () => {
+  assert.deepEqual(getQuotaLimits(codex({ primary_window: null, secondary_window: null })), []);
+  const limits = getQuotaLimits(codex({ secondary_window: { used_percent: 0, limit_window_seconds: 604800 } }));
+  assert.deepEqual(limits, [{ window: '7d', usageRatio: 0, status: 'available' }]);
+});
+
+test('unknown or invalid durations use localized role labels rather than assumed periods', () => {
+  for (const seconds of [undefined, null, 0, -1, NaN, Infinity, '604800']) {
+    const limits = getQuotaLimits(codex({
+      primary_window: { used_percent: 52, limit_window_seconds: seconds },
+      secondary_window: { used_percent: 0, limit_window_seconds: seconds },
+    }));
+    assert.equal(quotaWindowLabel(limits[0].window, t), 'quota.label.primary_window');
+    assert.equal(quotaWindowLabel(limits[1].window, t), 'quota.label.secondary_window');
+  }
+});
+
+test('legacy normalized-only Codex data keeps usage without guessing a duration', () => {
+  const limits = getQuotaLimits(codex(undefined));
+  assert.equal(limits[0].usageRatio, 0.52);
+  assert.equal(quotaWindowLabel(limits[0].window, t), 'quota.label.primary_window');
+});
+
+test('other provider window labels are preserved', () => {
+  const channel = { type: 'claudecode', providerQuotaStatus: { status: 'available', quotaData: {
+    windows: { '5h': { utilization: 0.2 }, '7d': { utilization: 0.4 } },
+  } } };
+  assert.deepEqual(getQuotaLimits(channel).map((limit) => quotaWindowLabel(limit.window, t)), ['5h', '7d']);
+  assert.equal(quotaWindowLabel('weekly', t), '7d');
+  assert.equal(quotaWindowLabel('monthly', t), '30d');
+});

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -126,26 +126,23 @@ function getQuotaLimits(channel: Channel): QuotaLimit[] {
     }
   }
 
-  // Codex exposes a secondary window in rate_limit while its normalized
-  // provider limit currently contains only the primary window.
+  // Window roles do not imply durations: some Codex plans have a weekly
+  // primary window. Prefer the reported windows over the normalized primary
+  // limit, which can exist even when the API returns no primary window.
   if (channel.type === 'codex') {
     const rateLimit = data.rate_limit as Record<string, unknown> | undefined;
-    for (const [key, label] of [
-      ['primary_window', '5h'],
-      ['secondary_window', '7d'],
-    ] as const) {
-      const window = rateLimit?.[key] as Record<string, unknown> | undefined;
-      if (typeof window?.used_percent !== 'number') continue;
-      const alreadyIncluded = normalized.some(
-        (limit) => limit.window === label || (key === 'primary_window' && limit.window === 'primary')
-      );
-      if (!alreadyIncluded) {
-        normalized.push({
-          window: label,
+    if (rateLimit) {
+      const codexLimits: QuotaLimit[] = [];
+      for (const role of ['primary', 'secondary'] as const) {
+        const window = rateLimit[`${role}_window`] as Record<string, unknown> | undefined;
+        if (typeof window?.used_percent !== 'number') continue;
+        codexLimits.push({
+          window: codexWindowDuration(window.limit_window_seconds) || role,
           usageRatio: window.used_percent / 100,
           status: quotaStatus.status,
         });
       }
+      return codexLimits;
     }
   }
 
@@ -156,10 +153,23 @@ function getQuotaLimits(channel: Channel): QuotaLimit[] {
   return normalized.filter((limit) => limit.usageRatio != null || limit.status === 'exhausted');
 }
 
-function quotaWindowLabel(window: string | undefined): string {
+function codexWindowDuration(seconds: unknown): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return '';
+  for (const [unit, size] of [
+    ['d', 86400],
+    ['h', 3600],
+    ['m', 60],
+    ['s', 1],
+  ] as const) {
+    if (seconds % size === 0) return `${seconds / size}${unit}`;
+  }
+  return '';
+}
+
+function quotaWindowLabel(window: string | undefined, t: (key: string) => string): string {
   if (!window) return '';
-  if (window === 'primary') return '5h';
-  if (window === 'secondary') return '7d';
+  if (window === 'primary') return t('quota.label.primary_window');
+  if (window === 'secondary') return t('quota.label.secondary_window');
   if (window === 'daily') return '1d';
   if (window === 'weekly') return '7d';
   if (window === 'monthly') return '30d';
@@ -574,7 +584,7 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
       {visibleLimits.map((limit, index) => {
         const usageRatio = limit.status === 'exhausted' ? 1 : (limit.usageRatio ?? 1);
         const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
-        const label = quotaWindowLabel(limit.window) || t('quota.label.quota');
+        const label = quotaWindowLabel(limit.window, t) || t('quota.label.quota');
         return (
           <div key={`${label}-${index}`} className='flex items-center justify-end gap-2'>
             <span className='text-muted-foreground min-w-24 whitespace-nowrap text-left'>{label}</span>
@@ -614,7 +624,7 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
           const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
           return (
             <div key={`${limit.window}-${index}`} className='text-xs'>
-              {quotaWindowLabel(limit.window) || t('quota.label.quota')}: {remaining}%
+              {quotaWindowLabel(limit.window, t) || t('quota.label.quota')}: {remaining}%
             </div>
           );
         })}

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -64,6 +64,12 @@ type QuotaLimit = {
   status?: string;
 };
 
+/**
+ * Collect displayable quota windows from persisted provider data.
+ * Codex uses its reported windows; older records fall back to normalized limits.
+ * @param channel Channel with optional persisted provider quota status.
+ * @returns Quota rows with window labels, usage ratios, and status, or an empty list.
+ */
 function getQuotaLimits(channel: Channel): QuotaLimit[] {
   const quotaStatus = channel.providerQuotaStatus;
   if (!quotaStatus) return [];
@@ -153,6 +159,11 @@ function getQuotaLimits(channel: Channel): QuotaLimit[] {
   return normalized.filter((limit) => limit.usageRatio != null || limit.status === 'exhausted');
 }
 
+/**
+ * Format a reported duration using the largest exact day, hour, minute, or second unit.
+ * @param seconds Untrusted window duration from the provider response.
+ * @returns A compact duration label, or an empty string for invalid/non-integer durations.
+ */
 function codexWindowDuration(seconds: unknown): string {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return '';
   for (const [unit, size] of [
@@ -166,6 +177,12 @@ function codexWindowDuration(seconds: unknown): string {
   return '';
 }
 
+/**
+ * Resolve window identifiers for the quota cell and tooltip without assuming role durations.
+ * @param window Provider window identifier or an already formatted duration.
+ * @param t Translation function for primary and secondary window names.
+ * @returns A display label, or an empty string when the window is unspecified.
+ */
 function quotaWindowLabel(window: string | undefined, t: (key: string) => string): string {
   if (!window) return '';
   if (window === 'primary') return t('quota.label.primary_window');


### PR DESCRIPTION
## Problem

The Channels table hardcodes Codex primary windows as `5h` and secondary windows as `7d`, regardless of the duration reported by the provider. The reported case shows a ChatGPT Pro x20 channel labeled `5h` with 48% remaining, although the user reports that the plan has no five-hour limit. The account's raw quota response was not captured, so its actual window duration is not inferred from the screenshot.

## Changes

- Derive Codex window labels from each returned `limit_window_seconds` in both the quota cell and tooltip.
- Use the existing localized primary/secondary window labels when the duration is missing or invalid.
- Prefer reported windows over the normalized primary entry to avoid duplicate or synthetic rows when a window is absent.
- Preserve the normalized fallback for older records without raw rate-limit data.

For example, the regression fixture with a 604800-second primary window and 52% used now displays one `7d` row with 48% remaining, instead of `5h`. This fixes display labels; it does not change provider quota enforcement.

## Validation

- Passed all 15 tests:
  ```bash
  cd frontend
  node --test src/features/channels/components/channel-quota.test.mjs src/features/channels/data/channel-config.test.mjs
  ```
- Added behavioral coverage for weekly-only and dual-window responses, other durations, absent windows, invalid duration metadata, legacy records, and unchanged labels for other providers.
- `git diff --cached --check` passed before committing.
- Lint and build were not run, as instructed by `AGENTS.md`. No development server was restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Channel quota displays now use the actual duration of each usage window instead of fixed time labels.
  - Codex quota windows display compact, accurate duration labels.
  - Quota labels are now translated consistently across supported languages.
  - Existing usage values remain accurate when quota windows are missing, invalid, or based on legacy data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->