### PR TITLE
fix(frontend): fall back to document copy when Clipboard API rejects

### DIFF
--- a/frontend/src/lib/clipboard.test.mjs
+++ b/frontend/src/lib/clipboard.test.mjs
@@ -113,12 +113,58 @@ test('falls back to the document copy command when the Clipboard API is unavaila
   }
 });
 
+test('falls back to the document copy command when the Clipboard API rejects', async () => {
+  const { document, state } = createFallbackDocument(true);
+  const restore = replaceGlobals({
+    document,
+    navigator: {
+      clipboard: {
+        async writeText() {
+          throw new Error('NotAllowedError');
+        },
+      },
+    },
+  });
+
+  try {
+    // Insecure HTTP origins such as Safari expose the Clipboard API but reject every write.
+    await copyTextToClipboard('fallback-after-reject');
+    assert.equal(state.command, 'copy');
+    assert.equal(state.textarea.value, 'fallback-after-reject');
+    assert.equal(state.removed, true);
+  } finally {
+    restore();
+  }
+});
+
 test('rejects when neither clipboard path can copy the text', async () => {
   const { document, state } = createFallbackDocument(false);
   const restore = replaceGlobals({ document, navigator: {} });
 
   try {
     await assert.rejects(copyTextToClipboard('failure'), /compatibility copy command failed/);
+    assert.equal(state.removed, true);
+  } finally {
+    restore();
+  }
+});
+
+test('rejects when the Clipboard API rejects and the fallback also fails', async () => {
+  const { document, state } = createFallbackDocument(false);
+  const restore = replaceGlobals({
+    document,
+    navigator: {
+      clipboard: {
+        async writeText() {
+          throw new Error('NotAllowedError');
+        },
+      },
+    },
+  });
+
+  try {
+    await assert.rejects(copyTextToClipboard('failure'), /compatibility copy command failed/);
+    assert.equal(state.command, 'copy');
     assert.equal(state.removed, true);
   } finally {
     restore();

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -27,8 +27,13 @@ function copyTextWithDocumentCommand(text: string): void {
 
 export async function copyTextToClipboard(text: string): Promise<void> {
   if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
-    await navigator.clipboard.writeText(text);
-    return;
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Insecure HTTP origins (e.g. Safari on http://) still expose the Clipboard
+      // API but reject every write, so fall through to the document command.
+    }
   }
 
   copyTextWithDocumentCommand(text);


### PR DESCRIPTION
## Problem

On plain HTTP deployments (e.g. `http://192.168.x.x:8090`), copy buttons never worked on Safari — including the one in the project-level API keys **view dialog** (`/project/api-keys` → view API key). Pasting showed stale clipboard content (a previously copied page title + URL) regardless of whether the masked key was revealed, and the operation always failed silently.

#2334 fixed the "Clipboard API is unavailable" case (Chrome on HTTP, where `navigator.clipboard` is `undefined`), but missed the "API exists yet every call is rejected" case: Safari still exposes `navigator.clipboard.writeText` on insecure origins, but the promise rejects (`NotAllowedError`). The previous availability-only check then awaited the rejected promise and threw, so the `execCommand('copy')` fallback was never reached.

## Changes

- `frontend/src/lib/clipboard.ts`: `copyTextToClipboard` now treats a rejected `navigator.clipboard.writeText` as a signal to fall through to the existing `copyTextWithDocumentCommand` fallback instead of failing outright. The behavior when the Clipboard API succeeds is unchanged.
- The fix lives in the shared clipboard helper, so the API key view dialog, the table-row copy buttons, and every other copy button in the app benefit.
- `frontend/src/lib/clipboard.test.mjs`: added two cases — the fallback engages when `writeText` rejects, and the promise still rejects when both the Clipboard API and the fallback fail.

## Verification

- Focused unit tests: `node --test src/lib/clipboard.test.mjs` — **5 pass / 0 fail** (3 existing + 2 new).
- Full unit run on the development machine: 67 pass / 12 fail. The 12 failing files fail with `Cannot find package 'typescript'` — a pre-existing local environment issue (this worktree has no `node_modules` installed); they do not touch clipboard code.

## Risk

Low. The only behavior change is on the rejection path: where Safari previously surfaced a copy error, it now falls back to the document command (called within the user-activation window) and succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying when the browser’s Clipboard API rejects a write.
  * Added a fallback to the document-based copy method, improving compatibility in insecure browsing contexts.
  * Copy operations now report an error when both available methods fail.

* **Tests**
  * Added coverage for successful and unsuccessful clipboard fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->