### PR TITLE
fix(version): compare glued prerelease counters numerically

### DIFF
--- a/internal/ent/migrate/datamigrate/migrator.go
+++ b/internal/ent/migrate/datamigrate/migrator.go
@@ -3,8 +3,6 @@ package datamigrate
 import (
 	"context"
 
-	"github.com/Masterminds/semver/v3"
-
 	"github.com/looplj/axonhub/internal/authz"
 	"github.com/looplj/axonhub/internal/build"
 	"github.com/looplj/axonhub/internal/ent"
@@ -73,19 +71,11 @@ func (m *Migrator) shouldRunMigration(ctx context.Context, migrationVersion stri
 		systemVersion = "v0.2.1"
 	}
 
-	migrationSemver, err := semver.NewVersion(migrationVersion)
+	result, err := biz.CompareVersions(systemVersion, migrationVersion)
 	if err != nil {
-		log.Warn(ctx, "invalid migration version, will run migration",
-			log.String("migration_version", migrationVersion),
-			log.Cause(err))
-
-		return true
-	}
-
-	systemSemver, err := semver.NewVersion(systemVersion)
-	if err != nil {
-		log.Warn(ctx, "invalid system version, will run migration",
+		log.Warn(ctx, "invalid version, will run migration",
 			log.String("system_version", systemVersion),
+			log.String("migration_version", migrationVersion),
 			log.Cause(err))
 
 		return true
@@ -93,7 +83,7 @@ func (m *Migrator) shouldRunMigration(ctx context.Context, migrationVersion stri
 
 	// Compare versions: if system version >= migration version, skip migration
 	// This means the migration has already been applied or a newer version is installed
-	if !systemSemver.LessThan(migrationSemver) {
+	if result >= 0 {
 		log.Info(ctx, "skipping migration: system version is equal or newer than migration version",
 			log.String("system_version", systemVersion),
 			log.String("migration_version", migrationVersion))
@@ -147,10 +137,10 @@ func (m *Migrator) Run(ctx context.Context) error {
 		return err
 	}
 
-	buildSemver, err := semver.NewVersion(build.Version)
-	if err != nil {
+	buildVersion := build.Version
+	if _, err := biz.ParseVersion(buildVersion); err != nil {
 		log.Warn(ctx, "invalid build version, skipping system version update",
-			log.String("build_version", build.Version),
+			log.String("build_version", buildVersion),
 			log.Cause(err))
 
 		return nil
@@ -161,15 +151,15 @@ func (m *Migrator) Run(ctx context.Context) error {
 	if currentVersion == "" {
 		updateSystemVersion = true
 	} else {
-		currentSemver, err := semver.NewVersion(currentVersion)
+		result, err := biz.CompareVersions(currentVersion, buildVersion)
 		if err != nil {
 			log.Warn(ctx, "invalid system version, updating to build version",
 				log.String("system_version", currentVersion),
-				log.String("build_version", build.Version),
+				log.String("build_version", buildVersion),
 				log.Cause(err))
 
 			updateSystemVersion = true
-		} else if currentSemver.LessThan(buildSemver) {
+		} else if result < 0 {
 			updateSystemVersion = true
 		}
 	}

--- a/internal/ent/migrate/datamigrate/migrator_test.go
+++ b/internal/ent/migrate/datamigrate/migrator_test.go
@@ -313,6 +313,50 @@ func TestMigrator_Run_BetaMigration(t *testing.T) {
 	assert.Equal(t, 1, unstableMigration.migrateCalls)
 }
 
+func TestMigrator_Run_BetaMigrationAcrossTenBoundary(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=1")
+	defer client.Close()
+
+	ctx := ent.NewContext(context.Background(), client)
+	ctx = authz.WithTestBypass(ctx)
+
+	systemService := biz.NewSystemService(biz.SystemServiceParams{})
+	err := systemService.Initialize(ctx, &biz.InitializeSystemParams{
+		OwnerEmail:     "owner@example.com",
+		OwnerPassword:  "password123",
+		OwnerFirstName: "System",
+		OwnerLastName:  "Owner",
+		BrandName:      "Test Brand",
+	})
+	require.NoError(t, err)
+	require.NoError(t, systemService.SetVersion(ctx, "v1.0.0-beta9"))
+
+	migrator := datamigrate.NewMigratorWithoutRegistrations(client)
+	migration := &mockMigrator{version: "v1.0.0-beta10"}
+	migrator.Register(migration)
+
+	require.NoError(t, migrator.Run(ctx))
+	assert.Equal(t, 1, migration.migrateCalls, "beta10 migration must run on a beta9 system")
+
+	// A beta10 system must not replay the beta10 migration.
+	require.NoError(t, systemService.SetVersion(ctx, "v1.0.0-beta10"))
+	replayed := &mockMigrator{version: "v1.0.0-beta10"}
+	migrator = datamigrate.NewMigratorWithoutRegistrations(client)
+	migrator.Register(replayed)
+
+	require.NoError(t, migrator.Run(ctx))
+	assert.Equal(t, 0, replayed.migrateCalls, "beta10 migration must not replay on a beta10 system")
+
+	// A beta10 system must skip the older beta9 migration.
+	require.NoError(t, systemService.SetVersion(ctx, "v1.0.0-beta10"))
+	older := &mockMigrator{version: "v1.0.0-beta9"}
+	migrator = datamigrate.NewMigratorWithoutRegistrations(client)
+	migrator.Register(older)
+
+	require.NoError(t, migrator.Run(ctx))
+	assert.Equal(t, 0, older.migrateCalls, "beta9 migration must be skipped on a beta10 system")
+}
+
 func TestMigrator_Run_EmptySystemVersion(t *testing.T) {
 	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=1")
 	defer client.Close()

--- a/internal/server/biz/version.go
+++ b/internal/server/biz/version.go
@@ -164,7 +164,7 @@ func selectLatestGitHubRelease(releases []GitHubRelease, includeBeta bool, now t
 			continue
 		}
 
-		if latestVersion == nil || version.GreaterThan(latestVersion) {
+		if latestVersion == nil || compareVersions(version, latestVersion) > 0 {
 			latestVersion = version
 			latestTag = release.TagName
 		}
@@ -206,17 +206,188 @@ func isBetaReleaseTag(tag string) bool {
 // IsNewerVersion compares two semantic versions and returns true if latest is newer than current.
 // Versions are expected to be in format "vX.Y.Z" or "X.Y.Z".
 func IsNewerVersion(current, latest string) bool {
-	vCurrent, err := semver.NewVersion(current)
+	result, err := CompareVersions(latest, current)
 	if err != nil {
 		// Handle error, maybe log it and return false
 		return false
 	}
 
-	vLatest, err := semver.NewVersion(latest)
+	return result > 0
+}
+
+// CompareVersions compares two version strings and reports whether a is less than,
+// equal to, or greater than b, returning -1, 0, or 1 respectively.
+// Versions are expected to be in format "vX.Y.Z" or "X.Y.Z", optionally with a
+// prerelease suffix. An error is returned when either version cannot be parsed.
+func CompareVersions(a, b string) (int, error) {
+	vA, err := ParseVersion(a)
 	if err != nil {
-		// Handle error, maybe log it and return false
-		return false
+		return 0, err
 	}
 
-	return vLatest.GreaterThan(vCurrent)
+	vB, err := ParseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+
+	return compareVersions(vA, vB), nil
+}
+
+// ParseVersion parses a version string in the format "vX.Y.Z" or "X.Y.Z".
+func ParseVersion(version string) (*semver.Version, error) {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+
+	return v, nil
+}
+
+// compareVersions compares the release numbers first and falls back to
+// comparePrerelease, which understands prerelease identifiers such as "beta10"
+// that glue a name to a counter without a dot separator.
+func compareVersions(a, b *semver.Version) int {
+	if result := compareUint64(a.Major(), b.Major()); result != 0 {
+		return result
+	}
+
+	if result := compareUint64(a.Minor(), b.Minor()); result != 0 {
+		return result
+	}
+
+	if result := compareUint64(a.Patch(), b.Patch()); result != 0 {
+		return result
+	}
+
+	return comparePrerelease(a.Prerelease(), b.Prerelease())
+}
+
+// comparePrerelease compares two prerelease strings following the SemVer
+// precedence rules, except that each identifier is further split into digit and
+// non-digit runs. That makes the counter in tags like "beta9" and "beta10"
+// compare numerically, and treats "beta10" as equal to "beta.10".
+// A release without a prerelease outranks any prerelease of the same version.
+func comparePrerelease(a, b string) int {
+	if a == b {
+		return 0
+	}
+
+	if a == "" {
+		return 1
+	}
+
+	if b == "" {
+		return -1
+	}
+
+	tokensA := prereleaseTokens(a)
+	tokensB := prereleaseTokens(b)
+
+	for i := 0; i < len(tokensA) && i < len(tokensB); i++ {
+		if result := comparePrereleaseToken(tokensA[i], tokensB[i]); result != 0 {
+			return result
+		}
+	}
+
+	// A larger set of prerelease tokens takes precedence when every shared token is equal.
+	return compareInt(len(tokensA), len(tokensB))
+}
+
+// prereleaseTokens splits a prerelease string on dots and then into digit and
+// non-digit runs, e.g. "beta10" and "beta.10" both become []string{"beta", "10"}.
+func prereleaseTokens(s string) []string {
+	var tokens []string
+
+	for _, identifier := range strings.Split(s, ".") {
+		tokens = append(tokens, splitDigitRuns(identifier)...)
+	}
+
+	return tokens
+}
+
+// comparePrereleaseToken compares a single flattened prerelease token.
+func comparePrereleaseToken(a, b string) int {
+	numericA, numericB := isDigitRun(a), isDigitRun(b)
+
+	switch {
+	case numericA && numericB:
+		return compareNumericRuns(a, b)
+	case numericA != numericB:
+		// Numeric identifiers always have lower precedence than alphanumeric ones.
+		if numericA {
+			return -1
+		}
+
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+// splitDigitRuns splits s into consecutive runs of digits and non-digits,
+// e.g. "beta10" becomes []string{"beta", "10"}.
+func splitDigitRuns(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	var runs []string
+
+	start := 0
+	digits := isASCIIDigit(s[0])
+
+	for i := 1; i < len(s); i++ {
+		if isASCIIDigit(s[i]) == digits {
+			continue
+		}
+
+		runs = append(runs, s[start:i])
+		start = i
+		digits = isASCIIDigit(s[i])
+	}
+
+	return append(runs, s[start:])
+}
+
+// compareNumericRuns compares two digit runs by value without parsing them,
+// so arbitrarily long counters cannot overflow.
+func compareNumericRuns(a, b string) int {
+	trimmedA := strings.TrimLeft(a, "0")
+	trimmedB := strings.TrimLeft(b, "0")
+
+	if result := compareInt(len(trimmedA), len(trimmedB)); result != 0 {
+		return result
+	}
+
+	return strings.Compare(trimmedA, trimmedB)
+}
+
+func isDigitRun(s string) bool {
+	return s != "" && isASCIIDigit(s[0])
+}
+
+func isASCIIDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func compareInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareUint64(a, b uint64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/internal/server/biz/version.go
+++ b/internal/server/biz/version.go
@@ -298,7 +298,7 @@ func comparePrerelease(a, b string) int {
 func prereleaseTokens(s string) []string {
 	var tokens []string
 
-	for _, identifier := range strings.Split(s, ".") {
+	for identifier := range strings.SplitSeq(s, ".") {
 		tokens = append(tokens, splitDigitRuns(identifier)...)
 	}
 

--- a/internal/server/biz/version_test.go
+++ b/internal/server/biz/version_test.go
@@ -135,6 +135,60 @@ func TestIsNewerVersion(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "beta counter crosses ten boundary",
+			current: "v1.0.0-beta9",
+			latest:  "v1.0.0-beta10",
+			want:    true,
+		},
+		{
+			name:    "beta counter crosses ten boundary in reverse",
+			current: "v1.0.0-beta10",
+			latest:  "v1.0.0-beta9",
+			want:    false,
+		},
+		{
+			name:    "beta counter crosses hundred boundary",
+			current: "v1.0.0-beta99",
+			latest:  "v1.0.0-beta100",
+			want:    true,
+		},
+		{
+			name:    "dotted beta counter crosses ten boundary",
+			current: "v1.0.0-beta.9",
+			latest:  "v1.0.0-beta.10",
+			want:    true,
+		},
+		{
+			name:    "glued and dotted beta counters are equivalent",
+			current: "v1.0.0-beta10",
+			latest:  "v1.0.0-beta.10",
+			want:    false,
+		},
+		{
+			name:    "rc counter crosses ten boundary",
+			current: "v1.0.0-rc9",
+			latest:  "v1.0.0-rc10",
+			want:    true,
+		},
+		{
+			name:    "unstable build of the same beta outranks the beta",
+			current: "v1.0.0-beta10",
+			latest:  "v1.0.0-beta10-unstable.20260907",
+			want:    true,
+		},
+		{
+			name:    "unstable build precedes the next beta",
+			current: "v1.0.0-beta9-unstable.20260907",
+			latest:  "v1.0.0-beta10",
+			want:    true,
+		},
+		{
+			name:    "stable release outranks its beta",
+			current: "v1.0.0-beta10",
+			latest:  "v1.0.0",
+			want:    true,
+		},
+		{
 			name:    "build metadata",
 			current: "v1.0.0+build.1",
 			latest:  "v1.0.0+build.2",
@@ -346,10 +400,66 @@ func TestSelectLatestGitHubRelease(t *testing.T) {
 		require.Equal(t, "v1.0.0-beta4", got)
 	})
 
+	t.Run("selects the highest beta across the ten boundary", func(t *testing.T) {
+		got, err := selectLatestGitHubRelease([]GitHubRelease{
+			{TagName: "v1.0.0-beta9", Prerelease: true, PublishedAt: now.Add(-96 * time.Hour)},
+			{TagName: "v1.0.0-beta10", Prerelease: true, PublishedAt: now.Add(-24 * time.Hour)},
+		}, true, now)
+		require.NoError(t, err)
+		require.Equal(t, "v1.0.0-beta10", got)
+	})
+
 	t.Run("returns an error when no release is eligible", func(t *testing.T) {
 		_, err := selectLatestGitHubRelease([]GitHubRelease{
 			{TagName: "v1.0.0-beta6", PublishedAt: now.Add(-time.Hour)},
 		}, false, now)
 		require.EqualError(t, err, "no eligible release found")
+	})
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "equal", a: "v1.0.0", b: "v1.0.0", want: 0},
+		{name: "major", a: "v2.0.0", b: "v1.0.0", want: 1},
+		{name: "minor", a: "v1.1.0", b: "v1.2.0", want: -1},
+		{name: "patch", a: "v1.0.2", b: "v1.0.1", want: 1},
+		{name: "beta below ten", a: "v1.0.0-beta5", b: "v1.0.0-beta6", want: -1},
+		{name: "beta across ten", a: "v1.0.0-beta10", b: "v1.0.0-beta9", want: 1},
+		{name: "beta across hundred", a: "v1.0.0-beta100", b: "v1.0.0-beta99", want: 1},
+		{name: "glued equals dotted", a: "v1.0.0-beta10", b: "v1.0.0-beta.10", want: 0},
+		{name: "padded counter equals bare counter", a: "v1.0.0-beta010", b: "v1.0.0-beta10", want: 0},
+		{name: "long counters do not overflow", a: "v1.0.0-beta99999999999999999999", b: "v1.0.0-beta99999999999999999998", want: 1},
+		{name: "bare name precedes counter", a: "v1.0.0-beta", b: "v1.0.0-beta1", want: -1},
+		{name: "alpha precedes beta", a: "v1.0.0-alpha10", b: "v1.0.0-beta1", want: -1},
+		{name: "beta precedes rc", a: "v1.0.0-beta10", b: "v1.0.0-rc1", want: -1},
+		{name: "stable outranks beta", a: "v1.0.0", b: "v1.0.0-beta10", want: 1},
+		{name: "build metadata ignored", a: "v1.0.0+build.2", b: "v1.0.0+build.1", want: 0},
+		{name: "missing v prefix", a: "1.0.0-beta10", b: "v1.0.0-beta9", want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CompareVersions(tt.a, tt.b)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got, "CompareVersions(%q, %q)", tt.a, tt.b)
+
+			// The comparison must be antisymmetric.
+			reverse, err := CompareVersions(tt.b, tt.a)
+			require.NoError(t, err)
+			require.Equal(t, -tt.want, reverse, "CompareVersions(%q, %q)", tt.b, tt.a)
+		})
+	}
+
+	t.Run("reports invalid versions", func(t *testing.T) {
+		_, err := CompareVersions("invalid", "v1.0.0")
+		require.Error(t, err)
+
+		_, err = CompareVersions("v1.0.0", "")
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## 问题现象

开启「包含 Beta 版本」后检查更新，`v1.0.0-beta10` 已发布，但结果显示 `v1.0.0-beta9` 已是最新版本。

## 根因

tag 使用 `-beta9` / `-beta10` 这种「字母与数字直接相连」的预发布标识。SemVer 第 11 条只对纯数字段做数值比较，`Masterminds/semver` 因此把 `beta9` 和 `beta10` 当单段字符串比较，得出 `beta10` < `beta9`。

同一比较还用于数据迁移：`v1.0.0-beta9` 的实例在后续加入 `v1.0.0-beta10` 迁移时会把该迁移静默跳过。

## 整改方案

- 在 `CompareVersions` 中把预发布标识再拆成数字 / 非数字 run，使 `beta9` < `beta10`，并把 `beta10` 与 `beta.10` 视为相等。
- 版本检查与数据迁移统一走这套比较，避免两处结论不一致。
- 增加跨十位数边界、长计数器、以及 beta9 → beta10 迁移的回归测试。

Closes #2430

## 测试结果

- `go test ./internal/server/biz/ -run 'TestIsNewerVersion|TestCompareVersions|TestSelectLatestGitHubRelease|TestIsAxonHubTag|TestIsPreReleaseTag' -count=1` ✅
- `CGO_ENABLED=1 go test ./internal/ent/migrate/datamigrate/ -run 'TestMigrator' -count=1` ✅

未运行 lint/build，符合仓库 `AGENTS.md` 约束。

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved version comparisons for prerelease versions, including beta and release-candidate numbers crossing from single to multiple digits.
  * Correctly identifies newer releases when comparing versions such as beta9 and beta10.
  * Prevents migrations from rerunning when the system is already on the applicable version.
  * Improved selection of the latest available release across prerelease versions.
  * Ensures stable releases are correctly prioritized over corresponding prerelease versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->