### PR TITLE
fix(trace): keep native trace extraction opt-in by default

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -229,9 +229,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.trace.extra_trace_headers", []string{})
 	v.SetDefault("server.trace.response_trace_headers", []string{})
 	v.SetDefault("server.trace.extra_trace_body_fields", []string{})
-	v.SetDefault("server.trace.claude_code_trace_enabled", true)
-	v.SetDefault("server.trace.codex_trace_enabled", true)
-	v.SetDefault("server.trace.opencode_trace_enabled", true)
+	// Native client trace extraction (Codex / Claude Code / OpenCode) is opt-in.
+	// These integrations reuse headers that every official client session sends, so
+	// enabling them by default persistently records traffic without an explicit
+	// trace ID (for example AH-Trace-Id).
+	v.SetDefault("server.trace.claude_code_trace_enabled", false)
+	v.SetDefault("server.trace.codex_trace_enabled", false)
+	v.SetDefault("server.trace.opencode_trace_enabled", false)
 
 	// Dashboard defaults
 	v.SetDefault("server.dashboard.all_time_token_stats_soft_ttl", "1h")

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -75,7 +75,7 @@ func TestSSEKeepAliveDefaultsToDisabled(t *testing.T) {
 	}
 }
 
-func TestTraceExtractionDefaultsToEnabled(t *testing.T) {
+func TestTraceExtractionDefaultsToDisabled(t *testing.T) {
 	configFile := writeTestConfig(t, "")
 
 	cfg, _, err := loadConfig(configFile)
@@ -84,14 +84,14 @@ func TestTraceExtractionDefaultsToEnabled(t *testing.T) {
 	}
 
 	trace := cfg.APIServer.Trace
-	if !trace.ClaudeCodeTraceEnabled {
-		t.Error("Claude Code trace extraction should default to enabled")
+	if trace.ClaudeCodeTraceEnabled {
+		t.Error("Claude Code trace extraction should default to disabled")
 	}
-	if !trace.CodexTraceEnabled {
-		t.Error("Codex trace extraction should default to enabled")
+	if trace.CodexTraceEnabled {
+		t.Error("Codex trace extraction should default to disabled")
 	}
-	if !trace.OpenCodeTraceEnabled {
-		t.Error("OpenCode trace extraction should default to enabled")
+	if trace.OpenCodeTraceEnabled {
+		t.Error("OpenCode trace extraction should default to disabled")
 	}
 }
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -23,9 +23,9 @@ server:
     extra_trace_headers: [] # Extra trace headers (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_HEADERS)
     response_trace_headers: [] # Response headers for the resolved trace ID (env: AXONHUB_SERVER_TRACE_RESPONSE_TRACE_HEADERS)
     extra_trace_body_fields: [] # Extra trace body fields (env: AXONHUB_SERVER_TRACE_EXTRA_TRACE_BODY_FIELDS)
-    claude_code_trace_enabled: true # Enable extracting trace IDs from Claude Code request metadata (env: AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED)
-    codex_trace_enabled: true # Enable extracting trace IDs from Codex Session_id header (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)
-    opencode_trace_enabled: true # Enable extracting trace IDs from OpenCode session headers (env: AXONHUB_SERVER_TRACE_OPENCODE_TRACE_ENABLED)
+    claude_code_trace_enabled: false # Enable extracting trace IDs from Claude Code request metadata (opt-in) (env: AXONHUB_SERVER_TRACE_CLAUDE_CODE_TRACE_ENABLED)
+    codex_trace_enabled: false # Enable extracting trace IDs from Codex Session_id header (opt-in) (env: AXONHUB_SERVER_TRACE_CODEX_TRACE_ENABLED)
+    opencode_trace_enabled: false # Enable extracting trace IDs from OpenCode session headers (opt-in) (env: AXONHUB_SERVER_TRACE_OPENCODE_TRACE_ENABLED)
   debug: false                  # Enable debug mode (env: AXONHUB_SERVER_DEBUG)
   disable_ssl_verify: false     # Disable SSL certificate verification for self-signed certificates (env: AXONHUB_SERVER_DISABLE_SSL_VERIFY)
   # Max multipart form memory for large uploads (e.g. backup restore).

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -39,15 +39,15 @@ type Config struct {
 	ExtraTraceBodyFields []string `conf:"extra_trace_body_fields" yaml:"extra_trace_body_fields" json:"extra_trace_body_fields"`
 
 	// ClaudeCodeTraceEnabled enables extracting trace IDs from Claude Code request metadata.
-	// Default to true.
+	// Default to false.
 	ClaudeCodeTraceEnabled bool `conf:"claude_code_trace_enabled" yaml:"claude_code_trace_enabled" json:"claude_code_trace_enabled"`
 
 	// CodexTraceEnabled enables extracting trace IDs from Codex request headers.
-	// Default to true.
+	// Default to false.
 	CodexTraceEnabled bool `conf:"codex_trace_enabled" yaml:"codex_trace_enabled" json:"codex_trace_enabled"`
 
 	// OpenCodeTraceEnabled enables extracting trace IDs from OpenCode request headers.
-	// Default to true.
+	// Default to false.
 	OpenCodeTraceEnabled bool `conf:"opencode_trace_enabled" yaml:"opencode_trace_enabled" json:"opencode_trace_enabled"`
 }
 


### PR DESCRIPTION
## 现象

在 `#2369` 之后，未额外配置任何 trace header 的部署也会自动开始记录 Trace：

- Codex Desktop / Codex CLI 每次请求都会携带 `Session-Id` / `Thread-Id` / `X-Codex-Window-Id` / `X-Codex-Turn-Metadata` 等 header。
- 因为 `server.trace.codex_trace_enabled` 默认被改成了 `true`，只要请求来自 Codex，AxonHub 就会把这些 session 解析成 Trace 并持久化。
- 结果就是：部署方并没有显式设置 `AH-Trace-Id`，也没有在配置里开启 trace，却看到每条 Codex 对话都被自动记录，甚至还会被继续用于 upstream 亲和/缓存路由等下游逻辑。

例如来自 Codex Desktop 的实际请求：

```
Session-Id: 01a07bb0-db81-7152-99b4-5901c8a5f743
Thread-Id: 01a07bb0-db81-7152-99b4-5901c8a5f743
X-Codex-Window-Id: 01a07bb0-db81-7152-99b4-5901c8a5f743:0
X-Codex-Turn-Metadata: {session_id:01a07bb0-db81-7152-99b4-5901c8a5f743, ...}
```

该请求没有 `AH-Trace-Id`，但仍会触发 Trace 持久化。

## 原因

`#2369`（feat: add opencode session header）在加入 OpenCode 自动识别时，把这三项默认值从 `false` 一起改成了 `true`：

```go
v.SetDefault(server.trace.claude_code_trace_enabled, false) // 改成了 true
v.SetDefault(server.trace.codex_trace_enabled, false)        // 改成了 true
v.SetDefault(server.trace.opencode_trace_enabled, false)     // 改成了 true
```

而 Codex / Claude Code / OpenCode 这类官方客户端**每次合法请求都会携带各自的 session 头**。默认 `true` 实际上等于“所有官方客户端流量自动进入 Trace”，这和 `#2208` 确立的原则冲突：

> Only explicitly identified traces should persist.

原生客户端 header 对“协议识别”是显式的，但对“是否要记录 Trace”并不是——是否记录应由部署者通过配置显式选择。

## 修复

把这三个默认值恢复为 `false`，保持为 opt-in：

```yaml
server:
  trace:
    claude_code_trace_enabled: false
    codex_trace_enabled: false
    opencode_trace_enabled: false
```

已有显式配置为 `true` 的部署完全不受影响；需要 Codex/Claude Code/OpenCode 自动聚合 Trace 的用户仍可按文档开启。

同步更新了：

- `conf/conf.go`
- `config.example.yml`
- `internal/tracing/tracing.go` 注释
- `conf/conf_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Native trace-ID extraction for Claude Code, Codex, and OpenCode is now disabled by default.
  * These trace-extraction options are explicitly marked as opt-in and can be enabled through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->