### PR TITLE
fix(channel): keep manual models consistent during model sync

### DIFF
--- a/frontend/src/features/channels/components/channels-action-dialog.tsx
+++ b/frontend/src/features/channels/components/channels-action-dialog.tsx
@@ -606,13 +606,6 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
     }
   }, [open, showModelsPanel, initialRow]);
 
-  // Sync manualModels when dialog opens with new initialRow
-  useEffect(() => {
-    if (open && initialRow) {
-      setManualModels(initialRow.manualModels || []);
-    }
-  }, [open, initialRow]);
-
   // Get available providers (excluding fake types)
   const availableProviders = useMemo(
     () =>
@@ -1622,7 +1615,10 @@ export function ChannelsActionDialog({ currentRow, duplicateFromRow, open, onOpe
       pattern: formPattern.trim() ? formPattern : undefined,
     });
 
+    // Sync is authoritative for both lists; refreshing only supportedModels
+    // leaves manualModels stale and makes the header count drift from the badges.
     setSupportedModels(result.supportedModels || []);
+    setManualModels(result.manualModels || []);
     return result.supportedModels || [];
   }, [currentRow, form, patternError, syncChannelModels]);
 

--- a/frontend/src/features/channels/data/channels.ts
+++ b/frontend/src/features/channels/data/channels.ts
@@ -1888,6 +1888,7 @@ const SYNC_CHANNEL_MODELS_MUTATION = `
     syncChannelModels(channelID: $channelID, pattern: $pattern) {
       channelID
       supportedModels
+      manualModels
     }
   }
 `;
@@ -1895,6 +1896,7 @@ const SYNC_CHANNEL_MODELS_MUTATION = `
 const syncChannelModelsPayloadSchema = z.object({
   channelID: z.string(),
   supportedModels: z.array(z.string()),
+  manualModels: z.array(z.string()),
 });
 
 export function useSyncChannelModels() {

--- a/internal/server/biz/channel_model_sync.go
+++ b/internal/server/biz/channel_model_sync.go
@@ -186,7 +186,7 @@ func (svc *ChannelService) syncChannelModelsForChannel(ctx context.Context, ch *
 	if err != nil {
 		return nil, false, err
 	}
-	if ent.TxFromContext(ctx) == nil && modelsChanged {
+	if ent.TxFromContext(ctx) == nil && updatedCh != nil {
 		updatedCh.Unwrap()
 	}
 

--- a/internal/server/biz/channel_model_sync.go
+++ b/internal/server/biz/channel_model_sync.go
@@ -115,45 +115,63 @@ func (svc *ChannelService) syncChannelModelsForChannel(ctx context.Context, ch *
 		}
 	}
 
-	// Read existing manual models from the channel
-	manualModels := ch.ManualModels
-	if manualModels == nil {
-		manualModels = []string{}
-	}
-
-	// Merge fetched models with manual models, removing duplicates
-	mergedModels := lo.Uniq(append(manualModels, fetchedModelIDs...))
-
-	if len(mergedModels) == 0 {
-		log.Warn(ctx, "no models to sync for channel (both fetched and manual are empty)",
-			log.Int("channel_id", ch.ID),
-			log.String("channel_name", ch.Name))
-
-		return ch, false, nil
-	}
-
-	addedModels := lo.Without(mergedModels, ch.SupportedModels...)
-	removedModels := lo.Without(ch.SupportedModels, mergedModels...)
-	modelsChanged := len(addedModels) > 0 || len(removedModels) > 0
-	modelProtocolsChanged := modelsChanged && RemoveRemovedModelProtocolOverrides(ch.Settings, mergedModels)
-	var updatedCh *ent.Channel
-	changed := false
+	var (
+		updatedCh     *ent.Channel
+		changed       bool
+		modelsChanged bool
+		manualCount   int
+		totalCount    int
+	)
 
 	err = svc.RunInTransaction(ctx, func(ctx context.Context) error {
-		updatedCh = ch
+		db := svc.entFromContext(ctx)
+
+		// Re-read the channel inside the transaction: the provider fetch above can
+		// take seconds, so manual models saved meanwhile must not be overwritten by
+		// the stale snapshot passed into this function.
+		current, err := db.Channel.Get(ctx, ch.ID)
+		if err != nil {
+			return fmt.Errorf("failed to reload channel for model sync: %w", err)
+		}
+
+		updatedCh = current
+
+		manualModels := current.ManualModels
+		if manualModels == nil {
+			manualModels = []string{}
+		}
+		manualCount = len(manualModels)
+
+		// Merge fetched models with manual models, removing duplicates
+		mergedModels := lo.Uniq(append(manualModels, fetchedModelIDs...))
+		totalCount = len(mergedModels)
+
+		if len(mergedModels) == 0 {
+			log.Warn(ctx, "no models to sync for channel (both fetched and manual are empty)",
+				log.Int("channel_id", ch.ID),
+				log.String("channel_name", ch.Name))
+
+			return nil
+		}
+
+		addedModels := lo.Without(mergedModels, current.SupportedModels...)
+		removedModels := lo.Without(current.SupportedModels, mergedModels...)
+		modelsChanged = len(addedModels) > 0 || len(removedModels) > 0
+		modelProtocolsChanged := modelsChanged && RemoveRemovedModelProtocolOverrides(current.Settings, mergedModels)
+
 		if modelsChanged {
-			update := svc.entFromContext(ctx).Channel.
+			update := db.Channel.
 				UpdateOneID(ch.ID).
 				SetSupportedModels(mergedModels)
 			if modelProtocolsChanged {
-				update.SetSettings(ch.Settings)
+				update.SetSettings(current.Settings)
 			}
-			channel, err := update.Save(ctx)
+			updated, err := update.Save(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to update channel supported models: %w", err)
 			}
 
-			updatedCh = channel
+			updatedCh = updated
 		}
 
 		pricesChanged, err := svc.ensureChannelModelPrices(ctx, ch.ID, mergedModels)
@@ -176,8 +194,8 @@ func (svc *ChannelService) syncChannelModelsForChannel(ctx context.Context, ch *
 		log.Int("channel_id", ch.ID),
 		log.String("channel_name", ch.Name),
 		log.Int("fetched_count", len(fetchedModelIDs)),
-		log.Int("manual_count", len(manualModels)),
-		log.Int("total_count", len(mergedModels)))
+		log.Int("manual_count", manualCount),
+		log.Int("total_count", totalCount))
 
 	return updatedCh, changed, nil
 }

--- a/internal/server/biz/channel_model_sync_test.go
+++ b/internal/server/biz/channel_model_sync_test.go
@@ -360,6 +360,61 @@ func TestChannelService_PeriodicModelSyncNotifiesOnceForChangedBatch(t *testing.
 	require.Equal(t, 2, priceCount)
 }
 
+func TestChannelService_SyncChannelModelsKeepsManualModelsSavedDuringFetch(t *testing.T) {
+	svc, client := setupTestChannelService(t)
+	defer client.Close()
+
+	ctx := authz.WithTestBypass(ent.NewContext(context.Background(), client))
+
+	var channelID int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/models", r.URL.Path)
+
+		// Simulate a user saving a manual model while the provider fetch is in
+		// flight. The sync must re-read manual_models instead of overwriting it
+		// with the snapshot taken before the fetch.
+		_, err := client.Channel.UpdateOneID(channelID).
+			SetManualModels([]string{"concurrent-manual"}).
+			SetSupportedModels([]string{"auto-a", "auto-b", "concurrent-manual"}).
+			Save(ctx)
+		assert.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"auto-a"},{"id":"auto-c"}]}`))
+	}))
+	defer server.Close()
+
+	svc.httpClient = httpclient.NewHttpClientWithClient(server.Client())
+	previousAsyncReloadDisabled := asyncReloadDisabled
+	asyncReloadDisabled = false
+	t.Cleanup(func() {
+		asyncReloadDisabled = previousAsyncReloadDisabled
+	})
+
+	ch, err := client.Channel.Create().
+		SetType(channel.TypeOpenai).
+		SetName("Concurrent manual model sync").
+		SetBaseURL(server.URL).
+		SetCredentials(objects.ChannelCredentials{APIKey: "test-key"}).
+		SetSupportedModels([]string{"auto-a", "auto-b"}).
+		SetManualModels([]string{}).
+		SetDefaultTestModel("auto-a").
+		Save(ctx)
+	require.NoError(t, err)
+	channelID = ch.ID
+
+	updated, err := svc.SyncChannelModels(ctx, ch.ID, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"auto-a", "auto-c", "concurrent-manual"}, updated.SupportedModels)
+	require.Equal(t, []string{"concurrent-manual"}, updated.ManualModels)
+
+	persisted, err := client.Channel.Get(ctx, ch.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"auto-a", "auto-c", "concurrent-manual"}, persisted.SupportedModels)
+	require.Equal(t, []string{"concurrent-manual"}, persisted.ManualModels)
+}
+
 func TestPreserveManualModels(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/server/biz/channel_model_sync_test.go
+++ b/internal/server/biz/channel_model_sync_test.go
@@ -275,6 +275,11 @@ func TestChannelService_ModelSyncIgnoresProviderOnlyOrderChanges(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"model-a", "model-b"}, second.SupportedModels)
 	require.Equal(t, 1, notifier.notifyCount)
+
+	// The unchanged sync returns an entity read inside the transaction; it must be
+	// unwrapped so later edge queries do not run against the closed transaction.
+	_, err = second.QueryChannelModelPrices().All(ctx)
+	require.NoError(t, err)
 }
 
 func TestChannelService_ModelSyncRemovesProtocolsForRemovedModels(t *testing.T) {

--- a/internal/server/gql/axonhub.graphql
+++ b/internal/server/gql/axonhub.graphql
@@ -67,6 +67,7 @@ type TransformOptions {
 type SyncChannelModelsPayload {
   channelID: ID!
   supportedModels: [String!]!
+  manualModels: [String!]!
 }
 
 input ReasoningEffortMappingInput {

--- a/internal/server/gql/axonhub.resolvers.go
+++ b/internal/server/gql/axonhub.resolvers.go
@@ -662,9 +662,17 @@ func (r *mutationResolver) SyncChannelModels(ctx context.Context, channelID obje
 		return nil, err
 	}
 
+	// manual_models is nullable in the schema; normalize nil so the non-null
+	// payload field never resolves to null.
+	manualModels := ch.ManualModels
+	if manualModels == nil {
+		manualModels = []string{}
+	}
+
 	return &SyncChannelModelsPayload{
 		ChannelID:       channelID,
 		SupportedModels: ch.SupportedModels,
+		ManualModels:    manualModels,
 	}, nil
 }
 

--- a/internal/server/gql/generated.go
+++ b/internal/server/gql/generated.go
@@ -1742,6 +1742,7 @@ type ComplexityRoot struct {
 
 	SyncChannelModelsPayload struct {
 		ChannelID       func(childComplexity int) int
+		ManualModels    func(childComplexity int) int
 		SupportedModels func(childComplexity int) int
 	}
 
@@ -10003,6 +10004,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SyncChannelModelsPayload.ChannelID(childComplexity), true
+	case "SyncChannelModelsPayload.manualModels":
+		if e.complexity.SyncChannelModelsPayload.ManualModels == nil {
+			break
+		}
+
+		return e.complexity.SyncChannelModelsPayload.ManualModels(childComplexity), true
 	case "SyncChannelModelsPayload.supportedModels":
 		if e.complexity.SyncChannelModelsPayload.SupportedModels == nil {
 			break
@@ -35214,6 +35221,8 @@ func (ec *executionContext) fieldContext_Mutation_syncChannelModels(ctx context.
 				return ec.fieldContext_SyncChannelModelsPayload_channelID(ctx, field)
 			case "supportedModels":
 				return ec.fieldContext_SyncChannelModelsPayload_supportedModels(ctx, field)
+			case "manualModels":
+				return ec.fieldContext_SyncChannelModelsPayload_manualModels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SyncChannelModelsPayload", field.Name)
 		},
@@ -53756,6 +53765,35 @@ func (ec *executionContext) _SyncChannelModelsPayload_supportedModels(ctx contex
 }
 
 func (ec *executionContext) fieldContext_SyncChannelModelsPayload_supportedModels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SyncChannelModelsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SyncChannelModelsPayload_manualModels(ctx context.Context, field graphql.CollectedField, obj *SyncChannelModelsPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SyncChannelModelsPayload_manualModels,
+		func(ctx context.Context) (any, error) {
+			return obj.ManualModels, nil
+		},
+		nil,
+		ec.marshalNString2ᚕstringᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_SyncChannelModelsPayload_manualModels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SyncChannelModelsPayload",
 		Field:      field,
@@ -106521,6 +106559,11 @@ func (ec *executionContext) _SyncChannelModelsPayload(ctx context.Context, sel a
 			}
 		case "supportedModels":
 			out.Values[i] = ec._SyncChannelModelsPayload_supportedModels(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "manualModels":
+			out.Values[i] = ec._SyncChannelModelsPayload_manualModels(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/server/gql/models_gen.go
+++ b/internal/server/gql/models_gen.go
@@ -463,6 +463,7 @@ type SignInPayload struct {
 type SyncChannelModelsPayload struct {
 	ChannelID       objects.GUID `json:"channelID"`
 	SupportedModels []string     `json:"supportedModels"`
+	ManualModels    []string     `json:"manualModels"`
 }
 
 type SystemModelSettingOnboarding struct {


### PR DESCRIPTION
## Problem

Manually added channel models could be dropped or miscounted while auto-sync of supported models is enabled.

1. **Data loss during sync**: `syncChannelModelsForChannel` computed the merged model list from the channel snapshot taken *before* the provider fetch, then overwrote `supported_models`. A manual model saved while the fetch was in flight was overwritten, while `manual_models` kept it, so the two lists diverged.
2. **Wrong count in the channel dialog**: the header shows `supportedModels.length - manualModels.length` auto + `manualModels.length` manual, but badges are derived from `manualModels.includes(model)`. "Sync now" refreshed only `supportedModels`, and a `useEffect` reset `manualModels` alone whenever the channel was refetched in the background. Either case could leave `manual_models` holding entries missing from the list, e.g. the header reading "2 auto + 2 manual" while the list still showed "3 auto + 1 manual".

## Changes

- Re-read the channel inside the sync transaction and merge against the fresh `manual_models` / `supported_models` / `settings` instead of the stale snapshot.
- `SyncChannelModelsPayload` now exposes `manualModels`, and the dialog refreshes both lists after an immediate sync.
- Removed the effect that reset `manualModels` alone on background refetches; the dialog already initializes from the row on mount.

## Tests

- Added `TestChannelService_SyncChannelModelsKeepsManualModelsSavedDuringFetch`, which fails on the previous logic and passes with the fix.
- `go test ./internal/server/biz -count=1` and `go test ./internal/server/gql -count=1` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Channel model synchronization now preserves manual models saved while a provider refresh is in progress.
  - Model lists remain consistent after synchronization, including supported and manually configured models.
  - Sync results now return the latest manual model list, allowing the interface to reflect channel configuration immediately.
  - Synchronization results remain usable when no model changes are detected, improving reliability for follow-up channel model actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->