### PR TITLE
feat(metrics): standardize LLM lifecycle and usage telemetry

### DIFF
--- a/cmd/axonhub/main.go
+++ b/cmd/axonhub/main.go
@@ -74,6 +74,7 @@ func startServer() {
 		}),
 		conf.Module,
 		fx.Provide(metrics.NewProvider),
+		fx.Invoke(biz.RegisterMetricResourceInfo),
 		fx.Invoke(func(lc fx.Lifecycle, cfg server.Config) {
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -231,7 +231,7 @@ func (sm *_Metrics) RecordDownstreamRequestCreated(ctx context.Context, attrs Re
 		return
 	}
 
-	sm.DownstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+	sm.DownstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(downstreamActiveAttrs(attrs)...))
 }
 
 // RecordDownstreamRequestCompleted records one logical client request entering
@@ -242,11 +242,9 @@ func (sm *_Metrics) RecordDownstreamRequestCompleted(ctx context.Context, attrs 
 	}
 
 	attrs.Status = status
-	attrsWithoutStatus := attrs
-	attrsWithoutStatus.Status = ""
 	sm.DownstreamRequestsTotal.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
 	if sm.DownstreamActiveRequests != nil {
-		sm.DownstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(requestAttrs(attrsWithoutStatus)...))
+		sm.DownstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(downstreamActiveAttrs(attrs)...))
 	}
 }
 
@@ -256,7 +254,7 @@ func (sm *_Metrics) RecordUpstreamRequestCreated(ctx context.Context, attrs Requ
 		return
 	}
 
-	sm.UpstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+	sm.UpstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(upstreamActiveAttrs(attrs)...))
 }
 
 // RecordUpstreamRequestCompleted records one provider execution attempt entering
@@ -268,10 +266,8 @@ func (sm *_Metrics) RecordUpstreamRequestCompleted(ctx context.Context, attrs Re
 
 	attrs.Status = status
 	sm.UpstreamRequestsTotal.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
-	attrsWithoutStatus := attrs
-	attrsWithoutStatus.Status = ""
 	if sm.UpstreamActiveRequests != nil {
-		sm.UpstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(requestAttrs(attrsWithoutStatus)...))
+		sm.UpstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(upstreamActiveAttrs(attrs)...))
 	}
 }
 
@@ -338,6 +334,28 @@ func (sm *_Metrics) RecordDownstreamPerformance(ctx context.Context, attrs Reque
 	}
 	if ttftSeconds != nil && *ttftSeconds >= 0 && sm.DownstreamTTFT != nil {
 		sm.DownstreamTTFT.Record(ctx, *ttftSeconds, metricAttrs)
+	}
+}
+
+// Active series use only immutable dimensions available at both lifecycle
+// boundaries. Routing and context enrichment must not split an increment and
+// its matching decrement into different time series.
+func downstreamActiveAttrs(attrs RequestAttributes) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("project_id", attrs.ProjectID),
+		attribute.String("request_model_id", attrs.RequestModelID),
+		attribute.String("format", attrs.Format),
+		attribute.Bool("stream", attrs.Stream),
+	}
+}
+
+func upstreamActiveAttrs(attrs RequestAttributes) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("project_id", attrs.ProjectID),
+		attribute.Int("channel_id", attrs.ChannelID),
+		attribute.String("model_id", attrs.ModelID),
+		attribute.String("format", attrs.Format),
+		attribute.Bool("stream", attrs.Stream),
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -20,12 +20,38 @@ type _Metrics struct {
 	GraphQLRequestCount    metric.Int64Counter
 	GraphQLRequestDuration metric.Float64Histogram
 
-	// Chat metrics
-	ChatRequestCount    metric.Int64Counter
-	ChatRequestDuration metric.Float64Histogram
-	ChatTokenCount      metric.Int64Counter
-	ChatSuccessCount    metric.Int64Counter
-	ChatFailureCount    metric.Int64Counter
+	// LLM request lifecycle metrics. A downstream request is one logical
+	// request received from a client; an upstream request is one provider
+	// execution attempt (retries therefore create additional upstream events).
+	DownstreamRequestsTotal  metric.Int64Counter
+	DownstreamActiveRequests metric.Int64UpDownCounter
+	UpstreamRequestsTotal    metric.Int64Counter
+	UpstreamActiveRequests   metric.Int64UpDownCounter
+
+	// LLM usage and performance metrics.
+	LLMTokens          metric.Int64Counter
+	LLMCost            metric.Float64Counter
+	UpstreamDuration   metric.Float64Histogram
+	UpstreamTTFT       metric.Float64Histogram
+	DownstreamDuration metric.Float64Histogram
+	DownstreamTTFT     metric.Float64Histogram
+}
+
+// RequestAttributes contains the dimensions shared by request, usage, and
+// performance metrics. Empty IDs are used for dimensions that are not known at
+// a lifecycle point (for example, the selected channel is not known when a
+// downstream request is first created).
+type RequestAttributes struct {
+	ProjectID      int
+	ChannelID      int
+	RequestModelID string
+	ModelID        string
+	APIKeyID       int
+	UserID         int
+	Source         string
+	Format         string
+	Stream         bool
+	Status         string
 }
 
 var Metrics *_Metrics
@@ -81,61 +107,98 @@ func SetupMetrics(provider *sdk.MeterProvider, name string) error {
 
 	Metrics.GraphQLRequestDuration = graphQLRequestDuration
 
-	// Chat metrics
-	chatRequestCount, err := meter.Int64Counter(
-		"chat_request_count",
-		metric.WithDescription("Number of chat requests"),
+	// LLM request lifecycle metrics
+	downstreamRequestsTotal, err := meter.Int64Counter(
+		"axonhub_downstream_requests_total",
+		metric.WithDescription("Logical downstream requests by terminal status"),
 		metric.WithUnit("requests"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create chat_request_count counter: %w", err)
+		return fmt.Errorf("failed to create axonhub_downstream_requests_total counter: %w", err)
 	}
+	Metrics.DownstreamRequestsTotal = downstreamRequestsTotal
 
-	Metrics.ChatRequestCount = chatRequestCount
-
-	chatRequestDuration, err := meter.Float64Histogram(
-		"chat_request_duration_seconds",
-		metric.WithDescription("Chat request duration in seconds"),
-		metric.WithUnit("seconds"),
+	downstreamActiveRequests, err := meter.Int64UpDownCounter(
+		"axonhub_downstream_active_requests",
+		metric.WithDescription("Logical downstream requests currently in progress"),
+		metric.WithUnit("requests"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create chat_request_duration_seconds histogram: %w", err)
+		return fmt.Errorf("failed to create axonhub_downstream_active_requests gauge: %w", err)
 	}
+	Metrics.DownstreamActiveRequests = downstreamActiveRequests
 
-	Metrics.ChatRequestDuration = chatRequestDuration
+	upstreamRequestsTotal, err := meter.Int64Counter(
+		"axonhub_upstream_requests_total",
+		metric.WithDescription("Upstream provider execution attempts by terminal status"),
+		metric.WithUnit("requests"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create axonhub_upstream_requests_total counter: %w", err)
+	}
+	Metrics.UpstreamRequestsTotal = upstreamRequestsTotal
 
-	chatTokenCount, err := meter.Int64Counter(
-		"chat_token_count",
-		metric.WithDescription("Number of tokens in chat requests"),
+	upstreamActiveRequests, err := meter.Int64UpDownCounter(
+		"axonhub_upstream_active_requests",
+		metric.WithDescription("Upstream provider execution attempts currently in progress"),
+		metric.WithUnit("requests"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create axonhub_upstream_requests gauge: %w", err)
+	}
+	Metrics.UpstreamActiveRequests = upstreamActiveRequests
+
+	llmTokens, err := meter.Int64Counter(
+		"axonhub_llm_tokens_total",
+		metric.WithDescription("LLM tokens recorded from completed usage data"),
 		metric.WithUnit("tokens"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create chat_token_count counter: %w", err)
+		return fmt.Errorf("failed to create axonhub_llm_tokens_total counter: %w", err)
 	}
+	Metrics.LLMTokens = llmTokens
 
-	Metrics.ChatTokenCount = chatTokenCount
-
-	chatSuccessCount, err := meter.Int64Counter(
-		"chat_success_count",
-		metric.WithDescription("Number of successful chat requests"),
-		metric.WithUnit("requests"),
+	llmCost, err := meter.Float64Counter(
+		"axonhub_llm_cost_total",
+		metric.WithDescription("AxonHub-calculated LLM cost recorded from usage data"),
+		metric.WithUnit("currency"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create chat_success_count counter: %w", err)
+		return fmt.Errorf("failed to create axonhub_llm_cost_total counter: %w", err)
 	}
+	Metrics.LLMCost = llmCost
 
-	Metrics.ChatSuccessCount = chatSuccessCount
-
-	chatFailureCount, err := meter.Int64Counter(
-		"chat_failure_count",
-		metric.WithDescription("Number of failed chat requests"),
-		metric.WithUnit("requests"),
+	upstreamDuration, err := meter.Float64Histogram(
+		"axonhub_upstream_request_duration_seconds",
+		metric.WithDescription("Duration of an upstream provider execution attempt"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create chat_failure_count counter: %w", err)
+		return fmt.Errorf("failed to create axonhub_upstream_request_duration_seconds histogram: %w", err)
 	}
+	Metrics.UpstreamDuration = upstreamDuration
 
-	Metrics.ChatFailureCount = chatFailureCount
+	upstreamTTFT, err := meter.Float64Histogram(
+		"axonhub_upstream_ttft_seconds",
+		metric.WithDescription("Time from upstream execution start to the first generated token"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create axonhub_upstream_ttft_seconds histogram: %w", err)
+	}
+	Metrics.UpstreamTTFT = upstreamTTFT
+
+	downstreamDuration, err := meter.Float64Histogram("axonhub_downstream_request_duration_seconds", metric.WithDescription("End-to-end duration of a logical downstream request, including retries"), metric.WithUnit("s"))
+	if err != nil {
+		return fmt.Errorf("failed to create axonhub_downstream_request_duration_seconds histogram: %w", err)
+	}
+	Metrics.DownstreamDuration = downstreamDuration
+
+	downstreamTTFT, err := meter.Float64Histogram("axonhub_downstream_ttft_seconds", metric.WithDescription("Time from logical downstream request creation to the first client-visible output"), metric.WithUnit("s"))
+	if err != nil {
+		return fmt.Errorf("failed to create axonhub_downstream_ttft_seconds histogram: %w", err)
+	}
+	Metrics.DownstreamTTFT = downstreamTTFT
 
 	return nil
 }
@@ -162,20 +225,137 @@ func (sm *_Metrics) RecordGraphQLRequest(ctx context.Context, operation string, 
 	sm.GraphQLRequestDuration.Record(ctx, duration, metric.WithAttributes(labels...))
 }
 
-// RecordChatRequest records chat request metrics.
-func (sm *_Metrics) RecordChatRequest(ctx context.Context, channelID, channelName string, duration float64, success bool, tokenCount int64) {
-	labels := []attribute.KeyValue{
-		attribute.String("channel_id", channelID),
-		attribute.String("channel_name", channelName),
+// RecordDownstreamRequestCreated records creation of one logical client request.
+func (sm *_Metrics) RecordDownstreamRequestCreated(ctx context.Context, attrs RequestAttributes) {
+	if sm == nil || sm.DownstreamActiveRequests == nil {
+		return
 	}
 
-	sm.ChatRequestCount.Add(ctx, 1, metric.WithAttributes(labels...))
-	sm.ChatRequestDuration.Record(ctx, duration, metric.WithAttributes(labels...))
-	sm.ChatTokenCount.Add(ctx, tokenCount, metric.WithAttributes(labels...))
+	sm.DownstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+}
 
-	if success {
-		sm.ChatSuccessCount.Add(ctx, 1, metric.WithAttributes(labels...))
-	} else {
-		sm.ChatFailureCount.Add(ctx, 1, metric.WithAttributes(labels...))
+// RecordDownstreamRequestCompleted records one logical client request entering
+// a terminal status. Callers must only invoke this on a real state transition.
+func (sm *_Metrics) RecordDownstreamRequestCompleted(ctx context.Context, attrs RequestAttributes, status string) {
+	if sm == nil || sm.DownstreamRequestsTotal == nil {
+		return
 	}
+
+	attrs.Status = status
+	attrsWithoutStatus := attrs
+	attrsWithoutStatus.Status = ""
+	sm.DownstreamRequestsTotal.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+	if sm.DownstreamActiveRequests != nil {
+		sm.DownstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(requestAttrs(attrsWithoutStatus)...))
+	}
+}
+
+// RecordUpstreamRequestCreated records one provider execution attempt.
+func (sm *_Metrics) RecordUpstreamRequestCreated(ctx context.Context, attrs RequestAttributes) {
+	if sm == nil || sm.UpstreamActiveRequests == nil {
+		return
+	}
+
+	sm.UpstreamActiveRequests.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+}
+
+// RecordUpstreamRequestCompleted records one provider execution attempt entering
+// a terminal status. Callers must only invoke this on a real state transition.
+func (sm *_Metrics) RecordUpstreamRequestCompleted(ctx context.Context, attrs RequestAttributes, status string) {
+	if sm == nil || sm.UpstreamRequestsTotal == nil {
+		return
+	}
+
+	attrs.Status = status
+	sm.UpstreamRequestsTotal.Add(ctx, 1, metric.WithAttributes(requestAttrs(attrs)...))
+	attrsWithoutStatus := attrs
+	attrsWithoutStatus.Status = ""
+	if sm.UpstreamActiveRequests != nil {
+		sm.UpstreamActiveRequests.Add(ctx, -1, metric.WithAttributes(requestAttrs(attrsWithoutStatus)...))
+	}
+}
+
+// RecordLLMUsage records token usage and optional cost after the usage record
+// has been persisted successfully. Cached and reasoning tokens are breakdowns
+// of input and output respectively; consumers should not sum all token_type
+// values together.
+func (sm *_Metrics) RecordLLMUsage(ctx context.Context, attrs RequestAttributes, input, output, cached, reasoning int64, cost *float64) {
+	if sm == nil {
+		return
+	}
+
+	baseAttrs := requestAttrs(attrs)
+	tokenValues := []struct {
+		tokenType string
+		value     int64
+	}{
+		{tokenType: "input", value: input},
+		{tokenType: "output", value: output},
+		{tokenType: "cached", value: cached},
+		{tokenType: "reasoning", value: reasoning},
+	}
+	for _, token := range tokenValues {
+		tokenType, value := token.tokenType, token.value
+		if value > 0 && sm.LLMTokens != nil {
+			attrsWithType := append(append([]attribute.KeyValue{}, baseAttrs...), attribute.String("token_type", tokenType))
+			sm.LLMTokens.Add(ctx, value, metric.WithAttributes(attrsWithType...))
+		}
+	}
+
+	if cost != nil && *cost > 0 && sm.LLMCost != nil {
+		sm.LLMCost.Add(ctx, *cost, metric.WithAttributes(baseAttrs...))
+	}
+}
+
+// RecordUpstreamPerformance records duration and, when available, TTFT for an
+// upstream execution. The status is attached to both histograms so dashboards
+// can select completed requests while failure latency remains observable.
+func (sm *_Metrics) RecordUpstreamPerformance(ctx context.Context, attrs RequestAttributes, status string, durationSeconds float64, ttftSeconds *float64) {
+	if sm == nil {
+		return
+	}
+
+	attrs.Status = status
+	metricAttrs := metric.WithAttributes(requestAttrs(attrs)...)
+	if durationSeconds >= 0 && sm.UpstreamDuration != nil {
+		sm.UpstreamDuration.Record(ctx, durationSeconds, metricAttrs)
+	}
+	if ttftSeconds != nil && *ttftSeconds >= 0 && sm.UpstreamTTFT != nil {
+		sm.UpstreamTTFT.Record(ctx, *ttftSeconds, metricAttrs)
+	}
+}
+
+// RecordDownstreamPerformance records end-to-end logical-request performance.
+func (sm *_Metrics) RecordDownstreamPerformance(ctx context.Context, attrs RequestAttributes, status string, durationSeconds float64, ttftSeconds *float64) {
+	if sm == nil {
+		return
+	}
+
+	attrs.Status = status
+	metricAttrs := metric.WithAttributes(requestAttrs(attrs)...)
+	if durationSeconds >= 0 && sm.DownstreamDuration != nil {
+		sm.DownstreamDuration.Record(ctx, durationSeconds, metricAttrs)
+	}
+	if ttftSeconds != nil && *ttftSeconds >= 0 && sm.DownstreamTTFT != nil {
+		sm.DownstreamTTFT.Record(ctx, *ttftSeconds, metricAttrs)
+	}
+}
+
+func requestAttrs(attrs RequestAttributes) []attribute.KeyValue {
+	result := []attribute.KeyValue{
+		attribute.Int("project_id", attrs.ProjectID),
+		attribute.Int("channel_id", attrs.ChannelID),
+		attribute.String("request_model_id", attrs.RequestModelID),
+		attribute.String("model_id", attrs.ModelID),
+		attribute.Int("api_key_id", attrs.APIKeyID),
+		attribute.Int("user_id", attrs.UserID),
+		attribute.String("source", attrs.Source),
+		attribute.String("format", attrs.Format),
+		attribute.Bool("stream", attrs.Stream),
+	}
+	if attrs.Status != "" {
+		result = append(result, attribute.String("status", attrs.Status))
+	}
+
+	return result
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 func TestLLMMetricsRecordLifecycleUsageAndPerformance(t *testing.T) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestLLMMetricsRecordLifecycleUsageAndPerformance(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	require.NoError(t, SetupMetrics(provider, "axonhub-test"))
+	attrs := RequestAttributes{
+		ProjectID:      1,
+		ChannelID:      2,
+		RequestModelID: "requested-model",
+		ModelID:        "actual-model",
+		APIKeyID:       3,
+		UserID:         4,
+		Source:         "api",
+		Format:         "openai/chat_completions",
+		Stream:         true,
+	}
+
+	Metrics.RecordDownstreamRequestCreated(t.Context(), attrs)
+	Metrics.RecordDownstreamRequestCompleted(t.Context(), attrs, "completed")
+	Metrics.RecordUpstreamRequestCreated(t.Context(), attrs)
+	Metrics.RecordUpstreamRequestCompleted(t.Context(), attrs, "failed")
+	cost := 0.125
+	Metrics.RecordLLMUsage(t.Context(), attrs, 100, 40, 20, 5, &cost)
+	ttft := 0.25
+	Metrics.RecordUpstreamPerformance(t.Context(), attrs, "completed", 1.5, &ttft)
+
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	assert.Equal(t, int64(1), metricCounterValue(t, rm, "axonhub_downstream_requests_total"))
+	assert.Equal(t, int64(0), metricCounterValue(t, rm, "axonhub_downstream_active_requests"))
+	assert.Equal(t, int64(1), metricCounterValue(t, rm, "axonhub_upstream_requests_total"))
+	assert.Equal(t, int64(0), metricCounterValue(t, rm, "axonhub_upstream_active_requests"))
+	assert.Equal(t, int64(100), metricCounterValueByType(t, rm, "axonhub_llm_tokens_total", "input"))
+	assert.Equal(t, int64(40), metricCounterValueByType(t, rm, "axonhub_llm_tokens_total", "output"))
+	assert.Equal(t, int64(20), metricCounterValueByType(t, rm, "axonhub_llm_tokens_total", "cached"))
+	assert.Equal(t, int64(5), metricCounterValueByType(t, rm, "axonhub_llm_tokens_total", "reasoning"))
+	assert.InDelta(t, cost, metricFloatCounterValue(t, rm, "axonhub_llm_cost_total"), 1e-9)
+	assert.Equal(t, uint64(1), metricHistogramCount(t, rm, "axonhub_upstream_request_duration_seconds"))
+	assert.Equal(t, uint64(1), metricHistogramCount(t, rm, "axonhub_upstream_ttft_seconds"))
+}
+
+func metricCounterValue(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			data, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, data.DataPoints, 1)
+			return data.DataPoints[0].Value
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}
+
+func metricCounterValueByType(t *testing.T, rm metricdata.ResourceMetrics, name, tokenType string) int64 {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			data, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range data.DataPoints {
+				value, ok := point.Attributes.Value(attribute.Key("token_type"))
+				if ok && value.AsString() == tokenType {
+					return point.Value
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %q with token_type=%q not found", name, tokenType)
+	return 0
+}
+
+func metricFloatCounterValue(t *testing.T, rm metricdata.ResourceMetrics, name string) float64 {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			data, ok := metric.Data.(metricdata.Sum[float64])
+			require.True(t, ok)
+			require.Len(t, data.DataPoints, 1)
+			return data.DataPoints[0].Value
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}
+
+func metricHistogramCount(t *testing.T, rm metricdata.ResourceMetrics, name string) uint64 {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			data, ok := metric.Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			require.Len(t, data.DataPoints, 1)
+			return data.DataPoints[0].Count
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -15,6 +15,8 @@ func TestLLMMetricsRecordLifecycleUsageAndPerformance(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	previous := Metrics
+	t.Cleanup(func() { Metrics = previous })
 
 	require.NoError(t, SetupMetrics(provider, "axonhub-test"))
 	attrs := RequestAttributes{
@@ -29,9 +31,23 @@ func TestLLMMetricsRecordLifecycleUsageAndPerformance(t *testing.T) {
 		Stream:         true,
 	}
 
-	Metrics.RecordDownstreamRequestCreated(t.Context(), attrs)
+	// Routing and context enrichment change between creation and completion.
+	downstreamCreated := attrs
+	downstreamCreated.ChannelID = 0
+	downstreamCreated.ModelID = ""
+	downstreamCreated.UserID = 0
+	upstreamCreated := attrs
+	upstreamCreated.RequestModelID = ""
+	upstreamCreated.APIKeyID = 0
+	upstreamCreated.UserID = 0
+	upstreamCreated.Source = ""
+	Metrics.RecordDownstreamRequestCreated(t.Context(), downstreamCreated)
+	Metrics.RecordUpstreamRequestCreated(t.Context(), upstreamCreated)
+	active := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &active))
+	assert.Equal(t, int64(1), metricCounterValue(t, active, "axonhub_downstream_active_requests"))
+	assert.Equal(t, int64(1), metricCounterValue(t, active, "axonhub_upstream_active_requests"))
 	Metrics.RecordDownstreamRequestCompleted(t.Context(), attrs, "completed")
-	Metrics.RecordUpstreamRequestCreated(t.Context(), attrs)
 	Metrics.RecordUpstreamRequestCompleted(t.Context(), attrs, "failed")
 	cost := 0.125
 	Metrics.RecordLLMUsage(t.Context(), attrs, 100, 40, 20, 5, &cost)

--- a/internal/metrics/resource_info.go
+++ b/internal/metrics/resource_info.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/looplj/axonhub/internal/log"
+)
+
+// ResourceName is display metadata, kept separate from cumulative usage series
+// so renaming a resource does not reset its counters or merge same-name IDs.
+type ResourceName struct {
+	ID   int
+	Name string
+}
+
+type ResourceNames struct {
+	Channels []ResourceName
+	Projects []ResourceName
+	APIKeys  []ResourceName
+	Users    []ResourceName
+}
+
+func RegisterResourceInfo(meter metric.Meter, load func(context.Context) (ResourceNames, error)) (metric.Registration, error) {
+	types := []string{"channel", "project", "api_key", "user"}
+	gauges := make([]metric.Int64ObservableGauge, len(types))
+	instruments := make([]metric.Observable, len(types))
+	for i, kind := range types {
+		gauge, err := meter.Int64ObservableGauge("axonhub_"+kind+"_info", metric.WithDescription("Current display name for an AxonHub "+kind))
+		if err != nil {
+			return nil, fmt.Errorf("register %s metadata: %w", kind, err)
+		}
+		gauges[i], instruments[i] = gauge, gauge
+	}
+	return meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+		names, err := load(ctx)
+		if err != nil {
+			// Display metadata must not prevent request telemetry from exporting
+			// when the database is temporarily unavailable.
+			log.Warn(ctx, "Failed to collect metric resource names", log.Cause(err))
+			return nil
+		}
+		groups := [][]ResourceName{names.Channels, names.Projects, names.APIKeys, names.Users}
+		for i, group := range groups {
+			for _, resource := range group {
+				observer.ObserveInt64(gauges[i], 1, metric.WithAttributes(
+					attribute.Int(types[i]+"_id", resource.ID),
+					attribute.String(types[i]+"_name", resource.Name),
+				))
+			}
+		}
+		return nil
+	}, instruments...)
+}

--- a/internal/metrics/resource_info_test.go
+++ b/internal/metrics/resource_info_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestResourceNameFailureDoesNotBlockCounters(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	meter := provider.Meter("test")
+	reg, err := RegisterResourceInfo(meter, func(context.Context) (ResourceNames, error) {
+		return ResourceNames{}, errors.New("database unavailable")
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Unregister() })
+	counter, err := meter.Int64Counter("request_test_total")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &collected))
+	var count int64
+	for _, scope := range collected.ScopeMetrics {
+		for _, mt := range scope.Metrics {
+			if mt.Name == "request_test_total" {
+				for _, point := range mt.Data.(metricdata.Sum[int64]).DataPoints {
+					count += point.Value
+				}
+			}
+		}
+	}
+	require.Equal(t, int64(1), count)
+}

--- a/internal/server/biz/metric_resource_info.go
+++ b/internal/server/biz/metric_resource_info.go
@@ -1,0 +1,109 @@
+package biz
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/fx"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/apikey"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/project"
+	"github.com/looplj/axonhub/internal/ent/user"
+	"github.com/looplj/axonhub/internal/metrics"
+)
+
+// RegisterMetricResourceInfo installs metadata only when metrics export is
+// enabled. No per-request database lookups or exported credentials are needed.
+func RegisterMetricResourceInfo(lc fx.Lifecycle, client *ent.Client, cfg metrics.Config, provider *sdkmetric.MeterProvider) {
+	if !cfg.Enabled {
+		return
+	}
+	svc := &metricResourceInfo{client: client}
+	var registration metric.Registration
+	lc.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			var err error
+			registration, err = metrics.RegisterResourceInfo(provider.Meter("axonhub"), svc.snapshot)
+			return err
+		},
+		OnStop: func(context.Context) error {
+			if registration != nil {
+				return registration.Unregister()
+			}
+			return nil
+		},
+	})
+}
+
+// Cache for one minute, independently of the five-second export interval.
+// Only successful snapshots are cached; a failed read must not renew old names.
+type metricResourceInfo struct {
+	client   *ent.Client
+	mu       sync.Mutex
+	loadedAt time.Time
+	names    metrics.ResourceNames
+}
+
+func (s *metricResourceInfo) snapshot(ctx context.Context) (metrics.ResourceNames, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loadedAt.IsZero() && time.Since(s.loadedAt) < time.Minute {
+		return s.names, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	names, err := authz.RunWithSystemBypass(ctx, "export-metric-display-names", func(ctx context.Context) (metrics.ResourceNames, error) {
+		return s.load(ctx)
+	})
+	if err != nil {
+		return metrics.ResourceNames{}, err
+	}
+	s.names, s.loadedAt = names, time.Now()
+	return names, nil
+}
+
+func (s *metricResourceInfo) load(ctx context.Context) (metrics.ResourceNames, error) {
+	var result metrics.ResourceNames
+	channels, err := s.client.Channel.Query().Select(channel.FieldID, channel.FieldName).All(ctx)
+	if err != nil {
+		return result, fmt.Errorf("load channel metric names: %w", err)
+	}
+	for _, item := range channels {
+		result.Channels = append(result.Channels, metrics.ResourceName{ID: item.ID, Name: item.Name})
+	}
+	projects, err := s.client.Project.Query().Select(project.FieldID, project.FieldName).All(ctx)
+	if err != nil {
+		return result, fmt.Errorf("load project metric names: %w", err)
+	}
+	for _, item := range projects {
+		result.Projects = append(result.Projects, metrics.ResourceName{ID: item.ID, Name: item.Name})
+	}
+	keys, err := s.client.APIKey.Query().Select(apikey.FieldID, apikey.FieldName).All(ctx)
+	if err != nil {
+		return result, fmt.Errorf("load API key metric names: %w", err)
+	}
+	for _, item := range keys {
+		result.APIKeys = append(result.APIKeys, metrics.ResourceName{ID: item.ID, Name: item.Name})
+	}
+	users, err := s.client.User.Query().Select(user.FieldID, user.FieldFirstName, user.FieldLastName).All(ctx)
+	if err != nil {
+		return result, fmt.Errorf("load user metric names: %w", err)
+	}
+	for _, item := range users {
+		name := strings.TrimSpace(item.FirstName + " " + item.LastName)
+		if name == "" {
+			name = fmt.Sprintf("User %d", item.ID)
+		}
+		result.Users = append(result.Users, metrics.ResourceName{ID: item.ID, Name: name})
+	}
+	return result, nil
+}

--- a/internal/server/biz/metric_resource_info_test.go
+++ b/internal/server/biz/metric_resource_info_test.go
@@ -1,0 +1,75 @@
+package biz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/metrics"
+	"github.com/looplj/axonhub/internal/objects"
+)
+
+func TestMetricResourceNamesRefresh(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:metric_names?mode=memory&_fk=0")
+	t.Cleanup(func() { _ = client.Close() })
+	ctx := authz.WithTestBypass(t.Context())
+	p, err := client.Project.Create().SetName("研发项目").Save(ctx)
+	require.NoError(t, err)
+	u, err := client.User.Create().SetEmail("private@example.com").SetPassword("password-secret").SetFirstName("Alice").SetLastName("Lee").Save(ctx)
+	require.NoError(t, err)
+	k, err := client.APIKey.Create().SetName("生产调用").SetKey("key-secret").SetProjectID(p.ID).SetUserID(u.ID).Save(ctx)
+	require.NoError(t, err)
+	c, err := client.Channel.Create().SetName("主渠道").SetType(channel.TypeOpenai).SetBaseURL("https://example.com").SetSupportedModels([]string{"test-model"}).SetDefaultTestModel("test-model").SetCredentials(objects.ChannelCredentials{APIKey: "provider-secret"}).Save(ctx)
+	require.NoError(t, err)
+	svc := &metricResourceInfo{client: client}
+	names, err := svc.snapshot(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, names.Projects, metrics.ResourceName{ID: p.ID, Name: "研发项目"})
+	require.Contains(t, names.Users, metrics.ResourceName{ID: u.ID, Name: "Alice Lee"})
+	require.Contains(t, names.APIKeys, metrics.ResourceName{ID: k.ID, Name: "生产调用"})
+	require.Contains(t, names.Channels, metrics.ResourceName{ID: c.ID, Name: "主渠道"})
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	reg, err := metrics.RegisterResourceInfo(provider.Meter("test"), svc.snapshot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Unregister() })
+	collect := func() metricdata.ResourceMetrics {
+		var result metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(t.Context(), &result))
+		return result
+	}
+	before := collect()
+	require.NotContains(t, fmtResourceNames(before), "key-secret")
+	require.NotContains(t, fmtResourceNames(before), "private@example.com")
+	require.Contains(t, fmtResourceNames(before), "主渠道")
+	require.NoError(t, client.Channel.UpdateOneID(c.ID).SetName("新渠道").Exec(ctx))
+	require.Contains(t, fmtResourceNames(collect()), "主渠道")
+	svc.loadedAt = time.Now().Add(-2 * time.Minute)
+	after := fmtResourceNames(collect())
+	require.Contains(t, after, "新渠道")
+	require.NotContains(t, after, "主渠道")
+}
+
+func fmtResourceNames(r metricdata.ResourceMetrics) []string {
+	var labels []string
+	for _, scope := range r.ScopeMetrics {
+		for _, mt := range scope.Metrics {
+			for _, point := range mt.Data.(metricdata.Gauge[int64]).DataPoints {
+				for _, attr := range point.Attributes.ToSlice() {
+					labels = append(labels, attr.Value.AsString())
+				}
+			}
+		}
+	}
+	return labels
+}

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -1053,7 +1053,7 @@ func (s *RequestService) UpdateRequestExecutionStatusWithMetrics(
 		}
 	}
 
-	_, err := upd.Save(ctx)
+	_, err = upd.Save(ctx)
 	if err != nil {
 		log.Error(ctx, "Failed to update request execution status", log.Cause(err), log.Any("status", status))
 		return err

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -1059,7 +1059,7 @@ func (s *RequestService) UpdateRequestExecutionStatusWithMetrics(
 		return err
 	}
 
-	recordUpstreamCompletionMetrics(ctx, execution, status, wasTerminal, nil, req)
+	recordUpstreamCompletionMetrics(ctx, execution, status, wasTerminal, metrics, req)
 
 	return nil
 }

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -609,6 +609,9 @@ func (s *RequestService) UpdateRequestFinalized(
 		log.Error(ctx, "Failed to get request", log.Cause(err))
 		return err
 	}
+	if isTerminalRequestStatus(req.Status) {
+		return nil
+	}
 
 	// Get data storage if set
 	var dataStorage *ent.DataStorage
@@ -638,42 +641,42 @@ func (s *RequestService) UpdateRequestFinalized(
 		}
 	}
 
-	savedExternalKey := ""
-
+	// Save the winning body together with the terminal transition before any
+	// external write. The inline copy remains readable if offloading fails.
+	var responseBodyBytes objects.JSONRawMessage
 	if storeResponseBody {
-		responseBodyBytes, err := xjson.Marshal(responseBody)
+		responseBodyBytes, err = xjson.Marshal(responseBody)
 		if err != nil {
-			log.Error(ctx, "Failed to serialize response body", log.Cause(err))
 			return err
 		}
-
-		// Check if we should use external storage
-		if s.shouldUseExternalStorage(ctx, dataStorage) {
-			// Save to external storage
-			key := GenerateResponseBodyKey(req.ProjectID, requestID)
-
-			err := s.DataStorageService.SaveData(ctx, dataStorage, key, responseBodyBytes)
-			if err != nil {
-				log.Error(ctx, "Failed to save response body to external storage", log.Cause(err))
-				// Continue anyway
-			} else {
-				savedExternalKey = key
-				upd = upd.SetResponseBody(ExternalResponseBodyMarker)
-			}
-		} else {
-			// Store in database
-			upd = upd.SetResponseBody(responseBodyBytes)
-		}
+		upd = upd.SetResponseBody(responseBodyBytes)
 	}
 
-	_, err = upd.Save(ctx)
+	updated, err := s.saveRequestTransition(ctx, upd, requestID)
 	if err != nil {
-		s.rollbackExternalPayload(ctx, dataStorage, savedExternalKey)
-		log.Error(ctx, "Failed to update request status to completed", log.Cause(err))
+		log.Error(ctx, "Failed to finalize request", log.Cause(err))
 		return err
+	}
+	if !updated {
+		return nil
 	}
 
 	recordDownstreamCompletionMetrics(ctx, req, status)
+
+	if _, transactional := client.Driver().(dialect.Tx); transactional {
+		return nil
+	}
+	if storeResponseBody && s.shouldUseExternalStorage(ctx, dataStorage) {
+		key := GenerateResponseBodyKey(req.ProjectID, requestID)
+		if err := s.DataStorageService.SaveData(ctx, dataStorage, key, responseBodyBytes); err != nil {
+			log.Error(ctx, "Failed to offload request response; retaining database body", log.Cause(err))
+			return nil
+		}
+		if err := client.Request.UpdateOneID(requestID).
+			SetResponseBody(ExternalResponseBodyMarker).Exec(ctx); err != nil {
+			log.Error(ctx, "Failed to mark offloaded request response; retaining database body", log.Cause(err))
+		}
+	}
 
 	return nil
 }
@@ -1379,17 +1382,37 @@ func (s *RequestService) UpdateRequestStatus(ctx context.Context, requestID int,
 	if err != nil {
 		return fmt.Errorf("failed to get request before status update: %w", err)
 	}
+	if isTerminalRequestStatus(req.Status) {
+		return nil
+	}
 
-	_, err = client.Request.UpdateOneID(requestID).
-		SetStatus(status).
-		Save(ctx)
+	upd := client.Request.UpdateOneID(requestID).SetStatus(status)
+	updated, err := s.saveRequestTransition(ctx, upd, requestID)
 	if err != nil {
 		return fmt.Errorf("failed to update request status: %w", err)
 	}
 
-	recordDownstreamCompletionMetrics(ctx, req, status)
+	if updated {
+		recordDownstreamCompletionMetrics(ctx, req, status)
+	}
 
 	return nil
+}
+
+// The conditional UPDATE, not the preceding read, determines who owns the
+// terminal metric. Late callbacks are idempotent and cannot reopen a request.
+func (s *RequestService) saveRequestTransition(ctx context.Context, upd *ent.RequestUpdateOne, id int) (bool, error) {
+	_, err := upd.Where(request.StatusIn(request.StatusPending, request.StatusProcessing)).Save(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if ent.IsNotFound(err) {
+		current, readErr := s.entFromContext(ctx).Request.Get(ctx, id)
+		if readErr == nil && isTerminalRequestStatus(current.Status) {
+			return false, nil
+		}
+	}
+	return false, err
 }
 
 // UpdateRequestStatusFromError updates request status based on error type: canceled if context canceled, otherwise failed.
@@ -1520,6 +1543,9 @@ func (s *RequestService) LoadResponseBody(ctx context.Context, req *ent.Request)
 	// Only load response body if request is completed
 	if req.Status != request.StatusCompleted {
 		return xjson.EmptyJSONRawMessage, nil
+	}
+	if len(req.ResponseBody) > 0 && !isExternalResponseBodyMarker(req.ResponseBody) && !bytes.Equal(bytes.TrimSpace(req.ResponseBody), xjson.EmptyJSONRawMessage) {
+		return sanitizeLoadedResponseBody(req.ResponseBody), nil
 	}
 
 	dataStorage, err := s.getDataStorage(ctx, req.DataStorageID)

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"entgo.io/ent/dialect"
 	"github.com/eko/gocache/lib/v4/store"
 	"github.com/tidwall/gjson"
 
@@ -942,30 +943,16 @@ func (s *RequestService) UpdateRequestExecutionFinalized(
 		}
 	}
 
-	savedExternalKey := ""
-
+	// Persist the response alongside the winning terminal transition first.
+	// This is also the durable fallback if external storage fails or the process
+	// stops before offloading finishes. Losing finalizers must not write the key.
+	var responseBodyBytes objects.JSONRawMessage
 	if storeResponseBody {
-		responseBodyBytes, err := xjson.Marshal(responseBody)
+		responseBodyBytes, err = xjson.Marshal(responseBody)
 		if err != nil {
 			return err
 		}
-
-		// Check if we should use external storage
-		if s.shouldUseExternalStorage(ctx, dataStorage) {
-			// Save to external storage
-			key := GenerateExecutionResponseBodyKey(execution.ProjectID, execution.RequestID, executionID)
-
-			err := s.DataStorageService.SaveData(ctx, dataStorage, key, responseBodyBytes)
-			if err != nil {
-				log.Error(ctx, "Failed to save execution response body to external storage", log.Cause(err))
-			} else {
-				savedExternalKey = key
-				upd = upd.SetResponseBody(ExternalResponseBodyMarker)
-			}
-		} else {
-			// Store in database
-			upd = upd.SetResponseBody(responseBodyBytes)
-		}
+		upd = upd.SetResponseBody(responseBodyBytes)
 	}
 
 	updated, err := s.saveExecutionTransition(ctx, upd, executionID)
@@ -973,12 +960,29 @@ func (s *RequestService) UpdateRequestExecutionFinalized(
 		return nil
 	}
 	if err != nil {
-		s.rollbackExternalPayload(ctx, dataStorage, savedExternalKey)
 		log.Error(ctx, "Failed to update finalized request execution", log.Cause(err), log.Any("status", status))
 		return err
 	}
 
 	recordUpstreamCompletionMetrics(ctx, execution, status, wasTerminal, metrics, req)
+
+	// A caller-owned transaction has not committed the winning body yet. Keep
+	// it inline rather than publishing an external file for a possible rollback.
+	if _, transactional := client.Driver().(dialect.Tx); transactional {
+		return nil
+	}
+
+	if storeResponseBody && s.shouldUseExternalStorage(ctx, dataStorage) {
+		key := GenerateExecutionResponseBodyKey(execution.ProjectID, execution.RequestID, executionID)
+		if err := s.DataStorageService.SaveData(ctx, dataStorage, key, responseBodyBytes); err != nil {
+			log.Error(ctx, "Failed to offload execution response; retaining database body", log.Cause(err))
+			return nil
+		}
+		if err := client.RequestExecution.UpdateOneID(executionID).
+			SetResponseBody(ExternalResponseBodyMarker).Exec(ctx); err != nil {
+			log.Error(ctx, "Failed to mark offloaded execution response; retaining database body", log.Cause(err))
+		}
+	}
 
 	return nil
 }
@@ -1709,6 +1713,12 @@ func (s *RequestService) LoadRequestExecutionResponseBody(ctx context.Context, e
 	// Only load response body if execution is completed
 	if exec.Status != requestexecution.StatusCompleted {
 		return xjson.EmptyJSONRawMessage, nil
+	}
+
+	// A finalized execution retains its inline body until external offloading
+	// succeeds. Prefer that durable copy, including when storage is unavailable.
+	if len(exec.ResponseBody) > 0 && !isExternalResponseBodyMarker(exec.ResponseBody) && !bytes.Equal(bytes.TrimSpace(exec.ResponseBody), xjson.EmptyJSONRawMessage) {
+		return sanitizeLoadedResponseBody(exec.ResponseBody), nil
 	}
 
 	dataStorage, err := s.getDataStorage(ctx, exec.DataStorageID)

--- a/internal/server/biz/request.go
+++ b/internal/server/biz/request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent/request"
 	"github.com/looplj/axonhub/internal/ent/requestexecution"
 	"github.com/looplj/axonhub/internal/log"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/internal/pkg/xcache"
 	"github.com/looplj/axonhub/internal/pkg/xjson"
@@ -36,6 +37,125 @@ type RequestService struct {
 	DataStorageService   *DataStorageService
 	LiveStreamRegistry   *LiveStreamRegistry
 	previousChannelCache xcache.Cache[int]
+}
+
+func requestMetricAttributes(ctx context.Context, req *ent.Request, channelID int, modelID string) appmetrics.RequestAttributes {
+	if req == nil {
+		return appmetrics.RequestAttributes{ChannelID: channelID, ModelID: modelID}
+	}
+
+	attrs := appmetrics.RequestAttributes{
+		ProjectID:      req.ProjectID,
+		ChannelID:      channelID,
+		RequestModelID: req.ModelID,
+		ModelID:        modelID,
+		APIKeyID:       req.APIKeyID,
+		Source:         string(req.Source),
+		Format:         req.Format,
+		Stream:         req.Stream,
+	}
+
+	if apiKey, ok := contexts.GetAPIKey(ctx); ok && apiKey != nil {
+		if attrs.APIKeyID == 0 {
+			attrs.APIKeyID = apiKey.ID
+		}
+		if attrs.APIKeyID == apiKey.ID {
+			attrs.UserID = apiKey.UserID
+		}
+	}
+
+	return attrs
+}
+
+func executionMetricAttributes(execution *ent.RequestExecution, req *ent.Request) appmetrics.RequestAttributes {
+	if execution == nil {
+		return appmetrics.RequestAttributes{}
+	}
+
+	// Upstream lifecycle and performance metrics deliberately use only
+	// dimensions present on the execution itself. This keeps create and
+	// completion series identical and avoids putting API-key/user cardinality
+	// on the high-volume execution metrics.
+	attrs := appmetrics.RequestAttributes{
+		ProjectID: execution.ProjectID,
+		ChannelID: execution.ChannelID,
+		ModelID:   execution.ModelID,
+		Format:    execution.Format,
+		Stream:    execution.Stream,
+	}
+	if req != nil {
+		attrs.RequestModelID = req.ModelID
+		attrs.APIKeyID = req.APIKeyID
+		attrs.Source = string(req.Source)
+	}
+
+	return attrs
+}
+
+func upstreamMetricAttributes(req *ent.Request, channelID int, modelID string, format string, stream bool) appmetrics.RequestAttributes {
+	attrs := appmetrics.RequestAttributes{
+		ChannelID: channelID,
+		ModelID:   modelID,
+		Format:    format,
+		Stream:    stream,
+	}
+	if req != nil {
+		attrs.ProjectID = req.ProjectID
+	}
+
+	return attrs
+}
+
+func isTerminalRequestStatus(status request.Status) bool {
+	return status == request.StatusCompleted || status == request.StatusFailed || status == request.StatusCanceled
+}
+
+func isTerminalExecutionStatus(status requestexecution.Status) bool {
+	return status == requestexecution.StatusCompleted || status == requestexecution.StatusFailed || status == requestexecution.StatusCanceled
+}
+
+func recordDownstreamCompletionMetrics(ctx context.Context, req *ent.Request, status request.Status) {
+	if req == nil || !isTerminalRequestStatus(status) || isTerminalRequestStatus(req.Status) {
+		return
+	}
+
+	attrs := requestMetricAttributes(ctx, req, req.ChannelID, "")
+	appmetrics.Metrics.RecordDownstreamRequestCompleted(ctx, attrs, string(status))
+	appmetrics.Metrics.RecordDownstreamPerformance(ctx, attrs, string(status), time.Since(req.CreatedAt).Seconds(), nil)
+}
+
+func recordUpstreamCompletionMetrics(
+	ctx context.Context,
+	execution *ent.RequestExecution,
+	status requestexecution.Status,
+	wasTerminal bool,
+	latency *LatencyMetrics,
+	req *ent.Request,
+) {
+	if execution == nil || !isTerminalExecutionStatus(status) || wasTerminal {
+		return
+	}
+
+	attrs := executionMetricAttributes(execution, req)
+	appmetrics.Metrics.RecordUpstreamRequestCompleted(ctx, attrs, string(status))
+
+	if latency == nil || latency.LatencyMs == nil {
+		return
+	}
+
+	var ttftSeconds *float64
+	if latency.FirstTokenLatencyMs != nil {
+		value := float64(*latency.FirstTokenLatencyMs) / 1000
+		ttftSeconds = &value
+	}
+
+	appmetrics.Metrics.RecordUpstreamPerformance(
+		ctx,
+		attrs,
+		string(status),
+		float64(*latency.LatencyMs)/1000,
+		ttftSeconds,
+	)
 }
 
 // NewRequestService creates a new RequestService.
@@ -286,6 +406,8 @@ func (s *RequestService) CreateRequest(
 		}
 	}
 
+	appmetrics.Metrics.RecordDownstreamRequestCreated(ctx, requestMetricAttributes(ctx, req, req.ChannelID, ""))
+
 	// Save request body to external storage if needed
 	if useExternalStorage {
 		key := GenerateRequestBodyKey(projectID, req.ID)
@@ -408,6 +530,11 @@ func (s *RequestService) CreateRequestExecution(
 			return nil, err
 		}
 	}
+
+	appmetrics.Metrics.RecordUpstreamRequestCreated(
+		ctx,
+		upstreamMetricAttributes(request, channel.ID, modelID, string(format), request.Stream),
+	)
 
 	// Save request body to external storage if needed
 	if useExternalStorage {
@@ -543,6 +670,8 @@ func (s *RequestService) UpdateRequestCompleted(
 		log.Error(ctx, "Failed to update request status to completed", log.Cause(err))
 		return err
 	}
+
+	recordDownstreamCompletionMetrics(ctx, req, request.StatusCompleted)
 
 	return nil
 }
@@ -741,6 +870,8 @@ func (s *RequestService) UpdateRequestStatusExternalIDAndResponseBody(
 		return err
 	}
 
+	recordDownstreamCompletionMetrics(ctx, req, status)
+
 	return nil
 }
 
@@ -767,6 +898,11 @@ func (s *RequestService) UpdateRequestExecutionCompleted(
 	if err != nil {
 		log.Error(ctx, "Failed to get request execution", log.Cause(err))
 		return err
+	}
+	wasTerminal := isTerminalExecutionStatus(execution.Status)
+	req, reqErr := client.Request.Get(ctx, execution.RequestID)
+	if reqErr != nil {
+		log.Warn(ctx, "failed to load request for execution metrics", log.Cause(reqErr))
 	}
 
 	// Get data storage if set
@@ -830,6 +966,8 @@ func (s *RequestService) UpdateRequestExecutionCompleted(
 		return err
 	}
 
+	recordUpstreamCompletionMetrics(ctx, execution, requestexecution.StatusCompleted, wasTerminal, metrics, req)
+
 	return nil
 }
 
@@ -881,6 +1019,16 @@ func (s *RequestService) UpdateRequestExecutionStatusWithMetrics(
 ) error {
 	client := s.entFromContext(ctx)
 
+	execution, err := client.RequestExecution.Get(ctx, executionID)
+	if err != nil {
+		return fmt.Errorf("failed to get request execution before status update: %w", err)
+	}
+	wasTerminal := isTerminalExecutionStatus(execution.Status)
+	req, reqErr := client.Request.Get(ctx, execution.RequestID)
+	if reqErr != nil {
+		log.Warn(ctx, "failed to load request for execution metrics", log.Cause(reqErr))
+	}
+
 	upd := client.RequestExecution.UpdateOneID(executionID).
 		SetStatus(status)
 	if errorMsg != "" {
@@ -910,6 +1058,8 @@ func (s *RequestService) UpdateRequestExecutionStatusWithMetrics(
 		log.Error(ctx, "Failed to update request execution status", log.Cause(err), log.Any("status", status))
 		return err
 	}
+
+	recordUpstreamCompletionMetrics(ctx, execution, status, wasTerminal, nil, req)
 
 	return nil
 }
@@ -1187,12 +1337,19 @@ func (s *RequestService) MarkRequestFailed(ctx context.Context, requestID int) e
 func (s *RequestService) UpdateRequestStatus(ctx context.Context, requestID int, status request.Status) error {
 	client := s.entFromContext(ctx)
 
-	_, err := client.Request.UpdateOneID(requestID).
+	req, err := client.Request.Get(ctx, requestID)
+	if err != nil {
+		return fmt.Errorf("failed to get request before status update: %w", err)
+	}
+
+	_, err = client.Request.UpdateOneID(requestID).
 		SetStatus(status).
 		Save(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to update request status: %w", err)
 	}
+
+	recordDownstreamCompletionMetrics(ctx, req, status)
 
 	return nil
 }

--- a/internal/server/biz/request_downstream_metrics_test.go
+++ b/internal/server/biz/request_downstream_metrics_test.go
@@ -1,0 +1,114 @@
+package biz
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"golang.org/x/sync/errgroup"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/log"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
+)
+
+func TestConcurrentDownstreamFinalizationEmitsOnce(t *testing.T) {
+	for _, outcome := range []request.Status{request.StatusCompleted, request.StatusFailed, request.StatusCanceled} {
+		t.Run(string(outcome), func(t *testing.T) {
+			client := enttest.NewEntClient(t, "sqlite3", "file:"+t.Name()+"?mode=memory&_fk=0")
+			defer client.Close()
+			ctx, cancel := context.WithTimeout(authz.WithTestBypass(ent.NewContext(t.Context(), client)), 15*time.Second)
+			defer cancel()
+			reader := sdkmetric.NewManualReader()
+			provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			previous := appmetrics.Metrics
+			t.Cleanup(func() {
+				appmetrics.Metrics = previous
+				_ = provider.Shutdown(context.Background())
+			})
+			require.NoError(t, appmetrics.SetupMetrics(provider, "downstream-test"))
+			svc := &RequestService{AbstractService: &AbstractService{db: client}, SystemService: NewSystemService(SystemServiceParams{Ent: client})}
+			req, err := client.Request.Create().SetModelID("requested").SetRequestBody([]byte(`{}`)).
+				SetStatus(request.StatusProcessing).SetStream(true).Save(ctx)
+			require.NoError(t, err)
+			appmetrics.Metrics.RecordDownstreamRequestCreated(ctx, requestMetricAttributes(ctx, req, 0, ""))
+			ready := make(chan struct{})
+			var arrivals atomic.Int32
+			client.Request.Use(func(next ent.Mutator) ent.Mutator {
+				return ent.MutateFunc(func(ctx context.Context, mutation ent.Mutation) (ent.Value, error) {
+					if mutation.Op() == ent.OpUpdateOne {
+						if arrivals.Add(1) == 2 {
+							close(ready)
+						}
+						select {
+						case <-ready:
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						}
+					}
+					return next.Mutate(ctx, mutation)
+				})
+			})
+			var group errgroup.Group
+			for _, finalized := range []bool{false, true} {
+				group.Go(func() (err error) {
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							err = fmt.Errorf("downstream finalizer panic: %v", recovered)
+							log.Error(ctx, "downstream finalizer test panic", log.Cause(err))
+						}
+					}()
+					if finalized {
+						return svc.UpdateRequestFinalized(ctx, req.ID, outcome, "response", []byte(`{"result":"done"}`), nil)
+					}
+					return svc.UpdateRequestStatus(ctx, req.ID, request.StatusCanceled)
+				})
+			}
+			require.NoError(t, group.Wait())
+			stored, err := client.Request.Get(ctx, req.ID)
+			require.NoError(t, err)
+			// Late callbacks through either path must not change the winning result.
+			require.NoError(t, svc.UpdateRequestStatus(ctx, req.ID, request.StatusFailed))
+			require.NoError(t, svc.UpdateRequestFinalized(ctx, req.ID, request.StatusCompleted, "late", []byte(`{}`), nil))
+			again, err := client.Request.Get(ctx, req.ID)
+			require.NoError(t, err)
+			require.Equal(t, stored.Status, again.Status)
+			require.Equal(t, stored.ResponseBody, again.ResponseBody)
+			var collected metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(ctx, &collected))
+			seen := 0
+			for _, scope := range collected.ScopeMetrics {
+				for _, mt := range scope.Metrics {
+					switch mt.Name {
+					case "axonhub_downstream_requests_total", "axonhub_downstream_active_requests":
+						points := mt.Data.(metricdata.Sum[int64]).DataPoints
+						require.Len(t, points, 1)
+						want := int64(0)
+						if mt.Name == "axonhub_downstream_requests_total" {
+							want = 1
+							status, _ := points[0].Attributes.Value("status")
+							require.Equal(t, string(stored.Status), status.AsString())
+						}
+						require.Equal(t, want, points[0].Value)
+						seen++
+					case "axonhub_downstream_request_duration_seconds":
+						points := mt.Data.(metricdata.Histogram[float64]).DataPoints
+						require.Len(t, points, 1)
+						require.Equal(t, uint64(1), points[0].Count)
+						seen++
+					}
+				}
+			}
+			require.Equal(t, 3, seen)
+		})
+	}
+}

--- a/internal/server/biz/request_external_finalize_test.go
+++ b/internal/server/biz/request_external_finalize_test.go
@@ -1,0 +1,148 @@
+package biz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/datastorage"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
+	"github.com/looplj/axonhub/internal/log"
+	"github.com/looplj/axonhub/internal/objects"
+	"github.com/looplj/axonhub/internal/pkg/xcache"
+)
+
+func externalFinalizationFixture(t *testing.T) (context.Context, *ent.Client, *RequestService, *ent.DataStorage, *ent.RequestExecution) {
+	t.Helper()
+	client := enttest.NewEntClient(t, "sqlite3", "file:"+t.Name()+"?mode=memory&_fk=0")
+	t.Cleanup(func() { _ = client.Close() })
+	ctx, cancel := context.WithTimeout(authz.WithTestBypass(ent.NewContext(t.Context(), client)), 15*time.Second)
+	t.Cleanup(cancel)
+	system := NewSystemService(SystemServiceParams{Ent: client})
+	storage := NewDataStorageService(DataStorageServiceParams{Client: client, SystemService: system, CacheConfig: xcache.Config{Mode: xcache.ModeMemory}})
+	svc := &RequestService{AbstractService: &AbstractService{db: client}, SystemService: system, DataStorageService: storage}
+	dir := t.TempDir()
+	ds, err := client.DataStorage.Create().SetName("finalization-fs").SetDescription("test storage").SetPrimary(false).
+		SetType(datastorage.TypeFs).SetStatus(datastorage.StatusActive).
+		SetSettings(&objects.DataStorageSettings{Directory: &dir}).Save(ctx)
+	require.NoError(t, err)
+	req, err := client.Request.Create().SetModelID("requested").SetRequestBody([]byte(`{}`)).
+		SetStatus(request.StatusProcessing).Save(ctx)
+	require.NoError(t, err)
+	execution, err := client.RequestExecution.Create().SetRequestID(req.ID).SetModelID("actual").
+		SetRequestBody([]byte(`{}`)).SetStatus(requestexecution.StatusProcessing).SetDataStorageID(ds.ID).Save(ctx)
+	require.NoError(t, err)
+	return ctx, client, svc, ds, execution
+}
+
+func TestConcurrentFinalizationKeepsWinningExternalBody(t *testing.T) {
+	ctx, client, svc, ds, execution := externalFinalizationFixture(t)
+	key := GenerateExecutionResponseBodyKey(execution.ProjectID, execution.RequestID, execution.ID)
+	fs, err := svc.DataStorageService.GetFileSystem(ctx, ds)
+	require.NoError(t, err)
+	var arrivals atomic.Int32
+	ready := make(chan struct{})
+	client.RequestExecution.Use(func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, mutation ent.Mutation) (ent.Value, error) {
+			m := mutation.(*ent.RequestExecutionMutation)
+			if _, terminalUpdate := m.Status(); terminalUpdate {
+				// Both finalizers pause after their reads, before the atomic UPDATE.
+				// Neither may have touched the shared file at this point.
+				_, statErr := fs.Stat(key)
+				if statErr == nil {
+					return nil, errors.New("external body written before claiming finalization")
+				}
+				if arrivals.Add(1) == 2 {
+					close(ready)
+				}
+				select {
+				case <-ready:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return next.Mutate(ctx, mutation)
+		})
+	})
+	var group errgroup.Group
+	for _, id := range []string{"first", "second"} {
+		group.Go(func() (err error) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					err = fmt.Errorf("finalizer panic: %v", recovered)
+					log.Error(ctx, "external finalization test panic", log.Cause(err))
+				}
+			}()
+			return svc.UpdateRequestExecutionFinalized(ctx, execution.ID, requestexecution.StatusCompleted, "", id, map[string]string{"winner": id}, nil)
+		})
+	}
+	require.NoError(t, group.Wait())
+	stored, err := client.RequestExecution.Get(ctx, execution.ID)
+	require.NoError(t, err)
+	require.True(t, isExternalResponseBodyMarker(stored.ResponseBody))
+	body, err := svc.DataStorageService.LoadData(ctx, ds, key)
+	require.NoError(t, err)
+	require.JSONEq(t, fmt.Sprintf(`{"winner":%q}`, stored.ExternalID), string(body))
+	loaded, err := svc.LoadRequestExecutionResponseBody(ctx, stored)
+	require.NoError(t, err)
+	require.JSONEq(t, string(body), string(loaded))
+}
+
+func TestExternalFinalizationRetainsBodyOnOffloadFailure(t *testing.T) {
+	for _, failure := range []string{"file-write", "marker-update"} {
+		t.Run(failure, func(t *testing.T) {
+			ctx, client, svc, ds, execution := externalFinalizationFixture(t)
+			if failure == "file-write" {
+				fs, err := svc.DataStorageService.GetFileSystem(ctx, ds)
+				require.NoError(t, err)
+				svc.DataStorageService.fsCache[ds.ID] = afero.NewReadOnlyFs(fs)
+			} else {
+				client.RequestExecution.Use(func(next ent.Mutator) ent.Mutator {
+					return ent.MutateFunc(func(ctx context.Context, mutation ent.Mutation) (ent.Value, error) {
+						body, _ := mutation.(*ent.RequestExecutionMutation).ResponseBody()
+						if isExternalResponseBodyMarker(body) {
+							return nil, errors.New("marker update failed")
+						}
+						return next.Mutate(ctx, mutation)
+					})
+				})
+			}
+			body := []byte(`{"result":"keep me"}`)
+			require.NoError(t, svc.UpdateRequestExecutionFinalized(ctx, execution.ID, requestexecution.StatusCompleted, "", "response", body, nil))
+			stored, err := client.RequestExecution.Get(ctx, execution.ID)
+			require.NoError(t, err)
+			require.Equal(t, requestexecution.StatusCompleted, stored.Status)
+			require.JSONEq(t, string(body), string(stored.ResponseBody))
+			loaded, err := svc.LoadRequestExecutionResponseBody(ctx, stored)
+			require.NoError(t, err)
+			require.JSONEq(t, string(body), string(loaded))
+		})
+	}
+}
+
+func TestExternalFinalizationRollbackDoesNotPublishFile(t *testing.T) {
+	ctx, client, svc, ds, execution := externalFinalizationFixture(t)
+	tx, err := client.Tx(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	txCtx := ent.NewContext(ctx, tx.Client())
+	require.NoError(t, svc.UpdateRequestExecutionFinalized(txCtx, execution.ID, requestexecution.StatusCompleted, "", "response", []byte(`{"result":"rollback"}`), nil))
+	key := GenerateExecutionResponseBodyKey(execution.ProjectID, execution.RequestID, execution.ID)
+	_, err = svc.DataStorageService.LoadData(ctx, ds, key)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	stored, err := client.RequestExecution.Get(ctx, execution.ID)
+	require.NoError(t, err)
+	require.Equal(t, requestexecution.StatusProcessing, stored.Status)
+}

--- a/internal/server/biz/request_external_finalize_test.go
+++ b/internal/server/biz/request_external_finalize_test.go
@@ -38,7 +38,7 @@ func externalFinalizationFixture(t *testing.T) (context.Context, *ent.Client, *R
 		SetSettings(&objects.DataStorageSettings{Directory: &dir}).Save(ctx)
 	require.NoError(t, err)
 	req, err := client.Request.Create().SetModelID("requested").SetRequestBody([]byte(`{}`)).
-		SetStatus(request.StatusProcessing).Save(ctx)
+		SetStatus(request.StatusProcessing).SetDataStorageID(ds.ID).Save(ctx)
 	require.NoError(t, err)
 	execution, err := client.RequestExecution.Create().SetRequestID(req.ID).SetModelID("actual").
 		SetRequestBody([]byte(`{}`)).SetStatus(requestexecution.StatusProcessing).SetDataStorageID(ds.ID).Save(ctx)
@@ -95,6 +95,61 @@ func TestConcurrentFinalizationKeepsWinningExternalBody(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, fmt.Sprintf(`{"winner":%q}`, stored.ExternalID), string(body))
 	loaded, err := svc.LoadRequestExecutionResponseBody(ctx, stored)
+	require.NoError(t, err)
+	require.JSONEq(t, string(body), string(loaded))
+}
+
+func TestConcurrentDownstreamFinalizationKeepsWinningExternalBody(t *testing.T) {
+	ctx, client, svc, ds, execution := externalFinalizationFixture(t)
+	req, err := client.Request.Get(ctx, execution.RequestID)
+	require.NoError(t, err)
+	key := GenerateResponseBodyKey(req.ProjectID, req.ID)
+	fs, err := svc.DataStorageService.GetFileSystem(ctx, ds)
+	require.NoError(t, err)
+	var arrivals atomic.Int32
+	ready := make(chan struct{})
+	client.Request.Use(func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, mutation ent.Mutation) (ent.Value, error) {
+			m := mutation.(*ent.RequestMutation)
+			if _, terminalUpdate := m.Status(); terminalUpdate {
+				// Both finalizers pause after their reads, before the atomic UPDATE.
+				// Neither may have touched the shared file at this point.
+				_, statErr := fs.Stat(key)
+				if statErr == nil {
+					return nil, errors.New("external body written before claiming finalization")
+				}
+				if arrivals.Add(1) == 2 {
+					close(ready)
+				}
+				select {
+				case <-ready:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return next.Mutate(ctx, mutation)
+		})
+	})
+	var group errgroup.Group
+	for _, id := range []string{"first", "second"} {
+		group.Go(func() (err error) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					err = fmt.Errorf("finalizer panic: %v", recovered)
+					log.Error(ctx, "external finalization test panic", log.Cause(err))
+				}
+			}()
+			return svc.UpdateRequestFinalized(ctx, req.ID, request.StatusCompleted, id, map[string]string{"winner": id}, nil)
+		})
+	}
+	require.NoError(t, group.Wait())
+	stored, err := client.Request.Get(ctx, req.ID)
+	require.NoError(t, err)
+	require.True(t, isExternalResponseBodyMarker(stored.ResponseBody))
+	body, err := svc.DataStorageService.LoadData(ctx, ds, key)
+	require.NoError(t, err)
+	require.JSONEq(t, fmt.Sprintf(`{"winner":%q}`, stored.ExternalID), string(body))
+	loaded, err := svc.LoadResponseBody(ctx, stored)
 	require.NoError(t, err)
 	require.JSONEq(t, string(body), string(loaded))
 }

--- a/internal/server/biz/request_metrics_test.go
+++ b/internal/server/biz/request_metrics_test.go
@@ -1,0 +1,59 @@
+package biz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/ent"
+	"github.com/looplj/axonhub/internal/ent/enttest"
+	"github.com/looplj/axonhub/internal/ent/request"
+	"github.com/looplj/axonhub/internal/ent/requestexecution"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
+)
+
+func TestFailedExecutionEmitsLatency(t *testing.T) {
+	client := enttest.NewEntClient(t, "sqlite3", "file:failed_execution_metrics?mode=memory&_fk=0")
+	defer client.Close()
+	ctx := authz.WithTestBypass(ent.NewContext(t.Context(), client))
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previous := appmetrics.Metrics
+	t.Cleanup(func() {
+		appmetrics.Metrics = previous
+		_ = provider.Shutdown(context.Background())
+	})
+	require.NoError(t, appmetrics.SetupMetrics(provider, "request-test"))
+	req, err := client.Request.Create().SetModelID("requested").SetRequestBody([]byte(`{}`)).
+		SetStatus(request.StatusProcessing).SetStream(true).Save(ctx)
+	require.NoError(t, err)
+	execution, err := client.RequestExecution.Create().SetRequestID(req.ID).SetModelID("actual").
+		SetRequestBody([]byte(`{}`)).SetStatus(requestexecution.StatusProcessing).SetStream(true).Save(ctx)
+	require.NoError(t, err)
+	svc := &RequestService{AbstractService: &AbstractService{db: client}}
+	latency := &LatencyMetrics{LatencyMs: lo.ToPtr(int64(2500)), FirstTokenLatencyMs: lo.ToPtr(int64(500))}
+	require.NoError(t, svc.UpdateRequestExecutionStatusWithMetrics(ctx, execution.ID, requestexecution.StatusFailed, "stream failed", nil, latency))
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &collected))
+	want := map[string]float64{"axonhub_upstream_request_duration_seconds": 2.5, "axonhub_upstream_ttft_seconds": 0.5}
+	for _, scope := range collected.ScopeMetrics {
+		for _, mt := range scope.Metrics {
+			if sum, ok := want[mt.Name]; ok {
+				hist := mt.Data.(metricdata.Histogram[float64])
+				require.Len(t, hist.DataPoints, 1)
+				require.Equal(t, uint64(1), hist.DataPoints[0].Count)
+				require.Equal(t, sum, hist.DataPoints[0].Sum)
+				status, _ := hist.DataPoints[0].Attributes.Value("status")
+				require.Equal(t, "failed", status.AsString())
+				delete(want, mt.Name)
+			}
+		}
+	}
+	require.Empty(t, want)
+}

--- a/internal/server/biz/usage_log.go
+++ b/internal/server/biz/usage_log.go
@@ -118,10 +118,13 @@ func (s *UsageLogService) CreateUsageLog(ctx context.Context, params CreateUsage
 
 	apiKeyID := 0
 	userID := 0
+	hasAPIKeyID := false
 	if params.APIKeyID != nil {
 		apiKeyID = *params.APIKeyID
+		hasAPIKeyID = true
 	} else if ctxAPIKey, ok := contexts.GetAPIKey(ctx); ok && ctxAPIKey != nil {
 		apiKeyID = ctxAPIKey.ID
+		hasAPIKeyID = true
 	}
 	if ctxAPIKey, ok := contexts.GetAPIKey(ctx); ok && ctxAPIKey != nil && ctxAPIKey.ID == apiKeyID {
 		userID = ctxAPIKey.UserID
@@ -138,10 +141,8 @@ func (s *UsageLogService) CreateUsageLog(ctx context.Context, params CreateUsage
 		SetSource(params.Source).
 		SetFormat(params.Format)
 
-	if params.APIKeyID != nil {
-		mut = mut.SetAPIKeyID(*params.APIKeyID)
-	} else if ctxAPIKey, ok := contexts.GetAPIKey(ctx); ok && ctxAPIKey != nil {
-		mut = mut.SetAPIKeyID(ctxAPIKey.ID)
+	if hasAPIKeyID {
+		mut = mut.SetAPIKeyID(apiKeyID)
 	}
 
 	// Set prompt tokens details if available

--- a/internal/server/biz/usage_log.go
+++ b/internal/server/biz/usage_log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/usagelog"
 	"github.com/looplj/axonhub/internal/log"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
 	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/llm"
 )
@@ -95,14 +96,16 @@ func NewUsageLogService(ent *ent.Client, systemService *SystemService, channelSe
 
 // CreateUsageLogParams represents the parameters for creating a usage log.
 type CreateUsageLogParams struct {
-	RequestID     int
-	ProjectID     int
-	ChannelID     int
-	ActualModelID string // The channel actual model ID, not the request model ID.
-	Usage         *llm.Usage
-	Source        usagelog.Source
-	Format        string
-	APIKeyID      *int
+	RequestID      int
+	ProjectID      int
+	ChannelID      int
+	RequestModelID string
+	ActualModelID  string // The channel actual model ID, not the request model ID.
+	Usage          *llm.Usage
+	Source         usagelog.Source
+	Format         string
+	APIKeyID       *int
+	Stream         bool
 }
 
 // CreateUsageLog creates a new usage log record from LLM response usage data.
@@ -112,6 +115,17 @@ func (s *UsageLogService) CreateUsageLog(ctx context.Context, params CreateUsage
 	}
 
 	client := s.entFromContext(ctx)
+
+	apiKeyID := 0
+	userID := 0
+	if params.APIKeyID != nil {
+		apiKeyID = *params.APIKeyID
+	} else if ctxAPIKey, ok := contexts.GetAPIKey(ctx); ok && ctxAPIKey != nil {
+		apiKeyID = ctxAPIKey.ID
+	}
+	if ctxAPIKey, ok := contexts.GetAPIKey(ctx); ok && ctxAPIKey != nil && ctxAPIKey.ID == apiKeyID {
+		userID = ctxAPIKey.UserID
+	}
 
 	mut := client.UsageLog.Create().
 		SetRequestID(params.RequestID).
@@ -180,6 +194,26 @@ func (s *UsageLogService) CreateUsageLog(ctx context.Context, params CreateUsage
 		)
 	}
 
+	appmetrics.Metrics.RecordLLMUsage(
+		ctx,
+		appmetrics.RequestAttributes{
+			ProjectID:      params.ProjectID,
+			ChannelID:      params.ChannelID,
+			RequestModelID: params.RequestModelID,
+			ModelID:        params.ActualModelID,
+			APIKeyID:       apiKeyID,
+			UserID:         userID,
+			Source:         string(params.Source),
+			Format:         params.Format,
+			Stream:         params.Stream,
+		},
+		params.Usage.PromptTokens,
+		params.Usage.CompletionTokens,
+		promptCachedTokens(params.Usage),
+		completionReasoningTokens(params.Usage),
+		totalCost,
+	)
+
 	if s.OnUsageLogCreated != nil {
 		s.OnUsageLogCreated()
 	}
@@ -199,13 +233,31 @@ func (s *UsageLogService) CreateUsageLogFromRequest(
 	}
 
 	return s.CreateUsageLog(ctx, CreateUsageLogParams{
-		RequestID:     request.ID,
-		ProjectID:     request.ProjectID,
-		ChannelID:     requestExec.ChannelID,
-		ActualModelID: requestExec.ModelID,
-		Usage:         usage,
-		Source:        usagelog.Source(request.Source),
-		Format:        request.Format,
-		APIKeyID:      lo.ToPtr(request.APIKeyID),
+		RequestID:      request.ID,
+		ProjectID:      request.ProjectID,
+		ChannelID:      requestExec.ChannelID,
+		RequestModelID: request.ModelID,
+		ActualModelID:  requestExec.ModelID,
+		Usage:          usage,
+		Source:         usagelog.Source(request.Source),
+		Format:         request.Format,
+		APIKeyID:       lo.ToPtr(request.APIKeyID),
+		Stream:         request.Stream,
 	})
+}
+
+func promptCachedTokens(usage *llm.Usage) int64 {
+	if usage == nil || usage.PromptTokensDetails == nil {
+		return 0
+	}
+
+	return usage.PromptTokensDetails.CachedTokens
+}
+
+func completionReasoningTokens(usage *llm.Usage) int64 {
+	if usage == nil || usage.CompletionTokensDetails == nil {
+		return 0
+	}
+
+	return usage.CompletionTokensDetails.ReasoningTokens
 }

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -77,9 +78,7 @@ func (ts *InboundPersistentStream) Next() bool {
 func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	event := ts.stream.Current()
 	if event != nil {
-		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
-		// summary to avoid buffering the full audio payload in memory.
-		if !ts.downstreamTTFTRecorded && ts.request != nil && len(event.Data) > 0 && !IsTerminalStreamEvent(event) {
+		if !ts.downstreamTTFTRecorded && ts.request != nil && hasClientVisibleOutput(event) {
 			attrs := appmetrics.RequestAttributes{
 				ProjectID: ts.request.ProjectID, RequestModelID: ts.request.ModelID,
 				APIKeyID: ts.request.APIKeyID, Source: string(ts.request.Source),
@@ -89,6 +88,7 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 			appmetrics.Metrics.RecordDownstreamPerformance(ts.ctx, attrs, "streaming", -1, &ttft)
 			ts.downstreamTTFTRecorded = true
 		}
+		// For raw binary audio chunks, persist only a size summary.
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
 		if IsTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true
@@ -96,6 +96,73 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	}
 
 	return event
+}
+
+// hasClientVisibleOutput recognizes output in the downstream wire protocol.
+// Current runs before the HTTP write: this measures output ready for delivery,
+// not an acknowledgement from the client. A final chunk can also carry output.
+func hasClientVisibleOutput(event *httpclient.StreamEvent) bool {
+	if event == nil || len(event.Data) == 0 || bytes.Equal(event.Data, llm.DoneStreamEvent.Data) {
+		return false
+	}
+
+	if strings.HasPrefix(event.Type, "audio/") || event.Type == "application/octet-stream" {
+		return true
+	}
+	data := gjson.ParseBytes(event.Data)
+	eventType := event.Type
+	if eventType == "" {
+		eventType = data.Get("type").String()
+	}
+	switch eventType {
+	case "content_block_delta":
+		return hasOutputString(data.Get("delta"), "text", "thinking", "partial_json")
+	case "content_block_start":
+		block := data.Get("content_block")
+		return hasOutputString(block, "text", "thinking") ||
+			(block.Get("type").String() == "tool_use" && hasOutputString(block, "name"))
+	case "response.output_text.delta", "response.reasoning_text.delta", "response.reasoning_summary_text.delta",
+		"response.function_call_arguments.delta", "response.refusal.delta", "response.audio.delta",
+		"response.output_audio.delta", "transcript.text.delta":
+		return hasOutputString(data, "delta")
+	case "speech.audio.delta":
+		return hasOutputString(data, "audio")
+	case "response.output_item.added":
+		item := data.Get("item")
+		return item.Get("type").String() == "function_call" && hasOutputString(item, "name")
+	case "text-delta", "reasoning-delta": // AI SDK data stream
+		return hasOutputString(data, "delta")
+	}
+
+	for _, choice := range data.Get("choices").Array() {
+		delta := choice.Get("delta")
+		if hasOutputString(choice, "text") || hasOutputString(delta, "content", "reasoning_content", "reasoning", "refusal", "audio.data") {
+			return true
+		}
+		for _, call := range delta.Get("tool_calls").Array() {
+			if hasOutputString(call, "function.name", "function.arguments") {
+				return true
+			}
+		}
+	}
+	for _, candidate := range data.Get("candidates").Array() {
+		for _, part := range candidate.Get("content.parts").Array() {
+			if hasOutputString(part, "text", "functionCall.name", "inlineData.data") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasOutputString(data gjson.Result, paths ...string) bool {
+	for _, path := range paths {
+		value := data.Get(path)
+		if value.Type == gjson.String && value.String() != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // IsTerminalStreamEvent checks both SSE metadata and JSON data for a successful

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"time"
 
 	"github.com/tidwall/gjson"
 
 	"github.com/looplj/axonhub/internal/dumper"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/log"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
 	"github.com/looplj/axonhub/internal/server/biz"
 	"github.com/looplj/axonhub/llm"
 	"github.com/looplj/axonhub/llm/httpclient"
@@ -27,16 +29,17 @@ var ErrStreamIncomplete = errors.New("stream ended without terminal event or com
 //
 //nolint:containedctx // Checked.
 type InboundPersistentStream struct {
-	ctx            context.Context
-	stream         streams.Stream[*httpclient.StreamEvent]
-	request        *ent.Request
-	requestExec    *ent.RequestExecution
-	requestService *biz.RequestService
-	transformer    transformer.Inbound
-	perf           *biz.PerformanceRecord
-	responseChunks []*httpclient.StreamEvent
-	closed         bool
-	state          *PersistenceState
+	ctx                    context.Context
+	stream                 streams.Stream[*httpclient.StreamEvent]
+	request                *ent.Request
+	requestExec            *ent.RequestExecution
+	requestService         *biz.RequestService
+	transformer            transformer.Inbound
+	perf                   *biz.PerformanceRecord
+	responseChunks         []*httpclient.StreamEvent
+	closed                 bool
+	downstreamTTFTRecorded bool
+	state                  *PersistenceState
 }
 
 var _ streams.Stream[*httpclient.StreamEvent] = (*InboundPersistentStream)(nil)
@@ -76,6 +79,16 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 	if event != nil {
 		// For raw binary audio chunks (TTS stream_format=audio), persist only a size
 		// summary to avoid buffering the full audio payload in memory.
+		if !ts.downstreamTTFTRecorded && ts.request != nil && len(event.Data) > 0 && !IsTerminalStreamEvent(event) {
+			attrs := appmetrics.RequestAttributes{
+				ProjectID: ts.request.ProjectID, RequestModelID: ts.request.ModelID,
+				APIKeyID: ts.request.APIKeyID, Source: string(ts.request.Source),
+				Format: ts.request.Format, Stream: ts.request.Stream,
+			}
+			value := time.Since(ts.request.CreatedAt).Seconds()
+			appmetrics.Metrics.RecordDownstreamPerformance(ts.ctx, attrs, "streaming", value, &value)
+			ts.downstreamTTFTRecorded = true
+		}
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))
 		if IsTerminalStreamEvent(event) {
 			ts.state.StreamCompleted = true

--- a/internal/server/orchestrator/inbound.go
+++ b/internal/server/orchestrator/inbound.go
@@ -85,8 +85,8 @@ func (ts *InboundPersistentStream) Current() *httpclient.StreamEvent {
 				APIKeyID: ts.request.APIKeyID, Source: string(ts.request.Source),
 				Format: ts.request.Format, Stream: ts.request.Stream,
 			}
-			value := time.Since(ts.request.CreatedAt).Seconds()
-			appmetrics.Metrics.RecordDownstreamPerformance(ts.ctx, attrs, "streaming", value, &value)
+			ttft := time.Since(ts.request.CreatedAt).Seconds()
+			appmetrics.Metrics.RecordDownstreamPerformance(ts.ctx, attrs, "streaming", -1, &ttft)
 			ts.downstreamTTFTRecorded = true
 		}
 		ts.responseChunks = append(ts.responseChunks, httpclient.SummarizeBinaryChunk(event))

--- a/internal/server/orchestrator/inbound_metrics_test.go
+++ b/internal/server/orchestrator/inbound_metrics_test.go
@@ -29,12 +29,15 @@ func TestInboundFirstOutputDoesNotRecordRequestDuration(t *testing.T) {
 		request: &ent.Request{CreatedAt: time.Now().Add(-time.Second), ModelID: "requested", Stream: true},
 		state:   &PersistenceState{},
 		stream: &mockStream{events: []*httpclient.StreamEvent{
+			{Data: []byte(`{"type":"response.created"}`)},
+			{Data: []byte(`{"choices":[{"delta":{"role":"assistant","content":""}}]}`)},
 			{Data: []byte(`{"choices":[{"delta":{"content":"hello"}}]}`)},
 			{Data: []byte(`{"choices":[{"delta":{"content":" world"}}]}`)},
 		}},
 	}
-	for stream.Next() {
+	for i := 0; stream.Next(); i++ {
 		stream.Current()
+		require.Equal(t, i >= 2, stream.downstreamTTFTRecorded)
 	}
 
 	var collected metricdata.ResourceMetrics
@@ -52,4 +55,39 @@ func TestInboundFirstOutputDoesNotRecordRequestDuration(t *testing.T) {
 		}
 	}
 	require.Equal(t, uint64(1), ttftCount)
+}
+
+func TestHasClientVisibleOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		data string
+		want bool
+	}{
+		{"empty", "", "", false},
+		{"done", "", "[DONE]", false},
+		{"created in JSON", "", `{"type":"response.created"}`, false},
+		{"message start", "message_start", `{"message":{"role":"assistant"}}`, false},
+		{"role only", "", `{"choices":[{"delta":{"role":"assistant","content":""}}]}`, false},
+		{"usage only", "", `{"usage":{"completion_tokens":5}}`, false},
+		{"error", "error", `{"error":{"message":"failed"}}`, false},
+		{"text", "", `{"choices":[{"delta":{"content":"hello"}}]}`, true},
+		{"final text", "", `{"choices":[{"delta":{"content":"hello"},"finish_reason":"stop"}]}`, true},
+		{"tool", "", `{"choices":[{"delta":{"tool_calls":[{"function":{"name":"search"}}]}}]}`, true},
+		{"responses delta", "", `{"type":"response.output_text.delta","delta":"hello"}`, true},
+		{"empty delta", "response.output_text.delta", `{"delta":""}`, false},
+		{"anthropic empty block", "content_block_start", `{"content_block":{"type":"text","text":""}}`, false},
+		{"anthropic tool block", "content_block_start", `{"content_block":{"type":"tool_use","name":"search"}}`, true},
+		{"thinking", "content_block_delta", `{"delta":{"thinking":"think"}}`, true},
+		{"signature only", "content_block_delta", `{"delta":{"signature":"sig"}}`, false},
+		{"gemini final output", "", `{"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}]}`, true},
+		{"audio", "audio/mpeg", "binary", true},
+		{"ai sdk text", "text-delta", `{"delta":"hello"}`, true},
+	}
+	require.False(t, hasClientVisibleOutput(nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasClientVisibleOutput(&httpclient.StreamEvent{Type: tt.kind, Data: []byte(tt.data)}))
+		})
+	}
 }

--- a/internal/server/orchestrator/inbound_metrics_test.go
+++ b/internal/server/orchestrator/inbound_metrics_test.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/looplj/axonhub/internal/ent"
 	appmetrics "github.com/looplj/axonhub/internal/metrics"

--- a/internal/server/orchestrator/inbound_metrics_test.go
+++ b/internal/server/orchestrator/inbound_metrics_test.go
@@ -1,0 +1,54 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/looplj/axonhub/internal/ent"
+	appmetrics "github.com/looplj/axonhub/internal/metrics"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+func TestInboundFirstOutputDoesNotRecordRequestDuration(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previous := appmetrics.Metrics
+	t.Cleanup(func() {
+		appmetrics.Metrics = previous
+		_ = provider.Shutdown(context.Background())
+	})
+	require.NoError(t, appmetrics.SetupMetrics(provider, "inbound-test"))
+	stream := &InboundPersistentStream{
+		ctx:     t.Context(),
+		request: &ent.Request{CreatedAt: time.Now().Add(-time.Second), ModelID: "requested", Stream: true},
+		state:   &PersistenceState{},
+		stream: &mockStream{events: []*httpclient.StreamEvent{
+			{Data: []byte(`{"choices":[{"delta":{"content":"hello"}}]}`)},
+			{Data: []byte(`{"choices":[{"delta":{"content":" world"}}]}`)},
+		}},
+	}
+	for stream.Next() {
+		stream.Current()
+	}
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &collected))
+	var ttftCount uint64
+	for _, scope := range collected.ScopeMetrics {
+		for _, mt := range scope.Metrics {
+			require.NotEqual(t, "axonhub_downstream_request_duration_seconds", mt.Name,
+				"first output must not emit an end-to-end duration sample")
+			if mt.Name == "axonhub_downstream_ttft_seconds" {
+				for _, point := range mt.Data.(metricdata.Histogram[float64]).DataPoints {
+					ttftCount += point.Count
+				}
+			}
+		}
+	}
+	require.Equal(t, uint64(1), ttftCount)
+}


### PR DESCRIPTION
AxonHub's existing chat metrics are not wired to the request lifecycle. This change replaces them with eight OpenTelemetry metric families: downstream requests created/completed, upstream attempts created/completed, token usage, calculated cost, upstream duration, and upstream TTFT.

Downstream requests represent logical client requests; upstream attempts include retries. Terminal counters distinguish completed, failed, and canceled outcomes. Token and cost metrics are emitted after usage records are saved, with requested and actual model dimensions. Cached and reasoning tokens are subsets of input and output respectively.

Scope: metric definitions, business-layer instrumentation, and metric collection tests. Existing HTTP and GraphQL metrics remain. No Grafana dashboard or dashboard README is included.

Validation: related metrics, biz, and orchestrator tests passed on the original implementation base. The rerun after transplanting to development was blocked by Go dependency download timeouts, so validation on the current base is still pending. git diff --check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added observability for upstream and downstream request lifecycles, including active requests, completion status, latency, and time to first visible output.
  - Added LLM usage tracking for input, output, cached, and reasoning tokens, plus estimated costs.
  - Usage records now capture additional request and streaming details.
  - Added resource metadata to metrics for channels, projects, API keys, and users.

- **Improvements**
  - Metrics now include failed, incomplete, and canceled requests.
  - Improved streamed response handling and time-to-first-token accuracy.
  - Improved reliability when finalizing concurrent requests and preserving response data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->