### PR TITLE
fix(security): prevent SSRF in video storage worker

### DIFF
--- a/internal/server/video_storage/worker.go
+++ b/internal/server/video_storage/worker.go
@@ -3,9 +3,12 @@ package video_storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -39,6 +42,10 @@ type Worker struct {
 	dataStorageService *biz.DataStorageService
 	videoService       *biz.VideoService
 }
+
+var ErrUnsafeVideoURL = errors.New("unsafe video download URL")
+
+var sharedAddressPrefix = netip.MustParsePrefix("100.64.0.0/10")
 
 func NewWorker(params Params) *Worker {
 	w := &Worker{
@@ -250,7 +257,11 @@ func openVideoStream(ctx context.Context, videoURL string) (io.ReadCloser, strin
 	}
 
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, "", fmt.Errorf("invalid URL scheme: %s", parsedURL.Scheme)
+		return nil, "", fmt.Errorf("%w: invalid URL scheme: %s", ErrUnsafeVideoURL, parsedURL.Scheme)
+	}
+
+	if err := validateVideoDownloadURL(ctx, parsedURL); err != nil {
+		return nil, "", err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, videoURL, nil)
@@ -258,8 +269,22 @@ func openVideoStream(ctx context.Context, videoURL string) (io.ReadCloser, strin
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// nolint:gosec
-	resp, err := http.DefaultClient.Do(req)
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, "", fmt.Errorf("failed to configure safe video transport")
+	}
+	transport = transport.Clone()
+	transport.Proxy = nil
+	transport.DialContext = safeVideoDialContext
+
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(redirectReq *http.Request, _ []*http.Request) error {
+			return validateVideoDownloadURL(redirectReq.Context(), redirectReq.URL)
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to download video: %w", err)
 	}
@@ -271,6 +296,85 @@ func openVideoStream(ctx context.Context, videoURL string) (io.ReadCloser, strin
 
 	filename := filenameFromResponse(resp, videoURL)
 	return resp.Body, filename, nil
+}
+
+func validateVideoDownloadURL(ctx context.Context, videoURL *url.URL) error {
+	if videoURL == nil || (videoURL.Scheme != "http" && videoURL.Scheme != "https") || videoURL.Hostname() == "" || videoURL.User != nil {
+		return fmt.Errorf("%w: URL must be an http(s) URL with a public host", ErrUnsafeVideoURL)
+	}
+
+	host := videoURL.Hostname()
+	addresses, err := resolveVideoHost(ctx, host)
+	if err != nil {
+		return fmt.Errorf("%w: failed to resolve host %q: %v", ErrUnsafeVideoURL, host, err)
+	}
+
+	for _, address := range addresses {
+		if isUnsafeVideoAddress(address) {
+			return fmt.Errorf("%w: host %q resolves to private or local address %s", ErrUnsafeVideoURL, host, address)
+		}
+	}
+
+	return nil
+}
+
+func resolveVideoHost(ctx context.Context, host string) ([]netip.Addr, error) {
+	if address, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{address.Unmap()}, nil
+	}
+
+	resolved, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return nil, err
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("host has no addresses")
+	}
+
+	addresses := make([]netip.Addr, 0, len(resolved))
+	for _, address := range resolved {
+		addresses = append(addresses, address.Unmap())
+	}
+
+	return addresses, nil
+}
+
+func isUnsafeVideoAddress(address netip.Addr) bool {
+	return !address.IsValid() ||
+		address.IsLoopback() ||
+		address.IsPrivate() ||
+		address.IsLinkLocalUnicast() ||
+		address.IsUnspecified() ||
+		address.IsMulticast() ||
+		sharedAddressPrefix.Contains(address)
+}
+
+func safeVideoDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid video download address %q: %w", address, err)
+	}
+
+	addresses, err := resolveVideoHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	for _, resolved := range addresses {
+		if isUnsafeVideoAddress(resolved) {
+			return nil, fmt.Errorf("%w: host %q resolved to private or local address %s", ErrUnsafeVideoURL, host, resolved)
+		}
+
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("failed to connect to video host %q: %w", host, lastErr)
 }
 
 func filenameFromResponse(resp *http.Response, fallbackURL string) string {

--- a/internal/server/video_storage/worker_test.go
+++ b/internal/server/video_storage/worker_test.go
@@ -1,0 +1,32 @@
+package video_storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenVideoStreamRejectsPrivateAndLocalAddresses(t *testing.T) {
+	for _, videoURL := range []string{
+		"http://127.0.0.1/video.mp4",
+		"http://10.0.0.1/video.mp4",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]/video.mp4",
+		"http://100.64.0.1/video.mp4",
+	} {
+		t.Run(videoURL, func(t *testing.T) {
+			_, _, err := openVideoStream(context.Background(), videoURL)
+
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrUnsafeVideoURL), err)
+		})
+	}
+}
+
+func TestOpenVideoStreamRejectsNonHTTPURL(t *testing.T) {
+	_, _, err := openVideoStream(context.Background(), "file:///etc/passwd")
+
+	require.ErrorIs(t, err, ErrUnsafeVideoURL)
+}


### PR DESCRIPTION
## 问题现象
视频自动落盘任务会读取上游返回的 `video_url`，再由 AxonHub 服务端主动下载。原实现对 URL 只校验了 `http`/`https`，没有限制目标地址，也没有在重定向时重新校验目标。恶意或被攻陷的上游可让服务访问本机回环地址、云实例元数据地址、私有网段或其它内网服务，形成 SSRF；下载结果还会被写入配置的数据存储。

## 根因
`openVideoStream` 使用 `http.DefaultClient` 直接访问 provider 返回的 URL，且允许默认 DNS/重定向行为。URL 来源虽是 provider 响应，但不能视为可信输入。

## 整改方案
- 保留 `http`/`https` 协议限制，并拒绝带用户信息的 URL。
- 解析域名后拒绝 loopback、private、link-local、unspecified、multicast 和 CGNAT 地址。
- 使用自定义 DialContext，对每次实际连接再次解析并校验目标地址，降低 DNS rebinding 风险。
- 重定向前重新执行同样的 URL/地址校验。
- 禁用该下载器对外部代理的隐式继承，避免绕过目标地址校验。
- 增加 localhost、私网、云元数据地址、IPv6 loopback、CGNAT 和非 HTTP URL 回归测试。

## 测试结果
- `go test ./internal/server/video_storage -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Video downloads now reject unsafe destinations, including private, local, link-local, multicast, unspecified, and shared address ranges.
  - Non-HTTP(S) URLs and URLs containing user information are rejected.
  - Redirects are revalidated to prevent bypassing download protections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->