### PR TITLE
fix: retain live preview chunks when request completes

### DIFF
--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -356,7 +356,6 @@ export default function RequestDetailPage() {
       setIsPreviewStreaming(false);
       clearReconnectTimer();
       controller.abort();
-      previousRequestIdRef.current = null;
     };
   }, [isLivePreviewEnabled, previewFallbackActive, requestData, refetchRequest, selectedProjectId]);
 

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -118,6 +118,7 @@ async function readPreviewStream(
   }
 }
 
+/** Request detail page with live preview streaming. */
 export default function RequestDetailPage() {
   const { t } = useTranslation();
   const { requestId } = useParams({ from: '/_authenticated/project/requests/$requestId' });

--- a/frontend/src/features/requests/components/request-detail-page.tsx
+++ b/frontend/src/features/requests/components/request-detail-page.tsx
@@ -133,6 +133,7 @@ export default function RequestDetailPage() {
   const [previewFallbackActive, setPreviewFallbackActive] = useState(false);
   const previewCompletedRef = useRef(false);
   const previewChunkCountRef = useRef(0);
+  const previousRequestIdRef = useRef<string | null>(null);
 
   const { data: requestData, refetch: refetchRequest } = useRequest(requestId, {
     projectId: selectedProjectId,
@@ -145,13 +146,29 @@ export default function RequestDetailPage() {
     if (!requestData) {
       setPreviewRequest(null);
       setPreviewFallbackActive(false);
+      previousRequestIdRef.current = null;
       return;
     }
 
+    const isSameRequest = previousRequestIdRef.current === requestData.id;
+    previousRequestIdRef.current = requestData.id;
+
     if (requestData.status !== 'processing' || !requestData.stream) {
-      setPreviewRequest(null);
-      setIsPreviewStreaming(false);
-      setPreviewFallbackActive(false);
+      if (isSameRequest && previewRequest?.responseChunks?.length) {
+        setIsPreviewStreaming(false);
+        setPreviewFallbackActive(false);
+        setPreviewRequest((current) => {
+          if (!current) return null;
+          return {
+            ...requestData,
+            responseChunks: current.responseChunks,
+          };
+        });
+      } else {
+        setPreviewRequest(null);
+        setIsPreviewStreaming(false);
+        setPreviewFallbackActive(false);
+      }
       previewCompletedRef.current = false;
       previewChunkCountRef.current = 0;
     }
@@ -339,6 +356,7 @@ export default function RequestDetailPage() {
       setIsPreviewStreaming(false);
       clearReconnectTimer();
       controller.abort();
+      previousRequestIdRef.current = null;
     };
   }, [isLivePreviewEnabled, previewFallbackActive, requestData, refetchRequest, selectedProjectId]);
 


### PR DESCRIPTION
Previously, when a streaming request finished, the preview state was unconditionally cleared, causing all received response chunks to disappear from the Request Detail page. The server correctly releases its in-memory buffer, but there is no reason to discard data already owned by the browser.

Now, when the request completes and the client has already received chunks, those chunks are preserved on the page and merged with the final request metadata (status, responseBody, etc.). Switching to a different request still correctly clears the preview state.

Track the previous requestId via a ref to distinguish 'same request completed' from 'user navigated to another request'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved streamed request previews when updated data arrives for the same request.
  * Prevented preview content from being cleared unnecessarily after streaming completes.
  * Continued clearing previews appropriately when viewing a different request or when no prior preview exists.
  * Improved continuity of request details as streaming transitions to the latest available data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->