### PR TITLE
fix(security): prevent spoofed client IP headers

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -217,6 +217,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.port", 8090)
 	v.SetDefault("server.pid_file", "")
 	v.SetDefault("server.public_url", "")
+	v.SetDefault("server.trusted_proxies", []string{})
 	v.SetDefault("server.name", "AxonHub")
 	v.SetDefault("server.base_path", "")
 	v.SetDefault("server.request_timeout", "30s")

--- a/config.example.yml
+++ b/config.example.yml
@@ -6,6 +6,9 @@
 server:
   host: "0.0.0.0"               # Server host (env: AXONHUB_SERVER_HOST)
   port: 8090                    # Server port (env: AXONHUB_SERVER_PORT)
+  # Only these proxy networks may provide X-Forwarded-For/X-Real-IP. Empty
+  # means forwarded client IP headers are ignored and the TCP peer is used.
+  trusted_proxies: []            # (env: AXONHUB_SERVER_TRUSTED_PROXIES)
   name: "AxonHub"               # Server name (env: AXONHUB_SERVER_NAME)
   base_path: ""                 # Base path for API routes (env: AXONHUB_SERVER_BASE_PATH)
   # pid_file: "~/.config/axonhub/axonhub.pid"  # PID file for axonhub reload (env: AXONHUB_SERVER_PID_FILE)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -77,13 +77,17 @@ func (m *MemorySize) UnmarshalText(text []byte) error {
 }
 
 type Config struct {
-	Host        string        `conf:"host" yaml:"host" json:"host"`
-	Port        int           `conf:"port" yaml:"port" json:"port"`
-	PublicURL   string        `conf:"public_url" yaml:"public_url" json:"public_url"`
-	Name        string        `conf:"name" yaml:"name" json:"name"`
-	BasePath    string        `conf:"base_path" yaml:"base_path" json:"base_path"`
-	PidFile     string        `conf:"pid_file" yaml:"pid_file" json:"pid_file"`
-	ReadTimeout time.Duration `conf:"read_timeout" yaml:"read_timeout" json:"read_timeout"`
+	Host      string `conf:"host" yaml:"host" json:"host"`
+	Port      int    `conf:"port" yaml:"port" json:"port"`
+	PublicURL string `conf:"public_url" yaml:"public_url" json:"public_url"`
+	// TrustedProxies contains the proxy networks allowed to provide the
+	// X-Forwarded-For and X-Real-IP headers. An empty list disables proxy header
+	// trust and uses the direct TCP peer address.
+	TrustedProxies []string      `conf:"trusted_proxies" yaml:"trusted_proxies" json:"trusted_proxies"`
+	Name           string        `conf:"name" yaml:"name" json:"name"`
+	BasePath       string        `conf:"base_path" yaml:"base_path" json:"base_path"`
+	PidFile        string        `conf:"pid_file" yaml:"pid_file" json:"pid_file"`
+	ReadTimeout    time.Duration `conf:"read_timeout" yaml:"read_timeout" json:"read_timeout"`
 
 	// RequestTimeout is the maximum duration for processing a request.
 	RequestTimeout time.Duration `conf:"request_timeout" yaml:"request_timeout" json:"request_timeout"`

--- a/internal/server/middleware/ip_blocklist.go
+++ b/internal/server/middleware/ip_blocklist.go
@@ -35,32 +35,12 @@ func WithIPBlocklist(systemService *biz.SystemService) gin.HandlerFunc {
 }
 
 func clientIPCandidates(c *gin.Context) []string {
-	candidates := make([]string, 0, 3)
-	seen := make(map[string]struct{}, 3)
-	add := func(value string) {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return
-		}
-
-		if _, ok := seen[value]; ok {
-			return
-		}
-
-		seen[value] = struct{}{}
-		candidates = append(candidates, value)
+	clientIP := strings.TrimSpace(c.ClientIP())
+	if clientIP == "" {
+		return nil
 	}
 
-	add(c.ClientIP())
-
-	if xff := c.Request.Header.Get("X-Forwarded-For"); xff != "" {
-		before, _, _ := strings.Cut(xff, ",")
-		add(before)
-	}
-
-	add(c.Request.Header.Get("X-Real-IP"))
-
-	return candidates
+	return []string{clientIP}
 }
 
 func isBlockedIP(clientIPs []string, blockedIPs []string) bool {

--- a/internal/server/middleware/ip_blocklist_test.go
+++ b/internal/server/middleware/ip_blocklist_test.go
@@ -97,7 +97,7 @@ func TestClientIPCandidates(t *testing.T) {
 	ctx.Request = req
 
 	got := clientIPCandidates(ctx)
-	want := []string{"10.0.0.1", "203.0.113.10", "192.0.2.30"}
+	want := []string{"10.0.0.1"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("clientIPCandidates() = %#v, want %#v", got, want)
 	}
@@ -120,6 +120,27 @@ func TestClientIPCandidatesDeduplicates(t *testing.T) {
 
 	got := clientIPCandidates(ctx)
 	want := []string{"203.0.113.10"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("clientIPCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestClientIPCandidatesUsesForwardedIPForTrustedProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, engine := gin.CreateTestContext(recorder)
+	if err := engine.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("failed to set trusted proxies: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.20")
+	ctx.Request = req
+
+	got := clientIPCandidates(ctx)
+	want := []string{"198.51.100.20"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("clientIPCandidates() = %#v, want %#v", got, want)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,14 @@ func New(config Config) *Server {
 
 	engine := gin.New()
 
+	// Gin trusts all proxies by default. Never inherit that unsafe default:
+	// forwarded client IP headers must only be honored for explicitly configured
+	// proxy networks, otherwise IP access controls and API-key IP restrictions
+	// can be bypassed with a forged request header.
+	if err := engine.SetTrustedProxies(config.TrustedProxies); err != nil {
+		panic(fmt.Errorf("invalid server.trusted_proxies: %w", err))
+	}
+
 	// Set max multipart memory for file uploads (e.g., backup restore).
 	// Default 32 MB may be insufficient for large backup files.
 	if config.MaxMultipartMemory > 0 {


### PR DESCRIPTION
## 问题现象
API Key 的 IP 白名单、全局 IP 白名单和 IP 黑名单会读取 `X-Forwarded-For` / `X-Real-IP`。在默认配置下，Gin 会信任所有代理；同时业务代码还会无条件把客户端提交的转发头加入候选 IP。攻击者可伪造一个白名单 IP，从而绕过 API Key 的 IP 限制和全局 IP 访问控制。

## 根因
- Gin 默认启用并信任全部代理网络，`Context.ClientIP()` 可能直接采用攻击者伪造的转发头。
- `clientIPCandidates` 在 Gin 已完成可信代理判断后，又无条件追加原始 `X-Forwarded-For` 与 `X-Real-IP`，使 `SetTrustedProxies(nil)` 也无法阻止伪造头绕过白名单。

## 整改方案
- 新增 `server.trusted_proxies` 配置，默认空列表，默认只使用 TCP 对端地址。
- 服务启动时显式调用 `SetTrustedProxies`，不再继承 Gin 的“信任所有代理”默认值。
- IP 访问控制统一只使用经过 Gin 可信代理校验后的 `Context.ClientIP()`。
- 只有显式配置的代理网段才允许使用转发头，兼顾反向代理部署场景。
- 增加不信任转发头和信任代理转发头的回归测试。

## 测试结果
- `go test ./internal/server/middleware ./internal/server ./conf -count=1` ✅
- `cd llm && go test ./httpclient -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `server.trusted_proxies` setting to configure which proxy networks may provide forwarded client-IP information.
  - The setting defaults to an empty list, using the direct connection address unless trusted proxies are explicitly configured.

- **Bug Fixes**
  - Improved client IP handling by preventing untrusted forwarded headers from affecting IP-based access controls.
  - Invalid trusted-proxy configuration is now reported during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->