### PR TITLE
fix(auth): reject invalid API keys in no-auth mode

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -37,7 +37,7 @@ func WithAPIKeyConfig(auth *biz.AuthService, config *APIKeyConfig) gin.HandlerFu
 		if err == nil {
 			apiKey, err = auth.AuthenticateAPIKey(c.Request.Context(), key)
 		}
-		if err != nil {
+		if errors.Is(err, ErrAPIKeyRequired) {
 			apiKey, err = auth.AuthenticateNoAuth(c.Request.Context())
 		}
 		if err != nil {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -1,13 +1,24 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/apikey"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/project"
+	"github.com/looplj/axonhub/internal/ent/user"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/server/biz"
 )
 
@@ -65,4 +76,66 @@ func TestWithAPIKeyConfig_AllowsMissingAuthorizationWhenNoAuthAllowed(t *testing
 	}
 }
 
+func TestWithAPIKeyConfig_DoesNotFallbackToNoAuthForInvalidKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
 
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	cacheConfig := xcache.Config{Mode: xcache.ModeMemory}
+	projectService := &biz.ProjectService{
+		ProjectCache: xcache.NewFromConfig[xcache.Entry[ent.Project]](cacheConfig),
+	}
+	apiKeyService := biz.NewAPIKeyService(biz.APIKeyServiceParams{
+		CacheConfig:    cacheConfig,
+		Ent:            client,
+		ProjectService: projectService,
+		KeyPrefix:      "ah",
+	})
+	t.Cleanup(apiKeyService.Stop)
+	auth := &biz.AuthService{
+		APIKeyService: apiKeyService,
+		AllowNoAuth:   true,
+	}
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+	owner, err := client.User.Create().
+		SetEmail("owner-" + uuid.NewString() + "@example.com").
+		SetPassword("unused").
+		SetFirstName("Owner").
+		SetLastName("User").
+		SetIsOwner(true).
+		SetStatus(user.StatusActivated).
+		Save(ctx)
+	require.NoError(t, err)
+
+	proj, err := client.Project.Create().
+		SetName(uuid.NewString()).
+		SetDescription("test").
+		SetStatus(project.StatusActive).
+		SetCreatedAt(time.Now()).
+		SetUpdatedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.APIKey.Create().
+		SetName(biz.NoAuthAPIKeyName).
+		SetKey(biz.NoAuthAPIKeyValue).
+		SetUserID(owner.ID).
+		SetProjectID(proj.ID).
+		SetType(apikey.TypeNoauth).
+		SetStatus(apikey.StatusEnabled).
+		Save(ctx)
+	require.NoError(t, err)
+
+	router := gin.New()
+	router.Use(WithEntClient(client), WithAPIKeyConfig(auth, nil))
+	router.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer definitely-invalid")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+}


### PR DESCRIPTION
## 问题现象
开启 `allow_no_auth` 后，只要请求带有任意无效 API Key，服务仍会把请求降级为内置 NoAuth API Key 并继续处理。结果是客户端明明携带了错误凭证，却不会收到 401；更严重的是，后续请求会以 NoAuth 项目/权限上下文执行，掩盖凭证错误并可能造成错误的项目归属和审计记录。

## 根因
`WithAPIKeyConfig` 原先对 `AuthenticateAPIKey` 的所有错误都执行 `AuthenticateNoAuth`，没有区分“请求没有提供 API Key”和“请求提供了无效/已禁用/已归档 API Key”。

## 整改方案
- 仅当提取阶段返回 `ErrAPIKeyRequired`（请求未提供凭证）时，才允许回退到 NoAuth。
- 已提供但验证失败的 API Key 直接按原有错误链路返回 401/500。
- 增加真实 Ent + AuthService 回归测试，验证在 `allow_no_auth=true` 时，错误凭证仍返回 401。

## 测试结果
- `go test ./internal/server/middleware -run TestWithAPIKeyConfig_(DoesNotFallback|RejectsNoAuth) -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid API keys are now rejected with a `401 Unauthorized` response, even when no-auth access is enabled.
  - Authentication and key-extraction errors no longer incorrectly fall back to no-auth access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->