### PR TITLE
fix(anthropic): preserve DeepSeek native web search tools

### DIFF
--- a/internal/ent/channel/type.go
+++ b/internal/ent/channel/type.go
@@ -35,11 +35,10 @@ func (t Type) SupportsGoogleNativeTools() bool {
 }
 
 // SupportsAnthropicNativeTools returns true if the channel type supports Anthropic native tools.
-// Anthropic native tools (web_search_20250305) are only supported by direct Anthropic API.
-// Note: Bedrock (anthropic_aws) and Vertex (anthropic_gcp) do NOT currently support
-// the web search beta feature, so they are excluded from native tool support.
-// Channels using Anthropic format but not native Anthropic API (e.g., deepseek_anthropic,
-// moonshot_anthropic) also do NOT support these tools.
+// Anthropic native tools (web_search_20250305) are supported by Anthropic-backed
+// channels, Claude Code, and DeepSeek's verified Anthropic-compatible endpoint.
+// Other Anthropic-compatible channels remain excluded until support is verified.
 func (t Type) SupportsAnthropicNativeTools() bool {
-	return t == TypeAnthropic || t == TypeAnthropicAWS || t == TypeAnthropicGcp || t == TypeClaudecode
+	return t == TypeAnthropic || t == TypeAnthropicAWS || t == TypeAnthropicGcp ||
+		t == TypeClaudecode || t == TypeDeepseekAnthropic
 }

--- a/internal/ent/channel/type_test.go
+++ b/internal/ent/channel/type_test.go
@@ -124,7 +124,7 @@ func TestType_SupportsAnthropicNativeTools(t *testing.T) {
 		},
 		{
 			name: "deepseek_anthropic",
-			want: false,
+			want: true,
 		},
 		{
 			name: "moonshot_anthropic",

--- a/internal/server/orchestrator/candidates_anthropic.go
+++ b/internal/server/orchestrator/candidates_anthropic.go
@@ -12,7 +12,7 @@ import (
 
 // AnthropicNativeToolsSelector is a decorator that prioritizes candidates supporting Anthropic native tools.
 // When a request contains Anthropic native tools (web_search -> web_search_20250305),
-// this selector filters out candidates whose channels don't support these tools (e.g., deepseek_anthropic).
+// this selector filters out candidates whose channels don't support these tools (e.g., moonshot_anthropic).
 // If no compatible candidates are found, it falls back to all candidates (allowing downstream fallback logic).
 type AnthropicNativeToolsSelector struct {
 	wrapped CandidateSelector

--- a/internal/server/orchestrator/candidates_anthropic_test.go
+++ b/internal/server/orchestrator/candidates_anthropic_test.go
@@ -1,0 +1,43 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/server/biz"
+	"github.com/looplj/axonhub/llm"
+)
+
+type staticAnthropicCandidateSelector []*ChannelModelsCandidate
+
+func (s staticAnthropicCandidateSelector) Select(context.Context, *llm.Request) ([]*ChannelModelsCandidate, error) {
+	return s, nil
+}
+
+func TestAnthropicNativeToolsSelector_Select_PreservesDeepSeek(t *testing.T) {
+	newCandidate := func(channelType channel.Type) *ChannelModelsCandidate {
+		return &ChannelModelsCandidate{
+			Channel: &biz.Channel{Channel: &ent.Channel{Type: channelType}},
+		}
+	}
+
+	direct := newCandidate(channel.TypeAnthropic)
+	deepseek := newCandidate(channel.TypeDeepseekAnthropic)
+	unsupported := newCandidate(channel.TypeMoonshotAnthropic)
+	selector := WithAnthropicNativeToolsSelector(staticAnthropicCandidateSelector{
+		direct,
+		deepseek,
+		unsupported,
+	})
+
+	got, err := selector.Select(context.Background(), &llm.Request{
+		APIFormat: llm.APIFormatAnthropicMessage,
+		Tools:     []llm.Tool{{Type: llm.ToolTypeWebSearch}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []*ChannelModelsCandidate{direct, deepseek}, got)
+}

--- a/llm/transformer/anthropic/outbound_convert.go
+++ b/llm/transformer/anthropic/outbound_convert.go
@@ -252,7 +252,7 @@ func buildThinking(chatReq *llm.Request, config *Config) *Thinking {
 }
 
 // convertToolsAnthropic converts LLM tools to Anthropic tools.
-// If the platform is not direct Anthropic API or Bedrock, anthropic native tools (like web_search) are filtered out.
+// If the platform does not support Anthropic native tools, tools like web_search are filtered out.
 // Only web_search tool is supported as native tool, other native tools (image_generation, google_*, etc.) are ignored.
 func convertToolsAnthropic(tools []llm.Tool, config *Config) []Tool {
 	if len(tools) == 0 {

--- a/llm/transformer/anthropic/outbound_test.go
+++ b/llm/transformer/anthropic/outbound_test.go
@@ -1225,11 +1225,12 @@ func TestOutboundTransformer_WebSearchBetaHeader(t *testing.T) {
 
 func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 	tests := []struct {
-		name              string
-		config            *Config
-		request           *llm.Request
-		expectedToolCount int
-		expectedToolNames []string
+		name                     string
+		config                   *Config
+		request                  *llm.Request
+		expectedToolCount        int
+		expectedToolNames        []string
+		expectedWebSearchMaxUses *int64
 	}{
 		{
 			name: "Direct platform preserves native tools",
@@ -1334,7 +1335,7 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 			expectedToolNames: []string{"web_search", "calculator"},
 		},
 		{
-			name: "DeepSeek platform filters native tools",
+			name: "DeepSeek platform preserves native tools",
 			config: &Config{
 				Type:           PlatformDeepSeek,
 				BaseURL:        "https://api.deepseek.com",
@@ -1353,7 +1354,10 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 				},
 				Tools: []llm.Tool{
 					{
-						Type: ToolTypeWebSearch20250305,
+						Type: llm.ToolTypeWebSearch,
+						WebSearch: &llm.WebSearch{
+							MaxUses: lo.ToPtr(int64(5)),
+						},
 					},
 					{
 						Type: "function",
@@ -1364,8 +1368,9 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 					},
 				},
 			},
-			expectedToolCount: 1,
-			expectedToolNames: []string{"calculator"},
+			expectedToolCount:        2,
+			expectedToolNames:        []string{"web_search", "calculator"},
+			expectedWebSearchMaxUses: lo.ToPtr(int64(5)),
 		},
 		{
 			name: "Doubao platform filters native tools",
@@ -1402,7 +1407,7 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 			expectedToolNames: []string{"get_weather"},
 		},
 		{
-			name: "Non-direct platform with only native tools results in empty tools",
+			name: "DeepSeek platform with only native tools preserves them",
 			config: &Config{
 				Type:           PlatformDeepSeek,
 				BaseURL:        "https://api.deepseek.com",
@@ -1421,12 +1426,12 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 				},
 				Tools: []llm.Tool{
 					{
-						Type: ToolTypeWebSearch20250305,
+						Type: llm.ToolTypeWebSearch,
 					},
 				},
 			},
-			expectedToolCount: 0,
-			expectedToolNames: []string{},
+			expectedToolCount: 1,
+			expectedToolNames: []string{"web_search"},
 		},
 		{
 			name: "Direct platform with llm.ToolTypeWebSearch type converts to native tool",
@@ -1597,6 +1602,12 @@ func TestOutboundTransformer_NativeToolFiltering(t *testing.T) {
 				actualNames := make([]string, len(anthropicReq.Tools))
 				for i, tool := range anthropicReq.Tools {
 					actualNames[i] = tool.Name
+					if tool.Name == WebSearchFunctionName {
+						require.Equal(t, ToolTypeWebSearch20250305, tool.Type)
+						if tt.expectedWebSearchMaxUses != nil {
+							require.Equal(t, tt.expectedWebSearchMaxUses, tool.MaxUses)
+						}
+					}
 				}
 
 				require.Equal(t, tt.expectedToolNames, actualNames)

--- a/llm/transformer/anthropic/tools.go
+++ b/llm/transformer/anthropic/tools.go
@@ -55,15 +55,16 @@ func FilterOutAnthropicNativeTools(tools []llm.Tool) []llm.Tool {
 }
 
 // supportsAnthropicNativeTools checks if the platform supports Anthropic native tools.
-// Only direct Anthropic API, Bedrock, and Claude Code support native tools like web_search.
+// Direct Anthropic API, Bedrock, Claude Code, and DeepSeek's Anthropic-compatible API
+// support native tools like web_search.
 func supportsAnthropicNativeTools(config *Config) bool {
 	if config == nil {
 		return true
 	}
 
-	//nolint:exhaustive // Only check direct, bedrock, and claude code platforms.
+	//nolint:exhaustive // Only check platforms with verified native tool support.
 	switch config.Type {
-	case PlatformDirect, PlatformBedrock, PlatformClaudeCode:
+	case PlatformDirect, PlatformBedrock, PlatformClaudeCode, PlatformDeepSeek:
 		return true
 	default:
 		return false

--- a/llm/transformer/anthropic/tools_test.go
+++ b/llm/transformer/anthropic/tools_test.go
@@ -223,6 +223,7 @@ func TestSupportsAnthropicNativeTools(t *testing.T) {
 		{name: "direct", config: &Config{Type: PlatformDirect}, want: true},
 		{name: "bedrock", config: &Config{Type: PlatformBedrock}, want: true},
 		{name: "claude code", config: &Config{Type: PlatformClaudeCode}, want: true},
+		{name: "deepseek", config: &Config{Type: PlatformDeepSeek}, want: true},
 		{name: "command code", config: &Config{Type: PlatformCommandCode}, want: false},
 		{name: "vertex", config: &Config{Type: PlatformVertex}, want: false},
 	}


### PR DESCRIPTION
Fixes #2226

DeepSeek's Anthropic-compatible Messages API supports the native `web_search_20250305` server tool, but AxonHub currently marks both `deepseek_anthropic` and `PlatformDeepSeek` as not supporting Anthropic native tools. In mixed candidate sets this filters out the DeepSeek channel, and outbound conversion also removes the tool definition.

This change aligns both existing capability checks so DeepSeek Anthropic channels remain eligible and the native web-search definition is preserved in the outbound request. Other Anthropic-compatible channels remain unchanged.

DeepSeek's official `deepseek-harness` sends this exact tool type to its Anthropic-compatible Messages endpoint:
https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/web/web-search-deepseek/src/provider.ts

Verification:

- Added regression coverage for mixed candidate routing.
- Covered native web search alone and beside a normal function tool.
- Verified the outbound `web_search_20250305` type and `max_uses` value.
- `go test ./transformer/anthropic -count=1`
- `go test ./internal/ent/channel -count=1`
- `go test ./internal/server/orchestrator -count=1`

🤖 Assisted by OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DeepSeek’s Anthropic-compatible endpoint now supports Anthropic native tools, including web search.
  * Web search settings such as maximum usage limits are preserved for DeepSeek requests.

* **Tests**
  * Added coverage confirming native tools are retained for supported DeepSeek channels and filtered from unsupported channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->