### PR TITLE
fix(auth): invalidate API key cache immediately

### DIFF
--- a/internal/server/biz/api_key.go
+++ b/internal/server/biz/api_key.go
@@ -1041,6 +1041,14 @@ func (s *APIKeyService) invalidateAPIKeyCaches(ctx context.Context, keys ...stri
 		return
 	}
 
+	// Invalidate this instance synchronously before broadcasting the best-effort
+	// cross-instance event. Authentication must observe status, scope, allowlist,
+	// and rotated-key changes immediately instead of serving a stale entry until
+	// the asynchronous watcher or periodic refresh runs.
+	for _, key := range keys {
+		s.APIKeyCache.Invalidate(buildAPIKeyCacheKey(key))
+	}
+
 	cacheKeys := buildAPIKeyCacheKeys(keys)
 	if err := s.apiKeyNotifier.Notify(ctx, live.NewInvalidateKeysEvent(cacheKeys...)); err != nil {
 		log.Warn(ctx, "api key cache watcher notify failed", log.Cause(err))

--- a/internal/server/biz/auth_test.go
+++ b/internal/server/biz/auth_test.go
@@ -396,9 +396,6 @@ func TestAuthService_AuthenticateAPIKey(t *testing.T) {
 	_, err = authService.APIKeyService.UpdateAPIKeyStatus(ctx, apiKey.ID, "disabled")
 	require.NoError(t, err)
 
-	// Synchronously invalidate the cache for testing (async notification may not complete in time)
-	authService.APIKeyService.APIKeyCache.Invalidate(buildAPIKeyCacheKey(apiKeyString))
-
 	_, err = authService.AuthenticateAPIKey(ctx, apiKeyString)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "api key not enabled")
@@ -407,9 +404,6 @@ func TestAuthService_AuthenticateAPIKey(t *testing.T) {
 	// First, re-enable the API key
 	_, err = authService.APIKeyService.UpdateAPIKeyStatus(ctx, apiKey.ID, "enabled")
 	require.NoError(t, err)
-
-	// Synchronously invalidate the cache for testing
-	authService.APIKeyService.APIKeyCache.Invalidate(buildAPIKeyCacheKey(apiKeyString))
 
 	// Then archive the project (making it inactive)
 	_, err = client.Project.UpdateOneID(testProject.ID).


### PR DESCRIPTION
## 问题现象
API Key 被禁用、权限/白名单被修改或密钥轮换后，同一进程内仍可能在缓存 TTL 内继续使用旧凭证。实际表现为：管理操作已成功返回，但旧 API Key 仍可通过鉴权，或者旧 scope/旧 IP 白名单仍然生效；只有异步 watcher 或定期刷新运行后才恢复正确状态。

## 根因
`invalidateAPIKeyCaches` 原先只广播 best-effort 的跨实例失效事件，没有同步删除本实例的 `IndexedCache` 条目。普通更新、禁用、轮换等路径随后仍会命中旧缓存；如果 watcher 队列拥塞、事件丢失或 goroutine 尚未调度，窗口可持续到缓存过期。

## 整改方案
- 在广播跨实例失效事件前，同步清理当前实例中所有受影响 API Key 的缓存项。
- 保留原有 watcher 广播，用于其它实例的最终一致性刷新。
- 删除测试中为等待异步通知而手工调用 `Invalidate` 的代码，让测试直接验证业务保证：状态变更后立即生效。

## 测试结果
- `go test ./internal/server/biz -run TestAuthService_AuthenticateAPIKey -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key status, scope, allowlist, and rotation changes now become effective immediately on the current instance.
  * Authentication more reliably reflects recently disabled API keys and inactive projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->