### PR TITLE
fix: allow adding custom models after fetching models in channel dialog

### DIFF
--- a/frontend/src/components/auto-complete.tsx
+++ b/frontend/src/components/auto-complete.tsx
@@ -43,6 +43,8 @@ type Props<T extends string> = {
   placeholder?: string;
   /** 指定 Popover Portal 的容器元素，用于解决在 Dialog 内无法滚动的问题 */
   portalContainer?: HTMLElement | null;
+  /** Pass a keydown handler through to the underlying input (e.g. for Enter-to-submit). */
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
 };
 
 export function AutoComplete<T extends string>({
@@ -55,6 +57,7 @@ export function AutoComplete<T extends string>({
   emptyMessage = 'No items.',
   placeholder = 'Search...',
   portalContainer,
+  onKeyDown,
 }: Props<T>) {
   const [open, setOpen] = useState(false);
 
@@ -125,7 +128,10 @@ export function AutoComplete<T extends string>({
               asChild
               value={searchValue}
               onValueChange={onSearchValueChange}
-              onKeyDown={(e) => setOpen(e.key !== 'Escape')}
+              onKeyDown={(e) => {
+                setOpen(e.key !== 'Escape');
+                onKeyDown?.(e);
+              }}
               onMouseDown={() => setOpen((open) => !!searchValue || !open)}
               onFocus={() => setOpen(true)}
               onBlur={onInputBlur}

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -24,7 +24,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TagsAutocompleteInput } from '@/components/ui/tags-autocomplete-input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { AutoCompleteSelect } from '@/components/auto-complete-select';
+import { AutoComplete } from '@/components/auto-complete';
 import { SelectDropdown } from '@/components/select-dropdown';
 import { useProxyPresets, useSaveProxyPreset } from '@/features/system/data/system';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -2652,10 +2652,12 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                         <div className='space-y-2 md:col-span-6'>
                           <div className='flex gap-2'>
                             {useFetchedModels && fetchedModels.length > 20 ? (
-                              <AutoCompleteSelect
+                              <AutoComplete
                                 items={fetchedModels.map((model) => ({ value: model, label: model }))}
                                 selectedValue={newModel}
                                 onSelectedValueChange={setNewModel}
+                                searchValue={newModel}
+                                onSearchValueChange={setNewModel}
                                 placeholder={t('channels.dialogs.fields.supportedModels.description')}
                               />
                             ) : (

--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -2658,6 +2658,7 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
                                 onSelectedValueChange={setNewModel}
                                 searchValue={newModel}
                                 onSearchValueChange={setNewModel}
+                                onKeyDown={handleKeyDown}
                                 placeholder={t('channels.dialogs.fields.supportedModels.description')}
                               />
                             ) : (


### PR DESCRIPTION
## Problem

In the channel create/edit dialog, after using the fetch-models (快速添加模型) feature, if the provider returns more than 20 models the model input is replaced by `AutoCompleteSelect`, which strictly selects from the provided items — free-form values are rejected and any typed text is reverted on blur. As a result users could no longer add custom model names (single add, batch add, and Enter-to-add were all broken) until the dialog was closed and reopened.

Introduced in #45, which reused `AutoCompleteSelect` (built for strict selection in API key profiles) for the model input.

## Fix

Use the sibling `AutoComplete` component (`frontend/src/components/auto-complete.tsx`) for the fetched-models branch instead. It keeps typed free-form text as the value on blur while preserving fuzzy filtering and click-to-select over the fetched model list. Both `selectedValue` and `searchValue` are bound to the existing `newModel` state, so `addModel`/`batchAddModels` work unchanged.

## Verification

- `eslint` passes on the changed file
- `tsc --noEmit` error set on the file is identical to the base branch (6 pre-existing errors, none introduced)
- The changed hunk matches `prettier` output byte-for-byte (no formatting churn)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection when adding a channel by enabling search input alongside model selection.
  * Updated the supported-models picker for lists containing more than 20 models.
  * Pressing Enter after typing a custom model now adds it directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->