### PR TITLE
fix(frontend): clear stale project selection on account switch

### DIFF
--- a/frontend/src/features/auth/data/auth.ts
+++ b/frontend/src/features/auth/data/auth.ts
@@ -5,6 +5,7 @@ import { graphqlRequest } from '@/gql/graphql';
 import { ME_QUERY } from '@/gql/users';
 import { toast } from 'sonner';
 import { useAuthStore, setTokenToStorage, removeTokenFromStorage } from '@/stores/authStore';
+import { useProjectStore } from '@/stores/projectStore';
 import { AuthUser } from '@/stores/authStore';
 import { authApi } from '@/lib/api-client';
 import i18n from '@/lib/i18n';
@@ -36,6 +37,15 @@ export function useMe(enabled = true) {
     if (query.data) {
       const userLanguage = query.data.preferLanguage || 'en';
 
+      // The selected project is persisted per browser, but only valid for the
+      // user it belonged to. Drop any project the current user is not a member
+      // of so a stale selection from a previous account is never sent to the
+      // server as X-Project-ID.
+      const { selectedProjectId, clearSelectedProjectId } = useProjectStore.getState();
+      if (selectedProjectId && !(query.data.projects ?? []).some((p) => p.projectID === selectedProjectId)) {
+        clearSelectedProjectId();
+      }
+
       setUser(query.data);
 
       // Initialize i18n with user's preferred language
@@ -65,6 +75,11 @@ export function useSignIn() {
       // Update auth store
       setAccessToken(data.token);
       setUser(data.user);
+
+      // Reset project selection: a persisted project from a previous account
+      // on the same browser must not leak into this session. The project
+      // switcher re-selects the first available project once myProjects loads.
+      useProjectStore.getState().clearSelectedProjectId();
 
       // Initialize i18n with user's preferred language
       if (userLanguage !== i18n.language) {
@@ -96,6 +111,10 @@ export function useSignOut() {
 
     // Clear auth store
     reset();
+
+    // Drop the persisted project selection so the next account on this browser
+    // does not inherit it.
+    useProjectStore.getState().clearSelectedProjectId();
 
     queryClient.clear();
 
@@ -157,6 +176,11 @@ export function useOIDCExchange() {
       // Update auth store
       setAccessToken(data.token);
       setUser(data.user);
+
+      // Reset project selection: a persisted project from a previous account
+      // on the same browser must not leak into this session. The project
+      // switcher re-selects the first available project once myProjects loads.
+      useProjectStore.getState().clearSelectedProjectId();
 
       // Initialize i18n with user's preferred language
       if (userLanguage !== i18n.language) {

--- a/frontend/src/features/users/data/users.ts
+++ b/frontend/src/features/users/data/users.ts
@@ -4,6 +4,7 @@ import { USERS_QUERY, CREATE_USER_MUTATION, UPDATE_USER_MUTATION, UPDATE_USER_ST
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useErrorHandler } from '@/hooks/use-error-handler';
+import { useSelectedProjectId } from '@/stores/projectStore';
 import { User, UserConnection, CreateUserInput, UpdateUserInput, userConnectionSchema, userSchema } from './schema';
 
 // Query hooks
@@ -20,6 +21,7 @@ export function useUsers(
 ) {
   const { t } = useTranslation();
   const { handleError } = useErrorHandler();
+  const selectedProjectId = useSelectedProjectId();
 
   const queryVariables = {
     ...variables,
@@ -27,10 +29,11 @@ export function useUsers(
   };
 
   return useQuery({
-    queryKey: ['users', queryVariables],
+    queryKey: ['users', queryVariables, selectedProjectId],
     queryFn: async () => {
       try {
-        const data = await graphqlRequest<{ users: UserConnection }>(USERS_QUERY, queryVariables);
+        const headers = selectedProjectId ? { 'X-Project-ID': selectedProjectId } : undefined;
+        const data = await graphqlRequest<{ users: UserConnection }>(USERS_QUERY, queryVariables, headers);
         return userConnectionSchema.parse(data?.users);
       } catch (error) {
         handleError(error, t('common.errors.loadFailed'));

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -102,6 +102,7 @@ func (User) Policy() ent.Policy {
 		Query: scopes.QueryPolicy{
 			scopes.OwnerRule(),
 			scopes.ProjectOwnerReadUsersRule(),
+			scopes.ProjectMemberReadUsersRule(scopes.ScopeReadUsers),
 			scopes.UserReadScopeRule(scopes.ScopeReadUsers),
 			scopes.UserOwnedQueryRule(),
 		},

--- a/internal/scopes/rule_user_project_scope.go
+++ b/internal/scopes/rule_user_project_scope.go
@@ -93,6 +93,39 @@ func ProjectOwnerReadUsersRule() privacy.QueryRule {
 	})
 }
 
+// ProjectMemberReadUsersRule allows project members to view users belonging to
+// their current project when they hold the required scope on that project.
+// Users with the scope at system level keep their current unrestricted view.
+func ProjectMemberReadUsersRule(requiredScope ScopeSlug) privacy.QueryRule {
+	return privacy.FilterFunc(func(ctx context.Context, q privacy.Filter) error {
+		projectID, hasProjectID := contexts.GetProjectID(ctx)
+		if !hasProjectID {
+			return privacy.Skipf("Project ID not found in context")
+		}
+
+		currentUser, err := getUserFromContext(ctx)
+		if err != nil {
+			return privacy.Skipf("User not found in context")
+		}
+
+		userFilter, ok := q.(*ent.UserFilter)
+		if !ok {
+			return privacy.Skipf("Not a user query")
+		}
+
+		if HasSystemScope(currentUser, requiredScope) {
+			return privacy.Allowf("User %d has system scope %s, querying users", currentUser.ID, requiredScope)
+		}
+
+		if !userHasProjectScope(currentUser, projectID, requiredScope) {
+			return privacy.Skipf("User %d can not query users in project %d with scope %s", currentUser.ID, requiredScope, requiredScope)
+		}
+
+		userFilter.WhereHasProjectUsersWith(userproject.ProjectID(projectID))
+		return privacy.Allowf("User %d can query users in project %d with scope %s", currentUser.ID, projectID, requiredScope)
+	})
+}
+
 // UserProjectScopeReadRule allows users to query projects they are members of.
 // It checks:
 // 1. If user has global scope permission -> Allow all


### PR DESCRIPTION
## Summary
Fixes scoped GraphQL queries failing with `permission denied` for project developers after switching accounts on the same browser.

Two defects, both surfaced on the API Keys page (`Users` and `GetApiKeys` errors that also blocked creating API keys):

### 1. Stale persisted project selection (frontend)
The selected project (`axonhub_selected_project_id` in localStorage) was never cleared on login/logout. Scoped queries (`apiKeys`, `users`, `allChannelSummarys`) send it as `X-Project-ID`. Switching accounts on one browser leaked the previous user's project into the new session; a developer without membership in that project got `permission denied` from the ent privacy policies and could not list or create API keys.

- `frontend/src/features/auth/data/auth.ts`: clear persisted project on password sign-in, OIDC exchange, and sign-out; in `useMe`, drop any persisted selection the current user is not a member of (`data.projects`).
- `frontend/src/features/users/data/users.ts`: send `X-Project-ID` so the `Users` query uses project context.

### 2. Project members could not read users (backend)
The `User` schema privacy policy only granted user reads to system-scope holders (`UserReadScopeRule`, system-only) or project owners (`ProjectOwnerReadUsersRule`). A project developer holding `read_users` at project level could never load the Users creator filter, because `useUsers` sent no project context and the scope lives on the project role/membership.

- `internal/scopes/rule_user_project_scope.go`: add `ProjectMemberReadUsersRule`, allowing members with the `read_users` scope on the current project to read users, filtered to that project; system-scope holders keep their unrestricted view.
- `internal/ent/schema/user.go`: chain `ProjectMemberReadUsersRule` before `UserReadScopeRule`.

## Verification
- `go build ./internal/scopes/... ./internal/ent/...` passes.
- `tsc --noEmit` (frontend) passes.

Root-cause analysis for both errors captured in prior session notes; `Users` failing was a backend policy gap independent of the stale-project header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User lists are now filtered to the selected project.
  * Project members with the appropriate permission can view users in their project.

* **Bug Fixes**
  * Selected project data is cleared when switching accounts or signing out.
  * Invalid or inaccessible project selections are automatically removed from the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->