### PR TITLE
fix(security): prevent OIDC Host header injection

### DIFF
--- a/internal/server/api/oidc.go
+++ b/internal/server/api/oidc.go
@@ -194,7 +194,7 @@ func (h *OIDCHandlers) getBaseURL() (string, error) {
 	}
 
 	parsed, err := url.Parse(baseURL)
-	if err != nil || parsed.Host == "" || parsed.Scheme == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+	if err != nil || parsed.Hostname() == "" || parsed.Scheme == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return "", fmt.Errorf("invalid server.public_url")
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {

--- a/internal/server/api/oidc.go
+++ b/internal/server/api/oidc.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,6 +22,8 @@ type OIDCHandlers struct {
 	auth      *biz.AuthService
 	publicURL string
 }
+
+var errOIDCPublicURLRequired = errors.New("server.public_url must be configured when OIDC is enabled")
 
 type OIDCHandlerParams struct {
 	fx.In
@@ -74,8 +77,11 @@ func (h *OIDCHandlers) GetAuthorizeURL(c *gin.Context) {
 		return
 	}
 
-	// Get the base URL (priority: config public URL > request host)
-	baseURL := h.getBaseURL(c)
+	baseURL, err := h.getBaseURL()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 
 	authURL, state, err := h.oidc.GetAuthorizeURL(c.Request.Context(), provider, baseURL)
 	if err != nil {
@@ -108,8 +114,11 @@ func (h *OIDCHandlers) GetLinkAuthorizeURL(c *gin.Context) {
 
 	userID := user.ID
 
-	// Get the base URL (priority: config public URL > request host)
-	baseURL := h.getBaseURL(c)
+	baseURL, err := h.getBaseURL()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 
 	authURL, state, err := h.oidc.GetLinkAuthorizeURL(c.Request.Context(), provider, baseURL, userID)
 	if err != nil {
@@ -157,15 +166,18 @@ func (h *OIDCHandlers) Callback(c *gin.Context) {
 		return
 	}
 
-	exchangeCode, intent, err := h.oidc.Callback(c.Request.Context(), provider, code, state, h.getBaseURL(c))
+	baseURL, err := h.getBaseURL()
 	if err != nil {
-		baseURL := h.getBaseURL(c)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	exchangeCode, intent, err := h.oidc.Callback(c.Request.Context(), provider, code, state, baseURL)
+	if err != nil {
 		c.Redirect(http.StatusFound, fmt.Sprintf("%s/oauth/oidc/idp-callback?error=auth_failed&error_description=%s", baseURL, url.QueryEscape(err.Error())))
 
 		return
 	}
-
-	baseURL := h.getBaseURL(c)
 
 	if intent == "link" {
 		c.Redirect(http.StatusFound, baseURL+"/settings/profile?oidc_link=success")
@@ -175,19 +187,21 @@ func (h *OIDCHandlers) Callback(c *gin.Context) {
 	c.Redirect(http.StatusFound, baseURL+"/oauth/oidc/idp-callback?code="+exchangeCode)
 }
 
-func (h *OIDCHandlers) getBaseURL(c *gin.Context) string {
-	if h.publicURL != "" {
-		return strings.TrimSuffix(h.publicURL, "/")
+func (h *OIDCHandlers) getBaseURL() (string, error) {
+	baseURL := strings.TrimSpace(h.publicURL)
+	if baseURL == "" {
+		return "", errOIDCPublicURLRequired
 	}
 
-	// Fallback to request host if publicURL is not configured.
-	// NOTE: In production, it's highly recommended to configure public_url to prevent Host header attacks.
-	scheme := "http"
-	if c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https" {
-		scheme = "https"
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Host == "" || parsed.Scheme == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid server.public_url")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("server.public_url must use http or https")
 	}
 
-	return fmt.Sprintf("%s://%s", scheme, c.Request.Host)
+	return strings.TrimSuffix(baseURL, "/"), nil
 }
 
 func (h *OIDCHandlers) Exchange(c *gin.Context) {

--- a/internal/server/api/oidc_test.go
+++ b/internal/server/api/oidc_test.go
@@ -29,6 +29,7 @@ func TestOIDCHandlersGetBaseURLRejectsUnsafeConfiguration(t *testing.T) {
 		"//attacker.example.com",
 		"https://axonhub.example.com/callback?next=attacker",
 		"https://user:secret@axonhub.example.com",
+		"https://:443",
 		"ftp://axonhub.example.com",
 	} {
 		t.Run(publicURL, func(t *testing.T) {

--- a/internal/server/api/oidc_test.go
+++ b/internal/server/api/oidc_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDCHandlersGetBaseURLRequiresConfiguredPublicURL(t *testing.T) {
+	h := &OIDCHandlers{}
+
+	got, err := h.getBaseURL()
+
+	require.ErrorIs(t, err, errOIDCPublicURLRequired)
+	require.Empty(t, got)
+}
+
+func TestOIDCHandlersGetBaseURLDoesNotUseRequestHost(t *testing.T) {
+	h := &OIDCHandlers{publicURL: "https://axonhub.example.com/"}
+
+	got, err := h.getBaseURL()
+
+	require.NoError(t, err)
+	require.Equal(t, "https://axonhub.example.com", got)
+}
+
+func TestOIDCHandlersGetBaseURLRejectsUnsafeConfiguration(t *testing.T) {
+	for _, publicURL := range []string{
+		"//attacker.example.com",
+		"https://axonhub.example.com/callback?next=attacker",
+		"https://user:secret@axonhub.example.com",
+		"ftp://axonhub.example.com",
+	} {
+		t.Run(publicURL, func(t *testing.T) {
+			h := &OIDCHandlers{publicURL: publicURL}
+
+			_, err := h.getBaseURL()
+
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## 问题现象
当 OIDC 未配置 `server.public_url` 时，服务会把当前 HTTP 请求的 `Host` 头拼接成 OIDC 回调基地址。攻击者可以构造恶意 Host 头访问授权入口，使生成的 `redirect_uri` 指向攻击者控制的域名，存在 Host Header Injection 和登录授权码泄露风险。

## 根因
`OIDCHandlers.getBaseURL` 在 `public_url` 为空时直接使用 `c.Request.Host`，且同时信任 `X-Forwarded-Proto` 判断协议。请求头属于不可信输入，在反向代理或直接暴露服务的部署中都不能作为 OIDC 回调地址的可信来源。

## 整改方案
- 删除基于请求 `Host` / `X-Forwarded-Proto` 的回退逻辑。
- OIDC 授权、账号绑定和回调流程统一要求配置 `server.public_url`。
- 对配置值进行校验，只接受带 Host 的 `http`/`https` URL，并拒绝用户信息、查询参数和片段。
- 增加回归测试，覆盖未配置、正常配置、恶意 URL 配置等场景。

这是一个有意的安全性优先变更：未配置公开地址时 OIDC 请求会返回配置错误，而不是生成可能被攻击者控制的回调地址。

## 测试结果
- `go test ./internal/server/api ./internal/server/biz ./internal/server/middleware` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC authentication now consistently uses the configured public URL for authorization, callbacks, and redirects.
  * Missing or invalid public URL configurations now return a clear server error instead of relying on the incoming request host.
  * Unsafe configurations—including unsupported schemes, credentials, queries, fragments, or missing hostnames—are rejected.
  * Trailing slashes in the configured public URL are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->