### PR TITLE
fix: should always respect retry settings, close #2429

### DIFF
--- a/internal/server/orchestrator/candidates.go
+++ b/internal/server/orchestrator/candidates.go
@@ -860,8 +860,8 @@ func (s *LoadBalancedSelector) pinStickyCandidate(
 
 // extractStickyCandidate returns the highest-priority candidate for channelID
 // and removes every candidate for that channel from the fallback set. This
-// prevents a failed sticky channel from being retried through another
-// association entry.
+// prevents a sticky channel from receiving another retry budget through a
+// duplicate association entry after its same-channel retries are exhausted.
 func extractStickyCandidate(
 	candidates []*ChannelModelsCandidate,
 	channelID int,

--- a/internal/server/orchestrator/orchestrator_basic_test.go
+++ b/internal/server/orchestrator/orchestrator_basic_test.go
@@ -953,3 +953,121 @@ func TestChatCompletionOrchestrator_Process_SameChannelRetryNextModel(t *testing
 	require.NoError(t, err)
 	require.Len(t, executions, 2)
 }
+
+func TestChatCompletionOrchestrator_Process_StickyChannelRetryBudget(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		retries    int
+		failures   int
+		fallback   bool
+		wantError  bool
+		wantModels []string
+	}{
+		{
+			name: "zero retries", failures: 1, wantError: true,
+			wantModels: []string{"gpt-4"},
+		},
+		{
+			name: "single channel exhausts retries", retries: 2, failures: 3, wantError: true,
+			wantModels: []string{"gpt-4", "gpt-4", "gpt-4"},
+		},
+		{
+			name: "single channel recovers on final retry", retries: 2, failures: 2,
+			wantModels: []string{"gpt-4", "gpt-4", "gpt-4"},
+		},
+		{
+			name: "fallback follows sticky retries", retries: 2, failures: 3, fallback: true,
+			wantModels: []string{"gpt-4", "gpt-4", "gpt-4", "gpt-3.5-turbo"},
+		},
+		{
+			name: "zero retries switches directly to fallback", failures: 1, fallback: true,
+			wantModels: []string{"gpt-4", "gpt-3.5-turbo"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := authz.WithTestBypass(context.Background())
+			client := enttest.NewEntClient(t, "sqlite3", "file:ent?mode=memory&_fk=0")
+			defer client.Close()
+			ctx = ent.NewContext(ctx, client)
+			project := createTestProject(t, ctx, client)
+			ctx = contexts.WithProjectID(ctx, project.ID)
+			ch := createTestChannel(t, ctx, client)
+			channelService, requestService, systemService, usageLogService := setupTestServices(t, client)
+			require.NoError(t, systemService.SetRetryPolicy(ctx, &biz.RetryPolicy{
+				Enabled:                 true,
+				MaxChannelRetries:       1,
+				MaxSingleChannelRetries: tt.retries,
+				LoadBalancerStrategy:    "adaptive",
+				TraceStickyMode:         biz.TraceStickyPreferPreviousChannel,
+			}))
+
+			outbound, err := openai.NewOutboundTransformer(ch.BaseURL, ch.Credentials.APIKey)
+			require.NoError(t, err)
+			selector := &staticChannelSelector{candidates: []*ChannelModelsCandidate{{
+				Channel:     &biz.Channel{Channel: ch, Outbound: outbound},
+				TraceSticky: true,
+				Models:      []biz.ChannelModelEntry{{RequestModel: "gpt-4", ActualModel: "gpt-4"}},
+			}}}
+			if tt.fallback {
+				backup, err := client.Channel.Create().
+					SetType(ch.Type).
+					SetName("Backup channel").
+					SetBaseURL(ch.BaseURL).
+					SetCredentials(ch.Credentials).
+					SetSupportedModels(ch.SupportedModels).
+					SetDefaultTestModel(ch.DefaultTestModel).
+					Save(ctx)
+				require.NoError(t, err)
+				selector.candidates = append(selector.candidates, &ChannelModelsCandidate{
+					Channel: &biz.Channel{Channel: backup, Outbound: outbound},
+					Models:  []biz.ChannelModelEntry{{RequestModel: "gpt-4", ActualModel: "gpt-3.5-turbo"}},
+				})
+			}
+
+			executor := &sequenceExecutor{}
+			for range tt.failures {
+				executor.steps = append(executor.steps, executorStep{err: &httpclient.Error{
+					StatusCode: http.StatusInternalServerError,
+					Body:       []byte(`{"error":{"message":"upstream error","type":"api_error"}}`),
+				}})
+			}
+			// Keep a success available even in exhaustion cases to detect extra attempts.
+			executor.steps = append(executor.steps, executorStep{resp: &httpclient.Response{
+				StatusCode: http.StatusOK,
+				Body:       buildMockOpenAIResponse("chatcmpl-sticky-retry", tt.wantModels[len(tt.wantModels)-1], "Recovered", 10, 20),
+				Headers:    http.Header{"Content-Type": []string{"application/json"}},
+			}})
+			orchestrator := &ChatCompletionOrchestrator{
+				channelSelector:       selector,
+				Inbound:               openai.NewInboundTransformer(),
+				RequestService:        requestService,
+				ChannelService:        channelService,
+				PromptProvider:        &stubPromptProvider{},
+				SystemService:         systemService,
+				UsageLogService:       usageLogService,
+				PipelineFactory:       pipeline.NewFactory(executor),
+				ModelMapper:           NewModelMapper(),
+				channelLimiterManager: NewChannelLimiterManager(),
+			}
+			result, err := orchestrator.Process(ctx, buildTestRequest("gpt-4", "Hello!", false))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result.ChatCompletion)
+			}
+			models := make([]string, 0, len(executor.requests))
+			for _, req := range executor.requests {
+				var body struct {
+					Model string `json:"model"`
+				}
+				require.NoError(t, json.Unmarshal(req.Body, &body))
+				models = append(models, body.Model)
+			}
+			require.Equal(t, tt.wantModels, models)
+			executions, err := client.RequestExecution.Query().All(ctx)
+			require.NoError(t, err)
+			require.Len(t, executions, len(tt.wantModels))
+		})
+	}
+}

--- a/internal/server/orchestrator/outbound.go
+++ b/internal/server/orchestrator/outbound.go
@@ -726,13 +726,6 @@ func (p *PersistentOutboundTransformer) CanRetry(err error) bool {
 		return false
 	}
 
-	// Trace/thread sticky candidates are intentionally one-shot. A failed
-	// sticky attempt must proceed to the normal fallback candidates instead of
-	// retrying the same channel or another mapped model on that channel.
-	if p.state.CurrentCandidate.TraceSticky {
-		return false
-	}
-
 	if errors.Is(err, errSkipCandidateByCircuitBreaker) {
 		return false
 	}

--- a/internal/server/orchestrator/outbound_test.go
+++ b/internal/server/orchestrator/outbound_test.go
@@ -759,7 +759,7 @@ func TestPersistentOutboundTransformer_CanRetry(t *testing.T) {
 		require.False(t, outbound.CanRetry(errSkipCandidateByCircuitBreaker))
 	})
 
-	t.Run("sticky candidate should not trigger same-channel retry", func(t *testing.T) {
+	t.Run("sticky candidate follows normal same-channel retry rules", func(t *testing.T) {
 		outbound := &PersistentOutboundTransformer{
 			wrapped: &mockTransformer{},
 			state: &PersistenceState{
@@ -768,13 +768,20 @@ func TestPersistentOutboundTransformer_CanRetry(t *testing.T) {
 					TraceSticky: true,
 					Models: []biz.ChannelModelEntry{
 						{RequestModel: "gpt-4", ActualModel: "gpt-4"},
-						{RequestModel: "gpt-4", ActualModel: "gpt-4-alternative"},
 					},
 				},
 			},
 		}
 
-		require.False(t, outbound.CanRetry(retryableErr))
+		require.True(t, outbound.CanRetry(&httpclient.Error{StatusCode: http.StatusInternalServerError}))
+		require.True(t, outbound.CanRetry(pipeline.ErrEmptyResponse))
+		require.False(t, outbound.CanRetry(nonRetryableErr))
+		require.False(t, outbound.CanRetry(&httpclient.Error{StatusCode: http.StatusTooManyRequests}))
+		require.False(t, outbound.CanRetry(errSkipCandidateByCircuitBreaker))
+
+		outbound.state.CurrentCandidate.Models = append(outbound.state.CurrentCandidate.Models,
+			biz.ChannelModelEntry{RequestModel: "gpt-4", ActualModel: "gpt-4-alternative"})
+		require.True(t, outbound.CanRetry(nonRetryableErr), "sticky channels can retry another mapped model")
 	})
 
 	t.Run("auto-aggregate empty errors are retryable", func(t *testing.T) {

--- a/llm/transformer/anthropic/claudecode/utils.go
+++ b/llm/transformer/anthropic/claudecode/utils.go
@@ -64,17 +64,7 @@ func applyClaudeToolPrefixStructured(llmReq *llm.Request, prefix string) *llm.Re
 		return llmReq
 	}
 
-	request := *llmReq
-	request.Tools = slices.Clone(llmReq.Tools)
-	if llmReq.ToolChoice != nil {
-		choice := *llmReq.ToolChoice
-		if choice.NamedToolChoice != nil {
-			named := *choice.NamedToolChoice
-			choice.NamedToolChoice = &named
-		}
-		request.ToolChoice = &choice
-	}
-	llmReq = &request
+	llmReq = cloneRequestForToolPrefix(llmReq)
 
 	// Prefix tool names in tools array
 	for i := range llmReq.Tools {
@@ -94,6 +84,21 @@ func applyClaudeToolPrefixStructured(llmReq *llm.Request, prefix string) *llm.Re
 	}
 
 	return llmReq
+}
+
+// cloneRequestForToolPrefix copies the fields modified when prefixing tool names.
+func cloneRequestForToolPrefix(src *llm.Request) *llm.Request {
+	request := *src
+	request.Tools = slices.Clone(src.Tools)
+	if src.ToolChoice != nil {
+		choice := *src.ToolChoice
+		if choice.NamedToolChoice != nil {
+			named := *choice.NamedToolChoice
+			choice.NamedToolChoice = &named
+		}
+		request.ToolChoice = &choice
+	}
+	return &request
 }
 
 // stripClaudeToolPrefixFromResponse removes the prefix from tool names in the response.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sticky-channel requests now correctly use available same-channel retry opportunities instead of immediately switching to fallback channels.
  - Retry behavior now handles empty responses, server errors, rate limits, and mapped model availability more consistently.
  - Once sticky-channel retries are exhausted, requests correctly fall back to other eligible channels without receiving duplicate retry opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->