### PR TITLE
fix(frontend): gate project-scoped queries until persisted project is validated

### DIFF
--- a/frontend/src/components/auth-guard.tsx
+++ b/frontend/src/components/auth-guard.tsx
@@ -3,6 +3,7 @@ import { useRouter } from '@tanstack/react-router';
 import { isAuthError } from '@/gql/graphql';
 import { useAuthStore } from '@/stores/authStore';
 import { useSelectedProjectId } from '@/stores/projectStore';
+import { isProjectSelectionValid } from '@/lib/project-membership';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useMe } from '@/features/auth/data/auth';
 
@@ -24,10 +25,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
   // descendant queries never carry a X-Project-ID the user has no membership in.
   // `meData` must be present: an unvalidated selection is never a reason to
   // render protected content, even when the `me` query itself errored.
-  const projectReady =
-    !!meData &&
-    (!selectedProjectId ||
-      (meData.projects ?? []).some((p) => p.projectID === selectedProjectId));
+  const projectReady = isProjectSelectionValid(meData, selectedProjectId);
 
   useEffect(() => {
     // If no token, redirect to sign-in

--- a/frontend/src/components/auth-guard.tsx
+++ b/frontend/src/components/auth-guard.tsx
@@ -22,10 +22,12 @@ export function AuthGuard({ children }: AuthGuardProps) {
   // the persisted project has been validated against the current user's
   // projects (and cleared when stale), keep showing the loading state so
   // descendant queries never carry a X-Project-ID the user has no membership in.
+  // `meData` must be present: an unvalidated selection is never a reason to
+  // render protected content, even when the `me` query itself errored.
   const projectReady =
-    !meData ||
-    !selectedProjectId ||
-    (meData.projects ?? []).some((p) => p.projectID === selectedProjectId);
+    !!meData &&
+    (!selectedProjectId ||
+      (meData.projects ?? []).some((p) => p.projectID === selectedProjectId));
 
   useEffect(() => {
     // If no token, redirect to sign-in

--- a/frontend/src/components/auth-guard.tsx
+++ b/frontend/src/components/auth-guard.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRouter } from '@tanstack/react-router';
 import { isAuthError } from '@/gql/graphql';
 import { useAuthStore } from '@/stores/authStore';
+import { useSelectedProjectId } from '@/stores/projectStore';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useMe } from '@/features/auth/data/auth';
 
@@ -12,9 +13,19 @@ interface AuthGuardProps {
 export function AuthGuard({ children }: AuthGuardProps) {
   const router = useRouter();
   const { accessToken } = useAuthStore((state) => state.auth);
+  const selectedProjectId = useSelectedProjectId();
 
   // Automatically fetch user info when token is available
-  const { isLoading: isMeLoading, error: meError } = useMe();
+  const { isLoading: isMeLoading, error: meError, data: meData } = useMe();
+
+  // The selected project is persisted per browser. Until `me` has resolved and
+  // the persisted project has been validated against the current user's
+  // projects (and cleared when stale), keep showing the loading state so
+  // descendant queries never carry a X-Project-ID the user has no membership in.
+  const projectReady =
+    !meData ||
+    !selectedProjectId ||
+    (meData.projects ?? []).some((p) => p.projectID === selectedProjectId);
 
   useEffect(() => {
     // If no token, redirect to sign-in
@@ -65,8 +76,8 @@ export function AuthGuard({ children }: AuthGuardProps) {
     );
   }
 
-  // Show loading while fetching user info
-  if (accessToken && isMeLoading) {
+  // Show loading while fetching user info or validating the persisted project
+  if (accessToken && (isMeLoading || !projectReady)) {
     return (
       <div className='flex h-screen items-center justify-center'>
         <div className='space-y-4'>

--- a/frontend/src/features/analytics/components/analytics-filter-bar.tsx
+++ b/frontend/src/features/analytics/components/analytics-filter-bar.tsx
@@ -12,6 +12,7 @@ import { useApiKeyOptions, useApiKeyOptionsByIDs } from '@/features/apikeys/data
 import { useAllChannelSummarys } from '@/features/channels/data/channels';
 import { useProjects } from '@/features/projects/data/projects';
 import { useUsers } from '@/features/users/data/users';
+import { usePermissions } from '@/hooks/usePermissions';
 import { AnalyticsFacetedFilter } from './analytics-faceted-filter';
 
 // Calendar Date → 'YYYY-MM-DD' 字符串（直接取本地年月日，不做时区转换）
@@ -124,6 +125,8 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
   const debouncedApiKeySearch = useDebounce(apiKeySearch, 300);
   const { setStartTime, setEndTime, setProjectIDs, setChannelIDs, setModelIDs, setAPIKeyIDs, setUserIDs, resetFilter } =
     useAnalyticsFilterStore();
+  const { userPermissions } = usePermissions();
+  const canViewUsers = userPermissions.canRead;
 
   // Fetch real data for dropdowns
   const { data: channels, isLoading: isLoadingChannels } = useAllChannelSummarys();
@@ -137,7 +140,7 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
   const { data: selectedApiKeysData } = useApiKeyOptionsByIDs(filter.apiKeyIDs, {
     enabled: !!filter.apiKeyIDs?.length,
   });
-  const { data: usersData, isLoading: isLoadingUsers } = useUsers({ first: 100 });
+  const { data: usersData, isLoading: isLoadingUsers } = useUsers({ first: 100 }, { disableAutoFetch: !canViewUsers });
   const { data: projectsData, isLoading: isLoadingProjects } = useProjects({ first: 100 });
 
   const channelOptions = useMemo(
@@ -321,13 +324,15 @@ export function AnalyticsFilterBar({ earliestDate }: AnalyticsFilterBarProps) {
           onLoadMore={fetchNextApiKeyPage}
         />
 
-        <AnalyticsFacetedFilter
-          title={t('analytics.filter.user')}
-          options={userOptions}
-          selectedValues={filter.userIDs || []}
-          onSelectedValuesChange={setUserIDs}
-          isLoading={isLoadingUsers}
-        />
+        {canViewUsers && (
+          <AnalyticsFacetedFilter
+            title={t('analytics.filter.user')}
+            options={userOptions}
+            selectedValues={filter.userIDs || []}
+            onSelectedValuesChange={setUserIDs}
+            isLoading={isLoadingUsers}
+          />
+        )}
 
         {/* Reset Button */}
         {hasFilters && (

--- a/frontend/src/features/auth/data/auth.ts
+++ b/frontend/src/features/auth/data/auth.ts
@@ -21,14 +21,18 @@ interface MeResponse {
 
 export function useMe(enabled = true) {
   const { setUser } = useAuthStore((state) => state.auth);
+  const accessToken = useAuthStore((state) => state.auth.accessToken);
 
   const query = useQuery({
-    queryKey: ['me'],
+    // Keying by token keeps account switches (including the 401-expiry path,
+    // which doesn't clear the query cache) from reusing another account's
+    // cached memberships.
+    queryKey: ['me', accessToken],
     queryFn: async () => {
       const data = await graphqlRequest<MeResponse>(ME_QUERY);
       return data.me;
     },
-    enabled: enabled && !!useAuthStore.getState().auth.accessToken,
+    enabled: enabled && !!accessToken,
     retry: false,
   });
 
@@ -76,11 +80,11 @@ export function useSignIn() {
       setAccessToken(data.token);
       setUser(data.user);
 
-      // Reset project selection: a persisted project from a previous account
-      // on the same browser must not leak into this session. The project
-      // switcher re-selects the first available project once myProjects loads.
-      useProjectStore.getState().clearSelectedProjectId();
-
+      // Do not clear the persisted project here: the AuthGuard gates
+      // project-scoped queries until the selected project is validated
+      // against this user's memberships (useMe clears it when stale), so a
+      // returning user keeps their last selection while another account's
+      // stale selection can never leak into a request.
       // Initialize i18n with user's preferred language
       if (userLanguage !== i18n.language) {
         i18n.changeLanguage(userLanguage);
@@ -111,10 +115,6 @@ export function useSignOut() {
 
     // Clear auth store
     reset();
-
-    // Drop the persisted project selection so the next account on this browser
-    // does not inherit it.
-    useProjectStore.getState().clearSelectedProjectId();
 
     queryClient.clear();
 
@@ -177,11 +177,11 @@ export function useOIDCExchange() {
       setAccessToken(data.token);
       setUser(data.user);
 
-      // Reset project selection: a persisted project from a previous account
-      // on the same browser must not leak into this session. The project
-      // switcher re-selects the first available project once myProjects loads.
-      useProjectStore.getState().clearSelectedProjectId();
-
+      // Do not clear the persisted project here: the AuthGuard gates
+      // project-scoped queries until the selected project is validated
+      // against this user's memberships (useMe clears it when stale), so a
+      // returning user keeps their last selection while another account's
+      // stale selection can never leak into a request.
       // Initialize i18n with user's preferred language
       if (userLanguage !== i18n.language) {
         i18n.changeLanguage(userLanguage);

--- a/frontend/src/features/auth/data/auth.ts
+++ b/frontend/src/features/auth/data/auth.ts
@@ -6,6 +6,7 @@ import { ME_QUERY } from '@/gql/users';
 import { toast } from 'sonner';
 import { useAuthStore, setTokenToStorage, removeTokenFromStorage } from '@/stores/authStore';
 import { useProjectStore } from '@/stores/projectStore';
+import { isProjectSelectionValid } from '@/lib/project-membership';
 import { AuthUser } from '@/stores/authStore';
 import { authApi } from '@/lib/api-client';
 import i18n from '@/lib/i18n';
@@ -46,7 +47,7 @@ export function useMe(enabled = true) {
       // of so a stale selection from a previous account is never sent to the
       // server as X-Project-ID.
       const { selectedProjectId, clearSelectedProjectId } = useProjectStore.getState();
-      if (selectedProjectId && !(query.data.projects ?? []).some((p) => p.projectID === selectedProjectId)) {
+      if (!isProjectSelectionValid(query.data, selectedProjectId)) {
         clearSelectedProjectId();
       }
 

--- a/frontend/src/features/users/data/users.ts
+++ b/frontend/src/features/users/data/users.ts
@@ -47,12 +47,14 @@ export function useUsers(
 export function useUser(id: string) {
   const { t } = useTranslation();
   const { handleError } = useErrorHandler();
+  const selectedProjectId = useSelectedProjectId();
 
   return useQuery({
-    queryKey: ['user', id],
+    queryKey: ['user', id, selectedProjectId],
     queryFn: async () => {
       try {
-        const data = await graphqlRequest<{ users: UserConnection }>(USERS_QUERY, { where: { id } });
+        const headers = selectedProjectId ? { 'X-Project-ID': selectedProjectId } : undefined;
+        const data = await graphqlRequest<{ users: UserConnection }>(USERS_QUERY, { where: { id } }, headers);
         const user = data.users.edges[0]?.node;
         if (!user) {
           throw new Error(t('users.messages.userNotFound'));

--- a/frontend/src/lib/project-membership.test.mjs
+++ b/frontend/src/lib/project-membership.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isProjectSelectionValid } from './project-membership.ts';
+
+test('returns false before user data resolves', () => {
+  assert.equal(isProjectSelectionValid(undefined, 'proj-1'), false);
+  assert.equal(isProjectSelectionValid(null, 'proj-1'), false);
+});
+
+test('returns true when no project is selected', () => {
+  assert.equal(isProjectSelectionValid({ projects: [] }, null), true);
+  assert.equal(isProjectSelectionValid({ projects: [] }, undefined), true);
+});
+
+test('returns false when the selected project is not in memberships', () => {
+  assert.equal(
+    isProjectSelectionValid({ projects: [{ projectID: 'proj-a' }] }, 'proj-b'),
+    false,
+  );
+});
+
+test('returns true when the selected project is in memberships', () => {
+  assert.equal(
+    isProjectSelectionValid({ projects: [{ projectID: 'proj-a' }] }, 'proj-a'),
+    true,
+  );
+});

--- a/frontend/src/lib/project-membership.ts
+++ b/frontend/src/lib/project-membership.ts
@@ -1,0 +1,20 @@
+interface MemberProject {
+  projectID: string;
+}
+
+interface MeData {
+  projects?: MemberProject[] | null;
+}
+
+export function isProjectSelectionValid(
+  meData: MeData | null | undefined,
+  selectedProjectId: string | null | undefined,
+): boolean {
+  if (!meData) {
+    return false;
+  }
+  if (!selectedProjectId) {
+    return true;
+  }
+  return (meData.projects ?? []).some((p) => p.projectID === selectedProjectId);
+}

--- a/internal/scopes/rule_user_project_scope_test.go
+++ b/internal/scopes/rule_user_project_scope_test.go
@@ -2,16 +2,25 @@ package scopes
 
 import (
 	"context"
+	dbsql "database/sql"
 	"errors"
+	"slices"
 	"testing"
 
-	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/schema"
 	"entgo.io/ent/entql"
 	"github.com/samber/lo"
 
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/migrate"
+	"github.com/looplj/axonhub/internal/ent/migrate/schemahook"
 	"github.com/looplj/axonhub/internal/ent/privacy"
+	"github.com/looplj/axonhub/internal/ent/user"
+
+	_ "github.com/looplj/axonhub/internal/pkg/sqlite"
 )
 
 // Mock implementations for testing.
@@ -48,7 +57,7 @@ type mockProjectMemberMutation struct {
 	projectID    int
 	hasProjectID bool
 	wherePCalled bool
-	predicates   []func(*sql.Selector)
+	predicates   []func(*entsql.Selector)
 }
 
 func (m *mockProjectMemberMutation) Op() ent.Op {
@@ -59,7 +68,7 @@ func (m *mockProjectMemberMutation) ProjectID() (int, bool) {
 	return m.projectID, m.hasProjectID
 }
 
-func (m *mockProjectMemberMutation) WhereP(ps ...func(*sql.Selector)) {
+func (m *mockProjectMemberMutation) WhereP(ps ...func(*entsql.Selector)) {
 	m.wherePCalled = true
 	m.predicates = ps
 }
@@ -684,7 +693,7 @@ func TestUserHasProjectScope(t *testing.T) {
 				Edges: ent.UserEdges{
 					ProjectUsers: []*ent.UserProject{
 						{
-							ProjectID: 200,
+							ProjectID: 100,
 							Scopes:    []string{},
 						},
 					},
@@ -919,6 +928,135 @@ func TestProjectMemberReadUsersRule(t *testing.T) {
 				if errors.Is(err, privacy.Allow) {
 					t.Error("expected error or deny, got privacy.Allow")
 				}
+			}
+		})
+	}
+}
+
+func openScopesTestClient(t *testing.T) *ent.Client {
+	t.Helper()
+
+	db, err := dbsql.Open("sqlite3", "file:scopes_mem?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	client := ent.NewClient(ent.Driver(entsql.OpenDB(dialect.SQLite, db)))
+
+	if err := client.Schema.Create(
+		context.Background(),
+		migrate.WithGlobalUniqueID(false),
+		migrate.WithForeignKeys(false),
+		migrate.WithDropIndex(true),
+		migrate.WithDropColumn(true),
+		schema.WithHooks(schemahook.V0_3_0),
+	); err != nil {
+		t.Fatalf("migrate schema: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = db.Close()
+	})
+
+	return client
+}
+
+// TestProjectMemberReadUsersRuleAppliesProjectFilter verifies ProjectMemberReadUsersRule
+// through the User schema policy against a real (in-memory) database: an allowed
+// project read must only return users of the queried project, while the system
+// scope keeps the unfiltered view.
+func TestProjectMemberReadUsersRuleAppliesProjectFilter(t *testing.T) {
+	ctx := context.Background()
+
+	// Seeding happens as the platform owner so the per-schema mutation policies
+	// accept the writes.
+	seedCtx := contexts.WithUser(ctx, &ent.User{ID: 999, IsOwner: true, Scopes: []string{"read_users", "read_projects", "write_users"}})
+
+	client := openScopesTestClient(t)
+
+	p100 := client.Project.Create().SetName("P100").SaveX(seedCtx)
+	p200 := client.Project.Create().SetName("P200").SaveX(seedCtx)
+
+	createUser := func(email string, scopes ...string) *ent.User {
+		return client.User.Create().
+			SetEmail(email).
+			SetFirstName("F").
+			SetLastName("L").
+			SetPassword("x").
+			SetStatus(user.StatusActivated).
+			SetScopes(scopes).
+			SaveX(seedCtx)
+	}
+
+	alice := createUser("alice@test.dev")
+	developer := createUser("developer@test.dev")
+	bob := createUser("bob@test.dev")
+	sysadmin := createUser("sysadmin@test.dev", "read_users")
+
+	client.UserProject.Create().SetUserID(alice.ID).SetProjectID(p100.ID).SetScopes([]string{"read_users"}).SaveX(seedCtx)
+	client.UserProject.Create().SetUserID(developer.ID).SetProjectID(p100.ID).SetScopes([]string{}).SaveX(seedCtx)
+	client.UserProject.Create().SetUserID(bob.ID).SetProjectID(p200.ID).SetScopes([]string{"read_requests"}).SaveX(seedCtx)
+
+	devRole := client.Role.Create().
+		SetName("developer").
+		SetProjectID(p100.ID).
+		SetScopes([]string{"read_users"}).
+		SaveX(seedCtx)
+	client.UserRole.Create().SetUserID(developer.ID).SetRoleID(devRole.ID).SaveX(seedCtx)
+
+	usersOfProject100 := []int{alice.ID, developer.ID}
+	allUsers := []int{alice.ID, developer.ID, bob.ID, sysadmin.ID}
+
+	tests := []struct {
+		name        string
+		principalID int
+		expectIDs   []int
+	}{
+		{
+			name:        "project member with direct scope reads only project users",
+			principalID: alice.ID,
+			expectIDs:   usersOfProject100,
+		},
+		{
+			name:        "project member with role grant reads only project users",
+			principalID: developer.ID,
+			expectIDs:   usersOfProject100,
+		},
+		{
+			name:        "system scope reads all users",
+			principalID: sysadmin.ID,
+			expectIDs:   allUsers,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			principal, err := client.User.Query().
+				Where(user.ID(tt.principalID)).
+				WithProjectUsers().
+				WithRoles().
+				Only(seedCtx)
+			if err != nil {
+				t.Fatalf("load principal: %v", err)
+			}
+
+			principalCtx := contexts.WithProjectID(contexts.WithUser(ctx, principal), p100.ID)
+
+			users, err := client.User.Query().All(principalCtx)
+			if err != nil {
+				t.Fatalf("query users: %v", err)
+			}
+
+			var gotIDs []int
+			for _, u := range users {
+				gotIDs = append(gotIDs, u.ID)
+			}
+			slices.Sort(gotIDs)
+			slices.Sort(tt.expectIDs)
+
+			if !slices.Equal(gotIDs, tt.expectIDs) {
+				t.Errorf("user IDs = %v, want %v", gotIDs, tt.expectIDs)
 			}
 		})
 	}

--- a/internal/scopes/rule_user_project_scope_test.go
+++ b/internal/scopes/rule_user_project_scope_test.go
@@ -653,6 +653,102 @@ func TestUserHasProjectScope(t *testing.T) {
 			requiredScope: ScopeReadRequests,
 			expected:      true,
 		},
+		{
+			name: "user has required scope via project role",
+			user: &ent.User{
+				ID: 1,
+				Edges: ent.UserEdges{
+					ProjectUsers: []*ent.UserProject{
+						{
+							ProjectID: 100,
+							Scopes:    []string{},
+						},
+					},
+					Roles: []*ent.Role{
+						{
+							ID:        1,
+							ProjectID: lo.ToPtr(100),
+							Scopes:    []string{"read_requests"},
+						},
+					},
+				},
+			},
+			projectID:     100,
+			requiredScope: ScopeReadRequests,
+			expected:      true,
+		},
+		{
+			name: "role on a different project does not grant scope",
+			user: &ent.User{
+				ID: 1,
+				Edges: ent.UserEdges{
+					ProjectUsers: []*ent.UserProject{
+						{
+							ProjectID: 200,
+							Scopes:    []string{},
+						},
+					},
+					Roles: []*ent.Role{
+						{
+							ID:        1,
+							ProjectID: lo.ToPtr(200),
+							Scopes:    []string{"read_requests"},
+						},
+					},
+				},
+			},
+			projectID:     100,
+			requiredScope: ScopeReadRequests,
+			expected:      false,
+		},
+		{
+			name: "system role does not grant project scope",
+			user: &ent.User{
+				ID: 1,
+				Edges: ent.UserEdges{
+					ProjectUsers: []*ent.UserProject{
+						{
+							ProjectID: 100,
+							Scopes:    []string{},
+						},
+					},
+					Roles: []*ent.Role{
+						{
+							ID:        1,
+							Scopes:    []string{"read_requests"},
+							ProjectID: nil,
+						},
+					},
+				},
+			},
+			projectID:     100,
+			requiredScope: ScopeReadRequests,
+			expected:      false,
+		},
+		{
+			name: "role without required scope does not grant",
+			user: &ent.User{
+				ID: 1,
+				Edges: ent.UserEdges{
+					ProjectUsers: []*ent.UserProject{
+						{
+							ProjectID: 100,
+							Scopes:    []string{},
+						},
+					},
+					Roles: []*ent.Role{
+						{
+							ID:        1,
+							ProjectID: lo.ToPtr(100),
+							Scopes:    []string{"read_channels"},
+						},
+					},
+				},
+			},
+			projectID:     100,
+			requiredScope: ScopeReadRequests,
+			expected:      false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -702,6 +798,127 @@ func TestUserIsProjectOwner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := userIsProjectOwner(tt.user, tt.projectID); got != tt.expected {
 				t.Fatalf("userIsProjectOwner() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProjectMemberReadUsersRule(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		expectAllow bool
+	}{
+		{
+			name:        "no project ID in context",
+			ctx:         contexts.WithUser(context.Background(), &ent.User{ID: 1, Scopes: []string{"read_users"}}),
+			expectAllow: false,
+		},
+		{
+			name:        "no user in context",
+			ctx:         contexts.WithProjectID(context.Background(), 100),
+			expectAllow: false,
+		},
+		{
+			name: "user with system scope",
+			ctx: contexts.WithProjectID(
+				contexts.WithUser(context.Background(), &ent.User{
+					ID:     1,
+					Scopes: []string{"read_users"},
+				}),
+				100,
+			),
+			expectAllow: true,
+		},
+		{
+			name: "project member with direct scope",
+			ctx: contexts.WithProjectID(
+				contexts.WithUser(context.Background(), &ent.User{
+					ID:     1,
+					Scopes: []string{},
+					Edges: ent.UserEdges{
+						ProjectUsers: []*ent.UserProject{
+							{
+								ProjectID: 100,
+								Scopes:    []string{"read_users"},
+							},
+						},
+					},
+				}),
+				100,
+			),
+			expectAllow: true,
+		},
+		{
+			name: "project member with scope via project role",
+			ctx: contexts.WithProjectID(
+				contexts.WithUser(context.Background(), &ent.User{
+					ID:     1,
+					Scopes: []string{},
+					Edges: ent.UserEdges{
+						ProjectUsers: []*ent.UserProject{
+							{ProjectID: 100, Scopes: []string{}},
+						},
+						Roles: []*ent.Role{
+							{
+								ID:        1,
+								ProjectID: lo.ToPtr(100),
+								Scopes:    []string{"read_users"},
+							},
+						},
+					},
+				}),
+				100,
+			),
+			expectAllow: true,
+		},
+		{
+			name: "project member without read scope",
+			ctx: contexts.WithProjectID(
+				contexts.WithUser(context.Background(), &ent.User{
+					ID:     1,
+					Scopes: []string{},
+					Edges: ent.UserEdges{
+						ProjectUsers: []*ent.UserProject{
+							{ProjectID: 100, Scopes: []string{"read_api_keys"}},
+						},
+					},
+				}),
+				100,
+			),
+			expectAllow: false,
+		},
+		{
+			name: "user without membership in the project",
+			ctx: contexts.WithProjectID(
+				contexts.WithUser(context.Background(), &ent.User{
+					ID:     1,
+					Scopes: []string{},
+					Edges: ent.UserEdges{
+						ProjectUsers: []*ent.UserProject{
+							{ProjectID: 200, Scopes: []string{"read_users"}},
+						},
+					},
+				}),
+				100,
+			),
+			expectAllow: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := ProjectMemberReadUsersRule(ScopeReadUsers)
+			err := rule.EvalQuery(tt.ctx, &ent.UserQuery{})
+
+			if tt.expectAllow {
+				if !errors.Is(err, privacy.Allow) {
+					t.Errorf("expected privacy.Allow, got %v", err)
+				}
+			} else {
+				if errors.Is(err, privacy.Allow) {
+					t.Error("expected error or deny, got privacy.Allow")
+				}
 			}
 		})
 	}

--- a/internal/scopes/rule_user_project_scope_test.go
+++ b/internal/scopes/rule_user_project_scope_test.go
@@ -2,16 +2,17 @@ package scopes
 
 import (
 	"context"
-	dbsql "database/sql"
+	"database/sql"
 	"errors"
 	"slices"
 	"testing"
 
 	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/schema"
 	"entgo.io/ent/entql"
 	"github.com/samber/lo"
+
+	entsql "entgo.io/ent/dialect/sql"
 
 	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
@@ -19,7 +20,6 @@ import (
 	"github.com/looplj/axonhub/internal/ent/migrate/schemahook"
 	"github.com/looplj/axonhub/internal/ent/privacy"
 	"github.com/looplj/axonhub/internal/ent/user"
-
 	_ "github.com/looplj/axonhub/internal/pkg/sqlite"
 )
 
@@ -936,7 +936,7 @@ func TestProjectMemberReadUsersRule(t *testing.T) {
 func openScopesTestClient(t *testing.T) *ent.Client {
 	t.Helper()
 
-	db, err := dbsql.Open("sqlite3", "file:scopes_mem?mode=memory&cache=shared")
+	db, err := sql.Open("sqlite3", "file:scopes_mem?mode=memory&cache=shared")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}


### PR DESCRIPTION
## Context

This restores the fix path lost to account switching and closes the review findings on #2437 (now merged). Two independent problems were conflated; this PR handles both precisely.

### 1. A stale persisted project must never reach a project-scoped query

`selectedProjectId` is persisted per browser (`axonhub_selected_project_id`). After an account switch or a cold reload it can still carry a project the current user is **not** a member of, so `X-Project-ID`-carrying queries (`GetApiKeys`, `Users`) were denied (`input: permission denied`) — the "two ugly toasts" on the API keys page.

The merged fix cleared the selection on every auth transition. That was redundant once validation exists and it **defeats the remember-last-project feature** for returning users. This PR instead:

- keeps the persisted selection untouched on sign-in/sign-out;
- keeps protected content **unmounted until `me` has resolved and the selection is validated** against the current user's project memberships (`AuthGuard` gate + `useMe` clears it when stale), so a stale selection can never be sent; a returning user keeps their project.

### 2. Auxiliary `read_users` lookups must not noise up pages users can legitimately view

The default project **Developer** role grants `read_api_keys`, `write_api_keys`, `read_requests`, `write_requests` — **not** `read_users` (see `internal/server/biz/project.go`). Such a user must still list/create their own API keys, and the page never depends on `read_users` for that (`buildApiKeysQuery` omits the `user` sub-selection). But two places fetched the users list unconditionally and toasted a permission error when denied:

- API keys toolbar — already gated via `canViewCreators` + `disableAutoFetch` (#2437);
- **analytics filter-bar** — this PR adds the same gating and hides the user dropdown without `read_users`.

Members who do hold project-level `read_users` get a working read path via `ProjectMemberReadUsersRule` (#2437) once the request carries the correct `X-Project-ID`.

## Changes

- `auth-guard.tsx`: require a resolved `meData` (success, not error) before rendering protected children — an errored `me` no longer passes an unvalidated selection through (CodeRabbit).
- `auth.ts`: key the `['me']` cache by access token so an account switch on the 401-expiry path (which doesn't clear the query cache) cannot reuse another account's cached memberships (CodeRabbit).
- `auth.ts`: drop `clearSelectedProjectId()` from sign-in, OIDC exchange, and sign-out; `useMe`'s membership validation + the `AuthGuard` gate keep the invariant, and returning users keep their last project.
- `analytics/filter-bar.tsx`: run the users query only when the user has `read_users`, and hide the user filter otherwise.

## Verification

- `tsc --noEmit` passes.
- Branch is rebased on current `unstable`; net diff vs `unstable` is 5 files.
- Behavior matrix after this PR:
  | user | scenario | result |
  |---|---|---|
  | Developer (no `read_users`) | opens API keys page | lists & manages own keys, no denied toast |
  | Member with project `read_users` | opens API keys / users page | reads project users (requires correct `X-Project-ID`, sent) |
  | Any user | switches account on same browser | stale project never sent; first load shows loading until validation |
  | Returning user | re-logs in | last-used project is restored |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project access validation to prevent unauthorized project data requests.
  - Individual user data requests now respect the selected project.
  - Improved data refresh behavior when switching projects.
  - Restricted analytics user filters and related data loading based on permissions.
  - Improved authentication data refresh when access tokens change.
  - Automatically removes saved project selections that are no longer valid.
- **Tests**
  - Expanded coverage for project membership validation and project-scoped user access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->