### PR TITLE
fix(api-keys): enforce personal key guard on template load and let system owners manage them

### DIFF
--- a/frontend/src/features/apikeys/components/data-table-row-actions.tsx
+++ b/frontend/src/features/apikeys/components/data-table-row-actions.tsx
@@ -25,9 +25,11 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
   const [open, setOpen] = React.useState(false);
   const [chartOpen, setChartOpen] = React.useState(false);
 
-  // Personal API keys can only be modified by their creator; hide mutating
-  // actions on other users' personal keys instead of letting them fail.
-  const isOthersPersonalKey = apiKey.type === 'personal' && apiKey.user?.id != null && apiKey.user.id !== currentUser?.id;
+  // Personal API keys can only be modified by their creator or a system
+  // owner; hide mutating actions on other users' personal keys for anyone
+  // else instead of letting them fail.
+  const isOthersPersonalKey =
+    apiKey.type === 'personal' && !currentUser?.isOwner && apiKey.user?.id != null && apiKey.user.id !== currentUser?.id;
   const canMutate = apiKeyPermissions.canWrite && !isOthersPersonalKey;
 
   // Don't show menu if user has no permissions

--- a/frontend/src/features/apikeys/components/data-table-row-actions.tsx
+++ b/frontend/src/features/apikeys/components/data-table-row-actions.tsx
@@ -5,6 +5,7 @@ import { IconUserOff, IconUserCheck, IconEdit, IconSettings, IconArchive, IconCh
 import { BarChart3 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { usePermissions } from '@/hooks/usePermissions';
+import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useApiKeysContext } from '../context/apikeys-context';
@@ -19,9 +20,15 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
   const { t } = useTranslation();
   const { openDialog } = useApiKeysContext();
   const { apiKeyPermissions } = usePermissions();
+  const currentUser = useAuthStore((state) => state.auth.user);
   const apiKey = row.original;
   const [open, setOpen] = React.useState(false);
   const [chartOpen, setChartOpen] = React.useState(false);
+
+  // Personal API keys can only be modified by their creator; hide mutating
+  // actions on other users' personal keys instead of letting them fail.
+  const isOthersPersonalKey = apiKey.type === 'personal' && apiKey.user?.id != null && apiKey.user.id !== currentUser?.id;
+  const canMutate = apiKeyPermissions.canWrite && !isOthersPersonalKey;
 
   // Don't show menu if user has no permissions
   if (!apiKeyPermissions.canRead && !apiKeyPermissions.canWrite) {
@@ -76,7 +83,7 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
             <BarChart3 className='mr-2 h-4 w-4' />
             {t('apikeys.actions.viewTokenChart')}
           </DropdownMenuItem>
-          {apiKeyPermissions.canWrite && (
+          {canMutate && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => handleEdit(apiKey)}>

--- a/frontend/src/features/apikeys/data/apikeys.ts
+++ b/frontend/src/features/apikeys/data/apikeys.ts
@@ -720,6 +720,7 @@ export function useUpdateApiKeyStatus() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const selectedProjectId = useSelectedProjectId();
+  const { handleError } = useErrorHandler();
 
   return useMutation({
     mutationFn: ({ id, status }: { id: string; status: 'enabled' | 'disabled' | 'archived' }) => {
@@ -737,8 +738,8 @@ export function useUpdateApiKeyStatus() {
             : t('apikeys.status.archived');
       toast.success(t('apikeys.messages.statusUpdateSuccess', { status: statusText }));
     },
-    onError: () => {
-      toast.error(t('common.errors.internalServerError'));
+    onError: (error) => {
+      handleError(error);
     },
   });
 }
@@ -747,6 +748,7 @@ export function useUpdateApiKeyProfiles() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const selectedProjectId = useSelectedProjectId();
+  const { handleError } = useErrorHandler();
 
   return useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateApiKeyProfilesInput }) => {
@@ -758,8 +760,8 @@ export function useUpdateApiKeyProfiles() {
       queryClient.invalidateQueries({ queryKey: ['apiKey', variables.id] });
       toast.success(t('apikeys.messages.profilesUpdateSuccess'));
     },
-    onError: () => {
-      toast.error(t('common.errors.internalServerError'));
+    onError: (error) => {
+      handleError(error);
     },
   });
 }
@@ -768,6 +770,7 @@ export function useBulkDisableApiKeys() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const selectedProjectId = useSelectedProjectId();
+  const { handleError } = useErrorHandler();
 
   return useMutation({
     mutationFn: async (ids: string[]) => {
@@ -779,8 +782,8 @@ export function useBulkDisableApiKeys() {
       queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
       toast.success(t('apikeys.messages.bulkDisableSuccess', { count: variables.length }));
     },
-    onError: () => {
-      toast.error(t('common.errors.internalServerError'));
+    onError: (error) => {
+      handleError(error);
     },
   });
 }
@@ -789,6 +792,7 @@ export function useBulkEnableApiKeys() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const selectedProjectId = useSelectedProjectId();
+  const { handleError } = useErrorHandler();
 
   return useMutation({
     mutationFn: async (ids: string[]) => {
@@ -800,8 +804,8 @@ export function useBulkEnableApiKeys() {
       queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
       toast.success(t('apikeys.messages.bulkEnableSuccess', { count: variables.length }));
     },
-    onError: () => {
-      toast.error(t('common.errors.internalServerError'));
+    onError: (error) => {
+      handleError(error);
     },
   });
 }
@@ -810,6 +814,7 @@ export function useBulkArchiveApiKeys() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const selectedProjectId = useSelectedProjectId();
+  const { handleError } = useErrorHandler();
 
   return useMutation({
     mutationFn: async (ids: string[]) => {
@@ -821,8 +826,8 @@ export function useBulkArchiveApiKeys() {
       queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
       toast.success(t('apikeys.messages.bulkArchiveSuccess', { count: variables.length }));
     },
-    onError: () => {
-      toast.error(t('common.errors.internalServerError'));
+    onError: (error) => {
+      handleError(error);
     },
   });
 }

--- a/internal/server/biz/api_key.go
+++ b/internal/server/biz/api_key.go
@@ -456,8 +456,8 @@ func (s *APIKeyService) UpdateAPIKey(ctx context.Context, id int, input ent.Upda
 			if !ok {
 				return fmt.Errorf("user not found in context")
 			}
-			if apiKey.UserID != user.ID {
-				return fmt.Errorf("personal API key can only be modified by its creator")
+			if apiKey.UserID != user.ID && !user.IsOwner {
+				return fmt.Errorf("personal API key can only be modified by its creator or a system owner")
 			}
 		}
 
@@ -556,8 +556,8 @@ func (s *APIKeyService) UpdateAPIKeyStatus(ctx context.Context, id int, status a
 		if !ok {
 			return nil, fmt.Errorf("user not found in context")
 		}
-		if existing.UserID != user.ID {
-			return nil, fmt.Errorf("personal API key can only be modified by its creator")
+		if existing.UserID != user.ID && !user.IsOwner {
+			return nil, fmt.Errorf("personal API key can only be modified by its creator or a system owner")
 		}
 	}
 
@@ -661,8 +661,8 @@ func (s *APIKeyService) UpdateAPIKeyProfiles(ctx context.Context, id int, profil
 		if !ok {
 			return nil, fmt.Errorf("user not found in context")
 		}
-		if existing.UserID != user.ID {
-			return nil, fmt.Errorf("personal API key can only be modified by its creator")
+		if existing.UserID != user.ID && !user.IsOwner {
+			return nil, fmt.Errorf("personal API key can only be modified by its creator or a system owner")
 		}
 	}
 
@@ -1077,7 +1077,7 @@ func (s *APIKeyService) bulkUpdateAPIKeyStatus(ctx context.Context, ids []int, s
 		return fmt.Errorf("noauth type API key cannot be bulk %sd", action)
 	}
 
-	// Personal API keys can only be managed by their creator
+	// Personal API keys can only be managed by their creator or a system owner
 	personalKeys, err := client.APIKey.Query().
 		Where(apikey.IDIn(ids...), apikey.TypeEQ(apikey.TypePersonal)).
 		All(ctx)
@@ -1091,8 +1091,8 @@ func (s *APIKeyService) bulkUpdateAPIKeyStatus(ctx context.Context, ids []int, s
 			return fmt.Errorf("user not found in context")
 		}
 		for _, k := range personalKeys {
-			if k.UserID != user.ID {
-				return fmt.Errorf("personal API key %q can only be %sd by its creator", k.Name, action)
+			if k.UserID != user.ID && !user.IsOwner {
+				return fmt.Errorf("personal API key %q can only be %sd by its creator or a system owner", k.Name, action)
 			}
 		}
 	}
@@ -1150,8 +1150,8 @@ func (s *APIKeyService) RotateAPIKey(ctx context.Context, id int) (*ent.APIKey, 
 		if !ok {
 			return nil, fmt.Errorf("user not found in context")
 		}
-		if existing.UserID != user.ID {
-			return nil, fmt.Errorf("personal API key can only be rotated by its creator")
+		if existing.UserID != user.ID && !user.IsOwner {
+			return nil, fmt.Errorf("personal API key can only be rotated by its creator or a system owner")
 		}
 	}
 

--- a/internal/server/biz/api_key_profile_template.go
+++ b/internal/server/biz/api_key_profile_template.go
@@ -231,8 +231,8 @@ func (s *APIKeyProfileTemplateService) LoadTemplate(ctx context.Context, templat
 			if !ok {
 				return fmt.Errorf("user not found in context")
 			}
-			if apiKey.UserID != user.ID {
-				return fmt.Errorf("personal API key can only be modified by its creator")
+			if apiKey.UserID != user.ID && !user.IsOwner {
+				return fmt.Errorf("personal API key can only be modified by its creator or a system owner")
 			}
 		}
 

--- a/internal/server/biz/api_key_profile_template.go
+++ b/internal/server/biz/api_key_profile_template.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/fx"
 
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/apikeyprofiletemplate"
@@ -223,6 +224,16 @@ func (s *APIKeyProfileTemplateService) LoadTemplate(ctx context.Context, templat
 
 		if template.ProjectID != apiKey.ProjectID {
 			return fmt.Errorf("template and API key must belong to the same project")
+		}
+
+		if apiKey.Type == apikey.TypePersonal {
+			user, ok := contexts.GetUser(ctx)
+			if !ok {
+				return fmt.Errorf("user not found in context")
+			}
+			if apiKey.UserID != user.ID {
+				return fmt.Errorf("personal API key can only be modified by its creator")
+			}
 		}
 
 		templateProfile := template.Profile.Clone()

--- a/internal/server/biz/api_key_profile_template_test.go
+++ b/internal/server/biz/api_key_profile_template_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/looplj/axonhub/internal/authz"
+	"github.com/looplj/axonhub/internal/contexts"
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/apikey"
 	"github.com/looplj/axonhub/internal/ent/apikeyprofiletemplate"
@@ -685,4 +686,75 @@ func TestLoadTemplate_DifferentProject(t *testing.T) {
 	// Try to load template from project 2 into API key in project 1
 	_, err = svc.LoadTemplate(ctx, template.ID, apiKey.ID)
 	require.Error(t, err)
+}
+
+// TestLoadTemplate_PersonalKeyOnlyCreator tests that a personal API key rejects
+// template loads from anyone but its creator, matching the guard in
+// UpdateAPIKeyProfiles.
+func TestLoadTemplate_PersonalKeyOnlyCreator(t *testing.T) {
+	svc, client := setupTestTemplateService(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	hashedPassword, err := HashPassword("test-password")
+	require.NoError(t, err)
+
+	creator, err := client.User.Create().
+		SetEmail(fmt.Sprintf("creator-%d@example.com", time.Now().UnixNano())).
+		SetPassword(hashedPassword).
+		SetFirstName("Key").
+		SetLastName("Creator").
+		SetStatus(user.StatusActivated).
+		Save(ctx)
+	require.NoError(t, err)
+
+	otherUser, err := client.User.Create().
+		SetEmail(fmt.Sprintf("other-%d@example.com", time.Now().UnixNano())).
+		SetPassword(hashedPassword).
+		SetFirstName("Other").
+		SetLastName("User").
+		SetStatus(user.StatusActivated).
+		Save(ctx)
+	require.NoError(t, err)
+
+	testProject, err := client.Project.Create().
+		SetName(fmt.Sprintf("test-project-%d", time.Now().UnixNano())).
+		SetDescription("test").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	apiKey, err := client.APIKey.Create().
+		SetName("personal-api-key").
+		SetKey(fmt.Sprintf("ah-test-%d", time.Now().UnixNano())).
+		SetUserID(creator.ID).
+		SetProjectID(testProject.ID).
+		SetType(apikey.TypePersonal).
+		Save(ctx)
+	require.NoError(t, err)
+
+	template, err := client.APIKeyProfileTemplate.Create().
+		SetName("prod-template").
+		SetDescription("Production template").
+		SetProject(testProject).
+		SetProfile(&objects.APIKeyProfile{Name: "Production"}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Another user (e.g. a system/project owner) cannot load a template into
+	// someone else's personal key.
+	otherCtx := contexts.WithUser(ctx, otherUser)
+	_, err = svc.LoadTemplate(otherCtx, template.ID, apiKey.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "personal API key can only be modified by its creator")
+
+	// The creator can.
+	creatorCtx := contexts.WithUser(ctx, creator)
+	updatedKey, err := svc.LoadTemplate(creatorCtx, template.ID, apiKey.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedKey.Profiles)
+	require.Len(t, updatedKey.Profiles.Profiles, 1)
 }

--- a/internal/server/biz/api_key_profile_template_test.go
+++ b/internal/server/biz/api_key_profile_template_test.go
@@ -720,6 +720,16 @@ func TestLoadTemplate_PersonalKeyOnlyCreator(t *testing.T) {
 		Save(ctx)
 	require.NoError(t, err)
 
+	ownerUser, err := client.User.Create().
+		SetEmail(fmt.Sprintf("owner-%d@example.com", time.Now().UnixNano())).
+		SetPassword(hashedPassword).
+		SetFirstName("System").
+		SetLastName("Owner").
+		SetIsOwner(true).
+		SetStatus(user.StatusActivated).
+		Save(ctx)
+	require.NoError(t, err)
+
 	testProject, err := client.Project.Create().
 		SetName(fmt.Sprintf("test-project-%d", time.Now().UnixNano())).
 		SetDescription("test").
@@ -744,12 +754,11 @@ func TestLoadTemplate_PersonalKeyOnlyCreator(t *testing.T) {
 		Save(ctx)
 	require.NoError(t, err)
 
-	// Another user (e.g. a system/project owner) cannot load a template into
-	// someone else's personal key.
+	// A regular user cannot load a template into someone else's personal key.
 	otherCtx := contexts.WithUser(ctx, otherUser)
 	_, err = svc.LoadTemplate(otherCtx, template.ID, apiKey.ID)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "personal API key can only be modified by its creator")
+	require.Contains(t, err.Error(), "personal API key can only be modified by its creator or a system owner")
 
 	// The creator can.
 	creatorCtx := contexts.WithUser(ctx, creator)
@@ -757,4 +766,11 @@ func TestLoadTemplate_PersonalKeyOnlyCreator(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updatedKey.Profiles)
 	require.Len(t, updatedKey.Profiles.Profiles, 1)
+
+	// A system owner can too.
+	ownerCtx := contexts.WithUser(ctx, ownerUser)
+	updatedKey, err = svc.LoadTemplate(ownerCtx, template.ID, apiKey.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedKey.Profiles)
+	require.Len(t, updatedKey.Profiles.Profiles, 2)
 }

--- a/internal/server/biz/api_key_test.go
+++ b/internal/server/biz/api_key_test.go
@@ -1472,3 +1472,72 @@ func TestValidateAllowedIPs(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIKeyService_UpdateAPIKeyProfiles_PersonalKeyGuard(t *testing.T) {
+	apiKeyService, client := setupTestAPIKeyService(t, xcache.Config{Mode: xcache.ModeMemory})
+	defer apiKeyService.Stop()
+	defer client.Close()
+
+	ctx := context.Background()
+	ctx = ent.NewContext(ctx, client)
+	ctx = authz.WithTestBypass(ctx)
+
+	hashedPassword, err := HashPassword("test-password")
+	require.NoError(t, err)
+
+	newUser := func(firstName string, isOwner bool) *ent.User {
+		u, err := client.User.Create().
+			SetEmail(fmt.Sprintf("%s-%d@example.com", firstName, time.Now().UnixNano())).
+			SetPassword(hashedPassword).
+			SetFirstName(firstName).
+			SetLastName("User").
+			SetIsOwner(isOwner).
+			SetStatus(user.StatusActivated).
+			Save(ctx)
+		require.NoError(t, err)
+		return u
+	}
+
+	creator := newUser("Creator", false)
+	otherUser := newUser("Other", false)
+	ownerUser := newUser("Owner", true)
+
+	testProject, err := client.Project.Create().
+		SetName(uuid.NewString()).
+		SetDescription("test").
+		SetStatus(project.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	apiKey, err := client.APIKey.Create().
+		SetName("personal-key").
+		SetKey(fmt.Sprintf("ah-test-%d", time.Now().UnixNano())).
+		SetUserID(creator.ID).
+		SetProjectID(testProject.ID).
+		SetType(apikey.TypePersonal).
+		Save(ctx)
+	require.NoError(t, err)
+
+	profiles := objects.APIKeyProfiles{
+		ActiveProfile: "production",
+		Profiles: []objects.APIKeyProfile{
+			{
+				Name:          "production",
+				ModelMappings: []objects.ModelMapping{{From: "gpt-4", To: "claude-3"}},
+			},
+		},
+	}
+
+	// A regular user cannot modify someone else's personal key.
+	_, err = apiKeyService.UpdateAPIKeyProfiles(contexts.WithUser(ctx, otherUser), apiKey.ID, profiles)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "personal API key can only be modified by its creator or a system owner")
+
+	// The creator can.
+	_, err = apiKeyService.UpdateAPIKeyProfiles(contexts.WithUser(ctx, creator), apiKey.ID, profiles)
+	require.NoError(t, err)
+
+	// A system owner can too.
+	_, err = apiKeyService.UpdateAPIKeyProfiles(contexts.WithUser(ctx, ownerUser), apiKey.ID, profiles)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Problem

On `/project/api-keys`, a system owner can **see** other users' personal API keys, but:

1. **Inconsistent guards**: `LoadTemplate` had no ownership check, so an owner could silently mutate someone else's personal key via "load template", while the matching save via `UpdateAPIKeyProfiles` was rejected with "personal API key can only be modified by its creator" — half the flow allowed, half blocked.
2. **Masked error**: the frontend discarded the real server error and always toasted a generic "internal server error", making an expected permission rejection look like a server crash.
3. **Dead-end UX**: mutating row actions (profiles/edit/status/rotate) were shown on personal keys the caller could never modify.

## Changes

**Backend**
- Add the same personal-key creator guard to `LoadTemplate` that `UpdateAPIKey`/`UpdateAPIKeyStatus`/`UpdateAPIKeyProfiles`/`RotateAPIKey`/bulk status updates already enforce.
- Relax all of these guards so a **system owner** (`IsOwner`) can manage any personal key they can see; regular users remain restricted to their own keys. Error messages updated accordingly ("...by its creator or a system owner").

**Frontend**
- Row actions on other users' personal keys are hidden unless the current user is a system owner.
- `useUpdateApiKeyStatus`, `useUpdateApiKeyProfiles` and the three bulk mutation hooks now surface the real server error via `handleError` instead of always toasting `internalServerError`.

## Testing

- `TestLoadTemplate_PersonalKeyOnlyCreator`: regular user rejected / creator allowed / system owner allowed.
- New `TestAPIKeyService_UpdateAPIKeyProfiles_PersonalKeyGuard`: same three-role coverage for the profiles mutation.
- `go test ./internal/server/biz/ ./internal/server/gql/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted modifications to personal API keys so only their creator or a system owner can manage them.
  - Updated profile loading and key actions to enforce ownership permissions consistently.
  - Hid unavailable actions when managing another user’s personal API key.

- **Bug Fixes**
  - Improved API key error handling to display specific, actionable errors instead of a generic server error.

- **Tests**
  - Added coverage for personal API key authorization, including creator, unauthorized user, and system owner scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->