### PR TITLE
fix(metrics): load exporter settings from environment

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -292,6 +292,12 @@ func setDefaults(v *viper.Viper) {
 
 	// Metrics defaults
 	v.SetDefault("metrics.enabled", false)
+	// Register exporter keys so Viper's AutomaticEnv includes their
+	// AXONHUB_METRICS_EXPORTER_* environment variable overrides even when no
+	// config file is present.
+	v.SetDefault("metrics.exporter.type", "")
+	v.SetDefault("metrics.exporter.endpoint", "")
+	v.SetDefault("metrics.exporter.insecure", false)
 
 	// GC defaults
 	v.SetDefault("gc.cron", "0 2 * * *") // Daily at 2:00 AM

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -75,6 +75,35 @@ func TestSSEKeepAliveDefaultsToDisabled(t *testing.T) {
 	}
 }
 
+func TestMetricsExporterConfigFromEnvironment(t *testing.T) {
+	t.Setenv("AXONHUB_METRICS_ENABLED", "true")
+	t.Setenv("AXONHUB_METRICS_EXPORTER_TYPE", "otlphttp")
+	t.Setenv("AXONHUB_METRICS_EXPORTER_ENDPOINT", "alloy.alloy.svc.cluster.local:4318")
+	t.Setenv("AXONHUB_METRICS_EXPORTER_INSECURE", "true")
+
+	configFile := writeTestConfig(t, "")
+	cfg, _, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if !cfg.Metrics.Enabled {
+		t.Fatal("metrics should be enabled")
+	}
+	if cfg.Metrics.Exporter.Type != "otlphttp" {
+		t.Fatalf("metrics exporter type = %q, want %q", cfg.Metrics.Exporter.Type, "otlphttp")
+	}
+	if cfg.Metrics.Exporter.Endpoint != "alloy.alloy.svc.cluster.local:4318" {
+		t.Fatalf(
+			"metrics exporter endpoint = %q, want %q",
+			cfg.Metrics.Exporter.Endpoint,
+			"alloy.alloy.svc.cluster.local:4318",
+		)
+	}
+	if !cfg.Metrics.Exporter.Insecure {
+		t.Fatal("metrics exporter should use an insecure connection")
+	}
+}
+
 func TestTraceExtractionDefaultsToEnabled(t *testing.T) {
 	configFile := writeTestConfig(t, "")
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -155,9 +155,9 @@ log:
 metrics:
   enabled: false                 # Enable metrics collection (env: AXONHUB_METRICS_ENABLED)
   exporter: 
-    type: "otlphttp"          # Metrics exporter type: prometheus, console (env: AXONHUB_METRICS_EXPORTER_TYPE)
-    endpoint: "localhost:8080" # Metrics exporter endpoint (env: AXONHUB_METRICS_EXPORTER_ENDPOINT)
-    insecure: true             # Enable insecure connection (env: AXONHUB_METRICS_EXPORTER_INSECURE)
+    type: "otlphttp"           # Metrics exporter type: stdout, otlpgrpc, otlphttp (env: AXONHUB_METRICS_EXPORTER_TYPE)
+    endpoint: "localhost:4318"  # Metrics exporter endpoint (env: AXONHUB_METRICS_EXPORTER_ENDPOINT)
+    insecure: true              # Enable insecure connection (env: AXONHUB_METRICS_EXPORTER_INSECURE)
     
 
 # Garbage Collection configuration


### PR DESCRIPTION
## Summary

- register metrics exporter configuration keys with Viper defaults so environment-only deployments load them
- add a regression test covering all AXONHUB_METRICS_EXPORTER_* variables without a config file
- correct the supported exporter list and OTLP/HTTP default port in the example configuration

## Root cause

Viper AutomaticEnv only considers keys already known through defaults, bindings, or a loaded config file. AxonHub registered metrics.enabled but not the nested exporter keys, so environment-only deployments enabled metrics while leaving exporter.type empty. Startup then failed in metrics.NewProvider with an unsupported empty exporter type.

## Test

- go test ./conf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics exporter settings can now be configured through environment variables, including exporter type, endpoint, and insecure connection mode.

* **Documentation**
  * Updated the example configuration to document OTLP HTTP support and the default endpoint on port 4318.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->