### PR TITLE
fix(frontend): hide empty channel column and correct ZenMux Gemini icon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          package_json_file: frontend/package.json
           run_install: false
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          package_json_file: frontend/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          package_json_file: frontend/package.json
           run_install: false
 
       # The *.test.mjs suites import .ts modules directly, which needs native

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "axonhub",
   "private": false,
   "version": "0.1.0",
+  "packageManager": "pnpm@10.34.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/channels/data/channel-config.test.mjs
+++ b/frontend/src/features/channels/data/channel-config.test.mjs
@@ -139,6 +139,21 @@ test('quota selection follows quota column visibility and preserves normalized f
   assert.equal(zhSystem['quota.window.cycle'], '周期窗口');
 });
 
+test('filter-only model column stays hidden while model filtering remains configured', () => {
+  const channelsData = read('features/channels/data/channels.ts');
+  const channelColumns = read('features/channels/components/channels-columns.tsx');
+  const channelsConfig = read('features/channels/data/config_channels.ts');
+
+  assert.match(channelsData, /DEFAULT_CHANNEL_COLUMN_VISIBILITY[\s\S]*model:\s*false/);
+  assert.match(channelsData, /\.\.\.parsed\.data,\s*model:\s*false/);
+  assert.match(
+    channelColumns,
+    /id:\s*'model'[\s\S]*?accessorFn:\s*\(\)\s*=>\s*''[\s\S]*?header:\s*\(\)\s*=>\s*null[\s\S]*?cell:\s*\(\)\s*=>\s*null[\s\S]*?filterFn:\s*\(\)\s*=>\s*true[\s\S]*?enableColumnFilter:\s*false[\s\S]*?enableGlobalFilter:\s*false/,
+    'the virtual model column must render nothing while keeping its server-side filtering hooks'
+  );
+  assert.match(channelsConfig, /zenmux_gemini:\s*\{[\s\S]*icon:\s*ZenMux/);
+});
+
 test('ZenMux quota schema accepts all channel variants without row grouping', () => {
   const schema = read('features/channels/data/schema.ts');
   const channelsData = read('features/channels/data/channels.ts');

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -872,6 +872,7 @@ const ALL_CHANNEL_TAGS_QUERY = `
 export type ChannelListColumnVisibility = Record<string, boolean>;
 
 export const DEFAULT_CHANNEL_COLUMN_VISIBILITY: ChannelListColumnVisibility = {
+  model: false,
   tags: false,
   proxy: false,
 };
@@ -880,7 +881,7 @@ const channelListColumnVisibilitySchema = z.record(z.string(), z.boolean());
 
 export function parseChannelColumnVisibility(value: unknown): ChannelListColumnVisibility {
   const parsed = channelListColumnVisibilitySchema.safeParse(value);
-  return parsed.success ? { ...DEFAULT_CHANNEL_COLUMN_VISIBILITY, ...parsed.data } : DEFAULT_CHANNEL_COLUMN_VISIBILITY;
+  return parsed.success ? { ...DEFAULT_CHANNEL_COLUMN_VISIBILITY, ...parsed.data, model: false } : DEFAULT_CHANNEL_COLUMN_VISIBILITY;
 }
 
 const CHANNEL_QUERY_FULL_NODE_SELECTION = `

--- a/frontend/src/features/channels/data/config_channels.ts
+++ b/frontend/src/features/channels/data/config_channels.ts
@@ -834,7 +834,7 @@ export const CHANNEL_CONFIGS: Record<ChannelType, ChannelConfig> = {
     defaultModels: ['google/gemini-2.5-pro'],
     apiFormat: GEMINI_CONTENTS,
     color: 'bg-gray-100 text-gray-800 border-gray-200',
-    icon: OpenRouter,
+    icon: ZenMux,
   },
   commandcode: {
     channelType: 'commandcode',


### PR DESCRIPTION
## Summary
- Keep the channel model filter virtual column available to query construction without allowing it to occupy table space, including when legacy persisted visibility sets `model: true`.
- Correct the `zenmux_gemini` provider icon from OpenRouter to ZenMux.
- Pin pnpm to `10.34.5` in `frontend/package.json` and make build, test, and release workflows consume that declaration.

## Root cause
- PR #165 introduced the filter-only `model` column without adding it to default visibility.
- PR #2418 changed the channel table to fixed layout, making the previously collapsed empty column visibly consume space.
- PR #2381 mapped `zenmux_gemini` to the OpenRouter icon.

## Verification
- `corepack pnpm test:unit` (105 passed)
- `corepack pnpm exec eslint src/features/channels/data/channels.ts src/features/channels/data/config_channels.ts` (passed)
- `corepack pnpm --version` (`10.34.5`)
- Workflow YAML and package JSON parsing passed.
- `git diff --check` passed; lockfile unchanged.

Full frontend lint currently reports pre-existing errors in untouched files (160 errors, 91 warnings); no changed-file errors remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the model column by default in channel lists, including when saved visibility settings are applied.
  * Corrected the channel icon displayed for ZenMux Gemini channels.

* **Tests**
  * Added coverage confirming model-column visibility behavior and the ZenMux Gemini icon.

* **Chores**
  * Standardized frontend workflows to use the project’s declared pnpm version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->