### PR TITLE
fix(webhook): render occurred_at in the configured system timezone

### DIFF
--- a/internal/server/biz/webhook_notifier.go
+++ b/internal/server/biz/webhook_notifier.go
@@ -38,8 +38,11 @@ type ChannelAutoDisabledEvent struct {
 }
 
 type WebhookRenderContext struct {
-	Event      string `json:"event"`
-	Severity   string `json:"severity"`
+	Event    string `json:"event"`
+	Severity string `json:"severity"`
+
+	// OccurredAt is RFC3339 in the configured system timezone, so it carries that
+	// zone's offset rather than a trailing Z. It is set by notify.
 	OccurredAt string `json:"occurred_at"`
 
 	Channel struct {
@@ -75,9 +78,8 @@ func (n *WebhookNotifier) NotifyChannelAutoDisabled(ctx context.Context, event C
 	log.Info(ctx, "notify channel auto disabled", log.Any("event", event))
 
 	renderCtx := WebhookRenderContext{
-		Event:      EventChannelAutoDisabled,
-		Severity:   "warning",
-		OccurredAt: event.OccurredAt.UTC().Format(time.RFC3339),
+		Event:    EventChannelAutoDisabled,
+		Severity: "warning",
 	}
 	renderCtx.Channel.ID = event.ChannelID
 	renderCtx.Channel.Name = event.ChannelName
@@ -90,11 +92,23 @@ func (n *WebhookNotifier) NotifyChannelAutoDisabled(ctx context.Context, event C
 	renderCtx.Trigger.ActualCount = event.ActualCount
 	renderCtx.Trigger.Reason = event.Reason
 
-	n.notify(ctx, EventChannelAutoDisabled, renderCtx)
+	n.notify(ctx, EventChannelAutoDisabled, renderCtx, event.OccurredAt)
 }
 
-func (n *WebhookNotifier) notify(ctx context.Context, eventName string, renderCtx WebhookRenderContext) {
+// notify renders and delivers one event to every subscribed target.
+//
+// occurredAt is formatted here rather than by the caller because resolving the
+// configured timezone reads system settings, which the ent privacy policy denies
+// on a context without a user. The system bypass below is what makes that read
+// succeed, so the formatting has to happen after it.
+func (n *WebhookNotifier) notify(
+	ctx context.Context,
+	eventName string,
+	renderCtx WebhookRenderContext,
+	occurredAt time.Time,
+) {
 	ctx = authz.WithSystemBypass(context.WithoutCancel(ctx), "webhook-notifier")
+	renderCtx.OccurredAt = occurredAt.In(n.SystemService.TimeLocation(ctx)).Format(time.RFC3339)
 	cfg := *n.SystemService.WebhookNotifierConfigOrDefault(ctx)
 	targets := n.selectTargets(cfg, eventName)
 

--- a/internal/server/biz/webhook_notifier_test.go
+++ b/internal/server/biz/webhook_notifier_test.go
@@ -98,6 +98,91 @@ func TestWebhookNotifier_NotifyChannelAutoDisabled(t *testing.T) {
 	require.Contains(t, receivedBody, `"actual_count":3`)
 }
 
+func TestWebhookNotifier_OccurredAtUsesSystemTimezone(t *testing.T) {
+	// A fixed instant, so each expectation below is just that instant in the
+	// configured zone. April puts New York on daylight saving time, at -04:00.
+	occurredAt := time.Date(2026, 4, 11, 4, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		timezone string
+		want     string
+	}{
+		{
+			name:     "configured timezone applies its offset",
+			timezone: "Asia/Shanghai",
+			want:     "2026-04-11T12:00:00+08:00",
+		},
+		{
+			name:     "negative offset",
+			timezone: "America/New_York",
+			want:     "2026-04-11T00:00:00-04:00",
+		},
+		{
+			name:     "UTC stays unchanged",
+			timezone: "UTC",
+			want:     "2026-04-11T04:00:00Z",
+		},
+		{
+			name:     "unset timezone falls back to the default",
+			timezone: "",
+			want:     "2026-04-11T04:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+
+			var receivedBody string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				receivedBody = string(body)
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			cfg := WebhookNotifierConfig{
+				Targets: []WebhookTarget{
+					{
+						Name:      "default",
+						Enabled:   true,
+						URL:       server.URL,
+						TimeoutMs: 1000,
+						Body:      `{"occurred_at":"{{.OccurredAt}}"}`,
+					},
+				},
+				Subscriptions: []WebhookSubscription{
+					{Event: EventChannelAutoDisabled, TargetNames: []string{"default"}},
+				},
+			}
+
+			systemService := newTestSystemServiceWithWebhookConfig(t, client, cfg)
+
+			settingsCtx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+			require.NoError(t, systemService.SetGeneralSettings(settingsCtx, SystemGeneralSettings{
+				Timezone: tt.timezone,
+			}))
+
+			notifier := NewWebhookNotifier(systemService, httpclient.NewHttpClient())
+
+			// A bare context, as the production callers pass: the notifier is
+			// responsible for the system bypass that lets the timezone read succeed.
+			notifier.NotifyChannelAutoDisabled(ent.NewContext(context.Background(), client), ChannelAutoDisabledEvent{
+				ChannelID:  1,
+				OccurredAt: occurredAt,
+			})
+
+			require.Equal(t, `{"occurred_at":"`+tt.want+`"}`, receivedBody)
+		})
+	}
+}
+
 func TestWebhookNotifier_SkipWhenTemplateInvalid(t *testing.T) {
 	client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
 	defer client.Close()


### PR DESCRIPTION
### Summary / 概述

`occurred_at` was formatted with a hardcoded `.UTC()`, so webhook payloads
carried a trailing Z even when the system timezone was set, for example to
`Asia/Shanghai`. The timezone setting is respected everywhere else (quota
windows, analytics date parsing, backup schedules) via
`SystemService.TimeLocation`.

The formatting now happens inside `notify()`, after the authz system bypass is
installed, because resolving the timezone reads system settings and the ent
privacy policy rejects that on a context without a user. Each event still
carries its own `time.Time`, so only the one formatting site needed to change.

The payload stays RFC3339 but now carries the configured zone's offset,
e.g. `2026-09-08T13:32:46+08:00` instead of `2026-09-08T05:32:46Z`.

### Test Plan / 测试计划

- Unit test `TestWebhookNotifier_OccurredAtUsesSystemTimezone` covers four
  cases: a configured positive offset, a negative offset (DST-aware), UTC, and
  the default fallback. Reverting the fix makes it fail with the expected
  `...Z` output.
- `go test ./internal/server/biz/...`, `go vet`, and `gofmt` pass.
- `golangci-lint run` passes with 0 issues (the repo config limits the run to
  new code relative to the base commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook event timestamps now consistently render in the configured system timezone and RFC3339 format.
  * Improved timestamp handling for configured, UTC, negative-offset, and unset time zones.

* **Tests**
  * Added coverage to verify webhook timestamps across supported system timezone configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->