### PR TITLE
fix(codex): support direct image generation and editing endpoints

### DIFF
--- a/llm/transformer/openai/codex/constants.go
+++ b/llm/transformer/openai/codex/constants.go
@@ -28,7 +28,7 @@ func DefaultModels() []string {
 }
 
 const (
-	defaultImageMainModel = "gpt-5.4-mini"
+	defaultImageMainModel = "gpt-5.6-luna"
 
 	AxonHubOriginator = "axonhub"
 	AuthorizeURL      = "https://auth.openai.com/oauth/authorize"

--- a/llm/transformer/openai/codex/image_direct.go
+++ b/llm/transformer/openai/codex/image_direct.go
@@ -1,0 +1,311 @@
+package codex
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer/openai/responses"
+)
+
+type codexImageGenerationRequest struct {
+	Prompt     string `json:"prompt"`
+	Background string `json:"background,omitempty"`
+	Model      string `json:"model"`
+	N          *int64 `json:"n,omitempty"`
+	Quality    string `json:"quality,omitempty"`
+	Size       string `json:"size,omitempty"`
+}
+
+// POST https://chatgpt.com/backend-api/codex/images/generations
+func (t *OutboundTransformer) rewriteDirectImageGenerationRequest(
+	hreq *httpclient.Request,
+	llmReq *llm.Request,
+) error {
+	if hreq == nil {
+		return errors.New("codex image request is nil")
+	}
+	if llmReq == nil || llmReq.Image == nil {
+		return errors.New("codex image gnneration payload is nil")
+	}
+
+	prompt := strings.TrimSpace(llmReq.Image.Prompt)
+	if prompt == "" {
+		return errors.New("codex image generation prompt is empty")
+	}
+
+	model := strings.TrimSpace(llmReq.Model)
+	if model == "" {
+		return errors.New("codex image generation model is empty")
+	}
+
+	background := strings.TrimSpace(llmReq.Image.Background)
+	if background == "" {
+		background = "auto"
+	}
+
+	quality := strings.TrimSpace(llmReq.Image.Quality)
+	if quality == "" {
+		quality = "auto"
+	}
+
+	size := strings.TrimSpace(llmReq.Image.Size)
+	if size == "" {
+		size = "auto"
+	}
+
+	payload := codexImageGenerationRequest{
+		Prompt:     prompt,
+		Background: background,
+		Model:      model,
+		N:          llmReq.Image.N,
+		Quality:    quality,
+		Size:       size,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshel codex image generation request: %w", err)
+	}
+
+	bashURL := strings.TrimRight(t.baseURL, "#/")
+	hreq.Method = http.MethodPost
+	hreq.URL = bashURL + "/images/generations"
+	hreq.Path = "/images/generations"
+
+	hreq.Body = body
+	hreq.JSONBody = body
+	hreq.ContentType = "application/json"
+
+	hreq.Headers.Set("Content-Type", "application/json")
+	hreq.Headers.Set("Accept", "application/json")
+	hreq.Headers.Set("x-codex-image-turn-id", uuid.NewString())
+
+	hreq.Headers.Del("Content-Encoding")
+	hreq.Headers.Del(ResponsesLiteHeader)
+	hreq.Headers.Del(BetaFeaturesHeader)
+
+	hreq.Query = nil
+
+	hreq.SkipInboundQueryMerge = true
+
+	if hreq.TransformerMetadata == nil {
+		hreq.TransformerMetadata = map[string]any{}
+	}
+
+	hreq.TransformerMetadata[responses.ImageGenerationToolModelMetadataKey] = model
+
+	return nil
+}
+
+type codexImageURL struct {
+	ImageURL string `json:"image_url"`
+}
+
+type codexImageEditRequest struct {
+	Images     []codexImageURL `json:"images"`
+	Prompt     string          `json:"prompt"`
+	Background string          `json:"background,omitempty"`
+	Model      string          `json:"model"`
+	N          *int64          `json:"n,omitempty"`
+	Quality    string          `json:"quality,omitempty"`
+	Size       string          `json:"size,omitempty"`
+}
+
+func imagesBytesToDataURL(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", errors.New("image data is empty")
+	}
+
+	header := data
+	if len(header) > 512 {
+		header = header[:512]
+	}
+
+	contentType := http.DetectContentType(header)
+
+	switch contentType {
+	case "image/png",
+		"image/jpeg",
+		"image/webp",
+		"image/gif",
+		"image/png\r",
+		"image/jpeg\r",
+		"image/webp\r",
+		"image/gif\r":
+	default:
+		return "", fmt.Errorf("[B2DURL]: unsupported image content type: %q", contentType)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	return "data:" + contentType + ";base64," + encoded, nil
+}
+
+func (t *OutboundTransformer) rewriteDirectImageEditRequest(
+	hreq *httpclient.Request,
+	llmReq *llm.Request,
+) error {
+	if hreq == nil {
+		return errors.New("codex image edit request is nil")
+	}
+
+	if llmReq == nil || llmReq.Image == nil {
+		return errors.New("codex image edit payload is nil")
+	}
+
+	prompt := strings.TrimSpace(llmReq.Image.Prompt)
+	if prompt == "" {
+		return errors.New("codex image edit prompt is empty")
+	}
+
+	model := strings.TrimSpace(llmReq.Model)
+	if model == "" {
+		return errors.New("codex image edit model is empty")
+	}
+
+	if len(llmReq.Image.Images) == 0 {
+		return errors.New("codex image edit request has no images")
+	}
+
+	if len(llmReq.Image.Images) > 16 {
+		return errors.New("codex image edit request has more than 16 images")
+	}
+
+	if len(llmReq.Image.Mask) > 0 {
+		return errors.New("codex image edit request has more than 1 mask")
+	}
+
+	images := make([]codexImageURL, 0, len(llmReq.Image.Images))
+
+	for _, raw := range llmReq.Image.Images {
+		dataURL, err := imagesBytesToDataURL(raw)
+		if err != nil {
+			return fmt.Errorf("codex image edit request image: %w", err)
+		}
+
+		images = append(images, codexImageURL{
+			ImageURL: dataURL,
+		})
+	}
+
+	background := strings.TrimSpace(llmReq.Image.Quality)
+	if background == "" {
+		background = "auto"
+	}
+
+	quality := strings.TrimSpace(llmReq.Image.Quality)
+	if quality == "" {
+		quality = "auto"
+	}
+
+	size := strings.TrimSpace(llmReq.Image.Size)
+	if size == "" {
+		size = "auto"
+	}
+
+	payload := codexImageEditRequest{
+		Images:     images,
+		Prompt:     prompt,
+		Background: background,
+		Model:      model,
+		N:          llmReq.Image.N,
+		Quality:    quality,
+		Size:       size,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal codex image edit request: %w", err)
+	}
+
+	baseURL := strings.TrimRight(t.baseURL, "#/")
+
+	hreq.Method = http.MethodPost
+	hreq.URL = baseURL + "/images/edits"
+	hreq.Path = "/images/edits"
+
+	hreq.Body = body
+	hreq.JSONBody = body
+	hreq.ContentType = "application/json"
+
+	hreq.Headers.Set("Content-Type", "application/json")
+	hreq.Headers.Set("Accept", "application/json")
+	hreq.Headers.Set("x-codex-image-turn-id", uuid.NewString())
+
+	hreq.Headers.Del("Content-Encoding")
+	hreq.Headers.Del(ResponsesLiteHeader)
+	hreq.Headers.Del(BetaFeaturesHeader)
+
+	hreq.Query = nil
+	hreq.SkipInboundQueryMerge = true
+
+	if hreq.TransformerMetadata == nil {
+		hreq.TransformerMetadata = map[string]any{}
+	}
+
+	hreq.TransformerMetadata[responses.ImageGenerationToolModelMetadataKey] = model
+
+	return nil
+}
+
+// transform standalone codex images JSON resp back into Axonhub's unified image response
+func transformDirectImageResponse(
+	httpResp *httpclient.Response,
+) (*llm.Response, error) {
+	if httpResp == nil {
+		return nil, errors.New("codex image response if nil")
+	}
+
+	if httpResp.StatusCode >= 400 {
+		return nil, fmt.Errorf(
+			"codex image HTPP error: %d: %s",
+			httpResp.StatusCode,
+			string(httpResp.Body),
+		)
+	}
+
+	var imageResp llm.ImageResponse
+	if err := json.Unmarshal(httpResp.Body, &imageResp); err != nil {
+		return nil, fmt.Errorf("decode codex image response: %w", err)
+	}
+
+	if len(imageResp.Data) == 0 {
+		return nil, fmt.Errorf("codex image response conained none image data")
+	}
+
+	metadata := map[string]any{}
+	model := ""
+
+	apiFormat := llm.APIFormatOpenAIImageGeneration
+
+	if httpResp.Request != nil {
+		if httpResp.Request.TransformerMetadata != nil {
+			metadata = httpResp.Request.TransformerMetadata
+		}
+
+		if httpResp.Request.APIFormat == string(llm.APIFormatOpenAIImageEdit) {
+			apiFormat = llm.APIFormatOpenAIImageEdit
+		}
+	}
+
+	if v, ok := metadata[responses.ImageGenerationToolModelMetadataKey].(string); ok {
+		model = v
+	}
+
+	return &llm.Response{
+		Object:              "image.generation",
+		Created:             imageResp.Created,
+		Model:               model,
+		RequestType:         llm.RequestTypeImage,
+		APIFormat:           apiFormat,
+		Image:               &imageResp,
+		TransformerMetadata: metadata,
+	}, nil
+}

--- a/llm/transformer/openai/codex/outbound.go
+++ b/llm/transformer/openai/codex/outbound.go
@@ -357,6 +357,31 @@ func (t *OutboundTransformer) TransformRequest(ctx context.Context, llmReq *llm.
 		hreq.Headers.Set("Version", codexDefaultVersion)
 	}
 
+	// if isImageRequest && originalAPIFormat == llm.APIFormatOpenAIImageGeneration {
+	// 	if err := t.rewriteDirectImageGenerationRequest(hreq, llmReq); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	if isImageRequest {
+		switch originalAPIFormat {
+		case llm.APIFormatOpenAIImageGeneration:
+			if err := t.rewriteDirectImageGenerationRequest(
+				hreq,
+				llmReq,
+			); err != nil {
+				return nil, err
+			}
+		case llm.APIFormatOpenAIImageEdit:
+			if err := t.rewriteDirectImageEditRequest(
+				hreq,
+				llmReq,
+			); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return hreq, nil
 }
 
@@ -365,6 +390,12 @@ func (t *OutboundTransformer) TransformResponse(ctx context.Context, httpResp *h
 		return t.transformAlphaSearchResponse(ctx, httpResp)
 	}
 	if httpResp != nil && httpResp.Request != nil && httpResp.Request.RequestType == llm.RequestTypeImage.String() {
+		switch httpResp.Request.APIFormat {
+		case string(llm.APIFormatOpenAIImageGeneration),
+			string(llm.APIFormatOpenAIImageEdit):
+			return transformDirectImageResponse(httpResp)
+		}
+
 		if httpResp.StatusCode >= 400 {
 			return nil, fmt.Errorf("codex image HTTP error %d: %s", httpResp.StatusCode, httpResp.Body)
 		}
@@ -456,7 +487,10 @@ func (e *codexExecutor) Do(ctx context.Context, request *httpclient.Request) (*h
 	// Compact and alpha search are non-streaming endpoints; proxy them
 	// through the real HTTP client instead of the SSE stream path.
 	if request.RequestType == string(llm.RequestTypeCompact) ||
-		request.RequestType == llm.RequestTypeAlphaSearch.String() {
+		request.RequestType == llm.RequestTypeAlphaSearch.String() ||
+		(request.RequestType == string(llm.RequestTypeImage) &&
+			(request.APIFormat == string(llm.APIFormatOpenAIImageGeneration) ||
+				request.APIFormat == string(llm.APIFormatOpenAIImageEdit))) {
 		return e.httpExecutor.Do(ctx, request)
 	}
 
@@ -615,6 +649,12 @@ func (e *codexExecutor) executor(_ context.Context) pipeline.Executor {
 
 func (e *codexExecutor) requestForTransport(request *httpclient.Request) *httpclient.Request {
 	if e == nil || e.transformer == nil {
+		return request
+	}
+
+	if request != nil && request.RequestType == string(llm.RequestTypeImage) &&
+		(request.APIFormat == string(llm.APIFormatOpenAIImageGeneration) ||
+			request.APIFormat == string(llm.APIFormatOpenAIImageEdit)) {
 		return request
 	}
 

--- a/llm/transformer/openai/image_inbound.go
+++ b/llm/transformer/openai/image_inbound.go
@@ -340,25 +340,31 @@ func (t *ImageInboundTransformer) transformEditRequest(httpReq *httpclient.Reque
 	return llmReq, nil
 }
 
+// Make the fucking wrong URL redirect to the correct URL
+type ImageEditJSONImage struct {
+	ImageURL	string	`json:"image_url"`
+}
+
 // ImageEditJSONRequest represents an application/json body for the image edit API.
 // The Image field accepts a single data URL string or an array of data URL strings;
 // Mask accepts a data URL string.
 type ImageEditJSONRequest struct {
-	Prompt            string          `json:"prompt"`
-	Model             string          `json:"model"`
-	Image             json.RawMessage `json:"image,omitempty"`
-	Mask              string          `json:"mask,omitempty"`
-	N                 *int64          `json:"n,omitempty"`
-	Size              string          `json:"size,omitempty"`
-	Quality           string          `json:"quality,omitempty"`
-	ResponseFormat    string          `json:"response_format,omitempty"`
-	User              string          `json:"user,omitempty"`
-	Background        string          `json:"background,omitempty"`
-	OutputFormat      string          `json:"output_format,omitempty"`
-	OutputCompression *int64          `json:"output_compression,omitempty"`
-	InputFidelity     string          `json:"input_fidelity,omitempty"`
-	PartialImages     *int64          `json:"partial_images,omitempty"`
-	Stream            bool            `json:"stream,omitempty"`
+	Prompt            string          		`json:"prompt"`
+	Model             string          		`json:"model"`
+	Image             json.RawMessage 		`json:"image,omitempty"`
+	Images			  []ImageEditJSONImage 	`json:"images,omitempty"`
+	Mask              string          		`json:"mask,omitempty"`
+	N                 *int64          		`json:"n,omitempty"`
+	Size              string          		`json:"size,omitempty"`
+	Quality           string          		`json:"quality,omitempty"`
+	ResponseFormat    string          		`json:"response_format,omitempty"`
+	User              string          		`json:"user,omitempty"`
+	Background        string          		`json:"background,omitempty"`
+	OutputFormat      string          		`json:"output_format,omitempty"`
+	OutputCompression *int64          		`json:"output_compression,omitempty"`
+	InputFidelity     string          		`json:"input_fidelity,omitempty"`
+	PartialImages     *int64          		`json:"partial_images,omitempty"`
+	Stream            bool            		`json:"stream,omitempty"`
 }
 
 func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.Request) (*llm.Request, error) {
@@ -388,9 +394,44 @@ func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.R
 		model = "dall-e-2"
 	}
 
-	images, err := parseGenerationImageField(editReq.Image)
-	if err != nil {
-		return nil, err
+	// images, err := parseGenerationImageField(editReq.Image)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	var images [][]byte
+	if len(editReq.Images) > 0 {
+		if len(editReq.Images) > maxImageCount {
+			return nil, fmt.Errorf(
+				"%w: too many images", 
+				transformer.ErrInvalidRequest,
+			)
+		}
+
+		images = make([][]byte, 0, len(editReq.Images))
+
+		for _, item := range editReq.Images {
+			imageURL := strings.TrimSpace(item.ImageURL)
+			if imageURL == "" {
+				return nil, fmt.Errorf(
+					"%w: image URL is empty", 
+					transformer.ErrInvalidRequest,
+				)
+			}
+
+			data, err := decodeDataURLToBytes(imageURL)
+			if err != nil {
+				return nil, err
+			}
+
+			images = append(images, data)
+		}
+	} else {
+		var err error
+		images, err = parseGenerationImageField(editReq.Image)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if len(images) == 0 {
@@ -404,6 +445,7 @@ func (t *ImageInboundTransformer) transformEditJSONRequest(httpReq *httpclient.R
 	var mask []byte
 
 	if maskDataURL := strings.TrimSpace(editReq.Mask); maskDataURL != "" {
+		var err error
 		mask, err = decodeDataURLToBytes(maskDataURL)
 		if err != nil {
 			return nil, err
@@ -720,7 +762,7 @@ func decodeDataURLToBytes(dataURL string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: image data URL must be base64-encoded", transformer.ErrInvalidRequest)
 	}
 	if !isAllowedImageType(parsed.MediaType) {
-		return nil, fmt.Errorf("%w: unsupported image content type %q", transformer.ErrInvalidRequest, parsed.MediaType)
+		return nil, fmt.Errorf("%w: fuck fuck fuck unsupported image content type %q", transformer.ErrInvalidRequest, parsed.MediaType)
 	}
 	if len(parsed.Data) > base64.StdEncoding.EncodedLen(maxImageFileSize) {
 		return nil, fmt.Errorf("%w: image file too large", transformer.ErrInvalidRequest)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct image generation and image editing support through the Codex integration.
  - Image editing requests can now include multiple input images using an array of image URLs.
  - Updated the default image model to `gpt-5.6-luna`.

- **Bug Fixes**
  - Improved handling and conversion of image inputs and responses across supported image-generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->