### PR TITLE
feat(opencode): route muse models to OpenAI Responses API

### DIFF
--- a/llm/transformer/opencode/outbound.go
+++ b/llm/transformer/opencode/outbound.go
@@ -162,7 +162,7 @@ func routeForModel(model string) route {
 	switch {
 	case strings.HasPrefix(model, "deepseek"):
 		return routeDeepseek
-	case strings.HasPrefix(model, "grok"), strings.HasPrefix(model, "gpt"):
+	case strings.HasPrefix(model, "grok"), strings.HasPrefix(model, "gpt"), strings.HasPrefix(model, "muse"):
 		return routeResponses
 	case strings.HasPrefix(model, "minimax"), strings.HasPrefix(model, "qwen3"):
 		return routeAnthropic

--- a/llm/transformer/opencode/outbound_test.go
+++ b/llm/transformer/opencode/outbound_test.go
@@ -52,6 +52,8 @@ func TestRouteForModel(t *testing.T) {
 		// Grok/GPT family → OpenAI Responses API
 		{"grok-4.5", routeResponses},
 		{"gpt-5.6-luna", routeResponses},
+		{"muse-spark-1.3-contributor", routeResponses},
+		{"muse-spark-1.2-contributor", routeResponses},
 		// MiniMax/Qwen family → Anthropic messages
 		{"minimax-m3", routeAnthropic},
 		{"minimax-m2.7", routeAnthropic},


### PR DESCRIPTION
## Summary

Muse Spark 1.3/1.2 Contributor models on OpenCode Go are only served at
`/v1/responses`, not `/v1/chat/completions`. The unified `routeForModel` in
`llm/transformer/opencode/outbound.go` currently has no prefix for `muse`,
so those models fall through to the default `routeChat` endpoint and the
upstream rejects the request.

Add the `muse` prefix to the `routeResponses` case alongside `grok` / `gpt`,
matching the OpenCode Go endpoint matrix.

## Changes

- `llm/transformer/opencode/outbound.go` — add `strings.HasPrefix(model, "muse")` to the `routeResponses` branch.
- `llm/transformer/opencode/outbound_test.go` — add `muse-spark-1.3-contributor` and `muse-spark-1.2-contributor` to `TestRouteForModel`.

## Verification

```
=== RUN   TestRouteForModel/muse-spark-1.3-contributor
--- PASS: TestRouteForModel/muse-spark-1.3-contributor
=== RUN   TestRouteForModel/muse-spark-1.2-contributor
--- PASS: TestRouteForModel/muse-spark-1.2-contributor
```

All `TestRouteForModel` subtests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing Muse model IDs through the OpenAI Responses API.
  * Added coverage for Muse Spark model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->