### PR TITLE
fix(frontend): make channels table responsive without clipping actions

### DIFF
--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -889,7 +889,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
               </div>
             ),
             meta: {
-              className: 'text-center',
+              className: 'w-10 text-center',
             },
             enableSorting: false,
             enableHiding: false,
@@ -1042,7 +1042,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
             ),
             cell: ActionCell,
             meta: {
-              className: 'text-center',
+              className: 'w-44 min-w-44 text-center',
             },
             enableSorting: false,
             enableHiding: false,

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -570,15 +570,15 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
   const visibleLimits = isExpanded ? limits : limits.slice(0, QUOTA_VISIBLE_LIMIT);
   const hiddenCount = limits.length - QUOTA_VISIBLE_LIMIT;
   const content = (
-    <div className='flex flex-col items-stretch gap-1.5 text-[11px]'>
+    <div className='flex min-w-0 flex-col items-stretch gap-1.5 text-[11px]'>
       {visibleLimits.map((limit, index) => {
         const usageRatio = limit.status === 'exhausted' ? 1 : (limit.usageRatio ?? 1);
         const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
         const label = quotaWindowLabel(limit.window) || t('quota.label.quota');
         return (
-          <div key={`${label}-${index}`} className='flex items-center justify-end gap-2'>
-            <span className='text-muted-foreground min-w-24 whitespace-nowrap text-left'>{label}</span>
-            <div className='bg-muted h-1.5 w-24 shrink-0 overflow-hidden rounded-full'>
+          <div key={`${label}-${index}`} className='flex min-w-0 items-center justify-end gap-2'>
+            <span className='text-muted-foreground min-w-0 truncate text-left'>{label}</span>
+            <div className='bg-muted h-1.5 w-16 shrink-0 overflow-hidden rounded-full sm:w-24'>
               <div
                 className={`h-full ${remaining <= 20 ? 'bg-red-500' : remaining <= 50 ? 'bg-yellow-500' : 'bg-green-500'}`}
                 style={{ width: `${remaining}%` }}
@@ -714,8 +714,8 @@ const SupportedModelsCell = memo(({ row }: { row: Row<Channel> }) => {
   }, [channel, setCurrentRow, setOpen]);
 
   return (
-    <div className='flex items-center justify-center gap-2'>
-      <div className='flex flex-wrap justify-center gap-1 overflow-hidden'>
+    <div className='flex min-w-0 items-center justify-center gap-2'>
+      <div className='flex min-w-0 flex-wrap justify-center gap-1 overflow-hidden'>
         {models.slice(0, 5).map((model) => (
           <Badge key={model} variant='secondary' className='block max-w-48 truncate text-left text-xs'>
             {model}
@@ -901,7 +901,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('common.columns.name')} className='justify-center' />,
       cell: NameCell,
       meta: {
-        className: 'md:table-cell min-w-32 text-center',
+        className: 'w-[18%] min-w-0 text-center',
       },
       enableHiding: false,
       enableSorting: true,
@@ -936,7 +936,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.quota')} className='justify-center' />,
       cell: QuotaCell,
       meta: {
-        className: 'hidden 2xl:table-cell text-center',
+        className: 'hidden min-w-0 2xl:table-cell text-center',
       },
       enableSorting: false,
       enableHiding: true,
@@ -947,7 +947,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.tags')} className='justify-center' />,
       cell: TagsCell,
       meta: {
-        className: 'hidden xl:table-cell text-center',
+        className: 'hidden min-w-0 xl:table-cell text-center',
       },
       filterFn: (row, id, value) => {
         const tags = (row.getValue(id) as string[]) || [];
@@ -975,7 +975,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       ),
       cell: SupportedModelsCell,
       meta: {
-        className: 'max-w-64 text-center',
+        className: 'w-[22%] min-w-0 max-w-none text-center',
       },
       enableSorting: false,
     },
@@ -985,7 +985,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.proxy')} className='justify-center' />,
       cell: ProxyCell,
       meta: {
-        className: 'hidden 2xl:table-cell text-center',
+        className: 'hidden min-w-0 2xl:table-cell text-center',
       },
       enableSorting: false,
       enableHiding: true,
@@ -1017,7 +1017,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       ),
       cell: OrderingWeightCell,
       meta: {
-        className: 'w-20 min-w-20 text-center',
+        className: 'w-16 min-w-0 text-center',
       },
       sortingFn: 'alphanumeric',
       enableSorting: true,
@@ -1028,7 +1028,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('common.columns.createdAt')} className='justify-center' />,
       cell: CreatedAtCell,
       meta: {
-        className: 'hidden xl:table-cell text-center',
+        className: 'hidden min-w-0 xl:table-cell text-center',
       },
       enableSorting: true,
       enableHiding: false,

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -570,7 +570,7 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
   const visibleLimits = isExpanded ? limits : limits.slice(0, QUOTA_VISIBLE_LIMIT);
   const hiddenCount = limits.length - QUOTA_VISIBLE_LIMIT;
   const content = (
-    <div className='flex min-w-80 flex-col items-stretch gap-1.5 text-[11px]'>
+    <div className='flex flex-col items-stretch gap-1.5 text-[11px]'>
       {visibleLimits.map((limit, index) => {
         const usageRatio = limit.status === 'exhausted' ? 1 : (limit.usageRatio ?? 1);
         const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
@@ -901,7 +901,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('common.columns.name')} className='justify-center' />,
       cell: NameCell,
       meta: {
-        className: 'md:table-cell min-w-48 text-center',
+        className: 'md:table-cell min-w-32 text-center',
       },
       enableHiding: false,
       enableSorting: true,
@@ -936,7 +936,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.quota')} className='justify-center' />,
       cell: QuotaCell,
       meta: {
-        className: 'w-96 min-w-96 text-center',
+        className: 'hidden 2xl:table-cell text-center',
       },
       enableSorting: false,
       enableHiding: true,
@@ -947,7 +947,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.tags')} className='justify-center' />,
       cell: TagsCell,
       meta: {
-        className: 'text-center',
+        className: 'hidden xl:table-cell text-center',
       },
       filterFn: (row, id, value) => {
         const tags = (row.getValue(id) as string[]) || [];
@@ -985,7 +985,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('channels.columns.proxy')} className='justify-center' />,
       cell: ProxyCell,
       meta: {
-        className: 'w-32 min-w-32 text-center',
+        className: 'hidden 2xl:table-cell text-center',
       },
       enableSorting: false,
       enableHiding: true,
@@ -1028,7 +1028,7 @@ export const createColumns = (t: ReturnType<typeof useTranslation>['t'], canWrit
       header: ({ column }) => <DataTableColumnHeader column={column} title={t('common.columns.createdAt')} className='justify-center' />,
       cell: CreatedAtCell,
       meta: {
-        className: 'text-center',
+        className: 'hidden xl:table-cell text-center',
       },
       enableSorting: true,
       enableHiding: false,

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -263,7 +263,7 @@ export function ChannelsTable({
   }, [data, rowSelection]);
 
   return (
-    <div className='flex flex-1 flex-col overflow-hidden'>
+    <div className='flex min-w-0 flex-1 flex-col overflow-hidden'>
       <DataTableToolbar
         table={table}
         isFiltered={isFiltered}
@@ -272,8 +272,8 @@ export function ChannelsTable({
         showErrorOnly={showErrorOnly}
         onExitErrorOnlyMode={onExitErrorOnlyMode}
       />
-      <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
-        <Table data-testid='channels-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
+      <div className='shadow-soft relative mt-4 min-w-0 flex-1 overflow-auto overflow-x-hidden rounded-2xl border border-[var(--table-border)]'>
+        <Table data-testid='channels-table' className='w-full table-fixed border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
           <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className='group/row border-0'>
@@ -282,7 +282,7 @@ export function ChannelsTable({
                     <TableHead
                       key={header.id}
                       colSpan={header.colSpan}
-                      className={`${header.column.columnDef.meta?.className ?? ''} text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
+                      className={`${header.column.columnDef.meta?.className ?? ''} overflow-hidden whitespace-normal text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
                     >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
@@ -305,7 +305,7 @@ export function ChannelsTable({
                       className='group/row table-row-hover rounded-xl border-0 !bg-[var(--table-background)]'
                     >
                       {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id} className={`${cell.column.columnDef.meta?.className ?? ''} border-0 bg-inherit px-4 py-3 transition-colors duration-200`}>
+                        <TableCell key={cell.id} className={`${cell.column.columnDef.meta?.className ?? ''} max-w-0 overflow-hidden whitespace-normal border-0 bg-inherit px-4 py-3 transition-colors duration-200`}>
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </TableCell>
                       ))}
@@ -319,7 +319,7 @@ export function ChannelsTable({
                           exit={{ opacity: 0 }}
                           className='border-0'
                         >
-                          <TableCell colSpan={columns.length} className='p-0 border-0'>
+                          <TableCell colSpan={columns.length} className='whitespace-normal p-0 border-0'>
                             <motion.div
                               initial={{ height: 0, opacity: 0 }}
                               animate={{ height: 'auto', opacity: 1 }}

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -278,11 +278,12 @@ export function ChannelsTable({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className='group/row border-0'>
                 {headerGroup.headers.map((header) => {
+                  const isAction = header.column.id === 'action';
                   return (
                     <TableHead
                       key={header.id}
                       colSpan={header.colSpan}
-                      className={`${header.column.columnDef.meta?.className ?? ''} overflow-hidden whitespace-normal text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
+                      className={`${header.column.columnDef.meta?.className ?? ''} ${isAction ? 'overflow-visible whitespace-nowrap' : 'overflow-hidden whitespace-normal'} text-muted-foreground border-0 text-xs font-semibold tracking-wider uppercase`}
                     >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
@@ -304,11 +305,17 @@ export function ChannelsTable({
                       data-state={row.getIsSelected() && 'selected'}
                       className='group/row table-row-hover rounded-xl border-0 !bg-[var(--table-background)]'
                     >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id} className={`${cell.column.columnDef.meta?.className ?? ''} max-w-0 overflow-hidden whitespace-normal border-0 bg-inherit px-4 py-3 transition-colors duration-200`}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
+                      {row.getVisibleCells().map((cell) => {
+                        const isAction = cell.column.id === 'action';
+                        return (
+                          <TableCell
+                            key={cell.id}
+                            className={`${cell.column.columnDef.meta?.className ?? ''} ${isAction ? 'overflow-visible whitespace-nowrap' : 'overflow-hidden whitespace-normal'} border-0 bg-inherit px-2 py-3 transition-colors duration-200`}
+                          >
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        );
+                      })}
                     </MotionTableRow>
                     <AnimatePresence initial={false}>
                       {row.getIsExpanded() && (

--- a/frontend/src/features/channels/components/channels-table.tsx
+++ b/frontend/src/features/channels/components/channels-table.tsx
@@ -273,7 +273,6 @@ export function ChannelsTable({
         onExitErrorOnlyMode={onExitErrorOnlyMode}
       />
       <div className='shadow-soft relative mt-4 flex-1 overflow-auto rounded-2xl border border-[var(--table-border)]'>
-        <div className='min-w-max'>
         <Table data-testid='channels-table' className='border-separate border-spacing-0 rounded-2xl bg-[var(--table-background)]'>
           <TableHeader className='sticky top-0 z-20 bg-[var(--table-header)] shadow-sm'>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -346,7 +345,6 @@ export function ChannelsTable({
             )}
           </TableBody>
         </Table>
-        </div>
       </div>
       <div className='mt-4 flex-shrink-0'>
         <ServerSidePagination

--- a/frontend/src/features/channels/components/data-table-toolbar.tsx
+++ b/frontend/src/features/channels/components/data-table-toolbar.tsx
@@ -97,7 +97,7 @@ export function DataTableToolbar<TData>({
   );
 
   return (
-    <div ref={scrollRef} className='flex items-center gap-4 overflow-x-auto pb-2 md:overflow-x-visible md:pb-0'>
+    <div ref={scrollRef} className='flex flex-wrap items-center gap-2 md:gap-4'>
       <div className='relative w-[150px] shrink-0 lg:flex-1 lg:w-auto'>
         <IconSearch className='text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2' />
         <Input

--- a/frontend/src/features/channels/index.tsx
+++ b/frontend/src/features/channels/index.tsx
@@ -262,7 +262,7 @@ function ChannelsContent() {
   const columns = useMemo(() => createColumns(t, channelPermissions.canWrite), [t, channelPermissions.canWrite]);
 
   return (
-    <div className='flex flex-1 flex-col overflow-hidden'>
+    <div className='flex min-w-0 flex-1 flex-col overflow-hidden'>
       <ChannelsErrorBanner
         errorCount={errorCount}
         onFilterErrorChannels={handleFilterErrorChannels}


### PR DESCRIPTION
## Summary
- Drop the channels table `min-w-max` wrapper and clip horizontal overflow so the page no longer paints a 1px scrollbar (`overflow-x-hidden` + `table-fixed`).
- Hide secondary columns (quota / proxy / tags / createdAt) below xl/2xl, wrap the toolbar instead of scrolling it, and keep the action column at 11rem so edit / test / menu buttons are not clipped.

This is independent of the specified-channel alias fix (#2406). It targets the leftover horizontal scrollbar after #2366 added the OAuth quota column, and the action-button clipping that appeared once the table was constrained.

## Test plan
- [ ] Open `/channels` at ~1280px and ~1728px: no page-level or table-level horizontal scrollbar.
- [ ] Confirm edit / default-test / row-menu buttons are fully visible in the actions column.
- [ ] Widen past `xl` / `2xl` and confirm tags, createdAt, quota, and proxy columns reappear.
- [ ] Toolbar filters wrap instead of scrolling horizontally on a narrow window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved channel table responsiveness across screen sizes.
  * Long channel names, labels, and supported-model badges now wrap or truncate cleanly.
  * Adjusted column widths and hides lower-priority columns on narrower screens.
  * Toolbar controls now wrap onto multiple lines instead of requiring horizontal scrolling.
  * Reduced table cell padding for a more efficient layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->