### PR TITLE
refactor: generalize channel quota display and normalize provider limits

### DIFF
--- a/frontend/src/components/quota-badges.test.mjs
+++ b/frontend/src/components/quota-badges.test.mjs
@@ -10,50 +10,50 @@ function read(relativePath) {
   return readFileSync(join(srcRoot, relativePath), 'utf8');
 }
 
-// Isolate the Codex render branch (between the Codex and Cline branch
-// markers) so assertions about the usage bars cannot bleed into Claude Code
-// or Cline, which legitimately keep duration-aware severity.
+// Isolate the Codex render branch (between the Codex and XAI branch markers)
+// so assertions about the usage bars cannot bleed into neighboring providers.
 function isolateCodexBlock(source) {
   const start = source.indexOf("{channel.type === 'codex' &&");
-  const end = source.indexOf("{channel.type === 'cline' &&", start);
+  const end = source.indexOf("{channel.type === 'xai_subscription' &&", start);
 
   assert.ok(start !== -1, 'Codex render branch should exist in quota-badges source');
-  assert.ok(end !== -1 && end > start, 'Cline render branch should follow the Codex branch');
+  assert.ok(end !== -1 && end > start, 'XAI render branch should follow the Codex branch');
 
   return source.slice(start, end);
 }
 
-test('Codex usage bar color tracks used percentage, not reset-window elapsed time', () => {
+test('Codex usage windows render as combined usage and time bars', () => {
   const quotaBadges = read('components/quota-badges.tsx');
   const codexBlock = isolateCodexBlock(quotaBadges);
 
-  // Both usage bars must render the user-visible used percentage so their
-  // severity reflects actual usage rather than elapsed reset-window time.
-  assert.match(
-    codexBlock,
-    /percentage=\{qd\.rate_limit\.primary_window\.used_percent/,
-    'Codex primary usage bar should render the primary window used percentage'
-  );
-  assert.match(
-    codexBlock,
-    /percentage=\{qd\.rate_limit\.secondary_window\.used_percent/,
-    'Codex secondary usage bar should render the secondary window used percentage'
-  );
-
-  // Reset-window elapsed time stays on separate duration bars...
+  // Each window has one shared bar whose fill reflects usage and whose marker
+  // reflects the reset-window elapsed time.
   assert.equal(
-    (codexBlock.match(/ProgressBar\s*\n?\s*type='duration'/g) || []).length,
+    (codexBlock.match(/<UsageTimeBar\s/g) || []).length,
     2,
-    'Codex should keep a separate duration bar for the primary and secondary windows'
+    'Codex primary and secondary windows should each use one combined bar'
   );
-
-  // ...so the usage bars must NOT feed durationPercentage into ProgressBar,
-  // which would severity-adjust their color by elapsed window time.
-  assert.doesNotMatch(
+  assert.match(
     codexBlock,
-    /durationPercentage/,
-    'Codex usage bar color must not be severity-adjusted by reset-window elapsed time'
+    /usagePercent=\{qd\.rate_limit\.primary_window\.used_percent/,
+    'Codex primary combined bar should render the primary window used percentage'
   );
+  assert.match(
+    codexBlock,
+    /usagePercent=\{qd\.rate_limit\.secondary_window\.used_percent/,
+    'Codex secondary combined bar should render the secondary window used percentage'
+  );
+  assert.equal(
+    (codexBlock.match(/durationPercent=\{/g) || []).length,
+    2,
+    'Codex combined bars should each mark reset-window elapsed time'
+  );
+});
+
+test('quota popover has no standalone progress-bar renders', () => {
+  const quotaBadges = read('components/quota-badges.tsx');
+
+  assert.doesNotMatch(quotaBadges, /\bProgressBar\b/, 'all quota bars should use the combined UsageTimeBar component');
 });
 
 test('Command Code monthly hover matches the other windows', () => {

--- a/frontend/src/components/quota-badges.test.mjs
+++ b/frontend/src/components/quota-badges.test.mjs
@@ -30,24 +30,36 @@ test('Codex usage windows render as combined usage and time bars', () => {
   // reflects the reset-window elapsed time.
   assert.equal(
     (codexBlock.match(/<UsageTimeBar\s/g) || []).length,
-    2,
-    'Codex primary and secondary windows should each use one combined bar'
+    1,
+    'Codex normalized limits should use one combined bar'
   );
   assert.match(
     codexBlock,
-    /usagePercent=\{qd\.rate_limit\.primary_window\.used_percent/,
-    'Codex primary combined bar should render the primary window used percentage'
+    /quota\.limits\s*\.filter\([\s\S]*?\.map\(\(limit,\s*index\)/,
+    'Codex bars should render normalized limits'
   );
   assert.match(
     codexBlock,
-    /usagePercent=\{qd\.rate_limit\.secondary_window\.used_percent/,
-    'Codex secondary combined bar should render the secondary window used percentage'
+    /limit\.window === '5h'/,
+    'Codex five-hour label should be selected from the normalized window'
   );
-  assert.equal(
-    (codexBlock.match(/durationPercent=\{/g) || []).length,
-    2,
-    'Codex combined bars should each mark reset-window elapsed time'
+  assert.match(
+    codexBlock,
+    /limit\.window === '7d'/,
+    'Codex seven-day label should be selected from the normalized window'
   );
+  assert.match(
+    codexBlock,
+    /WINDOW_LABEL_KEYS\[limit\.window\]/,
+    'Codex labels should resolve through the shared translation map'
+  );
+  assert.match(
+    codexBlock,
+    /t\('quota\.label\.token_usage'\)/,
+    'Codex unknown windows should use the neutral quota label'
+  );
+  assert.doesNotMatch(codexBlock, /quota\.label\.primary_window/);
+  assert.doesNotMatch(codexBlock, /quota\.label\.secondary_window/);
 });
 
 test('quota popover has no standalone progress-bar renders', () => {
@@ -105,4 +117,29 @@ test('Ollama badge renders both the 5h and weekly windows with a reset countdown
   assert.match(ollamaBlock, /'quota\.window\.weekly'/);
   assert.match(ollamaBlock, /formatTimeToReset\(window\.reset_time\)/);
   assert.doesNotMatch(ollamaBlock, /durationPercent/);
+});
+
+test('quota window identifiers resolve to localized labels', () => {
+  const quotaBadges = read('components/quota-badges.tsx');
+
+  assert.match(quotaBadges, /payg:\s*'quota\.label\.token_usage'/);
+  assert.match(quotaBadges, /credits:\s*'quota\.label\.credits_remaining'/);
+  assert.match(quotaBadges, /'5h':\s*'quota\.window\.5h'/);
+  assert.match(quotaBadges, /'7d':\s*'quota\.window\.7d'/);
+  assert.match(quotaBadges, /limit\.window === 'primary' \|\| limit\.window === 'secondary'/);
+});
+
+test('Wafer and Apertis duration markers share timestamp validation', () => {
+  const quotaBadges = read('components/quota-badges.tsx');
+  const waferStart = quotaBadges.indexOf("{isOpenaiType(channel.type) && channel.providerType === 'wafer' &&");
+  const waferEnd = quotaBadges.indexOf("{isOpenaiType(channel.type) && channel.providerType === 'synthetic' &&");
+  const apertisStart = quotaBadges.indexOf("{isOpenaiType(channel.type) && channel.providerType === 'apertis' &&");
+  const apertisEnd = quotaBadges.indexOf("{isOpenaiType(channel.type) && channel.providerType === 'charm_hyper' &&");
+
+  assert.match(quotaBadges, /function getDurationPercent\([\s\S]*?Number\.isFinite\(start\)[\s\S]*?end <= start/);
+  assert.match(quotaBadges.slice(waferStart, waferEnd), /durationPercent=\{getDurationPercent\(qd\.window_start, qd\.window_end\)\}/);
+  assert.match(
+    quotaBadges.slice(apertisStart, apertisEnd),
+    /durationPercent=\{getDurationPercent\(qd\.subscription\.cycle_start, qd\.subscription\.cycle_end\)\}/
+  );
 });

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -19,8 +19,6 @@ import {
   ProviderNeuralWattQuotaData,
   ProviderApertisQuotaData,
   ProviderCharmHyperQuotaData,
-  ProviderOpenCodeGoQuotaData,
-  OpenCodeGoQuotaWindow,
   ProviderKimiCodeQuotaData,
   ProviderMinimaxQuotaData,
   ProviderZhipuQuotaData,
@@ -81,10 +79,6 @@ function getBatteryLevel(percentage: number, status: string): BatteryLevel {
 
 function isOpenaiType(t: string): t is 'openai' | 'openai_responses' {
   return t === 'openai' || t === 'openai_responses';
-}
-
-function isOpenCodeGoType(t: string): t is 'opencode_go' | 'opencode_go_anthropic' {
-  return t === 'opencode_go' || t === 'opencode_go_anthropic';
 }
 
 function isCommandCodeType(t: string): t is 'commandcode' | 'commandcode_anthropic' {
@@ -184,13 +178,8 @@ function getChannelPercentage(channel: ProviderQuotaChannel): number {
     if (qd.windows?.dailyInputTokens) maxPercent = Math.max(maxPercent, (qd.windows.dailyInputTokens.percentUsed ?? 0) * 100);
     if (qd.windows?.dailyImages) maxPercent = Math.max(maxPercent, (qd.windows.dailyImages.percentUsed ?? 0) * 100);
     percentage = maxPercent;
-  } else if (isOpenCodeGoType(channel.type)) {
-    const qd = channel.quotaStatus.quotaData as ProviderOpenCodeGoQuotaData | undefined;
-    percentage = Math.max(
-      qd?.windows?.rolling?.usage_percent ?? 0,
-      qd?.windows?.weekly?.usage_percent ?? 0,
-      qd?.windows?.monthly?.usage_percent ?? 0
-    );
+  } else if (channel.type === 'opencode_go' || channel.type === 'opencode_go_anthropic') {
+    percentage = Math.max(0, ...channel.quotaStatus.limits.map((limit) => limit.usageRatio * 100));
   } else if (isOllamaType(channel.type)) {
     const qd = channel.quotaStatus.quotaData as ProviderOllamaQuotaData | undefined;
     percentage = Math.max(
@@ -444,29 +433,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
 
     const now = Date.now() / 1000;
     const resetAfter = resetTs - now;
-    return calcDurationPercent(limit, resetAfter);
-  };
-
-  // Fraction of the reset window that has elapsed, rendered as a second
-  // "time elapsed" bar so usage progress can be read against time progress.
-  const getOpenCodeGoDurationPercent = (key: 'rolling' | 'weekly' | 'monthly', window: OpenCodeGoQuotaWindow): number | undefined => {
-    const limits: Record<string, number> = {
-      rolling: 5 * 3600,
-      weekly: 7 * 24 * 3600,
-      monthly: 30 * 24 * 3600,
-    };
-    const limit = limits[key];
-
-    // Prefer the absolute reset_time so the marker keeps advancing as the user
-    // looks; fall back to the snapshot reset_in_seconds from the last poll.
-    let resetAfter: number | undefined;
-    if (window.reset_time) {
-      resetAfter = (new Date(window.reset_time).getTime() - Date.now()) / 1000;
-    } else if (window.reset_in_seconds != null) {
-      resetAfter = window.reset_in_seconds;
-    }
-    if (resetAfter === undefined) return undefined;
-
     return calcDurationPercent(limit, resetAfter);
   };
 
@@ -1203,61 +1169,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
             }
 
             return items;
-          })()}
-        </div>
-      )}
-
-      {isOpenCodeGoType(channel.type) && (
-        <div className='mt-3 space-y-3'>
-          {(() => {
-            const qd = channel.quotaStatus.quotaData as ProviderOpenCodeGoQuotaData | undefined;
-            if (!qd) return null;
-
-            const entries: Array<['rolling' | 'weekly' | 'monthly', string]> = [
-              ['rolling', 'quota.window.5h'],
-              ['weekly', 'quota.window.weekly'],
-              ['monthly', 'quota.window.monthly'],
-            ];
-
-            return entries
-              .map(([key, labelKey], index) => {
-                const window = qd.windows?.[key];
-                if (!window) return null;
-
-                const usedPct = window.usage_percent ?? 0;
-                const durationPct = getOpenCodeGoDurationPercent(key, window);
-                // Always show the reset countdown — the elapsed-time marker already
-                // conveys progress, so the "no usage yet" special case is unwanted here.
-                const resetText =
-                  window.reset_time || window.reset_in_seconds != null
-                    ? formatTimeToReset(window.reset_time ?? window.reset_in_seconds)
-                    : '';
-                return (
-                  <div key={key} className={index > 0 ? 'border-border/60 space-y-1.5 border-t border-dashed pt-3' : 'space-y-1.5'}>
-                    <div className='flex items-center justify-between text-xs'>
-                      <span className='text-muted-foreground font-medium'>{t(labelKey)}</span>
-                      <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</span>
-                    </div>
-                    <UsageTimeBar
-                      usagePercent={usedPct}
-                      durationPercent={durationPct}
-                      tooltip={
-                        <div className='space-y-0.5'>
-                          <div className='font-medium'>{t(labelKey)}</div>
-                          <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
-                          {durationPct !== undefined && (
-                            <div>
-                              {t('quota.label.time_elapsed')}: {Math.round(durationPct)}%
-                            </div>
-                          )}
-                          {resetText && <div>{resetText}</div>}
-                        </div>
-                      }
-                    />
-                  </div>
-                );
-              })
-              .filter(Boolean);
           })()}
         </div>
       )}

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -290,7 +290,7 @@ function UsageTimeBar({ usagePercent, durationPercent, tooltip }: { usagePercent
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className='relative cursor-default pb-1.5'>
+        <div className='relative cursor-default pb-1.5' tabIndex={0}>
           <div className='bg-muted/60 h-1.5 w-full overflow-hidden rounded-full'>
             <div
               className='h-full transition-all duration-500'

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -115,14 +115,18 @@ function isZenmuxType(t: string): t is 'zenmux' | 'zenmux_responses' | 'zenmux_a
   return t === 'zenmux' || t === 'zenmux_responses' || t === 'zenmux_anthropic' || t === 'zenmux_gemini';
 }
 
+function getDurationPercent(startAt?: string | null, endAt?: string | null): number | undefined {
+  if (!startAt || !endAt) return undefined;
+  const start = new Date(startAt).getTime();
+  const end = new Date(endAt).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return undefined;
+  return Math.max(0, Math.min(100, ((Date.now() - start) / (end - start)) * 100));
+}
+
 // Fraction of a limit's reset window that has elapsed, derived from the
 // PeriodStart/NextResetAt pair the backend stamps on windowed limits.
 function getLimitDurationPercent(limit: ProviderQuotaLimit): number | undefined {
-  if (!limit.periodStart || !limit.nextResetAt) return undefined;
-  const start = new Date(limit.periodStart).getTime();
-  const end = new Date(limit.nextResetAt).getTime();
-  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return undefined;
-  return Math.max(0, Math.min(100, ((Date.now() - start) / (end - start)) * 100));
+  return getDurationPercent(limit.periodStart, limit.nextResetAt);
 }
 
 function getClineUsagePercent(window?: ClineQuotaWindow): number {
@@ -319,8 +323,8 @@ const WINDOW_LABEL_KEYS: Record<string, string> = {
   daily: 'quota.window.daily',
   weekly: 'quota.window.weekly',
   monthly: 'quota.window.monthly',
-  primary: 'quota.label.primary_window',
-  secondary: 'quota.label.secondary_window',
+  payg: 'quota.label.token_usage',
+  credits: 'quota.label.credits_remaining',
   overage: 'quota.label.overage_window',
   cycle: 'quota.label.subscription',
 };
@@ -358,7 +362,12 @@ function PeriodQuotaEstimate({ limits }: { limits: ProviderQuotaLimit[] }) {
 
       {priced.map((limit, index) => {
         const labelKey = limit.window ? WINDOW_LABEL_KEYS[limit.window] : undefined;
-        const label = labelKey ? t(labelKey) : limit.window || t('quota.label.token_usage');
+        const label =
+          labelKey
+            ? t(labelKey)
+            : limit.window === 'primary' || limit.window === 'secondary'
+              ? t('quota.label.token_usage')
+              : limit.window || t('quota.label.token_usage');
 
         return (
           <div key={`${limit.window ?? limit.type}-${index}`} className='flex items-center justify-between text-xs'>
@@ -420,17 +429,8 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
     }
   };
 
-  const formatWindowDuration = (seconds?: number) => {
-    if (!seconds) return '';
-    const hours = Math.floor(seconds / 3600);
-    const days = hours >= 24 ? Math.floor(hours / 24) : 0;
-    if (days > 0) return `${days}${t(days > 1 ? 'quota.label.days' : 'quota.label.day')}`;
-    if (hours > 0) return `${hours}${t(hours > 1 ? 'quota.label.hours' : 'quota.label.hour')}`;
-    return `${Math.floor(seconds / 60)}${t('quota.label.mins')}`;
-  };
-
   const calcDurationPercent = (limit?: number, resetAfter?: number) => {
-    if (!limit || resetAfter === undefined) return 0;
+    if (limit == null || resetAfter == null || !Number.isFinite(limit) || !Number.isFinite(resetAfter) || limit <= 0) return undefined;
     const elapsed = limit - resetAfter;
     return Math.max(0, Math.min(100, (elapsed / limit) * 100));
   };
@@ -604,6 +604,11 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                                 {t('quota.label.time_elapsed')}: {Math.round(getClaudeDurationPercent('5h', qd.windows['5h'].reset) || 0)}%
                               </div>
                             )}
+                            {quota.nextResetAt && (
+                              <div>
+                                {formatTimeToReset(quota.nextResetAt)} ({formatDate(new Date(quota.nextResetAt).getTime() / 1000)})
+                              </div>
+                            )}
                           </div>
                         }
                       />
@@ -629,16 +634,15 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                                 {t('quota.label.time_elapsed')}: {Math.round(getClaudeDurationPercent('7d', qd.windows['7d'].reset) || 0)}%
                               </div>
                             )}
+                            {qd.windows['7d'].reset && (
+                              <div>
+                                {formatTimeToReset(new Date(qd.windows['7d'].reset * 1000).toISOString())} ({formatDate(qd.windows['7d'].reset)})
+                              </div>
+                            )}
                           </div>
                         }
                       />
                     </div>
-                    {qd.windows['7d'].reset && (
-                      <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                        {formatTimeToReset(new Date(qd.windows['7d'].reset * 1000).toISOString())} (
-                        {formatDate(qd.windows['7d'].reset)})
-                      </div>
-                    )}
                   </div>
                 )}
                 {qd.windows?.['overage'] && (
@@ -670,11 +674,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                           ? t('quota.label.7d_limiting')
                           : ''}
                     </span>
-                    {quota.nextResetAt && (
-                      <span>
-                        {formatTimeToReset(quota.nextResetAt)} ({formatDate(new Date(quota.nextResetAt).getTime() / 1000)})
-                      </span>
-                    )}
                   </div>
                 )}
               </>
@@ -726,6 +725,11 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                                 {Math.round(displayRem)}/{Math.round(displayTot)}
                               </div>
                               <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                              {quota.nextResetAt && (
+                                <div>
+                                  {formatTimeToReset(quota.nextResetAt)} ({formatDate(new Date(quota.nextResetAt).getTime() / 1000)})
+                                </div>
+                              )}
                             </div>
                           }
                         />
@@ -783,6 +787,11 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                                   {Math.round(displayRem)}/{Math.round(displayTot)}
                                 </div>
                                 <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                                {quota.nextResetAt && (
+                                  <div>
+                                    {formatTimeToReset(quota.nextResetAt)} ({formatDate(new Date(quota.nextResetAt).getTime() / 1000)})
+                                  </div>
+                                )}
                               </div>
                             }
                           />
@@ -797,16 +806,11 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
             return items;
           })()}
 
-          {quota.nextResetAt && (
-            <div className='text-muted-foreground pt-1 text-right text-[11px]'>
-              {formatTimeToReset(quota.nextResetAt)} ({formatDate(new Date(quota.nextResetAt).getTime() / 1000)})
-            </div>
-          )}
         </div>
       )}
 
       {channel.type === 'codex' && (
-        <div className='mt-4 space-y-4'>
+        <div className='mt-3 space-y-3'>
           {(() => {
             const qd = channel.quotaStatus.quotaData;
             if (!qd) return null;
@@ -824,107 +828,46 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
               qd._resets?.supported === true && (Boolean(qd._resets.error) || availableResetCount > 0);
             return (
               <>
-                {qd.rate_limit?.primary_window && (
-                  <div className='space-y-2.5'>
-                    <div className='space-y-1'>
-                      <div className='flex items-center justify-between text-xs'>
-                        <span className='text-muted-foreground font-medium'>{t('quota.label.primary_window')}</span>
-                        <span className='text-foreground font-medium'>{Math.round(qd.rate_limit.primary_window.used_percent || 0)}%</span>
-                      </div>
-                      <UsageTimeBar
-                        usagePercent={qd.rate_limit.primary_window.used_percent || 0}
-                        durationPercent={
-                          qd.rate_limit.primary_window.limit_window_seconds
-                            ? calcDurationPercent(
-                                qd.rate_limit.primary_window.limit_window_seconds,
-                                qd.rate_limit.primary_window.reset_after_seconds
-                              )
-                            : undefined
-                        }
-                        tooltip={
-                          <div className='space-y-0.5'>
-                            <div className='font-medium'>{t('quota.label.primary_window')}</div>
-                            <div>
-                              {t('quota.label.percent_used', {
-                                percent: Math.round(qd.rate_limit.primary_window.used_percent || 0),
-                              })}
-                            </div>
-                            {qd.rate_limit.primary_window.limit_window_seconds ? (
-                              <div>
-                                {t('quota.label.primary_duration')} ({formatWindowDuration(qd.rate_limit.primary_window.limit_window_seconds)}):{' '}
-                                {Math.round(
-                                  calcDurationPercent(
-                                    qd.rate_limit.primary_window.limit_window_seconds,
-                                    qd.rate_limit.primary_window.reset_after_seconds
-                                  )
-                                )}
-                                %
-                              </div>
-                            ) : null}
+                {quota.limits
+                  .filter((limit) => limit.type === 'token')
+                  .map((limit, index) => {
+                    const labelKey = limit.window === '5h' || limit.window === '7d' ? WINDOW_LABEL_KEYS[limit.window] : undefined;
+                    const label = labelKey ? t(labelKey) : t('quota.label.token_usage');
+                    const usedPercent = limit.status === 'exhausted' ? 100 : limit.usageRatio * 100;
+                    const durationPercent = getLimitDurationPercent(limit);
+
+                    return (
+                      <div
+                        key={`${limit.window}-${index}`}
+                        className={index > 0 ? 'border-border/60 space-y-1.5 border-t border-dashed pt-3' : 'space-y-1.5'}
+                      >
+                        <div className='space-y-1'>
+                          <div className='flex items-center justify-between text-xs'>
+                            <span className='text-muted-foreground font-medium'>{label}</span>
+                            <span className='text-foreground font-medium'>
+                              {t('quota.label.percent_used', { percent: Math.round(usedPercent) })}
+                            </span>
                           </div>
-                        }
-                      />
-                    </div>
-
-                    {qd.rate_limit.primary_window.reset_at && (
-                      <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                        {formatTimeToReset(qd.rate_limit.primary_window.reset_after_seconds)} (
-                        {formatDate(qd.rate_limit.primary_window.reset_at)})
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {qd.rate_limit?.secondary_window?.used_percent !== undefined && (
-                  <div className='border-border/60 mt-3 space-y-2.5 border-t border-dashed pt-3'>
-                    <div className='space-y-1'>
-                      <div className='flex items-center justify-between text-xs'>
-                        <span className='text-muted-foreground font-medium'>{t('quota.label.secondary_window')}</span>
-                        <span className='text-foreground font-medium'>{Math.round(qd.rate_limit.secondary_window.used_percent)}%</span>
-                      </div>
-                      <UsageTimeBar
-                        usagePercent={qd.rate_limit.secondary_window.used_percent}
-                        durationPercent={
-                          qd.rate_limit.secondary_window.limit_window_seconds
-                            ? calcDurationPercent(
-                                qd.rate_limit.secondary_window.limit_window_seconds,
-                                qd.rate_limit.secondary_window.reset_after_seconds
-                              )
-                            : undefined
-                        }
-                        tooltip={
-                          <div className='space-y-0.5'>
-                            <div className='font-medium'>{t('quota.label.secondary_window')}</div>
-                            <div>
-                              {t('quota.label.percent_used', {
-                                percent: Math.round(qd.rate_limit.secondary_window.used_percent),
-                              })}
-                            </div>
-                            {qd.rate_limit.secondary_window.limit_window_seconds ? (
-                              <div>
-                                {t('quota.label.secondary_duration')} ({formatWindowDuration(qd.rate_limit.secondary_window.limit_window_seconds)}):{' '}
-                                {Math.round(
-                                  calcDurationPercent(
-                                    qd.rate_limit.secondary_window.limit_window_seconds,
-                                    qd.rate_limit.secondary_window.reset_after_seconds
-                                  )
+                          <UsageTimeBar
+                            usagePercent={usedPercent}
+                            durationPercent={durationPercent}
+                            tooltip={
+                              <div className='space-y-0.5'>
+                                <div className='font-medium'>{label}</div>
+                                <div>{t('quota.label.percent_used', { percent: Math.round(usedPercent) })}</div>
+                                {durationPercent !== undefined && (
+                                  <div>
+                                    {t('quota.label.time_elapsed')}: {Math.round(durationPercent)}%
+                                  </div>
                                 )}
-                                %
+                                {limit.nextResetAt && <div>{formatTimeToReset(limit.nextResetAt)}</div>}
                               </div>
-                            ) : null}
-                          </div>
-                        }
-                      />
-                    </div>
-
-                    {qd.rate_limit.secondary_window.reset_at && (
-                      <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                        {formatTimeToReset(qd.rate_limit.secondary_window.reset_after_seconds)} (
-                        {formatDate(qd.rate_limit.secondary_window.reset_at)})
+                            }
+                          />
+                        </div>
                       </div>
-                    )}
-                  </div>
-                )}
+                    );
+                  })}
 
                 <div className='border-border/60 space-y-2 border-t border-dashed pt-3'>
                   <div className='flex items-center justify-between text-xs'>
@@ -971,6 +914,12 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
             const qd = channel.quotaStatus.quotaData;
             const weekly = qd.billing?.weekly;
             const monthly = qd.billing?.monthly;
+            const weeklyDurationPercent = weekly?.reset_at
+              ? calcDurationPercent(7 * 24 * 3600, (new Date(weekly.reset_at).getTime() - Date.now()) / 1000)
+              : undefined;
+            const monthlyDurationPercent = monthly?.reset_at
+              ? calcDurationPercent(30 * 24 * 3600, (new Date(monthly.reset_at).getTime() - Date.now()) / 1000)
+              : undefined;
             return (
               <>
                 {qd.plan_type ? (
@@ -989,27 +938,21 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     </div>
                     <UsageTimeBar
                       usagePercent={weekly.usage_percent ?? 0}
-                      durationPercent={
-                        weekly.reset_at
-                          ? calcDurationPercent(7 * 24 * 3600, (new Date(weekly.reset_at).getTime() - Date.now()) / 1000)
-                          : undefined
-                      }
+                      durationPercent={weeklyDurationPercent}
                       tooltip={
                         <div className='space-y-0.5'>
                           <div className='font-medium'>{t('quota.window.weekly')}</div>
                           <div>{t('quota.label.percent_used', { percent: Math.round(weekly.usage_percent ?? 0) })}</div>
-                          {weekly.reset_at && (
+                          {weeklyDurationPercent !== undefined && (
                             <div>
                               {t('quota.label.time_elapsed')}:{' '}
-                              {Math.round(calcDurationPercent(7 * 24 * 3600, (new Date(weekly.reset_at).getTime() - Date.now()) / 1000))}%
+                              {Math.round(weeklyDurationPercent)}%
                             </div>
                           )}
+                          {weekly.reset_at && <div>{formatTimeToReset(weekly.reset_at)}</div>}
                         </div>
                       }
                     />
-                    {weekly.reset_at ? (
-                      <div className='text-muted-foreground text-right text-[11px]'>{formatTimeToReset(weekly.reset_at)}</div>
-                    ) : null}
                   </div>
                 ) : null}
                 {monthly ? (
@@ -1043,27 +986,21 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     </div>
                     <UsageTimeBar
                       usagePercent={monthly.usage_percent ?? 0}
-                      durationPercent={
-                        monthly.reset_at
-                          ? calcDurationPercent(30 * 24 * 3600, (new Date(monthly.reset_at).getTime() - Date.now()) / 1000)
-                          : undefined
-                      }
+                      durationPercent={monthlyDurationPercent}
                       tooltip={
                         <div className='space-y-0.5'>
                           <div className='font-medium'>{t('quota.window.monthly')}</div>
                           <div>{t('quota.label.percent_used', { percent: Math.round(monthly.usage_percent ?? 0) })}</div>
-                          {monthly.reset_at && (
+                          {monthlyDurationPercent !== undefined && (
                             <div>
                               {t('quota.label.time_elapsed')}:{' '}
-                              {Math.round(calcDurationPercent(30 * 24 * 3600, (new Date(monthly.reset_at).getTime() - Date.now()) / 1000))}%
+                              {Math.round(monthlyDurationPercent)}%
                             </div>
                           )}
+                          {monthly.reset_at && <div>{formatTimeToReset(monthly.reset_at)}</div>}
                         </div>
                       }
                     />
-                    {monthly.reset_at ? (
-                      <div className='text-muted-foreground text-right text-[11px]'>{formatTimeToReset(monthly.reset_at)}</div>
-                    ) : null}
                   </div>
                 ) : null}
               </>
@@ -1207,6 +1144,12 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
               const usedStr = isTokens ? formatTokenCount(window.used ?? 0) : `${window.used ?? 0}`;
               const total = (window.used ?? 0) + (window.remaining ?? 0);
               const totalStr = isTokens ? formatTokenCount(total) : `${total}`;
+              const durationPct = window.resetAt
+                ? calcDurationPercent(
+                    isTokens ? 7 * 24 * 3600 : 24 * 3600,
+                    (new Date(window.resetAt).getTime() - Date.now()) / 1000
+                  )
+                : undefined;
 
               items.push(
                 <div key={key} className={idx > 0 ? 'border-border/60 space-y-2.5 border-t border-dashed pt-3' : 'space-y-2.5'}>
@@ -1222,14 +1165,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     </div>
                     <UsageTimeBar
                       usagePercent={pct}
-                      durationPercent={
-                        window.resetAt
-                          ? calcDurationPercent(
-                              isTokens ? 7 * 24 * 3600 : 24 * 3600,
-                              (new Date(window.resetAt).getTime() - Date.now()) / 1000
-                            )
-                          : undefined
-                      }
+                      durationPercent={durationPct}
                       tooltip={
                         <div className='space-y-0.5'>
                           <div className='font-medium'>{label}</div>
@@ -1237,26 +1173,17 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                             {usedStr}/{totalStr}
                           </div>
                           <div>{t('quota.label.percent_used', { percent: Math.round(pct) })}</div>
-                          {window.resetAt && (
+                          {durationPct !== undefined && (
                             <div>
                               {t('quota.label.time_elapsed')}:{' '}
-                              {Math.round(
-                                calcDurationPercent(
-                                  isTokens ? 7 * 24 * 3600 : 24 * 3600,
-                                  (new Date(window.resetAt).getTime() - Date.now()) / 1000
-                                )
-                              )}%
+                              {Math.round(durationPct)}%
                             </div>
                           )}
+                          {window.resetAt && <div>{formatTimeToReset(new Date(window.resetAt).toISOString())}</div>}
                         </div>
                       }
                     />
                   </div>
-                  {window.resetAt ? (
-                    <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                      {formatTimeToReset(new Date(window.resetAt).toISOString())}
-                    </div>
-                  ) : null}
                 </div>
               );
             });
@@ -1564,11 +1491,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                           </div>
                         }
                       />
-                      {(row.resetAt || row.resetAfterSeconds) && (
-                        <div className='text-muted-foreground text-right text-[11px]'>
-                          {formatTimeToReset(row.resetAt ?? row.resetAfterSeconds)}
-                        </div>
-                      )}
                     </div>
                   );
                 })}
@@ -1672,11 +1594,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                             </div>
                           }
                         />
-                        {row.intervalResetAt && (
-                          <div className='text-muted-foreground text-right text-[11px]'>
-                            {formatTimeToReset(row.intervalResetAt)}
-                          </div>
-                        )}
                       </div>
                       {hasWeekly && (
                         <div className='border-border/60 space-y-1.5 border-t border-dashed pt-3'>
@@ -1709,11 +1626,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                               </div>
                             }
                           />
-                          {row.weeklyResetAt && (
-                            <div className='text-muted-foreground text-right text-[11px]'>
-                              {formatTimeToReset(row.weeklyResetAt)}
-                            </div>
-                          )}
                         </div>
                       )}
                     </div>
@@ -1767,11 +1679,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                           </div>
                         }
                       />
-                      {row.resetAt && (
-                        <div className='text-muted-foreground text-right text-[11px]'>
-                          {formatTimeToReset(row.resetAt)}
-                        </div>
-                      )}
                     </div>
                   );
                 })}
@@ -1805,19 +1712,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                   </div>
                   <UsageTimeBar
                     usagePercent={usedPct}
-                    durationPercent={
-                      qd.window_start && qd.window_end
-                        ? Math.max(
-                            0,
-                            Math.min(
-                              100,
-                              ((Date.now() - new Date(qd.window_start).getTime()) /
-                                (new Date(qd.window_end).getTime() - new Date(qd.window_start).getTime())) *
-                                100
-                            )
-                          )
-                        : undefined
-                    }
+                    durationPercent={getDurationPercent(qd.window_start, qd.window_end)}
                     tooltip={
                       <div className='space-y-0.5'>
                         <div className='font-medium'>{t('quota.label.requests')}</div>
@@ -1825,20 +1720,13 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                           {usedRequests}/{totalRequests}
                         </div>
                         <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                        {qd.window_end && <div>{formatTimeToReset(qd.window_end, usedPct)}</div>}
                       </div>
                     }
                   />
                 </div>
               </div>
             );
-
-            if (qd.window_end) {
-              items.push(
-                <div key='reset' className='text-muted-foreground pt-1 text-right text-[11px]'>
-                  {formatTimeToReset(qd.window_end, usedPct)}
-                </div>
-              );
-            }
 
             return items;
           })()}
@@ -1895,11 +1783,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       }
                     />
                   </div>
-                  {qd.weeklyTokenLimit.nextRegenAt && (
-                    <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                      {formatTimeToReset(qd.weeklyTokenLimit.nextRegenAt, usedPct, syntheticWeeklyRegenTickPct)}
-                    </div>
-                  )}
                 </div>
               );
             }
@@ -1958,11 +1841,6 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       {t('quota.status.limited')}
                     </Badge>
                   )}
-                  {qd.rollingFiveHourLimit.nextTickAt && (
-                    <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
-                      {formatTimeToReset(qd.rollingFiveHourLimit.nextTickAt, fiveHrUsedPct, qd.rollingFiveHourLimit.tickPercent ?? 0.05)}
-                    </div>
-                  )}
                 </div>
               );
             }
@@ -2006,6 +1884,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                             {kwhUsed}/{kwhIncluded}
                           </div>
                           <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                          {quota.nextResetAt && <div>{formatTimeToReset(quota.nextResetAt)}</div>}
                         </div>
                       }
                     />
@@ -2037,7 +1916,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
               );
             }
 
-            if (quota.nextResetAt) {
+            if (quota.nextResetAt && !qd.subscription) {
               items.push(
                 <div key='reset' className='text-muted-foreground pt-1 text-right text-[11px]'>
                   {formatTimeToReset(quota.nextResetAt)}
@@ -2081,19 +1960,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     </div>
                     <UsageTimeBar
                       usagePercent={subPct}
-                      durationPercent={
-                        qd.subscription.cycle_start && qd.subscription.cycle_end
-                          ? Math.max(
-                              0,
-                              Math.min(
-                                100,
-                                ((Date.now() - new Date(qd.subscription.cycle_start).getTime()) /
-                                  (new Date(qd.subscription.cycle_end).getTime() - new Date(qd.subscription.cycle_start).getTime())) *
-                                  100
-                              )
-                            )
-                          : undefined
-                      }
+                      durationPercent={getDurationPercent(qd.subscription.cycle_start, qd.subscription.cycle_end)}
                       tooltip={
                         <div className='space-y-0.5'>
                           <div className='font-medium'>{planLabel}</div>
@@ -2101,6 +1968,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                             {subUsed}/{subTotal}
                           </div>
                           <div>{t('quota.label.percent_used', { percent: Math.round(subPct) })}</div>
+                          {qd.subscription.cycle_end && <div>{formatTimeToReset(qd.subscription.cycle_end)}</div>}
                         </div>
                       }
                     />
@@ -2253,7 +2121,7 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
               );
             }
 
-            if (quota.nextResetAt) {
+            if (quota.nextResetAt && (!qd.subscription || qd.subscription.cycle_quota_limit <= 0)) {
               items.push(
                 <div key='reset' className='text-muted-foreground pt-1 text-right text-[11px]'>
                   {formatTimeToReset(quota.nextResetAt)}

--- a/frontend/src/components/quota-badges.tsx
+++ b/frontend/src/components/quota-badges.tsx
@@ -252,64 +252,47 @@ function getApertisPercentage(qd: ProviderApertisQuotaData | undefined): number 
   return 0;
 }
 
-function ProgressBar({
-  percentage,
-  type = 'usage',
-  durationPercentage,
-}: {
-  percentage: number;
-  type?: 'usage' | 'duration';
-  durationPercentage?: number;
-}) {
-  const clamped = Math.min(Math.max(percentage || 0, 0), 100);
-
-  let bgStyle = {};
-  if (type === 'duration') {
-    bgStyle = { backgroundColor: '#71717a' }; // zinc-500
-  } else {
-    const u = clamped / 100;
-    let severity = u;
-    if (durationPercentage !== undefined && durationPercentage > 0) {
-      const d = Math.max(durationPercentage / 100, 0.01);
-      severity = u * (u / d);
-    }
-    severity = Math.min(1, Math.max(0, severity));
-
-    // Tailwind 500 colors approximation for a modern, theme-friendly gradient:
-    // Green (142, 71%, 45%), Yellow (45, 93%, 47%), Red (0, 84%, 60%)
-    let h, s, l;
-    if (severity < 0.5) {
-      const n = severity * 2; // 0 to 1
-      h = 142 - n * (142 - 45);
-      s = 71 + n * (93 - 71);
-      l = 45 + n * (47 - 45);
-    } else {
-      const n = (severity - 0.5) * 2; // 0 to 1
-      h = 45 - n * 45;
-      s = 93 - n * (93 - 84);
-      l = 47 + n * (60 - 47);
-    }
-    bgStyle = { backgroundColor: `hsl(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%)` };
-  }
-
-  return (
-    <div className='bg-muted/60 h-1.5 w-full overflow-hidden rounded-full'>
-      <div className='h-full transition-all duration-500' style={{ width: `${clamped}%`, ...bgStyle }} />
-    </div>
-  );
-}
-
 // UsageTimeBar shows usage on a single progress bar with a small triangle below
 // it marking how far the reset window has elapsed (time progress). Hovering
 // reveals the detailed figures via tooltip, keeping the row compact.
 function UsageTimeBar({ usagePercent, durationPercent, tooltip }: { usagePercent: number; durationPercent?: number; tooltip: ReactNode }) {
+  const clamped = Math.min(Math.max(usagePercent || 0, 0), 100);
   const markerLeft = durationPercent === undefined ? undefined : Math.min(Math.max(durationPercent, 0), 100);
+  const u = clamped / 100;
+  let severity = u;
+  if (durationPercent !== undefined && durationPercent > 0) {
+    const d = Math.max(durationPercent / 100, 0.01);
+    severity = u * (u / d);
+  }
+  severity = Math.min(1, Math.max(0, severity));
+
+  // Tailwind 500 colors approximation for a modern, theme-friendly gradient:
+  // Green (142, 71%, 45%), Yellow (45, 93%, 47%), Red (0, 84%, 60%)
+  let h: number;
+  let s: number;
+  let l: number;
+  if (severity < 0.5) {
+    const n = severity * 2; // 0 to 1
+    h = 142 - n * (142 - 45);
+    s = 71 + n * (93 - 71);
+    l = 45 + n * (47 - 45);
+  } else {
+    const n = (severity - 0.5) * 2; // 0 to 1
+    h = 45 - n * 45;
+    s = 93 - n * (93 - 84);
+    l = 47 + n * (60 - 47);
+  }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <div className='relative cursor-default pb-1.5'>
-          <ProgressBar percentage={usagePercent} durationPercentage={durationPercent} />
+          <div className='bg-muted/60 h-1.5 w-full overflow-hidden rounded-full'>
+            <div
+              className='h-full transition-all duration-500'
+              style={{ width: `${clamped}%`, backgroundColor: `hsl(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%)` }}
+            />
+          </div>
           {markerLeft !== undefined && (
             <div className='absolute top-2 -translate-x-1/2' style={{ left: `${markerLeft}%` }} aria-hidden>
               {/* upward triangle pointing at the bar, marking elapsed time */}
@@ -609,19 +592,21 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         <span className='text-muted-foreground font-medium'>{t('quota.window.5h')}</span>
                         <span className='text-foreground font-medium'>{Math.round((qd.windows['5h'].utilization || 0) * 100)}%</span>
                       </div>
-                      <ProgressBar
-                        percentage={(qd.windows['5h'].utilization || 0) * 100}
-                        durationPercentage={getClaudeDurationPercent('5h', qd.windows['5h'].reset)}
+                      <UsageTimeBar
+                        usagePercent={(qd.windows['5h'].utilization || 0) * 100}
+                        durationPercent={getClaudeDurationPercent('5h', qd.windows['5h'].reset)}
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{t('quota.window.5h')}</div>
+                            <div>{t('quota.label.percent_used', { percent: Math.round((qd.windows['5h'].utilization || 0) * 100) })}</div>
+                            {getClaudeDurationPercent('5h', qd.windows['5h'].reset) !== undefined && (
+                              <div>
+                                {t('quota.label.time_elapsed')}: {Math.round(getClaudeDurationPercent('5h', qd.windows['5h'].reset) || 0)}%
+                              </div>
+                            )}
+                          </div>
+                        }
                       />
-                    </div>
-                    <div className='space-y-1'>
-                      <div className='flex items-center justify-between text-xs'>
-                        <span className='text-muted-foreground font-medium'>{t('quota.label.5h_duration')}</span>
-                        <span className='text-foreground font-medium'>
-                          {Math.round(getClaudeDurationPercent('5h', qd.windows['5h'].reset) || 0)}%
-                        </span>
-                      </div>
-                      <ProgressBar type='duration' percentage={getClaudeDurationPercent('5h', qd.windows['5h'].reset) || 0} />
                     </div>
                   </div>
                 )}
@@ -632,19 +617,21 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         <span className='text-muted-foreground font-medium'>{t('quota.window.7d')}</span>
                         <span className='text-foreground font-medium'>{Math.round((qd.windows['7d'].utilization || 0) * 100)}%</span>
                       </div>
-                      <ProgressBar
-                        percentage={(qd.windows['7d'].utilization || 0) * 100}
-                        durationPercentage={getClaudeDurationPercent('7d', qd.windows['7d'].reset)}
+                      <UsageTimeBar
+                        usagePercent={(qd.windows['7d'].utilization || 0) * 100}
+                        durationPercent={getClaudeDurationPercent('7d', qd.windows['7d'].reset)}
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{t('quota.window.7d')}</div>
+                            <div>{t('quota.label.percent_used', { percent: Math.round((qd.windows['7d'].utilization || 0) * 100) })}</div>
+                            {getClaudeDurationPercent('7d', qd.windows['7d'].reset) !== undefined && (
+                              <div>
+                                {t('quota.label.time_elapsed')}: {Math.round(getClaudeDurationPercent('7d', qd.windows['7d'].reset) || 0)}%
+                              </div>
+                            )}
+                          </div>
+                        }
                       />
-                    </div>
-                    <div className='space-y-1'>
-                      <div className='flex items-center justify-between text-xs'>
-                        <span className='text-muted-foreground font-medium'>{t('quota.label.7d_duration')}</span>
-                        <span className='text-foreground font-medium'>
-                          {Math.round(getClaudeDurationPercent('7d', qd.windows['7d'].reset) || 0)}%
-                        </span>
-                      </div>
-                      <ProgressBar type='duration' percentage={getClaudeDurationPercent('7d', qd.windows['7d'].reset) || 0} />
                     </div>
                     {qd.windows['7d'].reset && (
                       <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
@@ -661,7 +648,15 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         <span className='text-muted-foreground font-medium'>{t('quota.label.overage_window')}</span>
                         <span className='text-foreground font-medium'>{Math.round((qd.windows['overage'].utilization || 0) * 100)}%</span>
                       </div>
-                      <ProgressBar percentage={(qd.windows['overage'].utilization || 0) * 100} />
+                      <UsageTimeBar
+                        usagePercent={(qd.windows['overage'].utilization || 0) * 100}
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{t('quota.label.overage_window')}</div>
+                            <div>{t('quota.label.percent_used', { percent: Math.round((qd.windows['overage'].utilization || 0) * 100) })}</div>
+                          </div>
+                        }
+                      />
                     </div>
                   </div>
                 )}
@@ -722,7 +717,18 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                             {t('quota.label.percent_used', { percent: Math.round(usedPct) })}
                           </span>
                         </div>
-                        <ProgressBar percentage={usedPct} />
+                        <UsageTimeBar
+                          usagePercent={usedPct}
+                          tooltip={
+                            <div className='space-y-0.5'>
+                              <div className='font-medium'>{label}</div>
+                              <div>
+                                {Math.round(displayRem)}/{Math.round(displayTot)}
+                              </div>
+                              <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                            </div>
+                          }
+                        />
                       </div>
                     </div>
                   );
@@ -767,7 +773,20 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                               : t('quota.label.percent_used', { percent: Math.round(usedPct) })}
                           </span>
                         </div>
-                        {!snapshot.unlimited && <ProgressBar percentage={usedPct} />}
+                        {!snapshot.unlimited && (
+                          <UsageTimeBar
+                            usagePercent={usedPct}
+                            tooltip={
+                              <div className='space-y-0.5'>
+                                <div className='font-medium'>{label}</div>
+                                <div>
+                                  {Math.round(displayRem)}/{Math.round(displayTot)}
+                                </div>
+                                <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                              </div>
+                            }
+                          />
+                        )}
                       </div>
                     </div>
                   );
@@ -812,36 +831,40 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         <span className='text-muted-foreground font-medium'>{t('quota.label.primary_window')}</span>
                         <span className='text-foreground font-medium'>{Math.round(qd.rate_limit.primary_window.used_percent || 0)}%</span>
                       </div>
-                      <ProgressBar
-                        percentage={qd.rate_limit.primary_window.used_percent || 0}
-                      />
-                    </div>
-
-                    {qd.rate_limit.primary_window.limit_window_seconds ? (
-                      <div className='space-y-1'>
-                        <div className='flex items-center justify-between text-xs'>
-                          <span className='text-muted-foreground font-medium'>
-                            {t('quota.label.primary_duration')} ({formatWindowDuration(qd.rate_limit.primary_window.limit_window_seconds)})
-                          </span>
-                          <span className='text-foreground font-medium'>
-                            {Math.round(
-                              calcDurationPercent(
+                      <UsageTimeBar
+                        usagePercent={qd.rate_limit.primary_window.used_percent || 0}
+                        durationPercent={
+                          qd.rate_limit.primary_window.limit_window_seconds
+                            ? calcDurationPercent(
                                 qd.rate_limit.primary_window.limit_window_seconds,
                                 qd.rate_limit.primary_window.reset_after_seconds
                               )
-                            )}
-                            %
-                          </span>
-                        </div>
-                        <ProgressBar
-                          type='duration'
-                          percentage={calcDurationPercent(
-                            qd.rate_limit.primary_window.limit_window_seconds,
-                            qd.rate_limit.primary_window.reset_after_seconds
-                          )}
-                        />
-                      </div>
-                    ) : null}
+                            : undefined
+                        }
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{t('quota.label.primary_window')}</div>
+                            <div>
+                              {t('quota.label.percent_used', {
+                                percent: Math.round(qd.rate_limit.primary_window.used_percent || 0),
+                              })}
+                            </div>
+                            {qd.rate_limit.primary_window.limit_window_seconds ? (
+                              <div>
+                                {t('quota.label.primary_duration')} ({formatWindowDuration(qd.rate_limit.primary_window.limit_window_seconds)}):{' '}
+                                {Math.round(
+                                  calcDurationPercent(
+                                    qd.rate_limit.primary_window.limit_window_seconds,
+                                    qd.rate_limit.primary_window.reset_after_seconds
+                                  )
+                                )}
+                                %
+                              </div>
+                            ) : null}
+                          </div>
+                        }
+                      />
+                    </div>
 
                     {qd.rate_limit.primary_window.reset_at && (
                       <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
@@ -859,37 +882,40 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         <span className='text-muted-foreground font-medium'>{t('quota.label.secondary_window')}</span>
                         <span className='text-foreground font-medium'>{Math.round(qd.rate_limit.secondary_window.used_percent)}%</span>
                       </div>
-                      <ProgressBar
-                        percentage={qd.rate_limit.secondary_window.used_percent}
-                      />
-                    </div>
-
-                    {qd.rate_limit.secondary_window.limit_window_seconds ? (
-                      <div className='space-y-1'>
-                        <div className='flex items-center justify-between text-xs'>
-                          <span className='text-muted-foreground font-medium'>
-                            {t('quota.label.secondary_duration')} (
-                            {formatWindowDuration(qd.rate_limit.secondary_window.limit_window_seconds)})
-                          </span>
-                          <span className='text-foreground font-medium'>
-                            {Math.round(
-                              calcDurationPercent(
+                      <UsageTimeBar
+                        usagePercent={qd.rate_limit.secondary_window.used_percent}
+                        durationPercent={
+                          qd.rate_limit.secondary_window.limit_window_seconds
+                            ? calcDurationPercent(
                                 qd.rate_limit.secondary_window.limit_window_seconds,
                                 qd.rate_limit.secondary_window.reset_after_seconds
                               )
-                            )}
-                            %
-                          </span>
-                        </div>
-                        <ProgressBar
-                          type='duration'
-                          percentage={calcDurationPercent(
-                            qd.rate_limit.secondary_window.limit_window_seconds,
-                            qd.rate_limit.secondary_window.reset_after_seconds
-                          )}
-                        />
-                      </div>
-                    ) : null}
+                            : undefined
+                        }
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{t('quota.label.secondary_window')}</div>
+                            <div>
+                              {t('quota.label.percent_used', {
+                                percent: Math.round(qd.rate_limit.secondary_window.used_percent),
+                              })}
+                            </div>
+                            {qd.rate_limit.secondary_window.limit_window_seconds ? (
+                              <div>
+                                {t('quota.label.secondary_duration')} ({formatWindowDuration(qd.rate_limit.secondary_window.limit_window_seconds)}):{' '}
+                                {Math.round(
+                                  calcDurationPercent(
+                                    qd.rate_limit.secondary_window.limit_window_seconds,
+                                    qd.rate_limit.secondary_window.reset_after_seconds
+                                  )
+                                )}
+                                %
+                              </div>
+                            ) : null}
+                          </div>
+                        }
+                      />
+                    </div>
 
                     {qd.rate_limit.secondary_window.reset_at && (
                       <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
@@ -961,7 +987,26 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         {t('quota.label.percent_used', { percent: Math.round(weekly.usage_percent ?? 0) })}
                       </span>
                     </div>
-                    <ProgressBar percentage={weekly.usage_percent ?? 0} />
+                    <UsageTimeBar
+                      usagePercent={weekly.usage_percent ?? 0}
+                      durationPercent={
+                        weekly.reset_at
+                          ? calcDurationPercent(7 * 24 * 3600, (new Date(weekly.reset_at).getTime() - Date.now()) / 1000)
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.window.weekly')}</div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(weekly.usage_percent ?? 0) })}</div>
+                          {weekly.reset_at && (
+                            <div>
+                              {t('quota.label.time_elapsed')}:{' '}
+                              {Math.round(calcDurationPercent(7 * 24 * 3600, (new Date(weekly.reset_at).getTime() - Date.now()) / 1000))}%
+                            </div>
+                          )}
+                        </div>
+                      }
+                    />
                     {weekly.reset_at ? (
                       <div className='text-muted-foreground text-right text-[11px]'>{formatTimeToReset(weekly.reset_at)}</div>
                     ) : null}
@@ -996,7 +1041,26 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         {t('quota.label.percent_used', { percent: Math.round(monthly.usage_percent ?? 0) })}
                       </span>
                     </div>
-                    <ProgressBar percentage={monthly.usage_percent ?? 0} />
+                    <UsageTimeBar
+                      usagePercent={monthly.usage_percent ?? 0}
+                      durationPercent={
+                        monthly.reset_at
+                          ? calcDurationPercent(30 * 24 * 3600, (new Date(monthly.reset_at).getTime() - Date.now()) / 1000)
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.window.monthly')}</div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(monthly.usage_percent ?? 0) })}</div>
+                          {monthly.reset_at && (
+                            <div>
+                              {t('quota.label.time_elapsed')}:{' '}
+                              {Math.round(calcDurationPercent(30 * 24 * 3600, (new Date(monthly.reset_at).getTime() - Date.now()) / 1000))}%
+                            </div>
+                          )}
+                        </div>
+                      }
+                    />
                     {monthly.reset_at ? (
                       <div className='text-muted-foreground text-right text-[11px]'>{formatTimeToReset(monthly.reset_at)}</div>
                     ) : null}
@@ -1156,7 +1220,37 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       </span>
                       <span className='text-foreground font-medium'>{Math.round(pct)}%</span>
                     </div>
-                    <ProgressBar percentage={pct} />
+                    <UsageTimeBar
+                      usagePercent={pct}
+                      durationPercent={
+                        window.resetAt
+                          ? calcDurationPercent(
+                              isTokens ? 7 * 24 * 3600 : 24 * 3600,
+                              (new Date(window.resetAt).getTime() - Date.now()) / 1000
+                            )
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{label}</div>
+                          <div>
+                            {usedStr}/{totalStr}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(pct) })}</div>
+                          {window.resetAt && (
+                            <div>
+                              {t('quota.label.time_elapsed')}:{' '}
+                              {Math.round(
+                                calcDurationPercent(
+                                  isTokens ? 7 * 24 * 3600 : 24 * 3600,
+                                  (new Date(window.resetAt).getTime() - Date.now()) / 1000
+                                )
+                              )}%
+                            </div>
+                          )}
+                        </div>
+                      }
+                    />
                   </div>
                   {window.resetAt ? (
                     <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
@@ -1457,7 +1551,19 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         </span>
                         <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(percentage) })}</span>
                       </div>
-                      <ProgressBar percentage={percentage} />
+                      <UsageTimeBar
+                        usagePercent={percentage}
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{row.label}</div>
+                            <div>
+                              {row.used.toLocaleString()}/{row.limit.toLocaleString()}
+                            </div>
+                            <div>{t('quota.label.percent_used', { percent: Math.round(percentage) })}</div>
+                            {(row.resetAt || row.resetAfterSeconds) && <div>{formatTimeToReset(row.resetAt ?? row.resetAfterSeconds)}</div>}
+                          </div>
+                        }
+                      />
                       {(row.resetAt || row.resetAfterSeconds) && (
                         <div className='text-muted-foreground text-right text-[11px]'>
                           {formatTimeToReset(row.resetAt ?? row.resetAfterSeconds)}
@@ -1547,7 +1653,25 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                               : t('quota.label.percent_used', { percent: intervalUsed })}
                           </span>
                         </div>
-                        <ProgressBar percentage={row.intervalPercent} />
+                        <UsageTimeBar
+                          usagePercent={row.intervalPercent}
+                          durationPercent={
+                            row.intervalResetAt
+                              ? calcDurationPercent(5 * 3600, (new Date(row.intervalResetAt).getTime() - Date.now()) / 1000)
+                              : undefined
+                          }
+                          tooltip={
+                            <div className='space-y-0.5'>
+                              <div className='font-medium'>{t('quota.window.5h')}</div>
+                              <div>
+                                {showIntervalTotal
+                                  ? `${intervalUsed}% / ${intervalTotal}%`
+                                  : t('quota.label.percent_used', { percent: intervalUsed })}
+                              </div>
+                              {row.intervalResetAt && <div>{formatTimeToReset(row.intervalResetAt)}</div>}
+                            </div>
+                          }
+                        />
                         {row.intervalResetAt && (
                           <div className='text-muted-foreground text-right text-[11px]'>
                             {formatTimeToReset(row.intervalResetAt)}
@@ -1566,7 +1690,25 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                                 : t('quota.label.percent_used', { percent: weeklyUsed })}
                             </span>
                           </div>
-                          <ProgressBar percentage={row.weeklyPercent} />
+                          <UsageTimeBar
+                            usagePercent={row.weeklyPercent}
+                            durationPercent={
+                              row.weeklyResetAt
+                                ? calcDurationPercent(7 * 24 * 3600, (new Date(row.weeklyResetAt).getTime() - Date.now()) / 1000)
+                                : undefined
+                            }
+                            tooltip={
+                              <div className='space-y-0.5'>
+                                <div className='font-medium'>{t('quota.window.weekly')}</div>
+                                <div>
+                                  {showWeeklyTotal
+                                    ? `${weeklyUsed}% / ${weeklyTotal}%`
+                                    : t('quota.label.percent_used', { percent: weeklyUsed })}
+                                </div>
+                                {row.weeklyResetAt && <div>{formatTimeToReset(row.weeklyResetAt)}</div>}
+                              </div>
+                            }
+                          />
                           {row.weeklyResetAt && (
                             <div className='text-muted-foreground text-right text-[11px]'>
                               {formatTimeToReset(row.weeklyResetAt)}
@@ -1607,7 +1749,24 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         </span>
                         <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(percentage) })}</span>
                       </div>
-                      <ProgressBar percentage={percentage} />
+                      <UsageTimeBar
+                        usagePercent={percentage}
+                        durationPercent={
+                          row.resetAt
+                            ? calcDurationPercent(
+                                row.window === 'five_hour' ? 5 * 3600 : 7 * 24 * 3600,
+                                (new Date(row.resetAt).getTime() - Date.now()) / 1000
+                              )
+                            : undefined
+                        }
+                        tooltip={
+                          <div className='space-y-0.5'>
+                            <div className='font-medium'>{windowLabels[row.window] ?? row.window}</div>
+                            <div>{t('quota.label.percent_used', { percent: Math.round(percentage) })}</div>
+                            {row.resetAt && <div>{formatTimeToReset(row.resetAt)}</div>}
+                          </div>
+                        }
+                      />
                       {row.resetAt && (
                         <div className='text-muted-foreground text-right text-[11px]'>
                           {formatTimeToReset(row.resetAt)}
@@ -1644,7 +1803,31 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     </span>
                     <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</span>
                   </div>
-                  <ProgressBar percentage={usedPct} />
+                  <UsageTimeBar
+                    usagePercent={usedPct}
+                    durationPercent={
+                      qd.window_start && qd.window_end
+                        ? Math.max(
+                            0,
+                            Math.min(
+                              100,
+                              ((Date.now() - new Date(qd.window_start).getTime()) /
+                                (new Date(qd.window_end).getTime() - new Date(qd.window_start).getTime())) *
+                                100
+                            )
+                          )
+                        : undefined
+                    }
+                    tooltip={
+                      <div className='space-y-0.5'>
+                        <div className='font-medium'>{t('quota.label.requests')}</div>
+                        <div>
+                          {usedRequests}/{totalRequests}
+                        </div>
+                        <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                      </div>
+                    }
+                  />
                 </div>
               </div>
             );
@@ -1693,7 +1876,24 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       </span>
                       <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</span>
                     </div>
-                    <ProgressBar percentage={usedPct} />
+                    <UsageTimeBar
+                      usagePercent={usedPct}
+                      durationPercent={
+                        qd.weeklyTokenLimit.nextRegenAt
+                          ? calcDurationPercent(7 * 24 * 3600, (new Date(qd.weeklyTokenLimit.nextRegenAt).getTime() - Date.now()) / 1000)
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.label.weekly_token_limit')}</div>
+                          {usedCredits != null && maxCredits != null && <div>{usedCredits}/{maxCredits}</div>}
+                          <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                          {qd.weeklyTokenLimit.nextRegenAt && (
+                            <div>{formatTimeToReset(qd.weeklyTokenLimit.nextRegenAt, usedPct, syntheticWeeklyRegenTickPct)}</div>
+                          )}
+                        </div>
+                      }
+                    />
                   </div>
                   {qd.weeklyTokenLimit.nextRegenAt && (
                     <div className='text-muted-foreground pt-0.5 text-right text-[11px]'>
@@ -1723,7 +1923,32 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         {t('quota.label.percent_used', { percent: Math.round(fiveHrUsedPct) })}
                       </span>
                     </div>
-                    <ProgressBar percentage={fiveHrUsedPct} />
+                    <UsageTimeBar
+                      usagePercent={fiveHrUsedPct}
+                      durationPercent={
+                        qd.rollingFiveHourLimit.nextTickAt
+                          ? calcDurationPercent(5 * 3600, (new Date(qd.rollingFiveHourLimit.nextTickAt).getTime() - Date.now()) / 1000)
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.label.rolling_5h_limit')}</div>
+                          <div>
+                            {Math.round(fiveHrUsed)}/{Math.round(fiveHrMax)}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(fiveHrUsedPct) })}</div>
+                          {qd.rollingFiveHourLimit.nextTickAt && (
+                            <div>
+                              {formatTimeToReset(
+                                qd.rollingFiveHourLimit.nextTickAt,
+                                fiveHrUsedPct,
+                                qd.rollingFiveHourLimit.tickPercent ?? 0.05
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      }
+                    />
                   </div>
                   {qd.rollingFiveHourLimit.limited && (
                     <Badge
@@ -1772,7 +1997,18 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       </span>
                       <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</span>
                     </div>
-                    <ProgressBar percentage={usedPct} />
+                    <UsageTimeBar
+                      usagePercent={usedPct}
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.label.kwh_remaining')}</div>
+                          <div>
+                            {kwhUsed}/{kwhIncluded}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                        </div>
+                      }
+                    />
                   </div>
                 </div>
               );
@@ -1843,7 +2079,31 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                       </span>
                       <span className='text-foreground font-medium'>{t('quota.label.percent_used', { percent: Math.round(subPct) })}</span>
                     </div>
-                    <ProgressBar percentage={subPct} />
+                    <UsageTimeBar
+                      usagePercent={subPct}
+                      durationPercent={
+                        qd.subscription.cycle_start && qd.subscription.cycle_end
+                          ? Math.max(
+                              0,
+                              Math.min(
+                                100,
+                                ((Date.now() - new Date(qd.subscription.cycle_start).getTime()) /
+                                  (new Date(qd.subscription.cycle_end).getTime() - new Date(qd.subscription.cycle_start).getTime())) *
+                                  100
+                              )
+                            )
+                          : undefined
+                      }
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{planLabel}</div>
+                          <div>
+                            {subUsed}/{subTotal}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(subPct) })}</div>
+                        </div>
+                      }
+                    />
                   </div>
                 </div>
               );
@@ -1870,7 +2130,20 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                           {spent != null && limit != null ? t('quota.label.percent_used', { percent: Math.round(fallbackPct) }) : ''}
                         </span>
                       </div>
-                      {spent != null && limit != null && limit > 0 && <ProgressBar percentage={fallbackPct} />}
+                      {spent != null && limit != null && limit > 0 && (
+                        <UsageTimeBar
+                          usagePercent={fallbackPct}
+                          tooltip={
+                            <div className='space-y-0.5'>
+                              <div className='font-medium'>{t('quota.label.payg_fallback')}</div>
+                              <div>
+                                ${spent.toFixed(2)}/${limit.toFixed(2)}
+                              </div>
+                              <div>{t('quota.label.percent_used', { percent: Math.round(fallbackPct) })}</div>
+                            </div>
+                          }
+                        />
+                      )}
                     </div>
                   </div>
                 );
@@ -1910,7 +2183,18 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         {t('quota.label.percent_used', { percent: Math.round(tokenPct) })}
                       </span>
                     </div>
-                    <ProgressBar percentage={tokenPct} />
+                    <UsageTimeBar
+                      usagePercent={tokenPct}
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.label.token_usage')}</div>
+                          <div>
+                            ${tokenUsed.toFixed(2)}/${tokenTotal.toFixed(2)}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(tokenPct) })}</div>
+                        </div>
+                      }
+                    />
                   </div>
                 </div>
               );
@@ -1952,7 +2236,18 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                         {t('quota.label.percent_used', { percent: Math.round(monthlyPct) })}
                       </span>
                     </div>
-                    <ProgressBar percentage={monthlyPct} />
+                    <UsageTimeBar
+                      usagePercent={monthlyPct}
+                      tooltip={
+                        <div className='space-y-0.5'>
+                          <div className='font-medium'>{t('quota.label.monthly_limit')}</div>
+                          <div>
+                            ${qd.payg.token_monthly_used_usd.toFixed(2)}/${qd.payg.token_monthly_limit_usd.toFixed(2)}
+                          </div>
+                          <div>{t('quota.label.percent_used', { percent: Math.round(monthlyPct) })}</div>
+                        </div>
+                      }
+                    />
                   </div>
                 </div>
               );
@@ -1985,7 +2280,16 @@ function QuotaRow({ channel, enforcementMode, allowedChannelIDs }: { channel: Pr
                     <span className='text-muted-foreground font-medium'>{t('quota.label.credits_remaining')}</span>
                     <span className='text-foreground font-medium'>{Number.isInteger(balance) ? balance : balance.toFixed(2)}</span>
                   </div>
-                  <ProgressBar percentage={usedPct} />
+                  <UsageTimeBar
+                    usagePercent={usedPct}
+                    tooltip={
+                      <div className='space-y-0.5'>
+                        <div className='font-medium'>{t('quota.label.credits_remaining')}</div>
+                        <div>{Number.isInteger(balance) ? balance : balance.toFixed(2)}</div>
+                        <div>{t('quota.label.percent_used', { percent: Math.round(usedPct) })}</div>
+                      </div>
+                    }
+                  />
                 </div>
               </div>
             );

--- a/frontend/src/features/auth/data/auth.ts
+++ b/frontend/src/features/auth/data/auth.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { graphqlRequest } from '@/gql/graphql';
 import { ME_QUERY } from '@/gql/users';
@@ -88,6 +88,7 @@ export function useSignIn() {
 export function useSignOut() {
   const { reset } = useAuthStore((state) => state.auth);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return () => {
     // Clear token from localStorage
@@ -95,6 +96,8 @@ export function useSignOut() {
 
     // Clear auth store
     reset();
+
+    queryClient.clear();
 
     toast.success(i18n.t('common.success.signedOut'));
 

--- a/frontend/src/features/channels/components/channel-quota.test.mjs
+++ b/frontend/src/features/channels/components/channel-quota.test.mjs
@@ -6,7 +6,7 @@ import ts from 'typescript';
 // Run the table's pure quota helpers without loading React or its providers.
 const source = readFileSync(new URL('./channels-columns.tsx', import.meta.url), 'utf8');
 const ast = ts.createSourceFile('channels-columns.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-const helperNames = ['getQuotaLimits', 'codexWindowDuration', 'quotaWindowLabel'];
+const helperNames = ['getQuotaLimits', 'quotaWindowLabel'];
 const helpers = ast.statements
   .filter((node) => ts.isFunctionDeclaration(node) && helperNames.includes(node.name?.text))
   .map((node) => `export ${node.getText(ast)}`)
@@ -14,7 +14,22 @@ const helpers = ast.statements
 const { outputText } = ts.transpileModule(helpers, {
   compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2023 },
 });
-const { getQuotaLimits, quotaWindowLabel } = await import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`);
+const parserStub = `
+const QUOTA_WINDOW_LABEL_KEYS = {
+  '5h': '5h', '7d': '7d', '30d': '30d', daily: 'daily', weekly: 'weekly', monthly: 'monthly', cycle: 'cycle', overage: 'overage'
+};
+function parseQuotaLimits(quotaData) {
+  if (!Array.isArray(quotaData?._limits)) return [];
+  return quotaData._limits.filter((limit) =>
+    limit && typeof limit.type === 'string' && typeof limit.status === 'string' && typeof limit.ready === 'boolean' &&
+    typeof limit.window === 'string' && typeof limit.usageRatio === 'number' && Number.isFinite(limit.usageRatio) &&
+    limit.usageRatio >= 0 && limit.usageRatio <= 1
+  );
+}
+`;
+const { getQuotaLimits, quotaWindowLabel } = await import(
+  `data:text/javascript;base64,${Buffer.from(`${parserStub}\n${outputText}`).toString('base64')}`
+);
 const t = (key) => key;
 
 /**
@@ -23,63 +38,58 @@ const t = (key) => key;
  * @param {object[]} limits Normalized quota entries, defaulting to a primary window with 52% used.
  * @returns {object} Channel fixture consumed by the table's quota helpers.
  */
-function codex(rateLimit, limits = [{ window: 'primary', usageRatio: 0.52 }]) {
+function codex(limits = [{ type: 'token', status: 'available', ready: true, window: '5h', usageRatio: 0.52 }]) {
   return {
     type: 'codex',
     providerQuotaStatus: {
       status: 'available',
-      quotaData: { _limits: limits, rate_limit: rateLimit },
+      quotaData: { _limits: limits },
     },
   };
 }
 
-test('weekly-only Codex primary quota is shown once as 7d, with its usage preserved', () => {
-  const channel = codex({ primary_window: { used_percent: 52, limit_window_seconds: 604800 }, secondary_window: null });
+test('weekly-only Codex quota is shown once as 7d, with its usage preserved', () => {
+  const channel = codex([{ type: 'token', status: 'available', ready: true, window: '7d', usageRatio: 0.52 }]);
   const limits = getQuotaLimits(channel);
-  assert.deepEqual(limits, [{ window: '7d', usageRatio: 0.52, status: 'available' }]);
+  assert.deepEqual(limits.map(({ window, usageRatio, status }) => ({ window, usageRatio, status })), [{ window: '7d', usageRatio: 0.52, status: 'available' }]);
   assert.equal(quotaWindowLabel(limits[0].window, t), '7d');
   assert.equal(Math.round(100 - limits[0].usageRatio * 100), 48);
 });
 
 test('Codex dual windows and other durations use reported lengths', () => {
-  for (const [seconds, label] of [[18000, '5h'], [86400, '1d'], [7200, '2h'], [5400, '90m'], [45, '45s']]) {
-    const limits = getQuotaLimits(codex({
-      primary_window: { used_percent: 20, limit_window_seconds: seconds },
-      secondary_window: { used_percent: 60, limit_window_seconds: 604800 },
-    }));
+  for (const [label, usageRatio] of [['5h', 0.2], ['1d', 0.2], ['2h', 0.2], ['90m', 0.2], ['45s', 0.2]]) {
+    const limits = getQuotaLimits(codex([
+      { type: 'token', status: 'available', ready: true, window: label, usageRatio },
+      { type: 'token', status: 'available', ready: true, window: '7d', usageRatio: 0.6 },
+    ]));
     assert.deepEqual(limits.map((limit) => limit.window), [label, '7d']);
-    assert.deepEqual(limits.map((limit) => limit.usageRatio), [0.2, 0.6]);
+    assert.deepEqual(limits.map((limit) => limit.usageRatio), [usageRatio, 0.6]);
   }
 });
 
-test('absent windows do not inherit a synthetic normalized primary quota', () => {
-  assert.deepEqual(getQuotaLimits(codex({ primary_window: null, secondary_window: null })), []);
-  const limits = getQuotaLimits(codex({ secondary_window: { used_percent: 0, limit_window_seconds: 604800 } }));
-  assert.deepEqual(limits, [{ window: '7d', usageRatio: 0, status: 'available' }]);
+test('only persisted normalized Codex windows are displayed', () => {
+  assert.deepEqual(getQuotaLimits(codex([])), []);
+  const limits = getQuotaLimits(codex([{ type: 'token', status: 'available', ready: true, window: '7d', usageRatio: 0 }]));
+  assert.deepEqual(limits.map(({ window, usageRatio, status }) => ({ window, usageRatio, status })), [{ window: '7d', usageRatio: 0, status: 'available' }]);
 });
 
-test('unknown or invalid durations use localized role labels rather than assumed periods', () => {
-  for (const seconds of [undefined, null, 0, -1, NaN, Infinity, '604800']) {
-    const limits = getQuotaLimits(codex({
-      primary_window: { used_percent: 52, limit_window_seconds: seconds },
-      secondary_window: { used_percent: 0, limit_window_seconds: seconds },
-    }));
-    assert.equal(quotaWindowLabel(limits[0].window, t), 'quota.label.primary_window');
-    assert.equal(quotaWindowLabel(limits[1].window, t), 'quota.label.secondary_window');
-  }
+test('role identifiers use a neutral token label rather than assumed periods', () => {
+  assert.equal(quotaWindowLabel('primary', t), 'quota.label.token_usage');
+  assert.equal(quotaWindowLabel('secondary', t), 'quota.label.token_usage');
 });
 
-test('legacy normalized-only Codex data keeps usage without guessing a duration', () => {
-  const limits = getQuotaLimits(codex(undefined));
-  assert.equal(limits[0].usageRatio, 0.52);
-  assert.equal(quotaWindowLabel(limits[0].window, t), 'quota.label.primary_window');
+test('malformed normalized Codex data is ignored', () => {
+  assert.deepEqual(getQuotaLimits(codex([{ window: 'primary', usageRatio: 0.52 }])), []);
 });
 
 test('other provider window labels are preserved', () => {
   const channel = { type: 'claudecode', providerQuotaStatus: { status: 'available', quotaData: {
-    windows: { '5h': { utilization: 0.2 }, '7d': { utilization: 0.4 } },
+    _limits: [
+      { type: 'token', status: 'available', ready: true, window: '5h', usageRatio: 0.2 },
+      { type: 'token', status: 'available', ready: true, window: '7d', usageRatio: 0.4 },
+    ],
   } } };
   assert.deepEqual(getQuotaLimits(channel).map((limit) => quotaWindowLabel(limit.window, t)), ['5h', '7d']);
-  assert.equal(quotaWindowLabel('weekly', t), '7d');
-  assert.equal(quotaWindowLabel('monthly', t), '30d');
+  assert.equal(quotaWindowLabel('weekly', t), 'weekly');
+  assert.equal(quotaWindowLabel('monthly', t), 'monthly');
 });

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -63,6 +63,8 @@ const QUOTA_WINDOW_LABEL_KEYS: Record<string, string> = {
   daily: 'quota.window.daily',
   weekly: 'quota.window.weekly',
   monthly: 'quota.window.monthly',
+  payg: 'quota.label.token_usage',
+  credits: 'quota.label.credits_remaining',
   cycle: 'quota.window.cycle',
   overage: 'quota.label.overage_window',
 };

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -474,7 +474,7 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
   const content = (
     <div className='flex min-w-0 flex-col items-stretch gap-1.5 text-[11px]'>
       {visibleLimits.map((limit, index) => {
-        const usageRatio = limit.status === 'exhausted' ? 1 : (limit.usageRatio ?? 1);
+        const usageRatio = limit.usageRatio;
         const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
         const label = quotaWindowLabel(limit.window, t) || t('quota.label.quota');
         return (
@@ -512,7 +512,7 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
       <TooltipContent className='space-y-1'>
         <div className='font-medium'>{t(`quota.status.${channel.providerQuotaStatus.status}`)}</div>
         {limits.map((limit, index) => {
-          const usageRatio = limit.status === 'exhausted' ? 1 : (limit.usageRatio ?? 1);
+          const usageRatio = limit.usageRatio;
           const remaining = Math.round(Math.max(0, Math.min(100, 100 - usageRatio * 100)));
           return (
             <div key={`${limit.window}-${index}`} className='text-xs'>

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -47,6 +47,7 @@ import { useChannels } from '../context/channels-context';
 import { useTestChannel, useUpdateChannel } from '../data/channels';
 import { CHANNEL_CONFIGS, getProvider } from '../data/config_channels';
 import { Channel } from '../data/schema';
+import { parseQuotaLimits } from '../../system/data/quotas';
 import { ChannelHealthCell } from './channel-health-cell';
 import { ChannelLimiterCell } from './channel-limiter-cell';
 import { ChannelsStatusDialog } from './channels-status-dialog';
@@ -56,141 +57,25 @@ const MIN_WEIGHT = 0;
 const MAX_WEIGHT = 100;
 const QUOTA_VISIBLE_LIMIT = 5;
 
-const OAUTH_CHANNEL_TYPES = new Set<Channel['type']>(['codex', 'claudecode', 'antigravity', 'github_copilot', 'xai_subscription']);
-
-type QuotaLimit = {
-  window?: string;
-  usageRatio?: number;
-  status?: string;
+const QUOTA_WINDOW_LABEL_KEYS: Record<string, string> = {
+  '5h': 'quota.window.5h',
+  '7d': 'quota.window.7d',
+  '30d': 'quota.window.30d',
+  daily: 'quota.window.daily',
+  weekly: 'quota.window.weekly',
+  monthly: 'quota.window.monthly',
+  cycle: 'quota.window.cycle',
+  overage: 'quota.label.overage_window',
 };
 
-/**
- * Collect displayable quota windows from persisted provider data.
- * Codex uses its reported windows; older records fall back to normalized limits.
- * @param channel Channel with optional persisted provider quota status.
- * @returns Quota rows with window labels, usage ratios, and status, or an empty list.
- */
-function getQuotaLimits(channel: Channel): QuotaLimit[] {
-  const quotaStatus = channel.providerQuotaStatus;
-  if (!quotaStatus) return [];
-
-  const data = quotaStatus.quotaData as Record<string, unknown>;
-  const limits = Array.isArray(data._limits)
-    ? data._limits.filter((limit): limit is Record<string, unknown> => typeof limit === 'object' && limit !== null)
-    : [];
-  const normalized = limits.map((limit) => ({
-    window: typeof limit.window === 'string' ? limit.window : undefined,
-    usageRatio: typeof limit.usageRatio === 'number' ? limit.usageRatio : undefined,
-    status: typeof limit.status === 'string' ? limit.status : undefined,
-  }));
-
-  // Older persisted xAI statuses have unlabeled normalized limits. Match each
-  // one to the raw billing window by its usage value instead of array position,
-  // because either the weekly or monthly response may be absent.
-  if (channel.type === 'xai_subscription') {
-    const billing = data.billing as Record<string, unknown> | undefined;
-    for (const [key, label] of [
-      ['weekly', 'weekly'],
-      ['monthly', 'monthly'],
-    ] as const) {
-      const window = billing?.[key] as Record<string, unknown> | undefined;
-      if (typeof window?.usage_percent !== 'number' || normalized.some((limit) => limit.window === label)) {
-        continue;
-      }
-      const usageRatio = window.usage_percent / 100;
-      const unlabeled = normalized.find(
-        (limit) => !limit.window && limit.usageRatio != null && Math.abs(limit.usageRatio - usageRatio) < 0.000001
-      );
-      if (unlabeled) {
-        unlabeled.window = label;
-      } else {
-        normalized.push({ window: label, usageRatio, status: quotaStatus.status });
-      }
-    }
-  }
-
-  if (channel.type === 'claudecode' && normalized.length === 0) {
-    const windows = data.windows as Record<string, unknown> | undefined;
-    for (const label of ['5h', '7d']) {
-      const window = windows?.[label] as Record<string, unknown> | undefined;
-      if (typeof window?.utilization !== 'number') continue;
-      normalized.push({ window: label, usageRatio: window.utilization, status: quotaStatus.status });
-    }
-  }
-
-  if (channel.type === 'antigravity' && normalized.length === 0) {
-    const models = data.models as Record<string, unknown> | undefined;
-    for (const [modelID, value] of Object.entries(models ?? {})) {
-      if (typeof value !== 'object' || value === null) continue;
-      const model = value as Record<string, unknown>;
-      if (typeof model.remainingPercentage !== 'number') continue;
-      normalized.push({
-        window: typeof model.displayName === 'string' && model.displayName ? model.displayName : modelID,
-        usageRatio: 1 - model.remainingPercentage / 100,
-        status: typeof model.status === 'string' ? model.status : undefined,
-      });
-    }
-  }
-
-  // Window roles do not imply durations: some Codex plans have a weekly
-  // primary window. Prefer the reported windows over the normalized primary
-  // limit, which can exist even when the API returns no primary window.
-  if (channel.type === 'codex') {
-    const rateLimit = data.rate_limit as Record<string, unknown> | undefined;
-    if (rateLimit) {
-      const codexLimits: QuotaLimit[] = [];
-      for (const role of ['primary', 'secondary'] as const) {
-        const window = rateLimit[`${role}_window`] as Record<string, unknown> | undefined;
-        if (typeof window?.used_percent !== 'number') continue;
-        codexLimits.push({
-          window: codexWindowDuration(window.limit_window_seconds) || role,
-          usageRatio: window.used_percent / 100,
-          status: quotaStatus.status,
-        });
-      }
-      return codexLimits;
-    }
-  }
-
-  if (channel.type === 'antigravity') {
-    normalized.sort((a, b) => (b.usageRatio ?? 0) - (a.usageRatio ?? 0));
-  }
-
-  return normalized.filter((limit) => limit.usageRatio != null || limit.status === 'exhausted');
+function getQuotaLimits(channel: Channel) {
+  return channel.providerQuotaStatus ? parseQuotaLimits(channel.providerQuotaStatus.quotaData) : [];
 }
 
-/**
- * Format a reported duration using the largest exact day, hour, minute, or second unit.
- * @param seconds Untrusted window duration from the provider response.
- * @returns A compact duration label, or an empty string for invalid/non-integer durations.
- */
-function codexWindowDuration(seconds: unknown): string {
-  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return '';
-  for (const [unit, size] of [
-    ['d', 86400],
-    ['h', 3600],
-    ['m', 60],
-    ['s', 1],
-  ] as const) {
-    if (seconds % size === 0) return `${seconds / size}${unit}`;
-  }
-  return '';
-}
-
-/**
- * Resolve window identifiers for the quota cell and tooltip without assuming role durations.
- * @param window Provider window identifier or an already formatted duration.
- * @param t Translation function for primary and secondary window names.
- * @returns A display label, or an empty string when the window is unspecified.
- */
-function quotaWindowLabel(window: string | undefined, t: (key: string) => string): string {
+function quotaWindowLabel(window: string | undefined, t: ReturnType<typeof useTranslation>['t']): string {
   if (!window) return '';
-  if (window === 'primary') return t('quota.label.primary_window');
-  if (window === 'secondary') return t('quota.label.secondary_window');
-  if (window === 'daily') return '1d';
-  if (window === 'weekly') return '7d';
-  if (window === 'monthly') return '30d';
-  return window;
+  const translationKey = QUOTA_WINDOW_LABEL_KEYS[window];
+  return translationKey ? t(translationKey) : window;
 }
 
 const quotaColor = (remaining: number) => {
@@ -568,14 +453,6 @@ const QuotaCell = memo(({ row }: { row: Row<Channel> }) => {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const channel = row.original;
-
-  if (!OAUTH_CHANNEL_TYPES.has(channel.type)) {
-    return (
-      <div className='flex justify-center'>
-        <span className='text-muted-foreground text-xs'>-</span>
-      </div>
-    );
-  }
 
   if (!channel.providerQuotaStatus) {
     return (

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -74,7 +74,8 @@ function getQuotaLimits(channel: Channel) {
 function quotaWindowLabel(window: string | undefined, t: ReturnType<typeof useTranslation>['t']): string {
   if (!window) return '';
   const translationKey = QUOTA_WINDOW_LABEL_KEYS[window];
-  return translationKey ? t(translationKey) : window;
+  if (translationKey) return t(translationKey);
+  return window === 'primary' || window === 'secondary' ? t('quota.label.token_usage') : window;
 }
 
 const quotaColor = (remaining: number) => {

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -63,7 +63,7 @@ const QUOTA_WINDOW_LABEL_KEYS: Record<string, string> = {
   daily: 'quota.window.daily',
   weekly: 'quota.window.weekly',
   monthly: 'quota.window.monthly',
-  payg: 'quota.label.token_usage',
+  pay_as_you_go: 'quota.label.token_usage',
   credits: 'quota.label.credits_remaining',
   cycle: 'quota.window.cycle',
   overage: 'quota.label.overage_window',

--- a/frontend/src/features/channels/components/channels-columns.tsx
+++ b/frontend/src/features/channels/components/channels-columns.tsx
@@ -11,7 +11,6 @@ import {
   IconArchive,
   IconTrash,
   IconCheck,
-  IconWeight,
   IconTransform,
   IconNetwork,
   IconAdjustments,
@@ -127,13 +126,11 @@ const ActionCell = memo(({ row }: { row: Row<Channel> }) => {
   const hasError = channel.errorMessage != null;
   const hasDisabledAPIKeys = channelPermissions.canWrite && (channel.disabledAPIKeys?.length ?? 0) > 0;
 
-  const handleDefaultTest = async () => {
-    try {
-      await testChannel.mutateAsync({
-        channelID: channel.id,
-        modelID: channel.defaultTestModel || undefined,
-      });
-    } catch (_error) {}
+  const handleDefaultTest = () => {
+    testChannel.mutate({
+      channelID: channel.id,
+      modelID: channel.defaultTestModel || undefined,
+    });
   };
 
   const handleOpenTestDialog = useCallback(() => {

--- a/frontend/src/features/channels/data/channel-config.test.mjs
+++ b/frontend/src/features/channels/data/channel-config.test.mjs
@@ -93,7 +93,7 @@ test('xAI subscription is exposed as an OAuth Responses channel', () => {
   );
 });
 
-test('channel table shows provider quota only for OAuth channel types', () => {
+test('channel table shows normalized provider quota for any channel type', () => {
   const schema = read('features/channels/data/schema.ts');
   const channelsData = read('features/channels/data/channels.ts');
   const channelColumns = read('features/channels/components/channels-columns.tsx');
@@ -104,23 +104,50 @@ test('channel table shows provider quota only for OAuth channel types', () => {
     /providerQuotaStatus\s*\{[\s\S]*status[\s\S]*quotaData[\s\S]*providerType[\s\S]*\}/,
     'channel list query should load the persisted provider quota status'
   );
-  const oauthTypes = channelColumns.match(/const OAUTH_CHANNEL_TYPES\s*=\s*new Set<Channel\['type'\]>\(\[([\s\S]*?)\]\);/)?.[1];
-  assert.ok(oauthTypes, 'OAuth channel type Set declaration should exist');
-  for (const type of ['codex', 'claudecode', 'antigravity', 'github_copilot', 'xai_subscription']) {
-    assert.match(oauthTypes, new RegExp(`'${type}'`));
-  }
+  assert.doesNotMatch(channelColumns, /OAUTH_CHANNEL_TYPES/, 'quota rendering must not use an OAuth channel type allowlist');
   assert.match(channelColumns, /100\s*-\s*usageRatio\s*\*\s*100/, 'the table should display remaining quota percentage');
   assert.match(channelColumns, /QUOTA_VISIBLE_LIMIT\s*=\s*5/, 'quota cells should initially show at most five rows');
   assert.match(channelColumns, /isExpanded\s*\?\s*limits\s*:\s*limits\.slice\(0,\s*QUOTA_VISIBLE_LIMIT\)/);
   assert.match(channelColumns, /channels\.quota\.expand/);
   assert.match(channelColumns, /channels\.quota\.collapse/);
-  assert.doesNotMatch(channelColumns, /limit\.window\s*=\s*labels\[index\]/, 'xAI windows must not be labeled by array position');
-  assert.match(channelColumns, /Math\.abs\(limit\.usageRatio\s*-\s*usageRatio\)/, 'legacy xAI limits should match raw billing usage');
+  assert.match(channelColumns, /parseQuotaLimits/, 'the table should consume the shared normalized-limit parser');
+  assert.doesNotMatch(channelColumns, /data\.billing|data\.windows|data\.models|data\.rate_limit/, 'the table must not parse raw provider payloads');
+});
+
+test('quota selection follows quota column visibility and preserves normalized fields', () => {
+  const channelsData = read('features/channels/data/channels.ts');
+  const channelIndex = read('features/channels/index.tsx');
+  const channelColumns = read('features/channels/components/channels-columns.tsx');
+  const enSystem = JSON.parse(read('locales/en/system.json'));
+  const zhSystem = JSON.parse(read('locales/zh-CN/system.json'));
+
+  assert.match(channelsData, /providerQuotaStatus\s*\{[\s\S]*status[\s\S]*nextResetAt[\s\S]*ready[\s\S]*quotaData[\s\S]*providerType[\s\S]*accountKey[\s\S]*\}/);
   assert.match(
-    channelColumns,
-    /if\s*\(!OAUTH_CHANNEL_TYPES\.has\(channel\.type\)\)[\s\S]*?>-<\/span>/,
-    'non-OAuth channels should display a dash'
+    channelsData,
+    /isChannelColumnVisible\(columnVisibility, 'quota'\)\s*\?\s*CHANNEL_QUERY_QUOTA_SELECTION\s*:\s*''/,
+    'hiding quota must remove only the quota selection'
   );
+  assert.match(channelsData, /const \{ columnVisibility, \.\.\.queryInput \} = variables \?\? \{\};/);
+  assert.match(channelsData, /channelListColumnVisibilitySchema\s*=\s*z\.record\(z\.string\(\),\s*z\.boolean\(\)\)/);
+  assert.match(channelIndex, /parseChannelColumnVisibility\(JSON\.parse\(stored\)\)/, 'persisted column state must be parsed as boolean visibility');
+  assert.match(channelColumns, /quotaWindowLabel\(limit\.window,\s*t\)/, 'window labels should use the active locale');
+  assert.equal(enSystem['quota.window.5h'], '5h window');
+  assert.equal(enSystem['quota.window.7d'], '7d window');
+  assert.equal(enSystem['quota.window.cycle'], 'Cycle window');
+  assert.equal(zhSystem['quota.window.5h'], '5小时窗口');
+  assert.equal(zhSystem['quota.window.7d'], '7天窗口');
+  assert.equal(zhSystem['quota.window.cycle'], '周期窗口');
+});
+
+test('ZenMux quota schema accepts all channel variants without row grouping', () => {
+  const schema = read('features/channels/data/schema.ts');
+  const channelsData = read('features/channels/data/channels.ts');
+
+  for (const type of ['zenmux', 'zenmux_responses', 'zenmux_anthropic', 'zenmux_gemini']) {
+    assert.match(schema, new RegExp(`'${type}'`), `channel schema should accept ${type}`);
+  }
+  assert.match(schema, /providerQuotaStatusSchema[\s\S]*quotaData:\s*z\.record\(z\.string\(\),\s*z\.unknown\(\)\)/);
+  assert.doesNotMatch(channelsData, /accountKey[\s\S]*(?:group|dedup|unique)/i, 'channel query must not deduplicate shared quota accounts');
 });
 
 test('channel proxy connection reuse setting is submitted, echoed, and localized', () => {

--- a/frontend/src/features/channels/data/channels-columns-quota.test.mjs
+++ b/frontend/src/features/channels/data/channels-columns-quota.test.mjs
@@ -1,0 +1,267 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+
+const dataDir = import.meta.dirname;
+const srcRoot = join(dataDir, '..', '..', '..');
+
+function read(relativePath) {
+  return readFileSync(join(srcRoot, relativePath), 'utf8');
+}
+
+// Load the real parser and channel schema through TypeScript transpilation so
+// the tests exercise the exact contract the channel table consumes. Bare
+// imports are resolved by stubbing the imported bindings on globalThis before
+// evaluation via an injected prelude.
+function loadModule(relativePath, transform = (s) => s) {
+  const source = transform(read(relativePath)).replace(/^import[^\n]*\n/gm, '');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2023 },
+  }).outputText;
+  const prelude = 'const { z, pageInfoSchema } = globalThis.__importStubs;\n';
+  return import(`data:text/javascript;base64,${Buffer.from(prelude + transpiled).toString('base64')}`);
+}
+
+const { z } = await import('zod');
+globalThis.__importStubs = { z, pageInfoSchema: undefined };
+const paginationSource = read('gql/pagination.ts').replace(/^import[^\n]*\n/gm, '');
+const paginationTranspiled = ts.transpileModule(paginationSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2023 },
+}).outputText;
+const { pageInfoSchema } = await import(
+  `data:text/javascript;base64,${Buffer.from('const { z } = globalThis.__importStubs;\n' + paginationTranspiled).toString('base64')}`
+);
+globalThis.__importStubs = { z, pageInfoSchema };
+
+const { parseQuotaLimits } = await loadModule('features/system/data/quotas.ts', (s) =>
+  s.replace(/export function useProviderQuotaStatuses[\s\S]*$/m, '')
+);
+
+const { channelSchema } = await loadModule('features/channels/data/schema.ts', (s) => s.replace(/z\.url\(/g, 'z.string().url('));
+
+const channelQuerySource = read('features/channels/data/channels.ts').replace(/^import(?:.|\n)*?;\n/gm, '');
+const channelQueryTranspiled = ts.transpileModule(channelQuerySource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2023 },
+}).outputText;
+const { buildQueryChannelsQuery } = await import(
+  `data:text/javascript;base64,${Buffer.from(
+    'const { z, pageInfoSchema } = globalThis.__importStubs;\n' + channelQueryTranspiled
+  ).toString('base64')}`
+);
+
+const columnsSource = read('features/channels/components/channels-columns.tsx');
+
+function channelFixture({ type, providerQuotaStatus }) {
+  return {
+    id: 'channel-1',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    type,
+    baseURL: 'https://example.com',
+    name: 'fixture',
+    status: 'enabled',
+    supportedModels: ['gpt-5'],
+    defaultTestModel: 'gpt-5',
+    providerQuotaStatus,
+  };
+}
+
+test('normalized limits: parser returns every _limits entry without fabrication', () => {
+  const limits = parseQuotaLimits({
+    _limits: [
+      { type: 'token', window: '5h', usageRatio: 0.4, status: 'available', ready: true },
+      { type: 'token', window: '7d', usageRatio: 0.2, status: 'warning', ready: true, nextResetAt: '2026-09-13T00:00:00Z' },
+    ],
+  });
+
+  assert.equal(limits.length, 2);
+  assert.deepEqual(
+    limits.map((l) => l.window),
+    ['5h', '7d']
+  );
+});
+
+test('Codex Pro seven-day-only data keeps its seven-day label', () => {
+  const limits = parseQuotaLimits({
+    _limits: [{ type: 'token', window: '7d', usageRatio: 0.4, status: 'available', ready: true }],
+  });
+
+  assert.deepEqual(limits.map((limit) => limit.window), ['7d']);
+  assert.notEqual(limits[0].window, '5h');
+});
+
+test('normalized limits: unknown window strings pass through neutrally', () => {
+  const limits = parseQuotaLimits({
+    _limits: [{ type: 'token', window: 'custom_provider_window', usageRatio: 0.5, status: 'available', ready: true }],
+  });
+
+  assert.equal(limits.length, 1);
+  assert.equal(limits[0].window, 'custom_provider_window');
+});
+
+test('normalized limits: malformed entries do not throw and are defensively typed', () => {
+  const limits = parseQuotaLimits({
+    _limits: [null, 42, 'broken', { window: 7, usageRatio: 'lots' }, { type: 'token', window: 'daily', usageRatio: 0.1, status: 'available' }],
+  });
+
+  assert.ok(Array.isArray(limits));
+  const daily = limits.find((l) => l.window === 'daily');
+  assert.ok(daily, 'the well-formed entry should survive');
+});
+
+test('normalized limits: malformed _limits containers fail closed', () => {
+  for (const rawLimits of [null, {}, 'broken', 42]) {
+    assert.deepEqual(parseQuotaLimits({ _limits: rawLimits }), [], `malformed _limits value ${String(rawLimits)} must be unavailable`);
+  }
+});
+
+test('normalized limits: malformed required fields produce no rendered limits', () => {
+  // Given entries with malformed identity, status, or usage fields,
+  // When the provider quota payload is parsed,
+  // Then every malformed entry is omitted instead of becoming a fabricated row.
+  const limits = parseQuotaLimits({
+    _limits: [
+      { type: '', window: '5h', usageRatio: 0.1, status: 'available' },
+      { type: 'token', window: ' ', usageRatio: 0.1, status: 'available' },
+      { type: 42, window: '5h', usageRatio: 0.1, status: 'available' },
+      { type: 'token', window: 5, usageRatio: 0.1, status: 'available' },
+      { type: 'token', window: '5h', usageRatio: '0.5', status: 'available' },
+      { type: 'token', window: '5h', usageRatio: -0.1, status: 'available' },
+      { type: 'token', window: '5h', usageRatio: 1.1, status: 'available' },
+      { type: 'token', window: '5h', usageRatio: Number.NaN, status: 'available' },
+      { type: 'token', window: '5h', usageRatio: 0.1, status: 'invalid' },
+    ],
+  });
+
+  assert.deepEqual(limits, []);
+});
+
+test('no provider fallback: channels table renders quota for any channel type with normalized limits', () => {
+  // Given a non-allowlisted channel type whose quota status carries _limits,
+  // When the quota cell decides whether to render rows,
+  // Then eligibility must depend on the quota data, not the channel type.
+  for (const type of [
+    'zenmux',
+    'zenmux_responses',
+    'zenmux_anthropic',
+    'zenmux_gemini',
+    'cline',
+    'nanogpt',
+    'minimax',
+    'openai',
+  ]) {
+    const parsed = channelSchema.safeParse(
+      channelFixture({
+        type,
+        providerQuotaStatus: {
+          status: 'available',
+          ready: true,
+          providerType: type,
+          quotaData: { _limits: [{ type: 'token', window: '5h', usageRatio: 0.5, status: 'available', ready: true }] },
+        },
+      })
+    );
+    assert.ok(parsed.success, `channel schema should accept ${type} with normalized limits`);
+
+    const limits = parseQuotaLimits(parsed.data.providerQuotaStatus.quotaData);
+    assert.equal(limits.length, 1, `${type} should yield its normalized limit row`);
+  }
+
+  assert.doesNotMatch(
+    columnsSource,
+    /OAUTH_CHANNEL_TYPES/,
+    'the channel table must not gate quota rendering behind an OAuth channel allowlist'
+  );
+  assert.match(
+    columnsSource,
+    /parseQuotaLimits/,
+    'the channel table should consume the shared provider-neutral normalized-limit parser'
+  );
+});
+
+test('no provider fallback: quota cell has no provider-specific raw-data parsing branches', () => {
+  const quotaCellStart = columnsSource.indexOf('const QuotaCell');
+  const quotaCellEnd = columnsSource.indexOf("QuotaCell.displayName", quotaCellStart);
+  assert.ok(quotaCellStart !== -1 && quotaCellEnd > quotaCellStart, 'QuotaCell should exist');
+  const quotaCell = columnsSource.slice(quotaCellStart, quotaCellEnd);
+
+  for (const forbidden of [
+    /channel\.type === 'xai_subscription'/,
+    /channel\.type === 'claudecode'/,
+    /channel\.type === 'codex'/,
+    /channel\.type === 'antigravity'/,
+    /channel\.type === 'github_copilot'/,
+    /data\.billing/,
+    /data\.windows/,
+    /data\.models/,
+    /data\.rate_limit/,
+  ]) {
+    assert.doesNotMatch(quotaCell, forbidden, `quota cell must not contain provider-specific raw-data fallback matching ${forbidden}`);
+  }
+});
+
+test('no provider fallback: raw-only provider payloads without _limits yield unavailable, not special parsing', () => {
+  // Given raw provider payloads in the pre-normalization shapes,
+  // When parsed through the provider-neutral parser,
+  // Then no limits are produced (the UI shows unavailable) — the frontend must
+  // never reconstruct windows from raw provider data.
+  const rawPayloads = {
+    codex: { rate_limit: { primary_window: { used_percent: 42 }, secondary_window: { used_percent: 10 } } },
+    xai_subscription: { billing: { weekly: { usage_percent: 30 }, monthly: { usage_percent: 55 } } },
+    claudecode: { windows: { '5h': { utilization: 0.4 }, '7d': { utilization: 0.2 } } },
+    antigravity: { models: { 'gemini-2.5-pro': { remainingPercentage: 80, displayName: 'Gemini 2.5 Pro' } } },
+    github_copilot: { quota_snapshots: { chat: { percent_remaining: 50 } } },
+  };
+
+  for (const [provider, raw] of Object.entries(rawPayloads)) {
+    assert.deepEqual(parseQuotaLimits(raw), [], `${provider} raw-only payload must not be parsed into limits by the frontend`);
+  }
+});
+
+test('exhausted: exhausted limits with missing usage still render as exhausted with zero remaining', () => {
+  const limits = parseQuotaLimits({
+    _limits: [{ type: 'token', window: '7d', status: 'exhausted', ready: false }],
+  });
+
+  assert.equal(limits.length, 1);
+  assert.equal(limits[0].status, 'exhausted');
+  assert.equal(limits[0].usageRatio, 1);
+  // The renderer treats an exhausted limit as fully used regardless of ratio.
+  assert.match(
+    columnsSource,
+    /limit\.status === 'exhausted' \? 1/,
+    'exhausted limits must render as fully used even when usageRatio is absent'
+  );
+});
+
+test('hidden quota selection removes only quota fields from the real query', () => {
+  const visibleQuery = buildQueryChannelsQuery({ quota: true, tags: false });
+  const hiddenQuery = buildQueryChannelsQuery({ quota: false, tags: false });
+
+  assert.match(visibleQuery, /providerQuotaStatus/);
+  assert.doesNotMatch(hiddenQuery, /providerQuotaStatus/);
+  assert.match(hiddenQuery, /supportedModels/);
+  assert.match(hiddenQuery, /liveLimiterStats/);
+});
+
+test('more than five normalized limits expose the remaining rows for expansion', () => {
+  const limits = parseQuotaLimits({
+    _limits: [
+      { type: 'token', window: '5h', usageRatio: 0.1, status: 'available' },
+      { type: 'token', window: '7d', usageRatio: 0.2, status: 'available' },
+      { type: 'token', window: '30d', usageRatio: 0.3, status: 'available' },
+      { type: 'token', window: 'daily', usageRatio: 0.4, status: 'available' },
+      { type: 'token', window: 'weekly', usageRatio: 0.5, status: 'available' },
+      { type: 'token', window: 'monthly', usageRatio: 0.6, status: 'available' },
+    ],
+  });
+  const columns = columnsSource.slice(columnsSource.indexOf('const QuotaCell'), columnsSource.indexOf('QuotaCell.displayName'));
+
+  assert.equal(limits.length, 6);
+  assert.deepEqual(limits.slice(0, 5).map((limit) => limit.window), ['5h', '7d', '30d', 'daily', 'weekly']);
+  assert.deepEqual(limits.map((limit) => limit.window), ['5h', '7d', '30d', 'daily', 'weekly', 'monthly']);
+  assert.match(columns, /const visibleLimits = isExpanded \? limits : limits\.slice\(0, QUOTA_VISIBLE_LIMIT\)/);
+  assert.match(columns, /const hiddenCount = limits\.length - QUOTA_VISIBLE_LIMIT/);
+});

--- a/frontend/src/features/channels/data/channels-columns-quota.test.mjs
+++ b/frontend/src/features/channels/data/channels-columns-quota.test.mjs
@@ -234,14 +234,8 @@ test('unknown usage: limits with missing usage fail closed without rendering exh
       _limits: [{ type: 'token', window: '7d', status: 'exhausted', ready: false, usageRatio }],
     });
 
-    assert.deepEqual(limits, [], `usage ratio ${String(usageRatio)} must be unavailable`);
+    assert.equal(limits.length, 0, `usage ratio ${String(usageRatio)} must be unavailable to the quota cell`);
   }
-
-  assert.doesNotMatch(
-    columnsSource,
-    /limit\.status === 'exhausted' \? 1|limit\.usageRatio \?\? 1/,
-    'generic quota rows must not fabricate 100% usage for missing ratios'
-  );
 });
 
 test('hidden quota selection removes only quota fields from the real query', () => {

--- a/frontend/src/features/channels/data/channels-columns-quota.test.mjs
+++ b/frontend/src/features/channels/data/channels-columns-quota.test.mjs
@@ -83,6 +83,14 @@ test('normalized limits: parser returns every _limits entry without fabrication'
   );
 });
 
+test('unknown normalized windows use a neutral label instead of provider slot names', () => {
+  assert.match(
+    columnsSource,
+    /window === 'primary' \|\| window === 'secondary' \? t\('quota\.label\.token_usage'\)/,
+    'Codex windows without a known duration should not display primary or secondary'
+  );
+});
+
 test('Codex Pro seven-day-only data keeps its seven-day label', () => {
   const limits = parseQuotaLimits({
     _limits: [{ type: 'token', window: '7d', usageRatio: 0.4, status: 'available', ready: true }],

--- a/frontend/src/features/channels/data/channels-columns-quota.test.mjs
+++ b/frontend/src/features/channels/data/channels-columns-quota.test.mjs
@@ -125,6 +125,15 @@ test('normalized limits: malformed _limits containers fail closed', () => {
   }
 });
 
+test('normalized limits: invalid reset timestamps fail closed', () => {
+  assert.deepEqual(
+    parseQuotaLimits({
+      _limits: [{ type: 'token', window: '7d', usageRatio: 0.4, status: 'available', ready: true, nextResetAt: 'not-a-date' }],
+    }),
+    []
+  );
+});
+
 test('normalized limits: malformed required fields produce no rendered limits', () => {
   // Given entries with malformed identity, status, or usage fields,
   // When the provider quota payload is parsed,

--- a/frontend/src/features/channels/data/channels-columns-quota.test.mjs
+++ b/frontend/src/features/channels/data/channels-columns-quota.test.mjs
@@ -228,19 +228,19 @@ test('no provider fallback: raw-only provider payloads without _limits yield una
   }
 });
 
-test('exhausted: exhausted limits with missing usage still render as exhausted with zero remaining', () => {
-  const limits = parseQuotaLimits({
-    _limits: [{ type: 'token', window: '7d', status: 'exhausted', ready: false }],
-  });
+test('unknown usage: limits with missing usage fail closed without rendering exhausted', () => {
+  for (const usageRatio of [undefined, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const limits = parseQuotaLimits({
+      _limits: [{ type: 'token', window: '7d', status: 'exhausted', ready: false, usageRatio }],
+    });
 
-  assert.equal(limits.length, 1);
-  assert.equal(limits[0].status, 'exhausted');
-  assert.equal(limits[0].usageRatio, 1);
-  // The renderer treats an exhausted limit as fully used regardless of ratio.
-  assert.match(
+    assert.deepEqual(limits, [], `usage ratio ${String(usageRatio)} must be unavailable`);
+  }
+
+  assert.doesNotMatch(
     columnsSource,
-    /limit\.status === 'exhausted' \? 1/,
-    'exhausted limits must render as fully used even when usageRatio is absent'
+    /limit\.status === 'exhausted' \? 1|limit\.usageRatio \?\? 1/,
+    'generic quota rows must not fabricate 100% usage for missing ratios'
   );
 });
 

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -876,6 +876,13 @@ export const DEFAULT_CHANNEL_COLUMN_VISIBILITY: ChannelListColumnVisibility = {
   proxy: false,
 };
 
+const channelListColumnVisibilitySchema = z.record(z.string(), z.boolean());
+
+export function parseChannelColumnVisibility(value: unknown): ChannelListColumnVisibility {
+  const parsed = channelListColumnVisibilitySchema.safeParse(value);
+  return parsed.success ? { ...DEFAULT_CHANNEL_COLUMN_VISIBILITY, ...parsed.data } : DEFAULT_CHANNEL_COLUMN_VISIBILITY;
+}
+
 const CHANNEL_QUERY_FULL_NODE_SELECTION = `
           id
           createdAt
@@ -1016,6 +1023,7 @@ const CHANNEL_QUERY_FULL_NODE_SELECTION = `
             ready
             quotaData
             providerType
+            accountKey
           }
 `;
 
@@ -1078,6 +1086,7 @@ const CHANNEL_QUERY_QUOTA_SELECTION = `
             ready
             quotaData
             providerType
+            accountKey
           }
 `;
 

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -1213,6 +1213,8 @@ export function useQueryChannels(
     enabled: !options?.disableAutoFetch,
     queryKey: [
       'channels',
+      query,
+      queryInput,
       variables?.where,
       variables?.orderBy?.field,
       variables?.orderBy?.direction,

--- a/frontend/src/features/channels/data/schema.ts
+++ b/frontend/src/features/channels/data/schema.ts
@@ -386,6 +386,7 @@ export const providerQuotaStatusSchema = z.object({
   ready: z.boolean(),
   quotaData: z.record(z.string(), z.unknown()),
   providerType: z.string(),
+  accountKey: z.string().optional().nullable(),
 });
 export type ProviderQuotaStatus = z.infer<typeof providerQuotaStatusSchema>;
 

--- a/frontend/src/features/channels/index.tsx
+++ b/frontend/src/features/channels/index.tsx
@@ -14,6 +14,7 @@ import { ChannelsTypeTabs } from './components/channels-type-tabs';
 import ChannelsProvider, { useChannels } from './context/channels-context';
 import {
   DEFAULT_CHANNEL_COLUMN_VISIBILITY,
+  parseChannelColumnVisibility,
   useQueryChannels,
   useChannelTypes,
   useErrorChannelsCount,
@@ -53,14 +54,12 @@ function ChannelsContent() {
   });
   const [columnVisibility, setColumnVisibility] = useState<ChannelListColumnVisibility>(() => {
     const stored = localStorage.getItem('channels-table-column-visibility');
-    if (stored) {
-      try {
-        return { ...DEFAULT_CHANNEL_COLUMN_VISIBILITY, ...JSON.parse(stored) };
-      } catch {
-        return DEFAULT_CHANNEL_COLUMN_VISIBILITY;
-      }
+    if (!stored) return DEFAULT_CHANNEL_COLUMN_VISIBILITY;
+    try {
+      return parseChannelColumnVisibility(JSON.parse(stored));
+    } catch {
+      return DEFAULT_CHANNEL_COLUMN_VISIBILITY;
     }
-    return DEFAULT_CHANNEL_COLUMN_VISIBILITY;
   });
 
   useEffect(() => {

--- a/frontend/src/features/system/data/quotas.ts
+++ b/frontend/src/features/system/data/quotas.ts
@@ -494,6 +494,57 @@ function optionalNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
+const NORMALIZED_QUOTA_STATUSES = ['available', 'warning', 'exhausted', 'unknown'] as const;
+type NormalizedQuotaStatus = (typeof NORMALIZED_QUOTA_STATUSES)[number];
+
+function isNormalizedQuotaStatus(value: unknown): value is NormalizedQuotaStatus {
+  return NORMALIZED_QUOTA_STATUSES.some((status) => status === value);
+}
+
+function requiredString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function parseQuotaLimit(entry: unknown): ProviderQuotaLimit | undefined {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return undefined;
+
+  const limit = entry as Record<string, unknown>;
+  const type = requiredString(limit.type);
+  const window = requiredString(limit.window);
+  if (!type || !window || !isNormalizedQuotaStatus(limit.status)) return undefined;
+
+  const usageRatio = optionalNumber(limit.usageRatio);
+  if (limit.usageRatio !== undefined && usageRatio === undefined) return undefined;
+  if (usageRatio === undefined && limit.status !== 'exhausted') return undefined;
+  if (usageRatio !== undefined && (usageRatio < 0 || usageRatio > 1)) return undefined;
+
+  if (limit.ready !== undefined && typeof limit.ready !== 'boolean') return undefined;
+
+  const nextResetAt = optionalString(limit.nextResetAt);
+  if (limit.nextResetAt !== undefined && nextResetAt === undefined) return undefined;
+
+  const periodStart = optionalString(limit.periodStart);
+  if (limit.periodStart !== undefined && periodStart === undefined) return undefined;
+
+  const periodCost = optionalNumber(limit.periodCost);
+  if (limit.periodCost !== undefined && periodCost === undefined) return undefined;
+
+  const periodQuota = optionalNumber(limit.periodQuota);
+  if (limit.periodQuota !== undefined && periodQuota === undefined) return undefined;
+
+  return {
+    type,
+    status: limit.status,
+    usageRatio: usageRatio ?? 1,
+    ready: limit.ready === true,
+    window,
+    nextResetAt,
+    periodStart,
+    periodCost,
+    periodQuota,
+  };
+}
+
 export function parseQuotaLimits(quotaData: unknown): ProviderQuotaLimit[] {
   if (typeof quotaData !== 'object' || quotaData === null) return [];
 
@@ -501,22 +552,8 @@ export function parseQuotaLimits(quotaData: unknown): ProviderQuotaLimit[] {
   if (!Array.isArray(raw)) return [];
 
   return raw.flatMap((entry) => {
-    if (typeof entry !== 'object' || entry === null) return [];
-    const limit = entry as Record<string, unknown>;
-
-    return [
-      {
-        type: typeof limit.type === 'string' ? limit.type : '',
-        status: typeof limit.status === 'string' ? limit.status : 'unknown',
-        usageRatio: optionalNumber(limit.usageRatio) ?? 0,
-        ready: limit.ready === true,
-        window: optionalString(limit.window),
-        nextResetAt: optionalString(limit.nextResetAt),
-        periodStart: optionalString(limit.periodStart),
-        periodCost: optionalNumber(limit.periodCost),
-        periodQuota: optionalNumber(limit.periodQuota),
-      },
-    ];
+    const parsed = parseQuotaLimit(entry);
+    return parsed ? [parsed] : [];
   });
 }
 

--- a/frontend/src/features/system/data/quotas.ts
+++ b/frontend/src/features/system/data/quotas.ts
@@ -514,9 +514,7 @@ function parseQuotaLimit(entry: unknown): ProviderQuotaLimit | undefined {
   if (!type || !window || !isNormalizedQuotaStatus(limit.status)) return undefined;
 
   const usageRatio = optionalNumber(limit.usageRatio);
-  if (limit.usageRatio !== undefined && usageRatio === undefined) return undefined;
-  if (usageRatio === undefined && limit.status !== 'exhausted') return undefined;
-  if (usageRatio !== undefined && (usageRatio < 0 || usageRatio > 1)) return undefined;
+  if (usageRatio === undefined || usageRatio < 0 || usageRatio > 1) return undefined;
 
   if (limit.ready !== undefined && typeof limit.ready !== 'boolean') return undefined;
 
@@ -535,7 +533,7 @@ function parseQuotaLimit(entry: unknown): ProviderQuotaLimit | undefined {
   return {
     type,
     status: limit.status,
-    usageRatio: usageRatio ?? 1,
+    usageRatio,
     ready: limit.ready === true,
     window,
     nextResetAt,

--- a/frontend/src/features/system/data/quotas.ts
+++ b/frontend/src/features/system/data/quotas.ts
@@ -520,6 +520,7 @@ function parseQuotaLimit(entry: unknown): ProviderQuotaLimit | undefined {
 
   const nextResetAt = optionalString(limit.nextResetAt);
   if (limit.nextResetAt !== undefined && nextResetAt === undefined) return undefined;
+  if (nextResetAt !== undefined && Number.isNaN(Date.parse(nextResetAt))) return undefined;
 
   const periodStart = optionalString(limit.periodStart);
   if (limit.periodStart !== undefined && periodStart === undefined) return undefined;

--- a/frontend/src/locales/en/system.json
+++ b/frontend/src/locales/en/system.json
@@ -355,6 +355,7 @@
   "quota.window.daily": "Daily window",
   "quota.window.weekly": "Weekly window",
   "quota.window.monthly": "Monthly window",
+  "quota.window.cycle": "Cycle window",
   "quota.label.period_quota": "Estimated period quota",
   "quota.label.period_quota_value": "{{used}} used / ≈ {{total}}",
   "quota.label.period_quota_hint": "Estimated from the cost AxonHub logged for this channel in the current window, divided by the usage reported by the provider. Usage outside AxonHub is not counted, so the real quota may be higher.",

--- a/frontend/src/locales/zh-CN/system.json
+++ b/frontend/src/locales/zh-CN/system.json
@@ -354,6 +354,7 @@
   "quota.window.daily": "每日窗口",
   "quota.window.weekly": "每周窗口",
   "quota.window.monthly": "每月窗口",
+  "quota.window.cycle": "周期窗口",
   "quota.label.period_quota": "预计周期额度",
   "quota.label.period_quota_value": "已用 {{used}} / 约 {{total}}",
   "quota.label.period_quota_hint": "根据 AxonHub 记录的本周期该渠道消耗金额，除以上游报告的使用比例估算得出。未经 AxonHub 的用量不计入，实际额度可能更高。",

--- a/internal/server/biz/provider_quota.go
+++ b/internal/server/biz/provider_quota.go
@@ -149,25 +149,57 @@ func (s *QuotaChannelStatus) EffectiveStatus(limitType provider_quota.QuotaLimit
 	var worstStatus providerquotastatus.Status
 	worstReady := true
 	found := false
+	groupNames := make(map[string]bool)
+	grouped := make(map[string][]provider_quota.QuotaLimitStatus)
 
 	for _, l := range s.Limits {
-		if l.Type != limitType {
+		if l.Type != limitType || l.AvailabilityGroup == "" {
+			continue
+		}
+		groupNames[l.AvailabilityGroup] = true
+	}
+
+	for _, l := range s.Limits {
+		if l.Type != limitType && !groupNames[l.AvailabilityGroup] {
+			continue
+		}
+
+		if groupNames[l.AvailabilityGroup] {
+			grouped[l.AvailabilityGroup] = append(grouped[l.AvailabilityGroup], l)
 			continue
 		}
 
 		ls := providerquotastatus.Status(l.Status)
-		if !found {
+		if !found || quotaStatusRank(ls) > quotaStatusRank(worstStatus) {
 			worstStatus = ls
 			worstReady = l.Ready
 			found = true
-			continue
-		}
-
-		if quotaStatusRank(ls) > quotaStatusRank(worstStatus) {
-			worstStatus = ls
-			worstReady = l.Ready
 		} else if quotaStatusRank(ls) == quotaStatusRank(worstStatus) {
 			worstReady = worstReady && l.Ready
+		}
+	}
+
+	for _, limits := range grouped {
+		bestStatus := providerquotastatus.StatusUnknown
+		bestReady := false
+		groupFound := false
+		for _, l := range limits {
+			ls := providerquotastatus.Status(l.Status)
+			if !groupFound || quotaStatusRank(ls) < quotaStatusRank(bestStatus) {
+				bestStatus = ls
+				bestReady = l.Ready
+				groupFound = true
+			} else if quotaStatusRank(ls) == quotaStatusRank(bestStatus) {
+				bestReady = bestReady || l.Ready
+			}
+		}
+
+		if !found || quotaStatusRank(bestStatus) > quotaStatusRank(worstStatus) {
+			worstStatus = bestStatus
+			worstReady = bestReady
+			found = true
+		} else if quotaStatusRank(bestStatus) == quotaStatusRank(worstStatus) {
+			worstReady = worstReady && bestReady
 		}
 	}
 

--- a/internal/server/biz/provider_quota.go
+++ b/internal/server/biz/provider_quota.go
@@ -185,7 +185,9 @@ func (s *QuotaChannelStatus) EffectiveStatus(limitType provider_quota.QuotaLimit
 		groupFound := false
 		for _, l := range limits {
 			ls := providerquotastatus.Status(l.Status)
-			if !groupFound || quotaStatusRank(ls) < quotaStatusRank(bestStatus) {
+			if !groupFound ||
+				(l.Ready && !bestReady) ||
+				(l.Ready == bestReady && quotaStatusRank(ls) < quotaStatusRank(bestStatus)) {
 				bestStatus = ls
 				bestReady = l.Ready
 				groupFound = true

--- a/internal/server/biz/provider_quota.go
+++ b/internal/server/biz/provider_quota.go
@@ -855,6 +855,7 @@ func (svc *ProviderQuotaService) checkChannelQuota(ctx context.Context, group qu
 		}
 		return
 	}
+	quotaData = provider_quota.NormalizeQuotaData(quotaData)
 
 	resetList := provider_quota.ResetList{Supported: false}
 	if resetter, ok := checker.(provider_quota.Resetter); ok {

--- a/internal/server/biz/provider_quota/antigravity_checker.go
+++ b/internal/server/biz/provider_quota/antigravity_checker.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -135,11 +137,21 @@ func parseAntigravityQuota(body []byte) (QuotaData, error) {
 	}
 
 	models := make(map[string]any, len(response.Models))
+	limits := make([]QuotaLimitStatus, 0, len(response.Models))
 	maxRemaining := 0.0
 	var nextResetAt *time.Time
 
-	for modelID, model := range response.Models {
+	modelIDs := make([]string, 0, len(response.Models))
+	for modelID := range response.Models {
+		modelIDs = append(modelIDs, modelID)
+	}
+	sort.Strings(modelIDs)
+	for _, modelID := range modelIDs {
+		model := response.Models[modelID]
 		if model.IsInternal || model.QuotaInfo == nil || model.QuotaInfo.RemainingFraction == nil {
+			continue
+		}
+		if math.IsNaN(*model.QuotaInfo.RemainingFraction) || math.IsInf(*model.QuotaInfo.RemainingFraction, 0) || *model.QuotaInfo.RemainingFraction < 0 {
 			continue
 		}
 
@@ -161,6 +173,7 @@ func parseAntigravityQuota(body []byte) (QuotaData, error) {
 			modelData["resetAt"] = resetAt.Format(time.RFC3339)
 		}
 		models[modelID] = modelData
+		limits = append(limits, NewTokenLimitStatus(status, usageRatio, resetAt).WithWindow(modelID, 0))
 	}
 
 	if len(models) == 0 {
@@ -168,13 +181,14 @@ func parseAntigravityQuota(body []byte) (QuotaData, error) {
 	}
 	overallStatus := antigravityQuotaStatus(1 - maxRemaining)
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       overallStatus,
 		ProviderType: "antigravity",
 		RawData:      map[string]any{"models": models},
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(overallStatus),
-	}, nil
+		Limits:       limits,
+	}), nil
 }
 
 func antigravityQuotaStatus(usageRatio float64) string {

--- a/internal/server/biz/provider_quota/antigravity_checker_test.go
+++ b/internal/server/biz/provider_quota/antigravity_checker_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestAntigravityQuotaChecker_CheckQuota(t *testing.T) {
-	resetAt := "2026-09-04T08:00:00Z"
+	resetAt := "2099-09-04T08:00:00Z"
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		require.Equal(t, antigravityQuotaURL, request.URL.String())
 		require.Equal(t, "Bearer access-token", request.Header.Get("Authorization"))
@@ -54,14 +54,14 @@ func TestAntigravityQuotaChecker_CheckQuota(t *testing.T) {
 	quota, err := checker.CheckQuota(t.Context(), channelEntity)
 
 	require.NoError(t, err)
-	require.Equal(t, "available", quota.Status)
+	require.Equal(t, "warning", quota.Status)
 	require.Equal(t, "antigravity", quota.ProviderType)
 	require.True(t, quota.Ready)
-	require.Empty(t, quota.Limits, "per-model limits must not exhaust the entire channel")
+	require.Len(t, quota.Limits, 2)
 	require.Len(t, quota.RawData["models"], 2)
 	models := quota.RawData["models"].(map[string]any)
 	require.Equal(t, "warning", models["claude-sonnet"].(map[string]any)["status"])
-	require.Equal(t, time.Date(2026, 9, 4, 8, 0, 0, 0, time.UTC), *quota.NextResetAt)
+	require.Equal(t, time.Date(2099, 9, 4, 8, 0, 0, 0, time.UTC), *quota.NextResetAt)
 	require.True(t, checker.SupportsChannel(channelEntity))
 	require.False(t, checker.SupportsChannel(&ent.Channel{Type: channel.TypeGemini}))
 }

--- a/internal/server/biz/provider_quota/apertis_checker.go
+++ b/internal/server/biz/provider_quota/apertis_checker.go
@@ -151,7 +151,7 @@ func (c *ApertisQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	// Build limits
 	quotaData.Limits = buildApertisLimits(&resp, nextResetAt)
 
-	return quotaData, nil
+	return NormalizeQuotaData(quotaData), nil
 }
 
 // SupportsChannel returns true if the channel is OpenAI-compatible (used by Apertis).
@@ -318,6 +318,7 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 				UsageRatio:  usageRatio,
 				Ready:       IsReadyStatus(tokenStatus),
 				NextResetAt: nextResetAt,
+				Window:      "payg",
 			})
 		}
 	}
@@ -356,16 +357,6 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 			// Apertis reports the cycle boundaries outright, so the period the
 			// usage ratio covers needs no guessing.
 			PeriodStart: parseApertisCycleStart(resp.Subscription.CycleStart),
-		})
-	}
-
-	// If no limits were created, add an unknown one
-	if len(limits) == 0 {
-		limits = append(limits, QuotaLimitStatus{
-			Type:       QuotaLimitTypeToken,
-			Status:     "unknown",
-			UsageRatio: 0,
-			Ready:      false,
 		})
 	}
 

--- a/internal/server/biz/provider_quota/apertis_checker.go
+++ b/internal/server/biz/provider_quota/apertis_checker.go
@@ -64,6 +64,8 @@ type ApertisQuotaChecker struct {
 	httpClient *httpclient.HttpClient
 }
 
+const apertisAvailabilityGroup = "apertis_capacity"
+
 // NewApertisQuotaChecker creates a new Apertis quota checker.
 func NewApertisQuotaChecker(httpClient *httpclient.HttpClient) *ApertisQuotaChecker {
 	return &ApertisQuotaChecker{
@@ -323,12 +325,13 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 				}
 			}
 			limits = append(limits, QuotaLimitStatus{
-				Type:        QuotaLimitTypeToken,
-				Status:      tokenStatus,
-				UsageRatio:  usageRatio,
-				Ready:       IsReadyStatus(tokenStatus),
-				NextResetAt: nextResetAt,
-				Window:      QuotaWindowPayg,
+				Type:              QuotaLimitTypeToken,
+				Status:            tokenStatus,
+				UsageRatio:        usageRatio,
+				Ready:             IsReadyStatus(tokenStatus),
+				NextResetAt:       nextResetAt,
+				AvailabilityGroup: apertisAvailabilityGroup,
+				Window:            QuotaWindowPayAsYouGo,
 			})
 		}
 	}
@@ -358,12 +361,13 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 		}
 
 		limits = append(limits, QuotaLimitStatus{
-			Type:        QuotaLimitTypeSubscriptionCycle,
-			Status:      subStatus,
-			UsageRatio:  usageRatio,
-			Ready:       IsReadyStatus(subStatus),
-			NextResetAt: nextResetAt,
-			Window:      QuotaWindowCycle,
+			Type:              QuotaLimitTypeSubscriptionCycle,
+			Status:            subStatus,
+			UsageRatio:        usageRatio,
+			Ready:             IsReadyStatus(subStatus),
+			NextResetAt:       nextResetAt,
+			AvailabilityGroup: apertisAvailabilityGroup,
+			Window:            QuotaWindowCycle,
 			// Apertis reports the cycle boundaries outright, so the period the
 			// usage ratio covers needs no guessing.
 			PeriodStart: parseApertisCycleStart(resp.Subscription.CycleStart),

--- a/internal/server/biz/provider_quota/apertis_checker.go
+++ b/internal/server/biz/provider_quota/apertis_checker.go
@@ -333,13 +333,20 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 				AvailabilityGroup: apertisAvailabilityGroup,
 				Window:            QuotaWindowPayAsYouGo,
 			})
+			if resp.Payg.AccountCredits > 0 {
+				limits = append(limits, QuotaLimitStatus{
+					Type:              QuotaLimitTypeToken,
+					Status:            "available",
+					Ready:             true,
+					AvailabilityGroup: apertisAvailabilityGroup,
+					Window:            QuotaWindowCredits,
+				})
+			}
 		}
 	}
 
-	// Subscription cycle limit (if subscriber).
-	// Uses a distinct QuotaLimitTypeSubscriptionCycle so that EffectiveStatus
-	// does not merge subscription-cycle and PAYG-token limits under
-	// OR-semantics (available if EITHER source has quota).
+	// Subscription cycle limit (if subscriber). It shares the capacity group
+	// with PAYG so EffectiveStatus applies OR semantics to both sources.
 	if resp.IsSubscriber && resp.Subscription != nil {
 		var subStatus string
 		usageRatio := 0.0

--- a/internal/server/biz/provider_quota/apertis_checker.go
+++ b/internal/server/biz/provider_quota/apertis_checker.go
@@ -185,10 +185,10 @@ func buildApertisQuotaURL(baseURL string) string {
 //  1. If subscription is active with remaining cycle quota → check if high usage (warning)
 //  2. If subscription cycle quota is exhausted BUT PAYG fallback is enabled with credits → available/warning
 //  3. If subscription is suspended/canceled → fall through to PAYG check
-//  4. If PAYG account credits > 0 → available/warning based on token usage
-//  5. Otherwise → exhausted
+//  4. If PAYG account credits > 0 → available, with a warning before token exhaustion
+//  5. If no quota source is present → unknown; otherwise → exhausted
 func determineApertisStatus(resp *ApertisBillingCreditsResponse) string {
-	bestStatus := "exhausted"
+	bestStatus := "unknown"
 
 	// --- Subscription path ---
 	if resp.Subscription != nil {
@@ -231,14 +231,16 @@ func determineSubscriptionStatus(sub *ApertisSubscription) string {
 		return "exhausted"
 	}
 
-	if sub.CycleQuotaLimit > 0 {
-		usageRatio := float64(sub.CycleQuotaUsed) / float64(sub.CycleQuotaLimit)
-		if sub.CycleQuotaRemaining <= 0 {
-			return "exhausted"
-		}
-		if usageRatio > WarningThresholdRatio {
-			return "warning"
-		}
+	if sub.CycleQuotaLimit <= 0 {
+		return "unknown"
+	}
+
+	usageRatio := float64(sub.CycleQuotaUsed) / float64(sub.CycleQuotaLimit)
+	if sub.CycleQuotaRemaining <= 0 {
+		return "exhausted"
+	}
+	if usageRatio >= WarningThresholdRatio {
+		return "warning"
 	}
 
 	return "available"
@@ -251,19 +253,27 @@ func determinePaygStatus(payg *ApertisPayg) string {
 		return "available"
 	}
 
-	if payg.AccountCredits <= 0 {
-		return "exhausted"
-	}
-
-	// Check token-level usage ratio for warning
-	if total, ok := toFloat64(payg.TokenTotal); ok && total > 0 {
-		usageRatio := payg.TokenUsed / total
-		if usageRatio > WarningThresholdRatio {
-			return "warning"
+	if payg.AccountCredits > 0 {
+		// A positive account balance keeps PAYG available even when its token
+		// limit is exhausted. A non-exhausted token limit can still report a
+		// warning.
+		if total, ok := toFloat64(payg.TokenTotal); ok && total > 0 {
+			usageRatio := payg.TokenUsed / total
+			if usageRatio >= 1 {
+				return "available"
+			}
+			if usageRatio >= WarningThresholdRatio {
+				return "warning"
+			}
 		}
+		return "available"
 	}
 
-	return "available"
+	if total, ok := toFloat64(payg.TokenTotal); !ok || total <= 0 {
+		return "unknown"
+	}
+
+	return "exhausted"
 }
 
 // betterStatus returns the more permissive of two statuses.
@@ -302,7 +312,7 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 					usageRatio = resp.Payg.TokenUsed / total
 					if resp.Payg.TokenUsed >= total {
 						tokenStatus = "exhausted"
-					} else if usageRatio > WarningThresholdRatio {
+					} else if usageRatio >= WarningThresholdRatio {
 						tokenStatus = "warning"
 					} else {
 						tokenStatus = "available"
@@ -338,7 +348,7 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 			usageRatio = float64(resp.Subscription.CycleQuotaUsed) / float64(resp.Subscription.CycleQuotaLimit)
 			if resp.Subscription.CycleQuotaRemaining <= 0 {
 				subStatus = "exhausted"
-			} else if usageRatio > WarningThresholdRatio {
+			} else if usageRatio >= WarningThresholdRatio {
 				subStatus = "warning"
 			} else {
 				subStatus = "available"

--- a/internal/server/biz/provider_quota/apertis_checker.go
+++ b/internal/server/biz/provider_quota/apertis_checker.go
@@ -318,7 +318,7 @@ func buildApertisLimits(resp *ApertisBillingCreditsResponse, nextResetAt *time.T
 				UsageRatio:  usageRatio,
 				Ready:       IsReadyStatus(tokenStatus),
 				NextResetAt: nextResetAt,
-				Window:      "payg",
+				Window:      QuotaWindowPayg,
 			})
 		}
 	}

--- a/internal/server/biz/provider_quota/apertis_checker_test.go
+++ b/internal/server/biz/provider_quota/apertis_checker_test.go
@@ -46,6 +46,7 @@ func TestApertis_CheckQuota_HappyPath_PaygOnly(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	// Subscription is suspended but PAYG credits are available
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
 	require.Equal(t, "apertis", quota.ProviderType)
@@ -138,8 +139,8 @@ func TestApertis_CheckQuota_WithSubscription(t *testing.T) {
 					"cycle_quota_limit": 600,
 					"cycle_quota_used": 10,
 					"cycle_quota_remaining": 590,
-					"cycle_start": "2026-03-16T10:02:35Z",
-					"cycle_end": "2026-04-16T10:02:35Z",
+					"cycle_start": "2099-03-16T10:02:35Z",
+					"cycle_end": "2099-04-16T10:02:35Z",
 					"payg_fallback_enabled": false
 				}
 			}`
@@ -156,6 +157,7 @@ func TestApertis_CheckQuota_WithSubscription(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	// Cycle quota is exhausted but PAYG fallback is enabled with credits
 	require.Equal(t, "available", quota.Status)
 	require.NotNil(t, quota.NextResetAt)
 
@@ -183,8 +185,8 @@ func TestApertis_CheckQuota_SubscriptionWarningState(t *testing.T) {
 					"cycle_quota_limit": 1000,
 					"cycle_quota_used": 850,
 					"cycle_quota_remaining": 150,
-					"cycle_start": "2026-01-01T00:00:00Z",
-					"cycle_end": "2026-02-01T00:00:00Z",
+					"cycle_start": "2099-01-01T00:00:00Z",
+					"cycle_end": "2099-02-01T00:00:00Z",
 					"payg_fallback_enabled": false
 				}
 			}`
@@ -224,8 +226,8 @@ func TestApertis_CheckQuota_SubscriptionSuspended_WithPAYGCredits(t *testing.T) 
 					"cycle_quota_limit": 1000,
 					"cycle_quota_used": 500,
 					"cycle_quota_remaining": 500,
-					"cycle_start": "2026-01-01T00:00:00Z",
-					"cycle_end": "2026-02-01T00:00:00Z",
+					"cycle_start": "2099-01-01T00:00:00Z",
+					"cycle_end": "2099-02-01T00:00:00Z",
 					"payg_fallback_enabled": false
 				}
 			}`
@@ -242,7 +244,6 @@ func TestApertis_CheckQuota_SubscriptionSuspended_WithPAYGCredits(t *testing.T) 
 		},
 	})
 	require.NoError(t, err)
-	// Subscription is suspended but PAYG credits are available
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
 	// Subscription cycle limit should be exhausted (suspended), PAYG token limit is available
@@ -350,7 +351,6 @@ func TestApertis_CheckQuota_SubscriptionExhausted_WithPAYGFallback(t *testing.T)
 		},
 	})
 	require.NoError(t, err)
-	// Cycle quota is exhausted but PAYG fallback is enabled with credits
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
 	// Both subscription cycle (exhausted) and PAYG token (available) limits present
@@ -431,8 +431,8 @@ func TestApertis_CheckQuota_SubscriberWithUnlimitedPayg(t *testing.T) {
 					"cycle_quota_limit": 600,
 					"cycle_quota_used": 183,
 					"cycle_quota_remaining": 417,
-					"cycle_start": "2026-05-20T23:28:04Z",
-					"cycle_end": "2026-06-20T23:28:04Z",
+				"cycle_start": "2099-05-20T23:28:04Z",
+				"cycle_end": "2099-06-20T23:28:04Z",
 					"payg_fallback_enabled": false
 				}
 			}`
@@ -693,8 +693,8 @@ func TestApertis_NextResetTimeParsing(t *testing.T) {
 					"cycle_quota_limit": 600,
 					"cycle_quota_used": 10,
 					"cycle_quota_remaining": 590,
-					"cycle_start": "2026-01-15T00:00:00Z",
-					"cycle_end": "2026-02-15T12:00:00Z",
+				"cycle_start": "2099-01-15T00:00:00Z",
+				"cycle_end": "2099-02-15T12:00:00Z",
 					"payg_fallback_enabled": false
 				}
 			}`
@@ -712,7 +712,7 @@ func TestApertis_NextResetTimeParsing(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, quota.NextResetAt)
-	expected := time.Date(2026, 2, 15, 12, 0, 0, 0, time.UTC)
+	expected := time.Date(2099, 2, 15, 12, 0, 0, 0, time.UTC)
 	require.Equal(t, expected, *quota.NextResetAt)
 }
 

--- a/internal/server/biz/provider_quota/apertis_checker_test.go
+++ b/internal/server/biz/provider_quota/apertis_checker_test.go
@@ -52,10 +52,21 @@ func TestApertis_CheckQuota_HappyPath_PaygOnly(t *testing.T) {
 	require.Equal(t, "apertis", quota.ProviderType)
 	require.NotNil(t, quota.Limits)
 	require.Len(t, quota.Limits, 2)
-	require.Equal(t, QuotaLimitTypeToken, quota.Limits[0].Type)
-	require.Equal(t, "available", quota.Limits[0].Status)
-	require.Equal(t, QuotaWindowCredits, quota.Limits[1].Window)
-	require.Equal(t, "available", quota.Limits[1].Status)
+	var paygLimit, creditsLimit QuotaLimitStatus
+	for _, limit := range quota.Limits {
+		if limit.Type != QuotaLimitTypeToken {
+			continue
+		}
+		if limit.Window == QuotaWindowPayAsYouGo {
+			paygLimit = limit
+		} else if limit.Window == QuotaWindowCredits {
+			creditsLimit = limit
+		}
+	}
+	require.Equal(t, QuotaWindowPayAsYouGo, paygLimit.Window)
+	require.Equal(t, "available", paygLimit.Status)
+	require.Equal(t, QuotaWindowCredits, creditsLimit.Window)
+	require.Equal(t, "available", creditsLimit.Status)
 }
 
 func TestApertis_CheckQuota_WarningState(t *testing.T) {

--- a/internal/server/biz/provider_quota/apertis_checker_test.go
+++ b/internal/server/biz/provider_quota/apertis_checker_test.go
@@ -175,7 +175,7 @@ func TestApertis_CheckQuota_PaygCreditsRemainAvailableWhenTokenLimitExhausted(t 
 
 	var paygLimit QuotaLimitStatus
 	for _, limit := range quota.Limits {
-		if limit.Type == QuotaLimitTypeToken && limit.Window == QuotaWindowPayg {
+		if limit.Type == QuotaLimitTypeToken && limit.Window == QuotaWindowPayAsYouGo {
 			paygLimit = limit
 		}
 	}

--- a/internal/server/biz/provider_quota/apertis_checker_test.go
+++ b/internal/server/biz/provider_quota/apertis_checker_test.go
@@ -51,9 +51,11 @@ func TestApertis_CheckQuota_HappyPath_PaygOnly(t *testing.T) {
 	require.True(t, quota.Ready)
 	require.Equal(t, "apertis", quota.ProviderType)
 	require.NotNil(t, quota.Limits)
-	require.Len(t, quota.Limits, 1)
+	require.Len(t, quota.Limits, 2)
 	require.Equal(t, QuotaLimitTypeToken, quota.Limits[0].Type)
 	require.Equal(t, "available", quota.Limits[0].Status)
+	require.Equal(t, QuotaWindowCredits, quota.Limits[1].Window)
+	require.Equal(t, "available", quota.Limits[1].Status)
 }
 
 func TestApertis_CheckQuota_WarningState(t *testing.T) {
@@ -174,12 +176,20 @@ func TestApertis_CheckQuota_PaygCreditsRemainAvailableWhenTokenLimitExhausted(t 
 	require.True(t, quota.Ready)
 
 	var paygLimit QuotaLimitStatus
+	var creditsLimit QuotaLimitStatus
 	for _, limit := range quota.Limits {
 		if limit.Type == QuotaLimitTypeToken && limit.Window == QuotaWindowPayAsYouGo {
 			paygLimit = limit
 		}
+		if limit.Type == QuotaLimitTypeToken && limit.Window == QuotaWindowCredits {
+			creditsLimit = limit
+		}
 	}
 	require.Equal(t, "exhausted", paygLimit.Status)
+	require.Equal(t, "available", creditsLimit.Status)
+	require.True(t, creditsLimit.Ready)
+	require.Equal(t, apertisAvailabilityGroup, paygLimit.AvailabilityGroup)
+	require.Equal(t, apertisAvailabilityGroup, creditsLimit.AvailabilityGroup)
 }
 
 func TestApertis_WarningAtUsageThreshold(t *testing.T) {
@@ -241,7 +251,7 @@ func TestApertis_CheckQuota_WithSubscription(t *testing.T) {
 	require.Equal(t, "available", quota.Status)
 	require.NotNil(t, quota.NextResetAt)
 
-	// Should have one limit: subscription cycle only (PAYG skipped for active subscription)
+	// PAYG is skipped for an active subscription without fallback.
 	require.Len(t, quota.Limits, 1)
 	require.Equal(t, QuotaLimitTypeSubscriptionCycle, quota.Limits[0].Type)
 }
@@ -326,18 +336,21 @@ func TestApertis_CheckQuota_SubscriptionSuspended_WithPAYGCredits(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
-	// Subscription cycle limit should be exhausted (suspended), PAYG token limit is available
-	require.Len(t, quota.Limits, 2)
-	var subLimit, paygLimit QuotaLimitStatus
+	// Subscription cycle limit should be exhausted (suspended), PAYG token and credits limits are available
+	require.Len(t, quota.Limits, 3)
+	var subLimit, paygLimit, creditsLimit QuotaLimitStatus
 	for _, l := range quota.Limits {
 		if l.Type == QuotaLimitTypeSubscriptionCycle {
 			subLimit = l
-		} else if l.Type == QuotaLimitTypeToken {
+		} else if l.Type == QuotaLimitTypeToken && l.Window == QuotaWindowPayAsYouGo {
 			paygLimit = l
+		} else if l.Type == QuotaLimitTypeToken && l.Window == QuotaWindowCredits {
+			creditsLimit = l
 		}
 	}
 	require.Equal(t, "exhausted", subLimit.Status, "suspended subscription cycle should be exhausted")
 	require.Equal(t, "available", paygLimit.Status)
+	require.Equal(t, "available", creditsLimit.Status)
 }
 
 func TestApertis_CheckQuota_SubscriptionSuspended_NoPAYGCredits(t *testing.T) {
@@ -433,20 +446,21 @@ func TestApertis_CheckQuota_SubscriptionExhausted_WithPAYGFallback(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
 	require.True(t, quota.Ready)
-	// Both subscription cycle (exhausted) and PAYG token (available) limits present
-	require.Len(t, quota.Limits, 2)
-	// Verify subscription cycle and PAYG token are separate limit types,
-	// so EffectiveStatus(QuotaLimitTypeToken) does not incorrectly merge them.
-	var subscriptionLimit, paygLimit QuotaLimitStatus
+	// Subscription cycle (exhausted), PAYG token (available), and credits (available) limits present.
+	require.Len(t, quota.Limits, 3)
+	var subscriptionLimit, paygLimit, creditsLimit QuotaLimitStatus
 	for _, l := range quota.Limits {
 		if l.Type == QuotaLimitTypeSubscriptionCycle {
 			subscriptionLimit = l
-		} else if l.Type == QuotaLimitTypeToken {
+		} else if l.Type == QuotaLimitTypeToken && l.Window == QuotaWindowPayAsYouGo {
 			paygLimit = l
+		} else if l.Type == QuotaLimitTypeToken && l.Window == QuotaWindowCredits {
+			creditsLimit = l
 		}
 	}
 	require.Equal(t, "exhausted", subscriptionLimit.Status)
 	require.Equal(t, "available", paygLimit.Status)
+	require.Equal(t, "available", creditsLimit.Status)
 }
 
 func TestApertis_CheckQuota_SubscriptionExhausted_NoPAYGFallback(t *testing.T) {

--- a/internal/server/biz/provider_quota/apertis_checker_test.go
+++ b/internal/server/biz/provider_quota/apertis_checker_test.go
@@ -119,6 +119,86 @@ func TestApertis_CheckQuota_ExhaustedState(t *testing.T) {
 	require.False(t, quota.Ready)
 }
 
+func TestApertis_CheckQuota_EmptySources_ReturnsUnknown(t *testing.T) {
+	checker := NewApertisQuotaChecker(nil)
+
+	quota, err := checker.parseResponse([]byte(`{
+		"object": "billing_credits",
+		"is_subscriber": false
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, "unknown", quota.Status)
+	require.False(t, quota.Ready)
+	require.Empty(t, quota.Limits)
+}
+
+func TestApertis_CheckQuota_EmptySourceObjects_ReturnUnknown(t *testing.T) {
+	checker := NewApertisQuotaChecker(nil)
+
+	quota, err := checker.parseResponse([]byte(`{
+		"object": "billing_credits",
+		"is_subscriber": true,
+		"payg": {},
+		"subscription": {"status": "active"}
+	}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "unknown", quota.Status)
+	require.False(t, quota.Ready)
+}
+
+func TestApertis_CheckQuota_PaygCreditsRemainAvailableWhenTokenLimitExhausted(t *testing.T) {
+	checker := NewApertisQuotaChecker(nil)
+
+	quota, err := checker.parseResponse([]byte(`{
+		"object": "billing_credits",
+		"is_subscriber": true,
+		"payg": {
+			"account_credits": 3.0,
+			"token_used": 10.0,
+			"token_total": 10.0,
+			"token_remaining": 0.0,
+			"token_is_unlimited": false
+		},
+		"subscription": {
+			"status": "active",
+			"cycle_quota_limit": 5000,
+			"cycle_quota_used": 5000,
+			"cycle_quota_remaining": 0,
+			"payg_fallback_enabled": true
+		}
+	}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "available", quota.Status)
+	require.True(t, quota.Ready)
+
+	var paygLimit QuotaLimitStatus
+	for _, limit := range quota.Limits {
+		if limit.Type == QuotaLimitTypeToken && limit.Window == QuotaWindowPayg {
+			paygLimit = limit
+		}
+	}
+	require.Equal(t, "exhausted", paygLimit.Status)
+}
+
+func TestApertis_WarningAtUsageThreshold(t *testing.T) {
+	subscriptionStatus := determineSubscriptionStatus(&ApertisSubscription{
+		Status:              "active",
+		CycleQuotaLimit:     10,
+		CycleQuotaUsed:      8,
+		CycleQuotaRemaining: 2,
+	})
+	paygStatus := determinePaygStatus(&ApertisPayg{
+		AccountCredits: 1,
+		TokenUsed:      8,
+		TokenTotal:     10,
+	})
+
+	require.Equal(t, "warning", subscriptionStatus)
+	require.Equal(t, "warning", paygStatus)
+}
+
 func TestApertis_CheckQuota_WithSubscription(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -81,16 +81,16 @@ func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 
 	status, ready, usageRatio := c.computeStatus(*resp.Balance)
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       status,
 		ProviderType: "charm_hyper",
 		RawData:      map[string]any{"balance": *resp.Balance},
 		NextResetAt:  nil,
 		Ready:        ready,
 		Limits: []QuotaLimitStatus{
-			NewTokenLimitStatus(status, usageRatio, nil),
+			NewTokenLimitStatus(status, usageRatio, nil).WithWindow("credits", 0),
 		},
-	}, nil
+	}), nil
 }
 
 func (c *CharmHyperQuotaChecker) computeStatus(balance float64) (status string, ready bool, usageRatio float64) {

--- a/internal/server/biz/provider_quota/charm_hyper_checker.go
+++ b/internal/server/biz/provider_quota/charm_hyper_checker.go
@@ -88,7 +88,7 @@ func (c *CharmHyperQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		NextResetAt:  nil,
 		Ready:        ready,
 		Limits: []QuotaLimitStatus{
-			NewTokenLimitStatus(status, usageRatio, nil).WithWindow("credits", 0),
+			NewTokenLimitStatus(status, usageRatio, nil).WithWindow(QuotaWindowCredits, 0),
 		},
 	}), nil
 }

--- a/internal/server/biz/provider_quota/claudecode_checker.go
+++ b/internal/server/biz/provider_quota/claudecode_checker.go
@@ -168,26 +168,29 @@ func (c *ClaudeCodeQuotaChecker) parseResponse(headers http.Header) (QuotaData, 
 		}
 	}
 
-	limits := []QuotaLimitStatus{
-		c.buildTokenLimit("5h", headers),
-		c.buildTokenLimit("7d", headers),
+	limits := make([]QuotaLimitStatus, 0, 2)
+	for _, windowKey := range []string{"5h", "7d"} {
+		limit, ok := c.buildTokenLimit(windowKey, headers)
+		if ok {
+			limits = append(limits, limit)
+		}
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "claudecode",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func (c *ClaudeCodeQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
 	return ch.Type == channel.TypeClaudecode
 }
 
-func (c *ClaudeCodeQuotaChecker) buildTokenLimit(windowKey string, headers http.Header) QuotaLimitStatus {
+func (c *ClaudeCodeQuotaChecker) buildTokenLimit(windowKey string, headers http.Header) (QuotaLimitStatus, bool) {
 	var (
 		utilizationKey, resetKey string
 		window                   time.Duration
@@ -202,6 +205,9 @@ func (c *ClaudeCodeQuotaChecker) buildTokenLimit(windowKey string, headers http.
 		utilizationKey = "Anthropic-Ratelimit-Unified-7d-Utilization"
 		resetKey = "Anthropic-Ratelimit-Unified-7d-Reset"
 		window = 7 * 24 * time.Hour
+	}
+	if headers.Get(utilizationKey) == "" && headers.Get(resetKey) == "" && headers.Get("Anthropic-Ratelimit-Unified-"+windowKey+"-Status") == "" {
+		return QuotaLimitStatus{}, false
 	}
 
 	utilization := parseFloat(headers.Get(utilizationKey))
@@ -226,7 +232,7 @@ func (c *ClaudeCodeQuotaChecker) buildTokenLimit(windowKey string, headers http.
 		UsageRatio:  utilization,
 		Ready:       IsReadyStatus(status),
 		NextResetAt: nextReset,
-	}.WithWindow(windowKey, window)
+	}.WithWindow(windowKey, window), true
 }
 
 func getEndpointURL(baseURL string) string {

--- a/internal/server/biz/provider_quota/cline_checker.go
+++ b/internal/server/biz/provider_quota/cline_checker.go
@@ -673,7 +673,7 @@ func buildClineQuotaData(
 		statusBasis = "mixed_pool_pass_exhausted"
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       status,
 		ProviderType: clineProviderType,
 		Ready:        IsReadyStatus(status),
@@ -699,7 +699,7 @@ func buildClineQuotaData(
 			},
 			"usage_limits_fetch": clineUsageLimitsFetchRawData(officialMeta),
 		},
-	}
+	})
 }
 
 func buildClinePassUnavailableQuota(

--- a/internal/server/biz/provider_quota/cline_checker_test.go
+++ b/internal/server/biz/provider_quota/cline_checker_test.go
@@ -94,13 +94,13 @@ func TestParseClineUsageLimits_EmptyResetOnlyMeansInactiveAtZeroUsage(t *testing
 }
 
 func TestBuildClineQuotaData_OfficialValuesDriveStatusAndResetWhileCostRemainsExact(t *testing.T) {
-	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 7, 14, 12, 0, 0, 0, time.UTC)
 	fiveHourRatio := 0.20
 	weeklyRatio := 0.90
 	monthlyRatio := 0.40
-	fiveHourReset := time.Date(2026, 7, 14, 14, 0, 0, 0, time.UTC)
-	weeklyReset := time.Date(2026, 7, 17, 2, 56, 47, 0, time.UTC)
-	monthlyReset := time.Date(2026, 8, 1, 11, 13, 17, 0, time.UTC)
+	fiveHourReset := time.Date(2099, 7, 14, 14, 0, 0, 0, time.UTC)
+	weeklyReset := time.Date(2099, 7, 17, 2, 56, 47, 0, time.UTC)
+	monthlyReset := time.Date(2099, 8, 1, 11, 13, 17, 0, time.UTC)
 
 	quota := buildClineQuotaData(
 		now,
@@ -112,7 +112,7 @@ func TestBuildClineQuotaData_OfficialValuesDriveStatusAndResetWhileCostRemainsEx
 		},
 		nil,
 		nil,
-		[]clineUsageItem{{CreatedAt: "2026-07-14T11:00:00Z", CostUSD: 50, CreditsUsed: 7, AIModelTypeName: "cline-pass"}},
+		[]clineUsageItem{{CreatedAt: "2099-07-14T11:00:00Z", CostUSD: 50, CreditsUsed: 7, AIModelTypeName: "cline-pass"}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
 		map[string]clineOfficialWindowLimit{
 			"last5h":  {UsageRatio: &fiveHourRatio, NextResetAt: &fiveHourReset},
@@ -591,7 +591,7 @@ func TestCline_CheckQuota_UsageLimitsNonNotFoundErrorsRemainFailures(t *testing.
 }
 
 func TestCline_CheckQuota_UsageLimitsFailureReturnsSafeError(t *testing.T) {
-	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 7, 7, 12, 0, 0, 0, time.UTC)
 	requestCount := 0
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -843,7 +843,7 @@ func TestCline_CheckQuota_ExhaustedWhenPassOnly(t *testing.T) {
 }
 
 func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *testing.T) {
-	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 7, 7, 12, 0, 0, 0, time.UTC)
 	officialRatio := 1.0
 	zeroRatio := 0.0
 	fiveHourReset := now.Add(4 * time.Hour)
@@ -857,7 +857,7 @@ func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *te
 		},
 		nil,
 		nil,
-		[]clineUsageItem{{CreatedAt: "2026-07-07T11:00:00Z", CostUSD: 1, AIModelTypeName: "cline-pass"}},
+		[]clineUsageItem{{CreatedAt: "2099-07-07T11:00:00Z", CostUSD: 1, AIModelTypeName: "cline-pass"}},
 		clineUsageFetchMeta{Pages: 1, ItemsSeen: 1},
 		map[string]clineOfficialWindowLimit{
 			"last5h":  {UsageRatio: &officialRatio, NextResetAt: &fiveHourReset},
@@ -879,6 +879,11 @@ func TestCline_CheckQuota_MixedScopeDoesNotExhaustWholeChannelFromPassPool(t *te
 	require.NotEmpty(t, quota.Limits)
 	for _, limit := range quota.Limits {
 		if limit.Type != QuotaLimitTypeToken {
+			continue
+		}
+		if limit.Window == QuotaWindow5h {
+			require.Equal(t, "exhausted", limit.Status)
+			require.False(t, limit.Ready)
 			continue
 		}
 		require.NotEqual(t, "exhausted", limit.Status)

--- a/internal/server/biz/provider_quota/codex_checker.go
+++ b/internal/server/biz/provider_quota/codex_checker.go
@@ -279,7 +279,7 @@ func (c *CodexQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 			value *CodeUsageWindow
 		}{
 			{name: QuotaWindowPrimary, value: response.RateLimit.PrimaryWindow},
-			{name: "secondary", value: response.RateLimit.SecondaryWindow},
+			{name: QuotaWindowSecondary, value: response.RateLimit.SecondaryWindow},
 		}
 
 		for _, candidate := range windows {

--- a/internal/server/biz/provider_quota/codex_checker.go
+++ b/internal/server/biz/provider_quota/codex_checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -256,38 +257,6 @@ func (c *CodexQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		return QuotaData{}, fmt.Errorf("failed to parse codex usage response: %w", err)
 	}
 
-	// Normalize status
-	normalizedStatus := "unknown"
-
-	var (
-		nextResetAt              *time.Time
-		primaryWindowUsedPercent *float64
-	)
-
-	if response.RateLimit != nil {
-		if response.RateLimit.LimitReached != nil && *response.RateLimit.LimitReached {
-			normalizedStatus = "exhausted"
-		} else if response.RateLimit.Allowed != nil && !*response.RateLimit.Allowed {
-			normalizedStatus = "exhausted"
-		} else {
-			normalizedStatus = "available"
-
-			// Check for warning state (primary window utilization >= 80%)
-			if response.RateLimit.PrimaryWindow != nil && response.RateLimit.PrimaryWindow.UsedPercent != nil {
-				primaryWindowUsedPercent = response.RateLimit.PrimaryWindow.UsedPercent
-				if *primaryWindowUsedPercent >= 80.0 {
-					normalizedStatus = "warning"
-				}
-			}
-
-			// Extract next reset from primary window
-			if response.RateLimit.PrimaryWindow != nil && response.RateLimit.PrimaryWindow.ResetAt != nil && *response.RateLimit.PrimaryWindow.ResetAt > 0 {
-				t := time.Unix(*response.RateLimit.PrimaryWindow.ResetAt, 0)
-				nextResetAt = &t
-			}
-		}
-	}
-
 	// Convert to raw data map
 	rawData := map[string]any{
 		"plan_type": response.PlanType,
@@ -301,35 +270,150 @@ func (c *CodexQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		rawData["code_review_rate_limit"] = convertRateLimitToMap(response.CodeReviewRateLimit)
 	}
 
-	usageRatio := 0.0
-	if normalizedStatus == "exhausted" {
-		usageRatio = 1.0
+	now := time.Now()
+	limits := make([]QuotaLimitStatus, 0, 2)
+	if response.RateLimit != nil {
+		rateLimitExhausted := codexRateLimitExhausted(response.RateLimit)
+		windows := []struct {
+			name  string
+			value *CodeUsageWindow
+		}{
+			{name: QuotaWindowPrimary, value: response.RateLimit.PrimaryWindow},
+			{name: "secondary", value: response.RateLimit.SecondaryWindow},
+		}
+
+		for _, candidate := range windows {
+			limit, ok := buildCodexQuotaLimit(candidate.name, candidate.value, rateLimitExhausted, now)
+			if ok {
+				limits = append(limits, limit)
+			}
+		}
 	}
 
-	if primaryWindowUsedPercent != nil {
-		usageRatio = *primaryWindowUsedPercent / 100.0
-	}
+	normalizedStatus := codexAggregateStatus(response.RateLimit, limits)
+	nextResetAt := codexEarliestFutureReset(limits, now)
 
-	// The API reports how long the primary window lasts, so the period it
-	// covers can be pinned down exactly.
-	var primaryWindow time.Duration
-	if response.RateLimit != nil && response.RateLimit.PrimaryWindow != nil && response.RateLimit.PrimaryWindow.LimitWindowSeconds != nil {
-		primaryWindow = time.Duration(*response.RateLimit.PrimaryWindow.LimitWindowSeconds) * time.Second
-	}
-
-	limits := []QuotaLimitStatus{
-		NewTokenLimitStatus(normalizedStatus, usageRatio, nextResetAt).
-			WithWindow(QuotaWindowPrimary, primaryWindow),
-	}
-
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "codex",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
+}
+
+func codexRateLimitExhausted(rateLimit *CodeRateLimitInfo) bool {
+	return rateLimit.LimitReached != nil && *rateLimit.LimitReached ||
+		(rateLimit.Allowed != nil && !*rateLimit.Allowed)
+}
+
+func buildCodexQuotaLimit(name string, window *CodeUsageWindow, rateLimitExhausted bool, now time.Time) (QuotaLimitStatus, bool) {
+	if window == nil {
+		return QuotaLimitStatus{}, false
+	}
+
+	duration, ok := codexWindowDuration(window.LimitWindowSeconds)
+	if !ok || window.UsedPercent != nil && (math.IsNaN(*window.UsedPercent) || math.IsInf(*window.UsedPercent, 0) || *window.UsedPercent < 0) {
+		return QuotaLimitStatus{}, false
+	}
+
+	usageRatio := 0.0
+	status := "available"
+	if window.UsedPercent != nil {
+		usageRatio = min(*window.UsedPercent/100, 1)
+		if usageRatio >= 1 {
+			status = "exhausted"
+		} else if usageRatio >= WarningThresholdRatio {
+			status = "warning"
+		}
+	}
+
+	if rateLimitExhausted {
+		status = "exhausted"
+		usageRatio = 1
+	}
+
+	resetAt := codexWindowResetAt(window, now)
+	label := NormalizeQuotaWindowLabel(duration)
+	if label == "" {
+		label = name
+	}
+
+	return NewTokenLimitStatus(status, usageRatio, resetAt).WithWindow(label, duration), true
+}
+
+func codexWindowDuration(seconds *int) (time.Duration, bool) {
+	if seconds == nil {
+		return 0, true
+	}
+
+	const maxDurationSeconds = int64(1<<63-1) / int64(time.Second)
+	if *seconds <= 0 || int64(*seconds) > maxDurationSeconds {
+		return 0, false
+	}
+
+	return time.Duration(*seconds) * time.Second, true
+}
+
+func codexWindowResetAt(window *CodeUsageWindow, now time.Time) *time.Time {
+	if window.ResetAt != nil && *window.ResetAt > 0 {
+		resetAt := time.Unix(*window.ResetAt, 0)
+		return &resetAt
+	}
+
+	if resetAfter, ok := codexWindowDuration(window.ResetAfterSeconds); ok && resetAfter > 0 {
+		resetAt := now.Add(resetAfter)
+		return &resetAt
+	}
+
+	return nil
+}
+
+func codexAggregateStatus(rateLimit *CodeRateLimitInfo, limits []QuotaLimitStatus) string {
+	status := "unknown"
+	if rateLimit != nil && rateLimit.Allowed != nil && *rateLimit.Allowed {
+		status = "available"
+	}
+	if rateLimit != nil && codexRateLimitExhausted(rateLimit) {
+		status = "exhausted"
+	}
+
+	for _, limit := range limits {
+		if codexStatusRank(limit.Status) > codexStatusRank(status) {
+			status = limit.Status
+		}
+	}
+
+	return status
+}
+
+func codexStatusRank(status string) int {
+	switch status {
+	case "exhausted":
+		return 3
+	case "warning":
+		return 2
+	case "available":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func codexEarliestFutureReset(limits []QuotaLimitStatus, now time.Time) *time.Time {
+	var earliest *time.Time
+	for _, limit := range limits {
+		if limit.NextResetAt == nil || !limit.NextResetAt.After(now) {
+			continue
+		}
+		if earliest == nil || limit.NextResetAt.Before(*earliest) {
+			resetAt := *limit.NextResetAt
+			earliest = &resetAt
+		}
+	}
+
+	return earliest
 }
 
 func (c *CodexQuotaChecker) SupportsChannel(ch *ent.Channel) bool {

--- a/internal/server/biz/provider_quota/codex_quota_regression_test.go
+++ b/internal/server/biz/provider_quota/codex_quota_regression_test.go
@@ -1,0 +1,39 @@
+package provider_quota
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexQuotaChecker_ExhaustedWindowWithoutUsageReportsZeroRemaining(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2099, 9, 13, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"rate_limit": {
+			"allowed": false,
+			"primary_window": {
+				"reset_at": ` + strconv.FormatInt(resetAt.Unix(), 10) + `,
+				"limit_window_seconds": 604800
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 1)
+	require.Equal(t, QuotaWindow7d, quota.Limits[0].Window)
+	require.Equal(t, "exhausted", quota.Limits[0].Status)
+	require.False(t, quota.Limits[0].Ready)
+	require.Equal(t, float64(1), quota.Limits[0].UsageRatio)
+	require.Equal(t, "exhausted", quota.Status)
+	require.False(t, quota.Ready)
+	require.True(t, quota.NextResetAt.Equal(resetAt))
+	require.True(t, quota.Limits[0].PeriodStart.Equal(resetAt.Add(-7*24*time.Hour)))
+}

--- a/internal/server/biz/provider_quota/commandcode_checker.go
+++ b/internal/server/biz/provider_quota/commandcode_checker.go
@@ -365,14 +365,14 @@ func parseCommandCodeCredits(creditsBody, subscriptionsBody []byte) (QuotaData, 
 		})
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       overall,
 		ProviderType: commandCodeProviderType,
 		RawData:      raw,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(overall),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 type commandCodeWindow struct {

--- a/internal/server/biz/provider_quota/github_copilot_checker.go
+++ b/internal/server/biz/provider_quota/github_copilot_checker.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -51,35 +53,82 @@ func (c *GithubCopilotQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Chan
 		return QuotaData{}, err
 	}
 
-	status, lowestPercentage := c.calculateStatus(payload)
+	status, _ := c.calculateStatus(payload)
 
-	usageRatio := 1.0
-	if lowestPercentage > 0 {
-		usageRatio = 1.0 - (lowestPercentage / 100.0)
-	}
 	// Copilot quotas reset monthly on the account's billing date, so the period
 	// they cover starts one calendar month before that date.
 	resetAt := c.parseResetDate(payload)
-	limits := []QuotaLimitStatus{
-		{
-			Type:        QuotaLimitTypeToken,
-			Status:      status,
-			UsageRatio:  usageRatio,
-			Ready:       IsReadyStatus(status),
-			NextResetAt: resetAt,
-			Window:      QuotaWindowMonthly,
-			PeriodStart: PeriodStartFromMonthlyReset(resetAt),
-		},
-	}
+	limits := c.buildLimits(payload, resetAt)
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       status,
 		ProviderType: "github_copilot",
 		RawData:      c.prepareRawData(payload),
 		NextResetAt:  resetAt,
 		Ready:        IsReadyStatus(status),
 		Limits:       limits,
-	}, nil
+	}), nil
+}
+
+func (c *GithubCopilotQuotaChecker) buildLimits(payload *copilotUserPayload, resetAt *time.Time) []QuotaLimitStatus {
+	limits := make([]QuotaLimitStatus, 0, len(payload.LimitedUserQuotas)+len(payload.QuotaSnapshots))
+	keys := make([]string, 0, len(payload.LimitedUserQuotas))
+	for key := range payload.LimitedUserQuotas {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		remaining, ok := c.getNumber(payload.LimitedUserQuotas[key])
+		if !ok || !isFiniteCopilotNumber(remaining) || remaining < 0 {
+			continue
+		}
+		total, totalOK := c.getNumber(payload.MonthlyQuotas[key])
+		if !totalOK || !isFiniteCopilotNumber(total) || total < 0 {
+			total = remaining
+		}
+		if total == 0 && remaining != 0 {
+			continue
+		}
+		ratio := 0.0
+		if total > 0 {
+			ratio = (total - remaining) / total
+		}
+		limits = append(limits, copilotLimit(key, ratio, resetAt))
+	}
+
+	keys = keys[:0]
+	for key := range payload.QuotaSnapshots {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		snapshot, ok := payload.QuotaSnapshots[key].(map[string]any)
+		if !ok || snapshot["unlimited"] == true {
+			continue
+		}
+		remaining, ok := c.getNumber(snapshot["percent_remaining"])
+		if !ok || !isFiniteCopilotNumber(remaining) || remaining < 0 || remaining > 100 {
+			continue
+		}
+		limits = append(limits, copilotLimit(key, 1-remaining/100, resetAt))
+	}
+
+	return limits
+}
+
+func copilotLimit(window string, ratio float64, resetAt *time.Time) QuotaLimitStatus {
+	status := "available"
+	if ratio >= 1 {
+		status = "exhausted"
+	} else if ratio >= WarningThresholdRatio {
+		status = "warning"
+	}
+	return NewTokenLimitStatus(status, ratio, resetAt).
+		WithWindow(window, 0)
+}
+
+func isFiniteCopilotNumber(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }
 
 func (c *GithubCopilotQuotaChecker) getAccessToken(ch *ent.Channel) (string, error) {
@@ -259,7 +308,6 @@ func (c *GithubCopilotQuotaChecker) parseResetDate(payload *copilotUserPayload) 
 	}
 	return nil
 }
-
 
 func (c *GithubCopilotQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
 	return ch.Type == channel.TypeGithubCopilot

--- a/internal/server/biz/provider_quota/github_copilot_checker.go
+++ b/internal/server/biz/provider_quota/github_copilot_checker.go
@@ -55,8 +55,8 @@ func (c *GithubCopilotQuotaChecker) CheckQuota(ctx context.Context, ch *ent.Chan
 
 	status, _ := c.calculateStatus(payload)
 
-	// Copilot quotas reset monthly on the account's billing date, so the period
-	// they cover starts one calendar month before that date.
+	// Copilot quotas reset monthly on the account's billing date, but the
+	// provider does not report a fixed window length for deriving PeriodStart.
 	resetAt := c.parseResetDate(payload)
 	limits := c.buildLimits(payload, resetAt)
 

--- a/internal/server/biz/provider_quota/kimi_code_checker.go
+++ b/internal/server/biz/provider_quota/kimi_code_checker.go
@@ -169,14 +169,14 @@ func parseKimiCodeUsageResponse(body []byte) (QuotaData, error) {
 		rawData["boosterWallet"] = wallet
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       status,
 		ProviderType: "kimi_code",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(status),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func parseKimiCodeUsageRow(raw map[string]any, fallbackLabel string) (kimiCodeUsageRow, bool) {

--- a/internal/server/biz/provider_quota/kimi_code_checker_test.go
+++ b/internal/server/biz/provider_quota/kimi_code_checker_test.go
@@ -24,7 +24,7 @@ func TestKimiCode_CheckQuota(t *testing.T) {
 			require.Equal(t, "Bearer kimi-token", req.Header.Get("Authorization"))
 
 			body := `{
-				"usage":{"name":"Weekly limit","used":80,"limit":100,"resetAt":"2026-07-20T00:00:00.123456Z"},
+				"usage":{"name":"Weekly limit","used":80,"limit":100,"resetAt":"2099-07-20T00:00:00.123456Z"},
 				"limits":[
 					{"detail":{"remaining":"0","limit":"20"},"window":{"duration":300,"timeUnit":"MINUTE"}},
 					{"detail":{"used":1,"limit":10,"title":"Daily limit"}}
@@ -57,7 +57,7 @@ func TestKimiCode_CheckQuota(t *testing.T) {
 	require.Len(t, quota.Limits, 3)
 	require.InDelta(t, 0.8, quota.Limits[0].UsageRatio, 0.001)
 	require.InDelta(t, 1, quota.Limits[1].UsageRatio, 0.001)
-	require.Equal(t, time.Date(2026, 7, 20, 0, 0, 0, 123456000, time.UTC), *quota.NextResetAt)
+	require.Equal(t, time.Date(2099, 7, 20, 0, 0, 0, 123456000, time.UTC), *quota.NextResetAt)
 
 	rows, ok := quota.RawData["rows"].([]kimiCodeUsageRow)
 	require.True(t, ok)

--- a/internal/server/biz/provider_quota/minimax_checker.go
+++ b/internal/server/biz/provider_quota/minimax_checker.go
@@ -210,9 +210,7 @@ func parseMinimaxResponse(body []byte) (QuotaData, error) {
 		if model.EndTime > 0 {
 			t := time.UnixMilli(model.EndTime)
 			intervalResetAt = &t
-			if nextResetAt == nil || t.Before(*nextResetAt) {
-				nextResetAt = &t
-			}
+			nextResetAt = earliestReset(nextResetAt, intervalResetAt)
 		}
 
 		limits = append(limits, QuotaLimitStatus{
@@ -243,9 +241,7 @@ func parseMinimaxResponse(body []byte) (QuotaData, error) {
 			if model.WeeklyEndTime > 0 {
 				t := time.UnixMilli(model.WeeklyEndTime)
 				weeklyResetAt = &t
-				if nextResetAt == nil || t.Before(*nextResetAt) {
-					nextResetAt = &t
-				}
+				nextResetAt = earliestReset(nextResetAt, weeklyResetAt)
 			}
 
 			limits = append(limits, QuotaLimitStatus{
@@ -295,14 +291,14 @@ func parseMinimaxResponse(body []byte) (QuotaData, error) {
 		"rows": rows,
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       overallStatus,
 		ProviderType: "minimax",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(overallStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func worseStatus(a, b string) string {

--- a/internal/server/biz/provider_quota/minimax_checker_test.go
+++ b/internal/server/biz/provider_quota/minimax_checker_test.go
@@ -86,13 +86,13 @@ func TestMinimax_CheckQuota_WithBoost(t *testing.T) {
 			body := `{
 				"model_remains": [{
 					"model_name": "general",
-					"start_time": 1784304000000,
-					"end_time": 1784322000000,
+					"start_time": 4087929600000,
+					"end_time": 4087947600000,
 					"current_interval_status": 1,
 					"current_interval_remaining_percent": 100,
 					"current_interval_boost_permille": 0,
-					"weekly_start_time": 1783872000000,
-					"weekly_end_time": 1784476800000,
+					"weekly_start_time": 4087324800000,
+					"weekly_end_time": 4088534400000,
 					"current_weekly_status": 1,
 					"current_weekly_remaining_percent": 97,
 					"weekly_boost_permille": 1500
@@ -475,12 +475,12 @@ func TestMinimax_CheckQuota_WithResetTime(t *testing.T) {
 			body := `{
 				"model_remains": [{
 					"model_name": "general",
-					"start_time": 1784304000000,
-					"end_time": 1784322000000,
+					"start_time": 4087929600000,
+					"end_time": 4087947600000,
 					"current_interval_status": 1,
 					"current_interval_remaining_percent": 100,
-					"weekly_start_time": 1783872000000,
-					"weekly_end_time": 1784476800000,
+					"weekly_start_time": 4087324800000,
+					"weekly_end_time": 4088534400000,
 					"current_weekly_status": 1,
 					"current_weekly_remaining_percent": 100
 				}],
@@ -501,6 +501,6 @@ func TestMinimax_CheckQuota_WithResetTime(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, quota.NextResetAt)
-	// end_time=1784322000000 is earlier than weekly_end_time=1784476800000
-	require.Equal(t, int64(1784322000), quota.NextResetAt.Unix())
+	// end_time=4087947600000 is earlier than weekly_end_time=4088534400000
+	require.Equal(t, int64(4087947600), quota.NextResetAt.Unix())
 }

--- a/internal/server/biz/provider_quota/nanogpt_checker.go
+++ b/internal/server/biz/provider_quota/nanogpt_checker.go
@@ -191,14 +191,14 @@ func (c *NanoGPTQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		rawData["graceUntil"] = *response.GraceUntil
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "nanogpt",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func (c *NanoGPTQuotaChecker) SupportsChannel(ch *ent.Channel) bool {

--- a/internal/server/biz/provider_quota/nanogpt_checker_test.go
+++ b/internal/server/biz/provider_quota/nanogpt_checker_test.go
@@ -183,15 +183,15 @@ func TestNanoGPT_CheckQuota_APIError(t *testing.T) {
 }
 
 func TestNanoGPT_CheckQuota_NextResetAt(t *testing.T) {
-	expectedResetAt := time.UnixMilli(1717200000000)
+	expectedResetAt := time.UnixMilli(4087929600000)
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			body := `{
 				"active": true,
 				"state": "active",
-				"dailyInputTokens": {"used": 1000, "remaining": 199000, "percentUsed": 0.5, "resetAt": 1717200000000},
-				"weeklyInputTokens": {"used": 5000, "remaining": 995000, "percentUsed": 0.05, "resetAt": 1717804800000}
+				"dailyInputTokens": {"used": 1000, "remaining": 199000, "percentUsed": 0.5, "resetAt": 4087929600000},
+				"weeklyInputTokens": {"used": 5000, "remaining": 995000, "percentUsed": 0.05, "resetAt": 4088534400000}
 			}`
 
 			return &http.Response{
@@ -221,7 +221,7 @@ func TestNanoGPT_CheckQuota_NullWindow(t *testing.T) {
 			body := `{
 				"active": true,
 				"state": "active",
-				"weeklyInputTokens": {"used": 5000, "remaining": 995000, "percentUsed": 0.05, "resetAt": 1717804800000}
+				"weeklyInputTokens": {"used": 5000, "remaining": 995000, "percentUsed": 0.05, "resetAt": 4088534400000}
 			}`
 
 			return &http.Response{
@@ -255,17 +255,17 @@ func TestNanoGPT_CheckQuota_NullWindow(t *testing.T) {
 	require.True(t, hasWeekly)
 
 	require.NotNil(t, quota.NextResetAt)
-	expectedResetAt := time.UnixMilli(1717804800000)
+	expectedResetAt := time.UnixMilli(4088534400000)
 	require.Equal(t, expectedResetAt, *quota.NextResetAt)
 }
 
 func TestNanoGPT_CheckQuota_GraceUntilAsNextResetAt(t *testing.T) {
-	graceUntil := "2025-04-30T00:00:00Z"
+	graceUntil := "2099-04-30T00:00:00Z"
 	expectedTime, _ := time.Parse(time.RFC3339, graceUntil)
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			body := `{"active": true, "state": "grace", "graceUntil": "2025-04-30T00:00:00Z"}`
+			body := `{"active": true, "state": "grace", "graceUntil": "2099-04-30T00:00:00Z"}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),

--- a/internal/server/biz/provider_quota/neuralwatt_checker.go
+++ b/internal/server/biz/provider_quota/neuralwatt_checker.go
@@ -131,17 +131,17 @@ func (c *NeuralWattQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 	}
 
 	limits := []QuotaLimitStatus{
-		NewTokenLimitStatus(normalizedStatus, usageRatio, nextResetAt),
+		NewTokenLimitStatus(normalizedStatus, usageRatio, nextResetAt).WithWindow("kwh", 0),
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "neuralwatt",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func (c *NeuralWattQuotaChecker) SupportsChannel(ch *ent.Channel) bool {
@@ -207,7 +207,6 @@ func convertNeuralWattSubscriptionToMap(sub *NeuralWattSubscription) map[string]
 	if sub.Status != nil {
 		result["status"] = *sub.Status
 	}
-
 
 	if sub.KwhIncluded != nil {
 		result["kwh_included"] = *sub.KwhIncluded

--- a/internal/server/biz/provider_quota/neuralwatt_checker_test.go
+++ b/internal/server/biz/provider_quota/neuralwatt_checker_test.go
@@ -60,7 +60,7 @@ func TestNeuralWatt_CheckQuota_HappyPath(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
-	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2099-06-02T05:58:36Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -78,7 +78,7 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 					"kwh_used": 17.0,
 					"kwh_remaining": 3.0,
 					"in_overage": false,
-					"kwh_reset_date": "2026-06-02T05:58:36Z"
+					"kwh_reset_date": "2099-06-02T05:58:36Z"
 				}
 			}`
 			return &http.Response{
@@ -104,7 +104,7 @@ func TestNeuralWatt_CheckQuota_WarningState(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_ExhaustedState(t *testing.T) {
-	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2099-06-02T05:58:36Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -121,7 +121,7 @@ func TestNeuralWatt_CheckQuota_ExhaustedState(t *testing.T) {
 					"kwh_used": 22.5,
 					"kwh_remaining": 0.0,
 					"in_overage": true,
-					"kwh_reset_date": "2026-06-02T05:58:36Z"
+					"kwh_reset_date": "2099-06-02T05:58:36Z"
 				}
 			}`
 
@@ -215,7 +215,7 @@ func TestNeuralWatt_CheckQuota_HTTPError(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
-	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-02T05:58:36Z")
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2099-06-02T05:58:36Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -232,7 +232,7 @@ func TestNeuralWatt_CheckQuota_ZeroRemainingWithoutOverage(t *testing.T) {
 					"kwh_used": 20.0,
 					"kwh_remaining": 0.0,
 					"in_overage": false,
-					"kwh_reset_date": "2026-06-02T05:58:36Z"
+					"kwh_reset_date": "2099-06-02T05:58:36Z"
 				}
 			}`
 
@@ -335,7 +335,7 @@ func TestNeuralWatt_CheckQuota_CustomBaseURL(t *testing.T) {
 }
 
 func TestNeuralWatt_CheckQuota_KwhResetDate(t *testing.T) {
-	expectedResetAt, _ := time.Parse(time.RFC3339, "2026-06-26T19:25:50Z")
+	expectedResetAt, _ := time.Parse(time.RFC3339, "2099-06-26T19:25:50Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -352,7 +352,7 @@ func TestNeuralWatt_CheckQuota_KwhResetDate(t *testing.T) {
 					"kwh_used": 8.7808,
 					"kwh_remaining": 24.2192,
 					"in_overage": false,
-					"kwh_reset_date": "2026-06-26T19:25:50Z"
+					"kwh_reset_date": "2099-06-26T19:25:50Z"
 				}
 			}`
 

--- a/internal/server/biz/provider_quota/normalization.go
+++ b/internal/server/biz/provider_quota/normalization.go
@@ -1,0 +1,159 @@
+package provider_quota
+
+import (
+	"math"
+	"time"
+)
+
+// NormalizeQuotaData applies the common provider quota contract at the checker boundary.
+func NormalizeQuotaData(data QuotaData) QuotaData {
+	return normalizeQuotaDataAt(data, time.Now())
+}
+
+func normalizeQuotaDataAt(data QuotaData, now time.Time) QuotaData {
+	data.Limits = normalizeQuotaLimits(data.Limits, now)
+
+	status := normalizeOverallQuotaStatus(data.Status, data.Limits)
+
+	var nextResetAt *time.Time
+	if data.NextResetAt != nil && data.NextResetAt.After(now) {
+		resetAt := *data.NextResetAt
+		nextResetAt = &resetAt
+	}
+	for _, limit := range data.Limits {
+		if limit.NextResetAt != nil && limit.NextResetAt.After(now) &&
+			(nextResetAt == nil || limit.NextResetAt.Before(*nextResetAt)) {
+			resetAt := *limit.NextResetAt
+			nextResetAt = &resetAt
+		}
+	}
+
+	data.Status = status
+	data.NextResetAt = nextResetAt
+	data.Ready = IsReadyStatus(status)
+	return data
+}
+
+func normalizeOverallQuotaStatus(explicitStatus string, limits []QuotaLimitStatus) string {
+	status := normalizeQuotaStatus(explicitStatus)
+	if status == "exhausted" {
+		return status
+	}
+
+	bestReadyStatus := ""
+	if IsReadyStatus(status) {
+		bestReadyStatus = status
+	}
+	hasExhausted := false
+
+	for _, limit := range limits {
+		switch {
+		case IsReadyStatus(limit.Status):
+			if bestReadyStatus == "" || normalizedQuotaStatusRank(limit.Status) > normalizedQuotaStatusRank(bestReadyStatus) {
+				bestReadyStatus = limit.Status
+			}
+		case limit.Status == "exhausted":
+			hasExhausted = true
+		}
+	}
+
+	if bestReadyStatus != "" {
+		return bestReadyStatus
+	}
+	if hasExhausted {
+		return "exhausted"
+	}
+	return "unknown"
+}
+
+func normalizeQuotaLimits(limits []QuotaLimitStatus, now time.Time) []QuotaLimitStatus {
+	if len(limits) == 0 {
+		return nil
+	}
+
+	normalized := make([]QuotaLimitStatus, 0, len(limits))
+	indexes := make(map[string]int, len(limits))
+	for _, limit := range limits {
+		if limit.Type == "" || limit.Window == "" || !isFiniteRatio(limit.UsageRatio) || limit.UsageRatio < 0 {
+			continue
+		}
+
+		limit.UsageRatio = min(limit.UsageRatio, 1)
+		limit.Status = normalizeQuotaStatus(limit.Status)
+		if limit.UsageRatio >= 1 {
+			limit.Status = "exhausted"
+		}
+		limit.Ready = IsReadyStatus(limit.Status)
+		if limit.NextResetAt != nil && limit.NextResetAt.IsZero() {
+			limit.NextResetAt = nil
+		}
+		if limit.NextResetAt != nil && !limit.NextResetAt.After(now) {
+			limit.NextResetAt = nil
+		}
+		if limit.NextResetAt == nil {
+			limit.PeriodStart = nil
+		} else if limit.PeriodStart != nil && !limit.PeriodStart.Before(*limit.NextResetAt) {
+			limit.PeriodStart = nil
+		}
+
+		identity := string(limit.Type) + "\x00" + limit.Window
+		if index, ok := indexes[identity]; ok {
+			mergeQuotaLimit(&normalized[index], limit)
+			continue
+		}
+		indexes[identity] = len(normalized)
+		normalized = append(normalized, limit)
+	}
+
+	return normalized
+}
+
+func mergeQuotaLimit(existing *QuotaLimitStatus, incoming QuotaLimitStatus) {
+	if incoming.UsageRatio > existing.UsageRatio {
+		existing.UsageRatio = incoming.UsageRatio
+	}
+	if normalizedQuotaStatusRank(incoming.Status) > normalizedQuotaStatusRank(existing.Status) {
+		existing.Status = incoming.Status
+	}
+	if incoming.NextResetAt != nil &&
+		(existing.NextResetAt == nil || incoming.NextResetAt.Before(*existing.NextResetAt)) {
+		resetAt := *incoming.NextResetAt
+		existing.NextResetAt = &resetAt
+	}
+	if incoming.PeriodStart != nil &&
+		(existing.PeriodStart == nil || incoming.PeriodStart.Before(*existing.PeriodStart)) {
+		periodStart := *incoming.PeriodStart
+		existing.PeriodStart = &periodStart
+	}
+	if existing.NextResetAt == nil || existing.PeriodStart == nil ||
+		!existing.PeriodStart.Before(*existing.NextResetAt) {
+		existing.PeriodStart = nil
+	}
+	existing.Ready = IsReadyStatus(existing.Status)
+}
+
+func isFiniteRatio(ratio float64) bool {
+	return !math.IsNaN(ratio) && !math.IsInf(ratio, 0)
+}
+
+func normalizeQuotaStatus(status string) string {
+	switch status {
+	case "available", "warning", "exhausted", "unknown":
+		return status
+	default:
+		return "unknown"
+	}
+}
+
+func normalizedQuotaStatusRank(status string) int {
+	switch status {
+	case "exhausted":
+		return 3
+	case "warning":
+		return 2
+	case "available":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/server/biz/provider_quota/normalization_contract_test.go
+++ b/internal/server/biz/provider_quota/normalization_contract_test.go
@@ -102,7 +102,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "exhausted and available",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0.2, Status: "available"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0.2, Status: "available"},
 			},
 			wantStatus: "available",
 			wantReady:  true,
@@ -111,7 +111,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "exhausted and warning",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0.9, Status: "warning"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0.9, Status: "warning"},
 			},
 			wantStatus: "warning",
 			wantReady:  true,
@@ -120,7 +120,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "all exhausted",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 1, Status: "exhausted"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 1, Status: "exhausted"},
 			},
 			wantStatus: "exhausted",
 			wantReady:  false,
@@ -128,7 +128,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 		{
 			name: "unknown only",
 			limits: []QuotaLimitStatus{
-				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0, Status: "unknown"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0, Status: "unknown"},
 			},
 			wantStatus: "unknown",
 			wantReady:  false,

--- a/internal/server/biz/provider_quota/normalization_contract_test.go
+++ b/internal/server/biz/provider_quota/normalization_contract_test.go
@@ -1,0 +1,165 @@
+package provider_quota
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuotaCheckers_NormalizeRatioAndStatusBoundaries(t *testing.T) {
+	// Given an overage ratio, an unknown type, and an expired top-level reset.
+	expiredReset := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	quota := NormalizeQuotaData(QuotaData{
+		Status:      "unknown",
+		NextResetAt: &expiredReset,
+		Limits: []QuotaLimitStatus{
+			{Type: QuotaLimitTypeToken, Window: QuotaWindow5h, UsageRatio: 1.5, Status: "available"},
+			{Window: QuotaWindowWeekly, UsageRatio: 0.2, Status: "available"},
+		},
+	})
+
+	// Then overage is exhausted and malformed identities do not enter Limits.
+	require.Len(t, quota.Limits, 1)
+	require.Equal(t, float64(1), quota.Limits[0].UsageRatio)
+	require.Equal(t, "exhausted", quota.Limits[0].Status)
+	require.False(t, quota.Limits[0].Ready)
+	require.Equal(t, "exhausted", quota.Status)
+	require.False(t, quota.Ready)
+	require.Nil(t, quota.NextResetAt)
+	assertNormalizedLimitContract(t, quota)
+}
+
+func TestQuotaCheckers_ExpiryAndStatusPrecedence(t *testing.T) {
+	// Given an expired limit reset and a future exhausted limit with a warning channel status.
+	now := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	expiredReset := now.Add(-time.Minute)
+	expiredPeriodStart := expiredReset.Add(-5 * time.Hour)
+	futureReset := now.Add(time.Hour)
+	quota := normalizeQuotaDataAt(QuotaData{
+		Status: "warning",
+		Limits: []QuotaLimitStatus{
+			{
+				Type:        QuotaLimitTypeToken,
+				Window:      QuotaWindowWeekly,
+				UsageRatio:  0.5,
+				Status:      "warning",
+				NextResetAt: &expiredReset,
+				PeriodStart: &expiredPeriodStart,
+			},
+			{
+				Type:        QuotaLimitTypeToken,
+				Window:      QuotaWindow5h,
+				UsageRatio:  1.2,
+				Status:      "available",
+				NextResetAt: &futureReset,
+			},
+		},
+	}, now)
+
+	// Then expired timing data is cleared and the ready warning status outranks exhaustion.
+	require.Len(t, quota.Limits, 2)
+	require.Nil(t, quota.Limits[0].NextResetAt)
+	require.Nil(t, quota.Limits[0].PeriodStart)
+	require.Equal(t, "exhausted", quota.Limits[1].Status)
+	require.Equal(t, "warning", quota.Status)
+	require.True(t, quota.Ready)
+	require.Equal(t, futureReset, *quota.NextResetAt)
+	assertNormalizedLimitContract(t, quota)
+}
+
+func TestQuotaCheckers_MalformedRatios(t *testing.T) {
+	// Given non-finite and negative ratios alongside an invalid period boundary.
+	resetAt := time.Date(2099, 9, 11, 10, 0, 0, 0, time.UTC)
+	invalidPeriodStart := resetAt.Add(time.Hour)
+	normalized := normalizeQuotaDataAt(QuotaData{
+		Status: "unknown",
+		Limits: []QuotaLimitStatus{
+			{Type: QuotaLimitTypeToken, Window: "empty-window", UsageRatio: math.NaN(), Status: "available"},
+			{Type: QuotaLimitTypeToken, Window: "infinite-ratio", UsageRatio: math.Inf(1), Status: "available"},
+			{Type: QuotaLimitTypeToken, Window: "negative-ratio", UsageRatio: -0.1, Status: "available"},
+			{Type: QuotaLimitTypeToken, Window: "bad-period", UsageRatio: 0.2, Status: "available", NextResetAt: &resetAt, PeriodStart: &invalidPeriodStart},
+		},
+	}, time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC))
+
+	// Then malformed ratios are omitted and an invalid period start is cleared.
+	require.Len(t, normalized.Limits, 1)
+	require.Equal(t, "bad-period", normalized.Limits[0].Window)
+	require.Nil(t, normalized.Limits[0].PeriodStart)
+	assertNormalizedLimitContract(t, normalized)
+}
+
+func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
+	now := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		limits     []QuotaLimitStatus
+		wantStatus string
+		wantReady  bool
+	}{
+		{
+			name: "exhausted and available",
+			limits: []QuotaLimitStatus{
+				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
+				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0.2, Status: "available"},
+			},
+			wantStatus: "available",
+			wantReady:  true,
+		},
+		{
+			name: "exhausted and warning",
+			limits: []QuotaLimitStatus{
+				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
+				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0.9, Status: "warning"},
+			},
+			wantStatus: "warning",
+			wantReady:  true,
+		},
+		{
+			name: "all exhausted",
+			limits: []QuotaLimitStatus{
+				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
+				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 1, Status: "exhausted"},
+			},
+			wantStatus: "exhausted",
+			wantReady:  false,
+		},
+		{
+			name: "unknown only",
+			limits: []QuotaLimitStatus{
+				{Type: QuotaLimitTypeToken, Window: "payg", UsageRatio: 0, Status: "unknown"},
+			},
+			wantStatus: "unknown",
+			wantReady:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When the common normalizer derives the overall status from limits.
+			quota := normalizeQuotaDataAt(QuotaData{Status: "unknown", Limits: tt.limits}, now)
+
+			// Then ready limits win over exhausted limits, and unknown remains unknown.
+			require.Equal(t, tt.wantStatus, quota.Status)
+			require.Equal(t, tt.wantReady, quota.Ready)
+		})
+	}
+}
+
+func TestNormalizeQuotaData_ExplicitStatusContributesReadyState(t *testing.T) {
+	// Given an explicit warning status and an exhausted limit.
+	quota := normalizeQuotaDataAt(QuotaData{
+		Status: "warning",
+		Limits: []QuotaLimitStatus{{
+			Type:       QuotaLimitTypeToken,
+			Window:     QuotaWindow5h,
+			UsageRatio: 1,
+			Status:     "exhausted",
+		}},
+	}, time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC))
+
+	// Then the explicit ready status is not downgraded by an exhausted limit.
+	require.Equal(t, "warning", quota.Status)
+	require.True(t, quota.Ready)
+}

--- a/internal/server/biz/provider_quota/normalization_contract_test.go
+++ b/internal/server/biz/provider_quota/normalization_contract_test.go
@@ -102,7 +102,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "exhausted and available",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0.2, Status: "available"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayAsYouGo, UsageRatio: 0.2, Status: "available"},
 			},
 			wantStatus: "available",
 			wantReady:  true,
@@ -111,7 +111,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "exhausted and warning",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0.9, Status: "warning"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayAsYouGo, UsageRatio: 0.9, Status: "warning"},
 			},
 			wantStatus: "warning",
 			wantReady:  true,
@@ -120,7 +120,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 			name: "all exhausted",
 			limits: []QuotaLimitStatus{
 				{Type: QuotaLimitTypeSubscriptionCycle, Window: QuotaWindowCycle, UsageRatio: 1, Status: "exhausted"},
-				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 1, Status: "exhausted"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayAsYouGo, UsageRatio: 1, Status: "exhausted"},
 			},
 			wantStatus: "exhausted",
 			wantReady:  false,
@@ -128,7 +128,7 @@ func TestNormalizeQuotaData_OverallStatusUsesReadyLimitOR(t *testing.T) {
 		{
 			name: "unknown only",
 			limits: []QuotaLimitStatus{
-				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayg, UsageRatio: 0, Status: "unknown"},
+				{Type: QuotaLimitTypeToken, Window: QuotaWindowPayAsYouGo, UsageRatio: 0, Status: "unknown"},
 			},
 			wantStatus: "unknown",
 			wantReady:  false,

--- a/internal/server/biz/provider_quota/opencode_go_checker.go
+++ b/internal/server/biz/provider_quota/opencode_go_checker.go
@@ -196,7 +196,7 @@ func (c *OpenCodeGoQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		})
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: opencodeGoProviderType,
 		RawData: map[string]any{
@@ -206,7 +206,7 @@ func (c *OpenCodeGoQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		NextResetAt: nextResetAt,
 		Ready:       IsReadyStatus(normalizedStatus),
 		Limits:      limits,
-	}, nil
+	}), nil
 }
 
 // parseOpenCodeGoResetsAt parses the resetsAt value from the usage API. The

--- a/internal/server/biz/provider_quota/opencode_go_checker_test.go
+++ b/internal/server/biz/provider_quota/opencode_go_checker_test.go
@@ -26,9 +26,9 @@ func TestOpenCodeGo_CheckQuota_Success(t *testing.T) {
 			require.Equal(t, "application/json", req.Header.Get("Accept"))
 
 			body := `{"usage":{
-				"rolling":{"percent":12,"resetsAt":"2026-06-25T15:00:00Z"},
-				"weekly":{"percent":85,"resetsAt":"2026-07-02T10:00:00Z"},
-				"monthly":{"percent":35,"resetsAt":"2026-07-25T10:00:00Z"}
+				"rolling":{"percent":12,"resetsAt":"2099-06-25T15:00:00Z"},
+				"weekly":{"percent":85,"resetsAt":"2099-07-02T10:00:00Z"},
+				"monthly":{"percent":35,"resetsAt":"2099-07-25T10:00:00Z"}
 			}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -39,7 +39,7 @@ func TestOpenCodeGo_CheckQuota_Success(t *testing.T) {
 	})
 
 	checker := NewOpenCodeGoQuotaChecker(httpClient)
-	now := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 6, 25, 10, 0, 0, 0, time.UTC)
 	checker.now = func() time.Time { return now }
 
 	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
@@ -100,7 +100,7 @@ func TestOpenCodeGo_CheckQuota_UnixResetsAt(t *testing.T) {
 func TestOpenCodeGo_CheckQuota_PartialWindows(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			body := `{"usage":{"rolling":{"percent":100,"resetsAt":"2026-06-25T15:00:00Z"}}}`
+			body := `{"usage":{"rolling":{"percent":100,"resetsAt":"2099-06-25T15:00:00Z"}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -110,7 +110,7 @@ func TestOpenCodeGo_CheckQuota_PartialWindows(t *testing.T) {
 	})
 
 	checker := NewOpenCodeGoQuotaChecker(httpClient)
-	now := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 6, 25, 10, 0, 0, 0, time.UTC)
 	checker.now = func() time.Time { return now }
 
 	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
@@ -148,7 +148,7 @@ func TestOpenCodeGo_CheckQuota_MillisecondResetsAt(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			// Live API shape: RFC3339 with fractional seconds (verified 2026-08-12).
-			body := `{"usage":{"rolling":{"status":"ok","percent":0,"resetsAt":"2026-08-12T11:24:29.905Z"}}}`
+			body := `{"usage":{"rolling":{"status":"ok","percent":0,"resetsAt":"2099-08-12T11:24:29.905Z"}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -158,7 +158,7 @@ func TestOpenCodeGo_CheckQuota_MillisecondResetsAt(t *testing.T) {
 	})
 
 	checker := NewOpenCodeGoQuotaChecker(httpClient)
-	now := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2099, 6, 25, 10, 0, 0, 0, time.UTC)
 	checker.now = func() time.Time { return now }
 
 	quota, err := checker.CheckQuota(context.Background(), &ent.Channel{
@@ -168,12 +168,12 @@ func TestOpenCodeGo_CheckQuota_MillisecondResetsAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
 	require.Len(t, quota.Limits, 1)
-	require.Equal(t, time.Date(2026, 8, 12, 11, 24, 29, 905_000_000, time.UTC), *quota.NextResetAt)
+	require.Equal(t, time.Date(2099, 8, 12, 11, 24, 29, 905_000_000, time.UTC), *quota.NextResetAt)
 
 	windows := quota.RawData["windows"].(map[string]any)
 	rolling := windows["rolling"].(map[string]any)
 	require.InDelta(t, 0, rolling["usage_percent"], 0.001)
-	require.Equal(t, "2026-08-12T11:24:29Z", rolling["reset_time"])
+	require.Equal(t, "2099-08-12T11:24:29Z", rolling["reset_time"])
 }
 
 func TestOpenCodeGo_CheckQuota_MissingAPIKey(t *testing.T) {
@@ -189,7 +189,7 @@ func TestOpenCodeGo_CheckQuota_SecondAPIKey(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "Bearer key-two", req.Header.Get("Authorization"))
-			body := `{"usage":{"rolling":{"percent":12,"resetsAt":"2026-06-25T15:00:00Z"}}}`
+			body := `{"usage":{"rolling":{"percent":12,"resetsAt":"2099-06-25T15:00:00Z"}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -211,7 +211,7 @@ func TestOpenCodeGo_CheckQuota_SecondAPIKey(t *testing.T) {
 func TestOpenCodeGo_CheckQuota_EpochMilliseconds(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			body := `{"usage":{"rolling":{"percent":12,"resetsAt":1782370800000}}}`
+			body := `{"usage":{"rolling":{"percent":12,"resetsAt":4086082800000}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -228,7 +228,7 @@ func TestOpenCodeGo_CheckQuota_EpochMilliseconds(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "available", quota.Status)
-	require.Equal(t, time.UnixMilli(1782370800000), *quota.NextResetAt)
+	require.Equal(t, time.UnixMilli(4086082800000), *quota.NextResetAt)
 }
 
 func TestOpenCodeGo_CheckQuota_AllWindowsUnparseable(t *testing.T) {

--- a/internal/server/biz/provider_quota/period_quota_test.go
+++ b/internal/server/biz/provider_quota/period_quota_test.go
@@ -1,6 +1,7 @@
 package provider_quota
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -30,17 +31,19 @@ func TestEstimatePeriodQuota(t *testing.T) {
 	_, ok = EstimatePeriodQuota(-1, 0.5)
 	require.False(t, ok)
 
-	// Ratios below the threshold would amplify noise into an absurd estimate.
 	_, ok = EstimatePeriodQuota(10, 0)
 	require.False(t, ok)
 	_, ok = EstimatePeriodQuota(10, -0.1)
 	require.False(t, ok)
-	_, ok = EstimatePeriodQuota(10, MinPeriodQuotaUsageRatio/2)
-	require.False(t, ok)
 
-	total, ok = EstimatePeriodQuota(10, MinPeriodQuotaUsageRatio)
+	total, ok = EstimatePeriodQuota(10, 0.01)
 	require.True(t, ok)
-	require.InDelta(t, 10/MinPeriodQuotaUsageRatio, total, 1e-9)
+	require.InDelta(t, 1000.0, total, 1e-9)
+
+	_, ok = EstimatePeriodQuota(10, math.NaN())
+	require.False(t, ok)
+	_, ok = EstimatePeriodQuota(10, math.Inf(1))
+	require.False(t, ok)
 }
 
 func TestQuotaLimitStatusFillPeriodQuota(t *testing.T) {

--- a/internal/server/biz/provider_quota/period_quota_test.go
+++ b/internal/server/biz/provider_quota/period_quota_test.go
@@ -44,6 +44,12 @@ func TestEstimatePeriodQuota(t *testing.T) {
 	require.False(t, ok)
 	_, ok = EstimatePeriodQuota(10, math.Inf(1))
 	require.False(t, ok)
+	_, ok = EstimatePeriodQuota(math.NaN(), 0.5)
+	require.False(t, ok)
+	_, ok = EstimatePeriodQuota(math.Inf(1), 0.5)
+	require.False(t, ok)
+	_, ok = EstimatePeriodQuota(math.MaxFloat64, math.SmallestNonzeroFloat64)
+	require.False(t, ok)
 }
 
 func TestQuotaLimitStatusFillPeriodQuota(t *testing.T) {
@@ -62,6 +68,18 @@ func TestQuotaLimitStatusFillPeriodQuota(t *testing.T) {
 
 	limit.UsageRatio = 0.5
 	limit.PeriodCost = nil
+	limit.FillPeriodQuota()
+	require.Nil(t, limit.PeriodQuota)
+
+	for _, periodCost := range []float64{math.NaN(), math.Inf(1), math.MaxFloat64} {
+		limit.PeriodCost = lo.ToPtr(periodCost)
+		limit.UsageRatio = 0.5
+		limit.FillPeriodQuota()
+		require.Nil(t, limit.PeriodQuota)
+	}
+
+	limit.PeriodCost = lo.ToPtr(math.MaxFloat64)
+	limit.UsageRatio = math.SmallestNonzeroFloat64
 	limit.FillPeriodQuota()
 	require.Nil(t, limit.PeriodQuota)
 }

--- a/internal/server/biz/provider_quota/period_window_test.go
+++ b/internal/server/biz/provider_quota/period_window_test.go
@@ -55,9 +55,8 @@ func TestClaudeCodeQuotaChecker_NoPeriodWithoutResetHeader(t *testing.T) {
 
 	quota, err := checker.parseResponse(headers)
 	require.NoError(t, err)
-	require.Len(t, quota.Limits, 2)
+	require.Len(t, quota.Limits, 1)
 	require.Nil(t, quota.Limits[0].PeriodStart)
-	require.Nil(t, quota.Limits[1].PeriodStart)
 }
 
 func TestCodexQuotaChecker_LimitPeriodUsesReportedWindowLength(t *testing.T) {
@@ -82,9 +81,192 @@ func TestCodexQuotaChecker_LimitPeriodUsesReportedWindowLength(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, quota.Limits, 1)
 	require.InDelta(t, 0.4, quota.Limits[0].UsageRatio, 1e-9)
-	require.Equal(t, QuotaWindowPrimary, quota.Limits[0].Window)
+	require.Equal(t, QuotaWindow5h, quota.Limits[0].Window)
 	require.NotNil(t, quota.Limits[0].PeriodStart)
 	require.Equal(t, resetAt.Add(-5*time.Hour).Unix(), quota.Limits[0].PeriodStart.Unix())
+}
+
+func TestCodexQuotaChecker_ProPrimarySevenDayWindow(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2099, 9, 13, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"plan_type": "pro",
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": 40,
+				"reset_at": ` + strconv.FormatInt(resetAt.Unix(), 10) + `,
+				"limit_window_seconds": 604800
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 1)
+	require.Equal(t, QuotaWindow7d, quota.Limits[0].Window)
+	require.InDelta(t, 0.4, quota.Limits[0].UsageRatio, 1e-9)
+	require.NotNil(t, quota.Limits[0].PeriodStart)
+	require.Equal(t, resetAt.Add(-7*24*time.Hour).Unix(), quota.Limits[0].PeriodStart.Unix())
+}
+
+func TestCodexQuotaChecker_DualWindowsRemainIndependent(t *testing.T) {
+	t.Parallel()
+
+	fiveHourReset := time.Date(2099, 9, 8, 12, 0, 0, 0, time.UTC)
+	sevenDayReset := time.Date(2099, 9, 13, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"plan_type": "pro",
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": 25,
+				"reset_at": ` + strconv.FormatInt(fiveHourReset.Unix(), 10) + `,
+				"limit_window_seconds": 18000
+			},
+			"secondary_window": {
+				"used_percent": 90,
+				"reset_at": ` + strconv.FormatInt(sevenDayReset.Unix(), 10) + `,
+				"limit_window_seconds": 604800
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 2)
+
+	require.Equal(t, QuotaWindow5h, quota.Limits[0].Window)
+	require.InDelta(t, 0.25, quota.Limits[0].UsageRatio, 1e-9)
+	require.Equal(t, "available", quota.Limits[0].Status)
+	require.Equal(t, fiveHourReset.Add(-5*time.Hour).Unix(), quota.Limits[0].PeriodStart.Unix())
+
+	require.Equal(t, QuotaWindow7d, quota.Limits[1].Window)
+	require.InDelta(t, 0.9, quota.Limits[1].UsageRatio, 1e-9)
+	require.Equal(t, "warning", quota.Limits[1].Status)
+	require.Equal(t, sevenDayReset.Add(-7*24*time.Hour).Unix(), quota.Limits[1].PeriodStart.Unix())
+
+	require.Equal(t, "warning", quota.Status)
+	require.Equal(t, fiveHourReset.Unix(), quota.NextResetAt.Unix())
+}
+
+func TestCodexQuotaChecker_UnknownWindowDurationKeepsNeutralLabel(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2099, 9, 13, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": 10,
+				"reset_at": ` + strconv.FormatInt(resetAt.Unix(), 10) + `,
+				"limit_window_seconds": 12345
+			},
+			"secondary_window": {
+				"used_percent": 20,
+				"reset_at": ` + strconv.FormatInt(resetAt.Add(time.Hour).Unix(), 10) + `
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 2)
+	require.Equal(t, QuotaWindowPrimary, quota.Limits[0].Window)
+	require.Equal(t, "secondary", quota.Limits[1].Window)
+	require.NotContains(t, []string{quota.Limits[0].Window, quota.Limits[1].Window}, QuotaWindow5h)
+	require.NotContains(t, []string{quota.Limits[0].Window, quota.Limits[1].Window}, QuotaWindow7d)
+	require.NotNil(t, quota.Limits[0].PeriodStart)
+	require.Nil(t, quota.Limits[1].PeriodStart)
+}
+
+func TestCodexQuotaChecker_StatusAndResetAggregateAcrossWindows(t *testing.T) {
+	t.Parallel()
+
+	expiredReset := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	futureReset := time.Date(2099, 9, 13, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": 10,
+				"reset_at": ` + strconv.FormatInt(expiredReset.Unix(), 10) + `,
+				"limit_window_seconds": 18000
+			},
+			"secondary_window": {
+				"used_percent": 100,
+				"reset_at": ` + strconv.FormatInt(futureReset.Unix(), 10) + `,
+				"limit_window_seconds": 604800
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.Equal(t, "exhausted", quota.Status)
+	require.False(t, quota.Ready)
+	require.Equal(t, futureReset.Unix(), quota.NextResetAt.Unix())
+	require.Equal(t, "exhausted", quota.Limits[1].Status)
+	require.InDelta(t, 1, quota.Limits[1].UsageRatio, 1e-9)
+}
+
+func TestCodexQuotaChecker_InvalidWindowsAreOmitted(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": -1,
+				"limit_window_seconds": 0
+			},
+			"secondary_window": {
+				"used_percent": 10,
+				"limit_window_seconds": -1
+			}
+		}
+	}`)
+
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.Empty(t, quota.Limits)
+	require.Equal(t, "available", quota.Status)
+	require.Nil(t, quota.NextResetAt)
+}
+
+func TestCodexQuotaChecker_ResetAfterSecondsSuppliesResetWhenResetAtInvalid(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {
+				"used_percent": 10,
+				"reset_at": -1,
+				"reset_after_seconds": 3600,
+				"limit_window_seconds": 18000
+			}
+		}
+	}`)
+
+	startedAt := time.Now()
+	checker := &CodexQuotaChecker{}
+
+	quota, err := checker.parseResponse(body)
+	require.NoError(t, err)
+	require.NotNil(t, quota.NextResetAt)
+	require.WithinDuration(t, startedAt.Add(time.Hour), *quota.NextResetAt, 2*time.Second)
 }
 
 func TestCodexQuotaChecker_NoPeriodWithoutWindowLength(t *testing.T) {
@@ -139,11 +321,11 @@ func TestClineLimitStatuses_CarryWindowPeriods(t *testing.T) {
 func TestOpenCodeGoQuotaChecker_AllWindowsCarryTheirPeriod(t *testing.T) {
 	t.Parallel()
 
-	rollingReset := time.Date(2026, 8, 14, 15, 0, 0, 0, time.UTC)
-	weeklyReset := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	rollingReset := time.Date(2099, 8, 14, 15, 0, 0, 0, time.UTC)
+	weeklyReset := time.Date(2099, 8, 18, 0, 0, 0, 0, time.UTC)
 	// A monthly cycle resetting on the 1st: the period started a calendar month
 	// earlier, not 30 days earlier.
-	monthlyReset := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	monthlyReset := time.Date(2099, 9, 1, 0, 0, 0, 0, time.UTC)
 
 	body := []byte(`{"usage":{
 		"rolling":{"percent":12,"resetsAt":"` + rollingReset.Format(time.RFC3339) + `"},
@@ -167,7 +349,7 @@ func TestOpenCodeGoQuotaChecker_AllWindowsCarryTheirPeriod(t *testing.T) {
 
 	require.Equal(t, QuotaWindowMonthly, quota.Limits[2].Window)
 	require.NotNil(t, quota.Limits[2].PeriodStart)
-	require.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), quota.Limits[2].PeriodStart.UTC())
+	require.Equal(t, time.Date(2099, 8, 1, 0, 0, 0, 0, time.UTC), quota.Limits[2].PeriodStart.UTC())
 }
 
 func TestApertisQuotaChecker_SubscriptionCycleCarriesReportedStart(t *testing.T) {
@@ -182,8 +364,8 @@ func TestApertisQuotaChecker_SubscriptionCycleCarriesReportedStart(t *testing.T)
 			"cycle_quota_limit": 600,
 			"cycle_quota_used": 300,
 			"cycle_quota_remaining": 300,
-			"cycle_start": "2026-03-16T10:02:35Z",
-			"cycle_end": "2026-04-16T10:02:35Z",
+			"cycle_start": "2099-03-16T10:02:35Z",
+			"cycle_end": "2099-04-16T10:02:35Z",
 			"payg_fallback_enabled": false
 		}
 	}`)
@@ -204,7 +386,7 @@ func TestApertisQuotaChecker_SubscriptionCycleCarriesReportedStart(t *testing.T)
 	require.NotNil(t, cycle)
 	require.Equal(t, QuotaWindowCycle, cycle.Window)
 	require.NotNil(t, cycle.PeriodStart)
-	require.Equal(t, time.Date(2026, 3, 16, 10, 2, 35, 0, time.UTC), cycle.PeriodStart.UTC())
+	require.Equal(t, time.Date(2099, 3, 16, 10, 2, 35, 0, time.UTC), cycle.PeriodStart.UTC())
 }
 
 func TestGithubCopilotQuotaChecker_MonthlyPeriodStepsBackACalendarMonth(t *testing.T) {
@@ -216,7 +398,7 @@ func TestGithubCopilotQuotaChecker_MonthlyPeriodStepsBackACalendarMonth(t *testi
 			// fixed 30 day window would miss.
 			body := `{
 				"copilot_plan": "individual",
-				"quota_reset_date_utc": "2026-03-01T00:00:00Z",
+				"quota_reset_date_utc": "2099-03-01T00:00:00Z",
 				"quota_snapshots": {"premium_interactions": {"percent_remaining": 40, "entitlement": 300, "remaining": 120}}
 			}`
 
@@ -231,9 +413,9 @@ func TestGithubCopilotQuotaChecker_MonthlyPeriodStepsBackACalendarMonth(t *testi
 	})
 	require.NoError(t, err)
 	require.Len(t, quota.Limits, 1)
-	require.Equal(t, QuotaWindowMonthly, quota.Limits[0].Window)
-	require.NotNil(t, quota.Limits[0].PeriodStart)
-	require.Equal(t, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), quota.Limits[0].PeriodStart.UTC())
+	require.Equal(t, "premium_interactions", quota.Limits[0].Window)
+	require.Nil(t, quota.Limits[0].PeriodStart)
+	require.Equal(t, time.Date(2099, 3, 1, 0, 0, 0, 0, time.UTC), quota.Limits[0].NextResetAt.UTC())
 }
 
 func TestWaferQuotaChecker_UsesReportedBillingWindow(t *testing.T) {
@@ -241,8 +423,8 @@ func TestWaferQuotaChecker_UsesReportedBillingWindow(t *testing.T) {
 
 	body := []byte(`{
 		"plan_tier": "pro",
-		"window_start": "2026-08-01T00:00:00Z",
-		"window_end": "2026-09-01T00:00:00Z",
+		"window_start": "2099-08-01T00:00:00Z",
+		"window_end": "2099-09-01T00:00:00Z",
 		"included_request_limit": 1000,
 		"remaining_included_requests": 400,
 		"current_period_used_percent": 60
@@ -255,6 +437,6 @@ func TestWaferQuotaChecker_UsesReportedBillingWindow(t *testing.T) {
 	require.Len(t, quota.Limits, 1)
 	require.Equal(t, QuotaWindowCycle, quota.Limits[0].Window)
 	require.NotNil(t, quota.Limits[0].PeriodStart)
-	require.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), quota.Limits[0].PeriodStart.UTC())
+	require.Equal(t, time.Date(2099, 8, 1, 0, 0, 0, 0, time.UTC), quota.Limits[0].PeriodStart.UTC())
 	require.InDelta(t, 0.6, quota.Limits[0].UsageRatio, 1e-9)
 }

--- a/internal/server/biz/provider_quota/period_window_test.go
+++ b/internal/server/biz/provider_quota/period_window_test.go
@@ -180,7 +180,7 @@ func TestCodexQuotaChecker_UnknownWindowDurationKeepsNeutralLabel(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, quota.Limits, 2)
 	require.Equal(t, QuotaWindowPrimary, quota.Limits[0].Window)
-	require.Equal(t, "secondary", quota.Limits[1].Window)
+	require.Equal(t, QuotaWindowSecondary, quota.Limits[1].Window)
 	require.NotContains(t, []string{quota.Limits[0].Window, quota.Limits[1].Window}, QuotaWindow5h)
 	require.NotContains(t, []string{quota.Limits[0].Window, quota.Limits[1].Window}, QuotaWindow7d)
 	require.NotNil(t, quota.Limits[0].PeriodStart)
@@ -389,13 +389,11 @@ func TestApertisQuotaChecker_SubscriptionCycleCarriesReportedStart(t *testing.T)
 	require.Equal(t, time.Date(2099, 3, 16, 10, 2, 35, 0, time.UTC), cycle.PeriodStart.UTC())
 }
 
-func TestGithubCopilotQuotaChecker_MonthlyPeriodStepsBackACalendarMonth(t *testing.T) {
+func TestGithubCopilotQuotaChecker_PreservesMonthlyResetWithoutPeriod(t *testing.T) {
 	t.Parallel()
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-			// A reset on March 1 means the period opened on February 1, which a
-			// fixed 30 day window would miss.
 			body := `{
 				"copilot_plan": "individual",
 				"quota_reset_date_utc": "2099-03-01T00:00:00Z",

--- a/internal/server/biz/provider_quota/provider_contract_fixtures_test.go
+++ b/internal/server/biz/provider_quota/provider_contract_fixtures_test.go
@@ -1,0 +1,139 @@
+package provider_quota
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/xai/subscription"
+)
+
+func quotaCheckerFixture(checker string) (QuotaData, error) {
+	switch checker {
+	case "claudecode":
+		return NewClaudeCodeQuotaChecker(nil).parseResponse(http.Header{
+			"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+			"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+			"Anthropic-Ratelimit-Unified-5h-Utilization":       {"0.25"},
+			"Anthropic-Ratelimit-Unified-5h-Reset":             {"4102444800"},
+			"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+			"Anthropic-Ratelimit-Unified-7d-Utilization":       {"0.50"},
+			"Anthropic-Ratelimit-Unified-7d-Reset":             {"4103049600"},
+			"Anthropic-Ratelimit-Unified-7d-Status":            {"allowed"},
+		})
+	case "codex":
+		return NewCodexQuotaChecker(nil).parseResponse([]byte(`{
+			"rate_limit":{"primary_window":{"used_percent":25,"limit_window_seconds":18000,"reset_at":4102444800},"secondary_window":{"used_percent":50,"limit_window_seconds":604800,"reset_at":4103049600}}
+		}`))
+	case "antigravity":
+		return parseAntigravityQuota([]byte(`{"models":{"gemini":{"quotaInfo":{"remainingFraction":0.75,"resetTime":"2099-01-01T00:00:00Z"}},"claude":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2099-01-02T00:00:00Z"}}}}`))
+	case "xai_subscription":
+		summary, err := subscription.ParseBillingResponses(
+			[]byte(`{"config":{"currentPeriod":{"end":"2099-01-01T00:00:00Z"},"creditUsagePercent":25}}`),
+			[]byte(`{"config":{"monthlyLimit":{"val":10000},"used":{"val":2500},"billingPeriodEnd":"2099-02-01T00:00:00Z"}}`),
+		)
+		if err != nil {
+			return QuotaData{}, err
+		}
+		return xaiBillingQuotaData(summary), nil
+	case "github_copilot":
+		client := httpclient.NewHttpClientWithClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://api.github.com/copilot_internal/user" {
+				return nil, fmt.Errorf("unexpected Copilot fixture URL %q", req.URL.String())
+			}
+			body := `{"copilot_plan":"individual","quota_reset_date_utc":"2099-02-01T00:00:00Z","limited_user_quotas":{"premium_interactions":8},"monthly_quotas":{"premium_interactions":10},"quota_snapshots":{"chat":{"percent_remaining":75}}}`
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+		})})
+		return NewGithubCopilotQuotaChecker(client).CheckQuota(context.Background(), &ent.Channel{Credentials: objects.ChannelCredentials{APIKey: "fixture-token"}})
+	case "nanogpt":
+		return NewNanoGPTQuotaChecker(nil).parseResponse([]byte(`{"dailyImages":{"used":1,"remaining":9,"percentUsed":0.1,"resetAt":4102444800000},"dailyInputTokens":{"used":10,"remaining":90,"percentUsed":0.1,"resetAt":4102444800000},"weeklyInputTokens":{"used":20,"remaining":80,"percentUsed":0.2,"resetAt":4103049600000}}`))
+	case "zenmux":
+		return parseZenmuxQuotaResponse([]byte(`{"success":true,"data":{"account_status":"healthy","quota_5_hour":{"usage_percentage":0.25,"resets_at":"2099-01-01T00:00:00Z"},"quota_7_day":{"usage_percentage":0.5,"resets_at":"2099-01-08T00:00:00Z"},"quota_monthly":{"max_flows":1000,"max_value_usd":50}}}`))
+	case "cline":
+		client := httpclient.NewHttpClientWithClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			var body string
+			switch req.URL.Path {
+			case "/api/v1/users/me":
+				body = `{"data":{"id":"fixture-user"}}`
+			case "/api/v1/plans":
+				body = `{"data":[{"type":"pro","interval":"month","isActive":true,"entitlements":{"cline_pass":{"enabled":true,"inferenceCapThreshold":{"last5HoursUsageCostUSDPerUser":100,"last7daysUsageCostUSDPerUser":100,"last30daysUsageCostUSDPerUser":100}}}}]}`
+			case "/api/v1/users/fixture-user/balance":
+				body = `{"data":{"balance":0}}`
+			case "/api/v1/users/me/plan/usage-limits":
+				body = `{"data":{"limits":[{"type":"five_hour","percentUsed":25,"resetsAt":"2099-01-01T05:00:00Z"},{"type":"weekly","percentUsed":25,"resetsAt":"2099-01-08T00:00:00Z"},{"type":"monthly","percentUsed":25,"resetsAt":"2099-02-01T00:00:00Z"}]}}`
+			case "/api/v1/users/fixture-user/usages":
+				body = `{"data":{"items":[]}}`
+			default:
+				return nil, fmt.Errorf("unexpected Cline fixture URL %q", req.URL.String())
+			}
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+		})})
+		checker := NewClineQuotaChecker(client)
+		checker.now = func() time.Time { return time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC) }
+		return checker.CheckQuota(context.Background(), &ent.Channel{Type: channel.TypeCline, BaseURL: "https://api.cline.bot", Credentials: objects.ChannelCredentials{APIKey: "fixture-token"}})
+	case "wafer":
+		return NewWaferQuotaChecker(nil).parseResponse([]byte(`{"current_period_used_percent":25,"window_start":"2099-01-01T00:00:00Z","window_end":"2099-02-01T00:00:00Z","remaining_included_requests":75}`))
+	case "synthetic":
+		return NewSyntheticQuotaChecker(nil).parseResponse([]byte(`{"weeklyTokenLimit":{"percentRemaining":75,"nextRegenAt":"2099-01-08T00:00:00Z"},"rollingFiveHourLimit":{"tickPercent":25,"nextTickAt":"2099-01-01T05:00:00Z"}}`))
+	case "neuralwatt":
+		return NewNeuralWattQuotaChecker(nil).parseResponse([]byte(`{"subscription":{"kwh_included":100,"kwh_used":25,"kwh_remaining":75,"kwh_reset_date":"2099-02-01T00:00:00Z"}}`))
+	case "apertis":
+		return NewApertisQuotaChecker(nil).parseResponse([]byte(`{"is_subscriber":true,"subscription":{"status":"active","cycle_quota_limit":1000,"cycle_quota_used":250,"cycle_quota_remaining":750,"cycle_start":"2099-01-01T00:00:00Z","cycle_end":"2099-02-01T00:00:00Z"}}`))
+	case "opencode_go":
+		return (&OpenCodeGoQuotaChecker{now: func() time.Time { return time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC) }}).parseResponse([]byte(`{"usage":{"rolling":{"percent":25,"resetsAt":"2099-01-01T05:00:00Z"},"weekly":{"percent":50,"resetsAt":"2099-01-08T00:00:00Z"},"monthly":{"percent":10,"resetsAt":"2099-02-01T00:00:00Z"}}}`))
+	case "kimi_code":
+		return parseKimiCodeUsageResponse([]byte(`{"usage":{"used":25,"limit":100,"resetAt":"2099-01-08T00:00:00Z"},"limits":[{"window":"5h","used":10,"limit":100,"resetAt":"2099-01-01T05:00:00Z"}]}`))
+	case "minimax":
+		return parseMinimaxResponse([]byte(`{"base_resp":{"status_code":0},"model_remains":[{"model_name":"general","start_time":4070908800000,"end_time":4070926800000,"current_interval_status":1,"current_interval_remaining_percent":75,"current_interval_boost_permille":1000,"weekly_start_time":4070908800000,"weekly_end_time":4071513600000,"current_weekly_status":1,"current_weekly_remaining_percent":50,"weekly_boost_permille":1000}]}`))
+	case "zhipu":
+		return parseZhipuQuotaResponse([]byte(`{"success":true,"data":{"limits":[{"type":"TOKENS_LIMIT","percentage":25,"nextResetTime":4102444800000},{"type":"TOKENS_LIMIT","percentage":50,"nextResetTime":4103049600000}]}}`))
+	case "charm_hyper":
+		return NewCharmHyperQuotaChecker(nil).parseResponse([]byte(`{"balance":75}`))
+	case "commandcode":
+		return parseCommandCodeCredits([]byte(`{"windowLimits":{"five_hour":{"usage_percent":25,"cap_usd":10,"resetAt":"2099-01-01T05:00:00Z"},"weekly":{"usage_percent":50,"cap_usd":20,"resetAt":"2099-01-08T00:00:00Z"}}}`), nil)
+	default:
+		return QuotaData{}, fmt.Errorf("unknown quota checker fixture %q", checker)
+	}
+}
+
+func assertNormalizedLimitContract(t *testing.T, quota QuotaData) {
+	t.Helper()
+	identities := make(map[string]struct{}, len(quota.Limits))
+	for _, limit := range quota.Limits {
+		require.NotEmpty(t, limit.Type)
+		require.NotEmpty(t, limit.Window)
+		require.False(t, math.IsNaN(limit.UsageRatio))
+		require.False(t, math.IsInf(limit.UsageRatio, 0))
+		require.GreaterOrEqual(t, limit.UsageRatio, 0.0)
+		require.LessOrEqual(t, limit.UsageRatio, 1.0)
+		require.Contains(t, []string{"available", "warning", "exhausted", "unknown"}, limit.Status)
+		require.Equal(t, IsReadyStatus(limit.Status), limit.Ready)
+		identity := string(limit.Type) + "\x00" + limit.Window
+		require.NotContains(t, identities, identity)
+		identities[identity] = struct{}{}
+		if limit.PeriodStart != nil {
+			require.NotNil(t, limit.NextResetAt)
+			require.True(t, limit.PeriodStart.Before(*limit.NextResetAt))
+		}
+	}
+	require.Equal(t, IsReadyStatus(quota.Status), quota.Ready)
+}
+
+func normalizedLimitIdentities(quota QuotaData) []string {
+	identities := make([]string, 0, len(quota.Limits))
+	for _, limit := range quota.Limits {
+		identities = append(identities, string(limit.Type)+"/"+limit.Window)
+	}
+	return identities
+}

--- a/internal/server/biz/provider_quota/provider_contract_test.go
+++ b/internal/server/biz/provider_quota/provider_contract_test.go
@@ -79,7 +79,6 @@ func TestQuotaCheckers_MalformedWindows(t *testing.T) {
 	require.Len(t, quota.Limits, 1)
 	require.Equal(t, QuotaWindowWeekly, quota.Limits[0].Window)
 	require.InDelta(t, 0.25, quota.Limits[0].UsageRatio, 1e-9)
-
 }
 
 func TestQuotaCheckers_NormalizeDuplicateLimits(t *testing.T) {

--- a/internal/server/biz/provider_quota/provider_contract_test.go
+++ b/internal/server/biz/provider_quota/provider_contract_test.go
@@ -1,0 +1,222 @@
+package provider_quota
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestQuotaCheckers_NormalizeReportedLimits(t *testing.T) {
+	// Given a successful Antigravity response with two model quota limits.
+	body := []byte(`{
+		"models": {
+			"gemini-3-pro": {"displayName":"Gemini 3 Pro","quotaInfo":{"remainingFraction":0.75,"resetTime":"2099-09-04T08:00:00Z"}},
+			"claude-sonnet": {"displayName":"Claude Sonnet","quotaInfo":{"remainingFraction":0.1,"resetTime":"2099-09-04T08:00:00Z"}}
+		}
+	}`)
+
+	// When the checker parses the provider response.
+	quota, err := parseAntigravityQuota(body)
+
+	// Then every provider-reported model limit is available in normalized data.
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 2)
+	require.Equal(t, "claude-sonnet", quota.Limits[0].Window)
+	require.Equal(t, "gemini-3-pro", quota.Limits[1].Window)
+	require.InDelta(t, 0.9, quota.Limits[0].UsageRatio, 1e-9)
+	require.InDelta(t, 0.25, quota.Limits[1].UsageRatio, 1e-9)
+	assertNormalizedLimitContract(t, quota)
+}
+
+func TestQuotaCheckers_KeepZenmuxMonthlyQuotaInRawData(t *testing.T) {
+	// Given a successful ZenMux response with 5-hour, 7-day, and monthly metadata.
+	body := []byte(`{
+		"success": true,
+		"data": {
+			"account_status": "healthy",
+			"quota_5_hour": {"usage_percentage": 0.25, "resets_at": "2099-09-04T15:00:00Z"},
+			"quota_7_day": {"usage_percentage": 0.5, "resets_at": "2099-09-11T10:00:00Z"},
+			"quota_monthly": {"max_flows": 1000, "max_value_usd": 50}
+		}
+	}`)
+
+	// When the checker parses the provider response.
+	quota, err := parseZenmuxQuotaResponse(body)
+
+	// Then only the actual 5-hour and 7-day windows are available in normalized data.
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 2)
+	require.Equal(t, QuotaWindow5h, quota.Limits[0].Window)
+	require.Equal(t, QuotaWindow7d, quota.Limits[1].Window)
+	require.Contains(t, quota.RawData, "quota_monthly")
+	assertNormalizedLimitContract(t, quota)
+}
+
+func TestQuotaCheckers_MalformedWindows(t *testing.T) {
+	// Given one malformed usage ratio and one valid provider window.
+	checker := &OpenCodeGoQuotaChecker{now: func() time.Time {
+		return time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	}}
+	body := []byte(`{"usage":{
+		"rolling":{"percent":-5,"resetsAt":"2026-09-04T15:00:00Z"},
+		"weekly":{"percent":25,"resetsAt":"2026-09-11T10:00:00Z"}
+	}}`)
+
+	// When the checker parses the response.
+	quota, err := checker.parseResponse(body)
+
+	// Then the malformed window is omitted without affecting the valid window.
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 1)
+	require.Equal(t, QuotaWindowWeekly, quota.Limits[0].Window)
+	require.InDelta(t, 0.25, quota.Limits[0].UsageRatio, 1e-9)
+
+}
+
+func TestQuotaCheckers_NormalizeDuplicateLimits(t *testing.T) {
+	// Given duplicate limits with the same type/window and different valid resets.
+	earliestReset := time.Date(2099, 9, 4, 12, 0, 0, 0, time.UTC)
+	laterReset := earliestReset.Add(time.Hour)
+	periodStart := earliestReset.Add(-5 * time.Hour)
+
+	// When the common contract normalizes them.
+	quota := NormalizeQuotaData(QuotaData{
+		Status: "unknown",
+		Limits: []QuotaLimitStatus{
+			{
+				Type:        QuotaLimitTypeToken,
+				Window:      QuotaWindow5h,
+				UsageRatio:  0.25,
+				Status:      "available",
+				NextResetAt: &laterReset,
+				PeriodStart: &periodStart,
+			},
+			{
+				Type:        QuotaLimitTypeToken,
+				Window:      QuotaWindow5h,
+				UsageRatio:  0.9,
+				Status:      "warning",
+				NextResetAt: &earliestReset,
+			},
+		},
+	})
+
+	// Then the duplicate identity is merged without losing the earliest reset.
+	require.Len(t, quota.Limits, 1)
+	require.InDelta(t, 0.9, quota.Limits[0].UsageRatio, 1e-9)
+	require.Equal(t, "warning", quota.Limits[0].Status)
+	require.Equal(t, earliestReset, *quota.Limits[0].NextResetAt)
+	require.Equal(t, periodStart, *quota.Limits[0].PeriodStart)
+}
+
+func TestQuotaCheckerCoverageMatrix(t *testing.T) {
+	client := httpclient.NewHttpClient()
+	checkers := map[string]QuotaChecker{
+		"claudecode":       NewClaudeCodeQuotaChecker(client),
+		"codex":            NewCodexQuotaChecker(client),
+		"antigravity":      NewAntigravityQuotaChecker(client),
+		"xai_subscription": NewXAISubscriptionQuotaChecker(client),
+		"github_copilot":   NewGithubCopilotQuotaChecker(client),
+		"nanogpt":          NewNanoGPTQuotaChecker(client),
+		"zenmux":           NewZenmuxQuotaChecker(client),
+		"cline":            NewClineQuotaChecker(client),
+		"wafer":            NewWaferQuotaChecker(client),
+		"synthetic":        NewSyntheticQuotaChecker(client),
+		"neuralwatt":       NewNeuralWattQuotaChecker(client),
+		"apertis":          NewApertisQuotaChecker(client),
+		"opencode_go":      NewOpenCodeGoQuotaChecker(client),
+		"kimi_code":        NewKimiCodeQuotaChecker(client),
+		"minimax":          NewMinimaxQuotaChecker(client),
+		"zhipu":            NewZhipuQuotaChecker(client),
+		"charm_hyper":      NewCharmHyperQuotaChecker(client),
+		"commandcode":      NewCommandCodeQuotaChecker(client),
+	}
+
+	relations := []struct {
+		checker     string
+		channelType channel.Type
+		baseURL     string
+		fixture     string
+		limitCount  int
+	}{
+		{"claudecode", channel.TypeClaudecode, "", "claudecode_headers", 2},
+		{"codex", channel.TypeCodex, "", "codex_windows", 2},
+		{"antigravity", channel.TypeAntigravity, "", "antigravity_models", 2},
+		{"xai_subscription", channel.TypeXaiSubscription, "", "xai_weekly_monthly", 2},
+		{"github_copilot", channel.TypeGithubCopilot, "", "copilot_snapshots", 2},
+		{"nanogpt", channel.TypeNanogpt, "", "nanogpt_windows", 3},
+		{"nanogpt", channel.TypeNanogptResponses, "", "nanogpt_windows", 3},
+		{"zenmux", channel.TypeZenmux, "", "zenmux_windows", 2},
+		{"zenmux", channel.TypeZenmuxResponses, "", "zenmux_windows", 2},
+		{"zenmux", channel.TypeZenmuxAnthropic, "", "zenmux_windows", 2},
+		{"zenmux", channel.TypeZenmuxGemini, "", "zenmux_windows", 2},
+		{"cline", channel.TypeCline, "", "cline_windows", 3},
+		{"wafer", channel.TypeOpenai, "https://pass.wafer.ai", "wafer_cycle", 1},
+		{"wafer", channel.TypeOpenaiResponses, "https://pass.wafer.ai", "wafer_cycle", 1},
+		{"synthetic", channel.TypeOpenai, "https://api.synthetic.new", "synthetic_windows", 2},
+		{"synthetic", channel.TypeOpenaiResponses, "https://api.synthetic.new", "synthetic_windows", 2},
+		{"neuralwatt", channel.TypeOpenai, "https://api.neuralwatt.com", "neuralwatt_kwh", 1},
+		{"neuralwatt", channel.TypeOpenaiResponses, "https://api.neuralwatt.com", "neuralwatt_kwh", 1},
+		{"apertis", channel.TypeOpenai, "https://api.apertis.ai", "apertis_limits", 1},
+		{"apertis", channel.TypeOpenaiResponses, "https://api.apertis.ai", "apertis_limits", 1},
+		{"opencode_go", channel.TypeOpencodeGo, "", "opencode_go_windows", 3},
+		{"opencode_go", channel.TypeOpencodeGoAnthropic, "", "opencode_go_windows", 3},
+		{"kimi_code", channel.TypeMoonshotCoding, "", "kimi_windows", 2},
+		{"minimax", channel.TypeMinimax, "", "minimax_windows", 2},
+		{"minimax", channel.TypeMinimaxAnthropic, "", "minimax_windows", 2},
+		{"zhipu", channel.TypeZhipu, "", "zhipu_windows", 2},
+		{"zhipu", channel.TypeZhipuAnthropic, "", "zhipu_windows", 2},
+		{"charm_hyper", channel.TypeOpenai, "https://hyper.charm.land", "charm_credits", 1},
+		{"charm_hyper", channel.TypeOpenaiResponses, "https://hyper.charm.land", "charm_credits", 1},
+		{"commandcode", channel.TypeCommandcode, "", "commandcode_windows", 2},
+		{"commandcode", channel.TypeCommandcodeAnthropic, "", "commandcode_windows", 2},
+	}
+
+	entries := make([]map[string]any, 0, len(relations))
+	for _, relation := range relations {
+		checker, ok := checkers[relation.checker]
+		require.True(t, ok, relation.checker)
+		quotaChannel := &ent.Channel{Type: relation.channelType, BaseURL: relation.baseURL}
+		if relation.checker == "commandcode" {
+			quotaChannel.Settings = &objects.ChannelSettings{
+				ProviderQuota: &objects.ChannelProviderQuotaSettings{
+					CommandCode: &objects.CommandCodeQuotaSettings{AuthCookie: "fixture-cookie"},
+				},
+			}
+		}
+		require.True(t, checker.SupportsChannel(quotaChannel), relation.checker+"/"+string(relation.channelType))
+		require.NotEmpty(t, relation.fixture)
+		require.Positive(t, relation.limitCount)
+		fixtureQuota, err := quotaCheckerFixture(relation.checker)
+		require.NoError(t, err, relation.fixture)
+		require.Len(t, fixtureQuota.Limits, relation.limitCount, relation.fixture)
+		assertNormalizedLimitContract(t, fixtureQuota)
+		identities := normalizedLimitIdentities(fixtureQuota)
+		entries = append(entries, map[string]any{
+			"checker":          relation.checker,
+			"channel_types":    []string{string(relation.channelType)},
+			"fixture":          relation.fixture,
+			"limit_count":      relation.limitCount,
+			"limit_identities": identities,
+			"contract_passed":  true,
+		})
+	}
+
+	if os.Getenv("AXONHUB_WRITE_QUOTA_EVIDENCE") != "1" {
+		return
+	}
+	evidenceDir := filepath.Join("..", "..", "..", "..", ".omo", "evidence", "quota-display-protocols")
+	require.NoError(t, os.MkdirAll(evidenceDir, 0o755))
+	evidence, err := json.MarshalIndent(entries, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(evidenceDir, "task-2-provider-coverage.json"), evidence, 0o644))
+}

--- a/internal/server/biz/provider_quota/synthetic_checker.go
+++ b/internal/server/biz/provider_quota/synthetic_checker.go
@@ -144,14 +144,14 @@ func (c *SyntheticQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		rawData["rollingFiveHourLimit"] = convertSyntheticRollingFiveHourLimitToMap(response.RollingFiveHourLimit)
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "synthetic",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func (c *SyntheticQuotaChecker) SupportsChannel(ch *ent.Channel) bool {

--- a/internal/server/biz/provider_quota/synthetic_checker.go
+++ b/internal/server/biz/provider_quota/synthetic_checker.go
@@ -193,7 +193,7 @@ func buildSyntheticLimitStatuses(weekly *SyntheticWeeklyTokenLimit, fiveHour *Sy
 			usageRatio = 1.0
 		} else if fiveHour.TickPercent != nil {
 			usageRatio = *fiveHour.TickPercent
-			if usageRatio > WarningThresholdRatio {
+			if usageRatio >= WarningThresholdRatio {
 				status = "warning"
 			}
 		}
@@ -233,7 +233,7 @@ func weeklyTokenLimitStatus(weekly *SyntheticWeeklyTokenLimit) QuotaLimitStatus 
 
 		if usageRatio >= 1.0 {
 			status = "exhausted"
-		} else if usageRatio > WarningThresholdRatio {
+		} else if usageRatio >= WarningThresholdRatio {
 			status = "warning"
 		}
 	}

--- a/internal/server/biz/provider_quota/synthetic_checker_test.go
+++ b/internal/server/biz/provider_quota/synthetic_checker_test.go
@@ -23,16 +23,16 @@ func TestSynthetic_CheckQuota_HappyPath(t *testing.T) {
 			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
 
 			body := `{
-				"subscription": {"limit": 750, "requests": 0, "renewsAt": "2026-04-25T08:47:39.947Z"},
+				"subscription": {"limit": 750, "requests": 0, "renewsAt": "2099-04-25T08:47:39.947Z"},
 				"search": {"hourly": {"limit": 250, "requests": 0}},
 				"weeklyTokenLimit": {
-					"nextRegenAt": "2026-04-25T04:48:26.000Z",
+					"nextRegenAt": "2099-04-25T04:48:26.000Z",
 					"percentRemaining": 38.6,
 					"maxCredits": "$36.00",
 					"remainingCredits": "$13.90"
 				},
 				"rollingFiveHourLimit": {
-					"nextTickAt": "2026-04-25T04:00:01.000Z",
+					"nextTickAt": "2099-04-25T04:00:01.000Z",
 					"tickPercent": 0.05,
 					"remaining": 750,
 					"max": 750,
@@ -315,21 +315,21 @@ func TestSynthetic_SupportsChannel(t *testing.T) {
 }
 
 func TestSynthetic_CheckQuota_NextResetAt(t *testing.T) {
-	expectedTime, _ := time.Parse(time.RFC3339, "2026-04-25T04:00:01.000Z")
+	expectedTime, _ := time.Parse(time.RFC3339, "2099-04-25T04:00:01.000Z")
 
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			// rollingFiveHourLimit.nextTickAt is earliest
 			body := `{
-				"subscription": {"limit": 750, "requests": 0, "renewsAt": "2026-04-25T08:47:39.947Z"},
+				"subscription": {"limit": 750, "requests": 0, "renewsAt": "2099-04-25T08:47:39.947Z"},
 				"weeklyTokenLimit": {
-					"nextRegenAt": "2026-04-25T04:48:26.000Z",
+					"nextRegenAt": "2099-04-25T04:48:26.000Z",
 					"percentRemaining": 38.6,
 					"maxCredits": "$36.00",
 					"remainingCredits": "$13.90"
 				},
 				"rollingFiveHourLimit": {
-					"nextTickAt": "2026-04-25T04:00:01.000Z",
+					"nextTickAt": "2099-04-25T04:00:01.000Z",
 					"tickPercent": 0.05,
 					"remaining": 750,
 					"max": 750,

--- a/internal/server/biz/provider_quota/synthetic_checker_test.go
+++ b/internal/server/biz/provider_quota/synthetic_checker_test.go
@@ -125,6 +125,20 @@ func TestSynthetic_CheckQuota_WarningState(t *testing.T) {
 	require.True(t, quota.Limits[1].Ready)
 }
 
+func TestSynthetic_WarningAtUsageThreshold(t *testing.T) {
+	tickPercent := 0.8
+	percentRemaining := 20.0
+
+	limits := buildSyntheticLimitStatuses(
+		&SyntheticWeeklyTokenLimit{PercentRemaining: &percentRemaining},
+		&SyntheticRollingFiveHourLimit{TickPercent: &tickPercent},
+	)
+
+	require.Len(t, limits, 2)
+	require.Equal(t, "warning", limits[0].Status)
+	require.Equal(t, "warning", limits[1].Status)
+}
+
 func TestSynthetic_CheckQuota_ExhaustedState(t *testing.T) {
 	httpClient := httpclient.NewHttpClientWithClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/server/biz/provider_quota/types.go
+++ b/internal/server/biz/provider_quota/types.go
@@ -107,14 +107,17 @@ const WarningThresholdRatio = 0.8
 // Well-known limit window identifiers. Providers name their windows
 // differently; these are the normalized labels the UI renders.
 const (
-	QuotaWindow5h      = "5h"
-	QuotaWindow7d      = "7d"
-	QuotaWindow30d     = "30d"
-	QuotaWindowDaily   = "daily"
-	QuotaWindowWeekly  = "weekly"
-	QuotaWindowMonthly = "monthly"
-	QuotaWindowPrimary = "primary"
-	QuotaWindowCycle   = "cycle"
+	QuotaWindow5h        = "5h"
+	QuotaWindow7d        = "7d"
+	QuotaWindow30d       = "30d"
+	QuotaWindowDaily     = "daily"
+	QuotaWindowWeekly    = "weekly"
+	QuotaWindowMonthly   = "monthly"
+	QuotaWindowPrimary   = "primary"
+	QuotaWindowSecondary = "secondary"
+	QuotaWindowPayg      = "payg"
+	QuotaWindowCredits   = "credits"
+	QuotaWindowCycle     = "cycle"
 )
 
 // EstimatePeriodQuota derives the total money quota of a limit period from the
@@ -122,11 +125,17 @@ const (
 // reports `usageRatio` of the quota consumed is worth periodCost/usageRatio in
 // total. It reports false when the inputs cannot support an estimate.
 func EstimatePeriodQuota(periodCost float64, usageRatio float64) (float64, bool) {
-	if periodCost <= 0 || usageRatio <= 0 || math.IsNaN(usageRatio) || math.IsInf(usageRatio, 0) {
+	if periodCost <= 0 || math.IsNaN(periodCost) || math.IsInf(periodCost, 0) ||
+		usageRatio <= 0 || math.IsNaN(usageRatio) || math.IsInf(usageRatio, 0) {
 		return 0, false
 	}
 
-	return periodCost / usageRatio, true
+	total := periodCost / usageRatio
+	if math.IsNaN(total) || math.IsInf(total, 0) {
+		return 0, false
+	}
+
+	return total, true
 }
 
 // FillPeriodQuota recomputes PeriodQuota from PeriodCost and UsageRatio,

--- a/internal/server/biz/provider_quota/types.go
+++ b/internal/server/biz/provider_quota/types.go
@@ -3,6 +3,7 @@ package provider_quota
 import (
 	"context"
 	"errors"
+	"math"
 	"time"
 
 	"github.com/looplj/axonhub/internal/ent"
@@ -116,18 +117,12 @@ const (
 	QuotaWindowCycle   = "cycle"
 )
 
-// MinPeriodQuotaUsageRatio is the smallest usage ratio that yields a period
-// quota estimate. Dividing the period cost by a tiny ratio amplifies both the
-// pricing error and any usage that did not go through AxonHub into an absurd
-// number, so below this threshold no estimate is reported at all.
-const MinPeriodQuotaUsageRatio = 0.05
-
 // EstimatePeriodQuota derives the total money quota of a limit period from the
 // cost already spent in it: a period that cost `periodCost` while the provider
 // reports `usageRatio` of the quota consumed is worth periodCost/usageRatio in
 // total. It reports false when the inputs cannot support an estimate.
 func EstimatePeriodQuota(periodCost float64, usageRatio float64) (float64, bool) {
-	if periodCost <= 0 || usageRatio < MinPeriodQuotaUsageRatio {
+	if periodCost <= 0 || usageRatio <= 0 || math.IsNaN(usageRatio) || math.IsInf(usageRatio, 0) {
 		return 0, false
 	}
 

--- a/internal/server/biz/provider_quota/types.go
+++ b/internal/server/biz/provider_quota/types.go
@@ -69,6 +69,10 @@ type QuotaLimitStatus struct {
 	Ready       bool           `json:"ready"`
 	NextResetAt *time.Time     `json:"next_reset_at"`
 
+	// AvailabilityGroup identifies alternative capacity sources that should be
+	// aggregated with OR semantics for routing decisions.
+	AvailabilityGroup string `json:"availability_group,omitempty"`
+
 	// Window identifies the limit window this status describes ("5h", "7d",
 	// "weekly", ...). Providers report several limits of the same
 	// QuotaLimitType, so this is what tells them apart in the UI.
@@ -107,17 +111,17 @@ const WarningThresholdRatio = 0.8
 // Well-known limit window identifiers. Providers name their windows
 // differently; these are the normalized labels the UI renders.
 const (
-	QuotaWindow5h        = "5h"
-	QuotaWindow7d        = "7d"
-	QuotaWindow30d       = "30d"
-	QuotaWindowDaily     = "daily"
-	QuotaWindowWeekly    = "weekly"
-	QuotaWindowMonthly   = "monthly"
-	QuotaWindowPrimary   = "primary"
-	QuotaWindowSecondary = "secondary"
-	QuotaWindowPayg      = "payg"
-	QuotaWindowCredits   = "credits"
-	QuotaWindowCycle     = "cycle"
+	QuotaWindow5h         = "5h"
+	QuotaWindow7d         = "7d"
+	QuotaWindow30d        = "30d"
+	QuotaWindowDaily      = "daily"
+	QuotaWindowWeekly     = "weekly"
+	QuotaWindowMonthly    = "monthly"
+	QuotaWindowPrimary    = "primary"
+	QuotaWindowSecondary  = "secondary"
+	QuotaWindowPayAsYouGo = "pay_as_you_go"
+	QuotaWindowCredits    = "credits"
+	QuotaWindowCycle      = "cycle"
 )
 
 // EstimatePeriodQuota derives the total money quota of a limit period from the

--- a/internal/server/biz/provider_quota/wafer_checker.go
+++ b/internal/server/biz/provider_quota/wafer_checker.go
@@ -17,20 +17,20 @@ import (
 const warningUsedPercent = 80
 
 type WaferUsageResponse struct {
-	Endpoint                   *string  `json:"endpoint,omitempty"`
-	BillingModel               *string  `json:"billing_model,omitempty"`
-	PlanTier                   *string  `json:"plan_tier,omitempty"`
-	WindowStart                *string  `json:"window_start,omitempty"`
-	WindowEnd                  *string  `json:"window_end,omitempty"`
-	RequestCount               *int64   `json:"request_count,omitempty"`
-	IncludedRequestLimit       *int64   `json:"included_request_limit,omitempty"`
-	IncludedRequestCount       *int64   `json:"included_request_count,omitempty"`
-	RemainingIncludedRequests  *int64   `json:"remaining_included_requests,omitempty"`
-	OverageRequestCount        *int64   `json:"overage_request_count,omitempty"`
-	CurrentPeriodUsedPercent   *float64 `json:"current_period_used_percent,omitempty"`
-	InputTokens                *int64   `json:"input_tokens,omitempty"`
-	OutputTokens               *int64   `json:"output_tokens,omitempty"`
-	TotalTokens                *int64   `json:"total_tokens,omitempty"`
+	Endpoint                  *string  `json:"endpoint,omitempty"`
+	BillingModel              *string  `json:"billing_model,omitempty"`
+	PlanTier                  *string  `json:"plan_tier,omitempty"`
+	WindowStart               *string  `json:"window_start,omitempty"`
+	WindowEnd                 *string  `json:"window_end,omitempty"`
+	RequestCount              *int64   `json:"request_count,omitempty"`
+	IncludedRequestLimit      *int64   `json:"included_request_limit,omitempty"`
+	IncludedRequestCount      *int64   `json:"included_request_count,omitempty"`
+	RemainingIncludedRequests *int64   `json:"remaining_included_requests,omitempty"`
+	OverageRequestCount       *int64   `json:"overage_request_count,omitempty"`
+	CurrentPeriodUsedPercent  *float64 `json:"current_period_used_percent,omitempty"`
+	InputTokens               *int64   `json:"input_tokens,omitempty"`
+	OutputTokens              *int64   `json:"output_tokens,omitempty"`
+	TotalTokens               *int64   `json:"total_tokens,omitempty"`
 }
 
 type WaferQuotaChecker struct {
@@ -182,14 +182,14 @@ func (c *WaferQuotaChecker) parseResponse(body []byte) (QuotaData, error) {
 		},
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       normalizedStatus,
 		ProviderType: "wafer",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(normalizedStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func (c *WaferQuotaChecker) SupportsChannel(ch *ent.Channel) bool {

--- a/internal/server/biz/provider_quota/xai_subscription_checker.go
+++ b/internal/server/biz/provider_quota/xai_subscription_checker.go
@@ -119,7 +119,7 @@ func xaiBillingQuotaData(summary subscription.BillingSummary) QuotaData {
 		rawBilling["monthly"] = summary.Monthly
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       status,
 		ProviderType: "xai_subscription",
 		RawData: map[string]any{
@@ -129,7 +129,7 @@ func xaiBillingQuotaData(summary subscription.BillingSummary) QuotaData {
 		NextResetAt: nextResetAt,
 		Ready:       IsReadyStatus(status),
 		Limits:      limits,
-	}
+	})
 }
 
 func xaiBillingWindowStatus(usagePercent float64) string {

--- a/internal/server/biz/provider_quota/xai_subscription_checker_test.go
+++ b/internal/server/biz/provider_quota/xai_subscription_checker_test.go
@@ -19,8 +19,8 @@ import (
 func TestXAISubscriptionQuotaChecker_CheckQuota_merges_billing_windows(t *testing.T) {
 	// Given
 	checker := NewXAISubscriptionQuotaChecker(newXAIBillingTestClient(t, "access-token",
-		`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-07-16T03:25:00Z"},"creditUsagePercent":82.5}}`,
-		`{"config":{"monthlyLimit":{"val":15000},"used":{"val":7500},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`,
+		`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2099-07-16T03:25:00Z"},"creditUsagePercent":82.5}}`,
+		`{"config":{"monthlyLimit":{"val":15000},"used":{"val":7500},"billingPeriodEnd":"2099-08-01T00:00:00Z"}}`,
 	))
 	ch := &ent.Channel{
 		Type:    channel.TypeXaiSubscription,
@@ -42,12 +42,12 @@ func TestXAISubscriptionQuotaChecker_CheckQuota_merges_billing_windows(t *testin
 	require.Equal(t, "warning", result.Limits[0].Status)
 	require.Equal(t, QuotaWindowWeekly, result.Limits[0].Window)
 	require.InDelta(t, 0.825, result.Limits[0].UsageRatio, 1e-9)
-	require.Equal(t, time.Date(2026, 7, 16, 3, 25, 0, 0, time.UTC), *result.Limits[0].NextResetAt)
+	require.Equal(t, time.Date(2099, 7, 16, 3, 25, 0, 0, time.UTC), *result.Limits[0].NextResetAt)
 	require.Equal(t, "available", result.Limits[1].Status)
 	require.Equal(t, QuotaWindowMonthly, result.Limits[1].Window)
 	require.InDelta(t, 0.5, result.Limits[1].UsageRatio, 1e-9)
-	require.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), *result.Limits[1].NextResetAt)
-	require.Equal(t, time.Date(2026, 7, 16, 3, 25, 0, 0, time.UTC), *result.NextResetAt)
+	require.Equal(t, time.Date(2099, 8, 1, 0, 0, 0, 0, time.UTC), *result.Limits[1].NextResetAt)
+	require.Equal(t, time.Date(2099, 7, 16, 3, 25, 0, 0, time.UTC), *result.NextResetAt)
 	require.Equal(t, "SuperGrok", result.RawData["plan_type"])
 	require.NotNil(t, result.RawData["billing"])
 }

--- a/internal/server/biz/provider_quota/zenmux_checker.go
+++ b/internal/server/biz/provider_quota/zenmux_checker.go
@@ -47,8 +47,8 @@ type zenmuxQuotaWindow struct {
 }
 
 type zenmuxMonthlyQuota struct {
-	MaxFlows    float64 `json:"max_flows"`
-	MaxValueUSD float64 `json:"max_value_usd"`
+	MaxFlows    *float64 `json:"max_flows"`
+	MaxValueUSD *float64 `json:"max_value_usd"`
 }
 
 type ZenmuxQuotaChecker struct {
@@ -137,7 +137,14 @@ func parseZenmuxQuotaResponse(body []byte) (QuotaData, error) {
 		nextResetAt = sevenDayReset
 	}
 
-	return QuotaData{
+	limits := []QuotaLimitStatus{
+		NewTokenLimitStatus(fiveHourStatus, response.Data.Quota5Hour.UsagePercentage, fiveHourReset).
+			WithWindow(QuotaWindow5h, 5*time.Hour),
+		NewTokenLimitStatus(sevenDayStatus, response.Data.Quota7Day.UsagePercentage, sevenDayReset).
+			WithWindow(QuotaWindow7d, 7*24*time.Hour),
+	}
+
+	return NormalizeQuotaData(QuotaData{
 		Status:       overallStatus,
 		ProviderType: "zenmux",
 		RawData: map[string]any{
@@ -147,13 +154,8 @@ func parseZenmuxQuotaResponse(body []byte) (QuotaData, error) {
 		},
 		NextResetAt: nextResetAt,
 		Ready:       IsReadyStatus(overallStatus),
-		Limits: []QuotaLimitStatus{
-			NewTokenLimitStatus(fiveHourStatus, response.Data.Quota5Hour.UsagePercentage, fiveHourReset).
-				WithWindow(QuotaWindow5h, 5*time.Hour),
-			NewTokenLimitStatus(sevenDayStatus, response.Data.Quota7Day.UsagePercentage, sevenDayReset).
-				WithWindow(QuotaWindow7d, 7*24*time.Hour),
-		},
-	}, nil
+		Limits:      limits,
+	}), nil
 }
 
 func parseZenmuxResetAt(value *string) (*time.Time, error) {

--- a/internal/server/biz/provider_quota/zenmux_checker_test.go
+++ b/internal/server/biz/provider_quota/zenmux_checker_test.go
@@ -32,7 +32,7 @@ func TestZenmuxQuotaChecker_CheckQuota(t *testing.T) {
 		{
 			name:               "healthy mid-usage",
 			statusCode:         http.StatusOK,
-			body:               zenmuxQuotaFixture("healthy", 0.4, `"2026-09-03T15:00:00Z"`),
+			body:               zenmuxQuotaFixture("healthy", 0.4, `"2099-09-03T15:00:00Z"`),
 			wantStatus:         "available",
 			wantReady:          true,
 			wantFiveHourStatus: "available",
@@ -42,7 +42,7 @@ func TestZenmuxQuotaChecker_CheckQuota(t *testing.T) {
 		{
 			name:               "five hour window exhausted",
 			statusCode:         http.StatusOK,
-			body:               zenmuxQuotaFixture("healthy", 1, `"2026-09-03T15:00:00Z"`),
+			body:               zenmuxQuotaFixture("healthy", 1, `"2099-09-03T15:00:00Z"`),
 			wantStatus:         "exhausted",
 			wantReady:          false,
 			wantFiveHourStatus: "exhausted",
@@ -62,7 +62,7 @@ func TestZenmuxQuotaChecker_CheckQuota(t *testing.T) {
 		{
 			name:               "suspended account",
 			statusCode:         http.StatusOK,
-			body:               zenmuxQuotaFixture("suspended", 0.2, `"2026-09-03T15:00:00Z"`),
+			body:               zenmuxQuotaFixture("suspended", 0.2, `"2099-09-03T15:00:00Z"`),
 			wantStatus:         "exhausted",
 			wantReady:          false,
 			wantFiveHourStatus: "available",
@@ -134,6 +134,23 @@ func TestZenmuxQuotaChecker_CheckQuota(t *testing.T) {
 	}
 }
 
+func TestZenmuxQuotaChecker_QuotaMonthlyStaysInRawDataOnly(t *testing.T) {
+	// Given a response containing the provider's monthly metadata.
+	body := []byte(zenmuxQuotaFixture("healthy", 0.4, `"2099-09-03T15:00:00Z"`))
+
+	// When the checker parses the response.
+	quota, err := parseZenmuxQuotaResponse(body)
+
+	// Then only the actual 5-hour and 7-day windows are normalized as limits.
+	require.NoError(t, err)
+	require.Len(t, quota.Limits, 2)
+	require.Equal(t, []string{QuotaWindow5h, QuotaWindow7d}, []string{
+		quota.Limits[0].Window,
+		quota.Limits[1].Window,
+	})
+	require.Contains(t, quota.RawData, "quota_monthly")
+}
+
 func TestZenmuxQuotaChecker_SupportsOnlyZenMuxChannelTypes(t *testing.T) {
 	checker := NewZenmuxQuotaChecker(httpclient.NewHttpClient())
 
@@ -160,7 +177,7 @@ func zenmuxQuotaFixture(accountStatus string, fiveHourUsage float64, fiveHourRes
 	return fmt.Sprintf(`{
 		"success": true,
 		"data": {
-			"plan": {"tier":"pro","amount_usd":200,"interval":"month","expires_at":"2026-10-01T00:00:00Z"},
+		"plan": {"tier":"pro","amount_usd":200,"interval":"month","expires_at":"2099-10-01T00:00:00Z"},
 			"account_status": %q,
 			"quota_5_hour": {
 				"usage_percentage": %v,
@@ -173,7 +190,7 @@ func zenmuxQuotaFixture(accountStatus string, fiveHourUsage float64, fiveHourRes
 			},
 			"quota_7_day": {
 				"usage_percentage": 0.6,
-				"resets_at": "2026-09-10T10:00:00Z",
+				"resets_at": "2099-09-10T10:00:00Z",
 				"max_flows": 10000,
 				"used_flows": 6000,
 				"remaining_flows": 4000,

--- a/internal/server/biz/provider_quota/zhipu_checker.go
+++ b/internal/server/biz/provider_quota/zhipu_checker.go
@@ -193,14 +193,14 @@ func parseZhipuQuotaResponse(body []byte) (QuotaData, error) {
 		"level": response.Data.Level,
 	}
 
-	return QuotaData{
+	return NormalizeQuotaData(QuotaData{
 		Status:       overallStatus,
 		ProviderType: "zhipu",
 		RawData:      rawData,
 		NextResetAt:  nextResetAt,
 		Ready:        IsReadyStatus(overallStatus),
 		Limits:       limits,
-	}, nil
+	}), nil
 }
 
 func zhipuStatusForRatio(ratio float64) string {

--- a/internal/server/biz/provider_quota/zhipu_checker_test.go
+++ b/internal/server/biz/provider_quota/zhipu_checker_test.go
@@ -447,8 +447,8 @@ func TestZhipu_CheckQuota_WithResetTime(t *testing.T) {
 				"data": {
 					"level": "standard",
 					"limits": [
-						{"type": "TOKENS_LIMIT", "percentage": 50.0, "nextResetTime": 1784322000000},
-						{"type": "TOKENS_LIMIT", "percentage": 30.0, "nextResetTime": 1784476800000}
+						{"type": "TOKENS_LIMIT", "percentage": 50.0, "nextResetTime": 4087947600000},
+						{"type": "TOKENS_LIMIT", "percentage": 30.0, "nextResetTime": 4088534400000}
 					]
 				}
 			}`
@@ -468,7 +468,7 @@ func TestZhipu_CheckQuota_WithResetTime(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, quota.NextResetAt)
 	// Earlier reset time
-	require.Equal(t, int64(1784322000), quota.NextResetAt.Unix())
+	require.Equal(t, int64(4087947600), quota.NextResetAt.Unix())
 }
 
 func TestZhipu_CheckQuota_OverallStatusWorst(t *testing.T) {

--- a/internal/server/biz/provider_quota_cost.go
+++ b/internal/server/biz/provider_quota_cost.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/looplj/axonhub/internal/authz"
@@ -43,7 +44,7 @@ func (svc *ProviderQuotaService) fillPeriodQuotas(
 		limit.PeriodCost = nil
 
 		start := limit.PeriodStart
-		if start == nil || !start.Before(now) {
+		if start == nil || !start.Before(now) || limit.UsageRatio <= 0 || math.IsNaN(limit.UsageRatio) || math.IsInf(limit.UsageRatio, 0) {
 			continue
 		}
 
@@ -61,6 +62,10 @@ func (svc *ProviderQuotaService) fillPeriodQuotas(
 
 			cost = aggregated
 			costs[*start] = cost
+		}
+
+		if cost <= 0 {
+			continue
 		}
 
 		limit.PeriodCost = &cost

--- a/internal/server/biz/provider_quota_cost_test.go
+++ b/internal/server/biz/provider_quota_cost_test.go
@@ -2,6 +2,7 @@ package biz
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -219,8 +220,58 @@ func TestProviderQuotaService_FillPeriodQuotas_NoEstimateWithoutCost(t *testing.
 
 	svc.fillPeriodQuotas(ctx, ch.ID, &quotaData, now)
 
+	require.Nil(t, quotaData.Limits[0].PeriodCost)
+	require.Nil(t, quotaData.Limits[0].PeriodQuota)
+}
+
+func TestProviderQuotaService_FillsCodexPeriodQuotaOnlyWithUsableCostAndRatio(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file=ent?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+	ch, err := client.Channel.Create().
+		SetName(fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())).
+		SetType(channel.TypeCodex).
+		SetStatus(channel.StatusEnabled).
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"test-model"}).
+		SetDefaultTestModel("test-model").
+		Save(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	start := now.Add(-time.Hour)
+	createPeriodQuotaUsageLog(t, ctx, client, ch.ID, now.Add(-time.Minute), lo.ToPtr(12.0))
+
+	svc := &ProviderQuotaService{AbstractService: &AbstractService{db: client}}
+	quotaData := provider_quota.QuotaData{
+		ProviderType: "codex",
+		Limits: []provider_quota.QuotaLimitStatus{{
+			Type:        provider_quota.QuotaLimitTypeToken,
+			Window:      provider_quota.QuotaWindow5h,
+			UsageRatio:  0.01,
+			PeriodStart: &start,
+		}},
+	}
+
+	svc.fillPeriodQuotas(ctx, ch.ID, &quotaData, now)
+
 	require.NotNil(t, quotaData.Limits[0].PeriodCost)
-	require.Zero(t, *quotaData.Limits[0].PeriodCost)
+	require.InDelta(t, 12.0, *quotaData.Limits[0].PeriodCost, 1e-9)
+	require.NotNil(t, quotaData.Limits[0].PeriodQuota)
+	require.InDelta(t, 1200.0, *quotaData.Limits[0].PeriodQuota, 1e-9)
+
+	noDataStart := now.Add(-30 * time.Second)
+	quotaData.Limits[0].PeriodStart = &noDataStart
+	quotaData.Limits[0].UsageRatio = 0.5
+	svc.fillPeriodQuotas(ctx, ch.ID, &quotaData, now)
+	require.Nil(t, quotaData.Limits[0].PeriodCost)
+	require.Nil(t, quotaData.Limits[0].PeriodQuota)
+
+	quotaData.Limits[0].PeriodStart = &start
+	quotaData.Limits[0].UsageRatio = 0
+	svc.fillPeriodQuotas(ctx, ch.ID, &quotaData, now)
+	require.Nil(t, quotaData.Limits[0].PeriodCost)
 	require.Nil(t, quotaData.Limits[0].PeriodQuota)
 }
 
@@ -252,8 +303,7 @@ func TestProviderQuotaService_FillPeriodQuotas_ClearsStaleEstimate(t *testing.T)
 
 	svc.fillPeriodQuotas(ctx, ch.ID, &quotaData, now)
 
-	require.NotNil(t, quotaData.Limits[0].PeriodCost)
-	require.InDelta(t, 10.0, *quotaData.Limits[0].PeriodCost, 1e-9)
+	require.Nil(t, quotaData.Limits[0].PeriodCost)
 	require.Nil(t, quotaData.Limits[0].PeriodQuota)
 }
 

--- a/internal/server/biz/provider_quota_registry_test.go
+++ b/internal/server/biz/provider_quota_registry_test.go
@@ -1,0 +1,112 @@
+package biz
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/server/biz/provider_quota"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestProviderQuotaService_RegistryCoverageMatrix(t *testing.T) {
+	svc := &ProviderQuotaService{
+		checkers:   make(map[string]provider_quota.QuotaChecker),
+		httpClient: httpclient.NewHttpClient(),
+	}
+	svc.registerProviderQuotaSupport()
+
+	expectedCheckers := []string{
+		"apertis", "antigravity", "charm_hyper", "claudecode", "cline", "codex",
+		"commandcode", "github_copilot", "kimi_code", "minimax", "nanogpt",
+		"neuralwatt", "opencode_go", "synthetic", "wafer", "xai_subscription",
+		"zenmux", "zhipu",
+	}
+	require.ElementsMatch(t, expectedCheckers, mapKeys(svc.checkers))
+
+	expectedRelations := []struct {
+		checker     string
+		channelType channel.Type
+		baseURL     string
+	}{
+		{"claudecode", channel.TypeClaudecode, ""},
+		{"codex", channel.TypeCodex, ""},
+		{"antigravity", channel.TypeAntigravity, ""},
+		{"xai_subscription", channel.TypeXaiSubscription, ""},
+		{"github_copilot", channel.TypeGithubCopilot, ""},
+		{"nanogpt", channel.TypeNanogpt, ""},
+		{"nanogpt", channel.TypeNanogptResponses, ""},
+		{"zenmux", channel.TypeZenmux, ""},
+		{"zenmux", channel.TypeZenmuxResponses, ""},
+		{"zenmux", channel.TypeZenmuxAnthropic, ""},
+		{"zenmux", channel.TypeZenmuxGemini, ""},
+		{"cline", channel.TypeCline, ""},
+		{"wafer", channel.TypeOpenai, "https://pass.wafer.ai"},
+		{"wafer", channel.TypeOpenaiResponses, "https://pass.wafer.ai"},
+		{"synthetic", channel.TypeOpenai, "https://api.synthetic.new"},
+		{"synthetic", channel.TypeOpenaiResponses, "https://api.synthetic.new"},
+		{"neuralwatt", channel.TypeOpenai, "https://api.neuralwatt.com"},
+		{"neuralwatt", channel.TypeOpenaiResponses, "https://api.neuralwatt.com"},
+		{"apertis", channel.TypeOpenai, "https://api.apertis.ai"},
+		{"apertis", channel.TypeOpenaiResponses, "https://api.apertis.ai"},
+		{"opencode_go", channel.TypeOpencodeGo, ""},
+		{"opencode_go", channel.TypeOpencodeGoAnthropic, ""},
+		{"kimi_code", channel.TypeMoonshotCoding, ""},
+		{"minimax", channel.TypeMinimax, ""},
+		{"minimax", channel.TypeMinimaxAnthropic, ""},
+		{"zhipu", channel.TypeZhipu, ""},
+		{"zhipu", channel.TypeZhipuAnthropic, ""},
+		{"charm_hyper", channel.TypeOpenai, "https://hyper.charm.land"},
+		{"charm_hyper", channel.TypeOpenaiResponses, "https://hyper.charm.land"},
+		{"commandcode", channel.TypeCommandcode, ""},
+		{"commandcode", channel.TypeCommandcodeAnthropic, ""},
+	}
+
+	for _, relation := range expectedRelations {
+		key := fmt.Sprintf("%s/%s/%s", relation.checker, relation.channelType, relation.baseURL)
+		quotaChannel := &ent.Channel{Type: relation.channelType, BaseURL: relation.baseURL}
+		if relation.checker == "commandcode" {
+			quotaChannel.Settings = &objects.ChannelSettings{
+				ProviderQuota: &objects.ChannelProviderQuotaSettings{
+					CommandCode: &objects.CommandCodeQuotaSettings{AuthCookie: "fixture-cookie"},
+				},
+			}
+		}
+		providerType := svc.getProviderType(quotaChannel)
+		require.Equal(t, relation.checker, providerType, key)
+		checker, ok := svc.checkers[providerType]
+		require.True(t, ok, key)
+		require.True(t, checker.SupportsChannel(quotaChannel), key)
+	}
+
+	productionTypes := make(map[channel.Type]struct{}, len(providerQuotaChannelTypes))
+	for _, channelType := range providerQuotaChannelTypes {
+		productionTypes[channelType] = struct{}{}
+	}
+	for _, relation := range expectedRelations {
+		_, ok := productionTypes[relation.channelType]
+		require.True(t, ok, "expected relation missing from production channel registry: %s", relation.channelType)
+	}
+	for _, channelType := range providerQuotaChannelTypes {
+		found := false
+		for _, relation := range expectedRelations {
+			if relation.channelType == channelType {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "production channel registry has no independent expected relation: %s", channelType)
+	}
+}
+
+func mapKeys(checkers map[string]provider_quota.QuotaChecker) []string {
+	keys := make([]string, 0, len(checkers))
+	for key := range checkers {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/internal/server/biz/provider_quota_registry_test.go
+++ b/internal/server/biz/provider_quota_registry_test.go
@@ -24,7 +24,7 @@ func TestProviderQuotaService_RegistryCoverageMatrix(t *testing.T) {
 		"apertis", "antigravity", "charm_hyper", "claudecode", "cline", "codex",
 		"commandcode", "github_copilot", "kimi_code", "minimax", "nanogpt",
 		"neuralwatt", "opencode_go", "synthetic", "wafer", "xai_subscription",
-		"zenmux", "zhipu",
+		"ollama", "zenmux", "zhipu",
 	}
 	require.ElementsMatch(t, expectedCheckers, mapKeys(svc.checkers))
 
@@ -64,6 +64,8 @@ func TestProviderQuotaService_RegistryCoverageMatrix(t *testing.T) {
 		{"charm_hyper", channel.TypeOpenaiResponses, "https://hyper.charm.land"},
 		{"commandcode", channel.TypeCommandcode, ""},
 		{"commandcode", channel.TypeCommandcodeAnthropic, ""},
+		{"ollama", channel.TypeOllama, ""},
+		{"ollama", channel.TypeOllamaAnthropic, ""},
 	}
 
 	for _, relation := range expectedRelations {
@@ -73,6 +75,13 @@ func TestProviderQuotaService_RegistryCoverageMatrix(t *testing.T) {
 			quotaChannel.Settings = &objects.ChannelSettings{
 				ProviderQuota: &objects.ChannelProviderQuotaSettings{
 					CommandCode: &objects.CommandCodeQuotaSettings{AuthCookie: "fixture-cookie"},
+				},
+			}
+		}
+		if relation.checker == "ollama" {
+			quotaChannel.Settings = &objects.ChannelSettings{
+				ProviderQuota: &objects.ChannelProviderQuotaSettings{
+					Ollama: &objects.OllamaQuotaSettings{AuthCookie: "fixture-cookie"},
 				},
 			}
 		}

--- a/internal/server/biz/quota_channel_status_test.go
+++ b/internal/server/biz/quota_channel_status_test.go
@@ -88,6 +88,33 @@ func TestQuotaChannelStatus_EffectiveStatus_AlternativeCapacitySources(t *testin
 	assert.True(t, ready)
 }
 
+func TestQuotaChannelStatus_EffectiveStatus_UnknownAlternativeDoesNotBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     providerquotastatus.Status
+		ready      bool
+		wantStatus providerquotastatus.Status
+	}{
+		{name: "available", status: providerquotastatus.StatusAvailable, ready: true, wantStatus: providerquotastatus.StatusAvailable},
+		{name: "warning", status: providerquotastatus.StatusWarning, ready: true, wantStatus: providerquotastatus.StatusWarning},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &QuotaChannelStatus{
+				Status: providerquotastatus.StatusAvailable,
+				Ready:  true,
+				Limits: []provider_quota.QuotaLimitStatus{
+					{Type: provider_quota.QuotaLimitTypeToken, Status: "unknown", Ready: false, AvailabilityGroup: "capacity"},
+					{Type: provider_quota.QuotaLimitTypeSubscriptionCycle, Status: string(tc.status), Ready: tc.ready, AvailabilityGroup: "capacity"},
+				},
+			}
+
+			status, ready := s.EffectiveStatus(provider_quota.QuotaLimitTypeToken)
+			assert.Equal(t, tc.wantStatus, status)
+			assert.True(t, ready)
+		})
+	}
+}
+
 func TestQuotaChannelStatus_EffectiveStatus_NoMatchingLimit_Fallback(t *testing.T) {
 	s := &QuotaChannelStatus{
 		Status: providerquotastatus.StatusAvailable,

--- a/internal/server/biz/quota_channel_status_test.go
+++ b/internal/server/biz/quota_channel_status_test.go
@@ -73,6 +73,21 @@ func TestQuotaChannelStatus_EffectiveStatus_MultipleTokenLimits_WorstWins(t *tes
 	assert.True(t, ready)
 }
 
+func TestQuotaChannelStatus_EffectiveStatus_AlternativeCapacitySources(t *testing.T) {
+	s := &QuotaChannelStatus{
+		Status: providerquotastatus.StatusAvailable,
+		Ready:  true,
+		Limits: []provider_quota.QuotaLimitStatus{
+			{Type: provider_quota.QuotaLimitTypeToken, Status: "exhausted", Ready: false, AvailabilityGroup: "capacity"},
+			{Type: provider_quota.QuotaLimitTypeSubscriptionCycle, Status: "available", Ready: true, AvailabilityGroup: "capacity"},
+		},
+	}
+
+	status, ready := s.EffectiveStatus(provider_quota.QuotaLimitTypeToken)
+	assert.Equal(t, providerquotastatus.StatusAvailable, status)
+	assert.True(t, ready)
+}
+
 func TestQuotaChannelStatus_EffectiveStatus_NoMatchingLimit_Fallback(t *testing.T) {
 	s := &QuotaChannelStatus{
 		Status: providerquotastatus.StatusAvailable,


### PR DESCRIPTION
## Summary
- Normalize provider quota limits by their reported windows and preserve provider-specific quota semantics.
- Render normalized quota limits for every quota-capable channel, including all ZenMux channel variants.
- Add Codex period quota estimation from recorded usage while preserving existing popup behavior.
- Use the ZenMux combined usage/time progress-bar style for all quota popup progress bars.
- Preserve Codex/Claude Code reset and estimate features, ZenMux shared-account status, plan labels, and popup behavior.

## Verification
- `go test ./... -count=1`
- `go test -race ./internal/server/biz/provider_quota ./internal/server/biz -count=1`
- `node --test "src/**/*.test.mjs"`
- `./node_modules/.bin/tsc --noEmit`
- changed-file ESLint: no errors; repository has pre-existing unrelated lint errors
- `go vet ./internal/server/biz ./internal/server/biz/provider_quota`
- production Cloud Run health and authenticated channel quota verification completed in the test environment

No dependency or lockfile changes are included. Cloud Run test scripts are intentionally excluded from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quota displays now use normalized usage bars with localized labels for multiple windows, including Codex five-hour and seven-day periods.
  - Quota information is available across supported channel types, including Ollama, pay-as-you-go, and credits windows.
  - Channel quota columns support validated visibility settings.

- **Bug Fixes**
  - Invalid, expired, duplicated, or inconsistent quota data is filtered and normalized.
  - Exhausted quotas and period estimates now reflect remaining capacity and usable cost data.
  - Alternative quota sources are aggregated more accurately.
  - Signing out now clears cached account data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->