### PR TITLE
fix(security): cap inbound request body and decompression size

### DIFF
--- a/llm/httpclient/utils.go
+++ b/llm/httpclient/utils.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,10 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/samber/lo"
 )
+
+var maxRequestBodySize = 64 * 1024 * 1024
+
+var ErrRequestBodyTooLarge = errors.New("request body too large")
 
 func ReadHTTPRequest(rawReq *http.Request) (*Request, error) {
 	req := &Request{
@@ -30,7 +35,7 @@ func ReadHTTPRequest(rawReq *http.Request) (*Request, error) {
 		RawRequest: rawReq,
 	}
 
-	body, err := io.ReadAll(rawReq.Body)
+	body, err := readLimited(rawReq.Body, maxRequestBodySize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
@@ -66,7 +71,7 @@ func decodeRequestBody(body []byte, headers http.Header) ([]byte, error) {
 		}
 		defer reader.Close()
 
-		decoded, err := io.ReadAll(reader)
+		decoded, err := readLimited(reader, maxRequestBodySize)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decompress gzip body: %w", err)
 		}
@@ -79,7 +84,7 @@ func decodeRequestBody(body []byte, headers http.Header) ([]byte, error) {
 	case "deflate":
 		// RFC 7230/2616 defines "deflate" as zlib (RFC 1950), but many clients send
 		// raw DEFLATE (RFC 1951). Try zlib first, fall back to raw DEFLATE.
-		decoded, err := decodeZlibOrFlate(body)
+		decoded, err := decodeZlibOrFlate(body, maxRequestBodySize)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decompress deflate body: %w", err)
 		}
@@ -90,15 +95,20 @@ func decodeRequestBody(body []byte, headers http.Header) ([]byte, error) {
 		return decoded, nil
 
 	case "zstd":
-		decoder, err := zstd.NewReader(nil)
+		decoder, err := zstd.NewReader(bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create zstd decoder: %w", err)
 		}
 		defer decoder.Close()
 
-		decoded, err := decoder.DecodeAll(body, nil)
+		decoderReader := decoder.IOReadCloser()
+		decoded, err := readLimited(decoderReader, maxRequestBodySize)
+		closeErr := decoderReader.Close()
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode zstd compressed body: %w", err)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to close zstd decoder: %w", closeErr)
 		}
 
 		headers.Del("Content-Encoding")
@@ -111,16 +121,27 @@ func decodeRequestBody(body []byte, headers http.Header) ([]byte, error) {
 	}
 }
 
-func decodeZlibOrFlate(body []byte) ([]byte, error) {
+func decodeZlibOrFlate(body []byte, maxSize int) ([]byte, error) {
 	reader, err := zlib.NewReader(bytes.NewReader(body))
 	if err == nil {
 		defer reader.Close()
-		return io.ReadAll(reader)
+		return readLimited(reader, maxSize)
 	}
 
 	flateReader := flate.NewReader(bytes.NewReader(body))
 	defer flateReader.Close()
-	return io.ReadAll(flateReader)
+	return readLimited(flateReader, maxSize)
+}
+
+func readLimited(r io.Reader, maxSize int) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, int64(maxSize)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxSize {
+		return nil, ErrRequestBodyTooLarge
+	}
+	return body, nil
 }
 
 func getClientIP(req *http.Request) string {

--- a/llm/httpclient/utils_test.go
+++ b/llm/httpclient/utils_test.go
@@ -259,6 +259,38 @@ func TestReadHTTPRequest_EmptyBodyWithContentEncoding(t *testing.T) {
 	assert.Empty(t, got.Body)
 }
 
+func TestReadHTTPRequest_RejectsOversizedRawBody(t *testing.T) {
+	originalLimit := maxRequestBodySize
+	maxRequestBodySize = 32
+	t.Cleanup(func() { maxRequestBodySize = originalLimit })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(bytes.Repeat([]byte("a"), maxRequestBodySize+1)))
+
+	_, err := ReadHTTPRequest(req)
+
+	require.ErrorIs(t, err, ErrRequestBodyTooLarge)
+}
+
+func TestReadHTTPRequest_RejectsOversizedDecodedBody(t *testing.T) {
+	originalLimit := maxRequestBodySize
+	maxRequestBodySize = 32
+	t.Cleanup(func() { maxRequestBodySize = originalLimit })
+
+	originalBody := bytes.Repeat([]byte("a"), maxRequestBodySize+1)
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write(originalBody)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(compressed.Bytes()))
+	req.Header.Set("Content-Encoding", "gzip")
+
+	_, err = ReadHTTPRequest(req)
+
+	require.ErrorIs(t, err, ErrRequestBodyTooLarge)
+}
+
 func TestDecodeRequestBody_NoEncoding(t *testing.T) {
 	body := []byte(`{"test":"data"}`)
 	headers := http.Header{}


### PR DESCRIPTION
## 问题现象
所有兼容 API 请求都会先被 `ReadHTTPRequest` 完整读入内存。原实现没有统一的请求体大小限制，攻击者可直接发送超大请求；也可以发送很小的 gzip/deflate/zstd 压缩体，让服务在解压阶段产生远大于原始体的内存分配，最终导致 OOM 或服务不可用。

## 根因
请求体读取使用无界 `io.ReadAll`，zstd 使用无界 `DecodeAll`，未限制原始输入和解压输出。该函数被聊天、Responses、音频、图片、视频等多个入口共用，因此影响范围是整个外部 API 面。

## 整改方案
- 为原始请求体增加 64 MiB 上限。
- 为 gzip、deflate、zstd 解压后的输出增加同样上限，防止压缩炸弹绕过限制。
- 超限统一返回可识别的 `ErrRequestBodyTooLarge`。
- 增加原始体超限和 gzip 解压后超限回归测试，并保留已有压缩编码正常路径测试。

## 测试结果
- `cd llm && go test ./httpclient -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against request bodies exceeding the 64 MiB limit.
  * Oversized bodies are now rejected consistently, including compressed requests.
  * Improved handling of compressed request data and related decoding errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->