### PR TITLE
fix: apply channel header overrides to model-list probes

### DIFF
--- a/internal/server/biz/channel_override.go
+++ b/internal/server/biz/channel_override.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/http"
 	"strings"
 
 	"github.com/samber/lo"
@@ -307,4 +308,58 @@ func deepMergeMap(base, override map[string]any) map[string]any {
 	}
 
 	return result
+}
+
+// ApplyModelFetchHeaderOverrides applies the channel's header override operations to an
+// HTTP request used for model-list probing.
+//
+// Model probing runs outside the LLM request pipeline, so there is no RenderContext to
+// evaluate against: operations guarded by a Condition and set-values containing a template
+// placeholder ("{{") are skipped. Unconditional literal operations use the same semantics as
+// the chat/completion path (applyOverrideOperationToHeaders in
+// internal/server/orchestrator/override.go): set, delete, rename, copy. The legacy
+// "__AXONHUB_CLEAR__" value deletes the header.
+func ApplyModelFetchHeaderOverrides(headers http.Header, ops []objects.OverrideOperation) {
+	if headers == nil || len(ops) == 0 {
+		return
+	}
+
+	for _, op := range ops {
+		if op.Condition != "" {
+			continue
+		}
+
+		switch op.Op {
+		case objects.OverrideOpSet:
+			if strings.Contains(op.Value, "{{") {
+				// A templated value cannot be rendered without an LLM request context;
+				// sending the raw template would corrupt the probe request.
+				continue
+			}
+
+			if op.Value == ClearHeaderDirective {
+				headers.Del(op.Path)
+				continue
+			}
+
+			headers.Set(op.Path, op.Value)
+		case objects.OverrideOpDelete:
+			headers.Del(op.Path)
+		case objects.OverrideOpRename:
+			values := headers.Values(op.From)
+			if len(values) == 0 {
+				continue
+			}
+
+			headers.Del(op.From)
+
+			for _, v := range values {
+				headers.Add(op.To, v)
+			}
+		case objects.OverrideOpCopy:
+			for _, v := range headers.Values(op.From) {
+				headers.Add(op.To, v)
+			}
+		}
+	}
 }

--- a/internal/server/biz/model_fetcher.go
+++ b/internal/server/biz/model_fetcher.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/looplj/axonhub/internal/ent"
 	"github.com/looplj/axonhub/internal/ent/channel"
+	"github.com/looplj/axonhub/internal/objects"
 	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer/anthropic/claudecode"
 	"github.com/looplj/axonhub/llm/transformer/antigravity"
@@ -390,8 +391,9 @@ func (f *ModelFetcher) FetchModels(ctx context.Context, input FetchModelsInput) 
 	}
 
 	var (
-		apiKey      string
-		proxyConfig *httpclient.ProxyConfig
+		apiKey            string
+		proxyConfig       *httpclient.ProxyConfig
+		headerOverrideOps []objects.OverrideOperation
 	)
 
 	if input.APIKey != nil && *input.APIKey != "" {
@@ -431,6 +433,15 @@ func (f *ModelFetcher) FetchModels(ctx context.Context, input FetchModelsInput) 
 
 		if ch.Settings != nil {
 			proxyConfig = ch.Settings.Proxy
+
+			// The new schema field takes precedence; the legacy OverrideHeaders list is
+			// converted when the new field is absent (same precedence as
+			// (*Channel).GetHeaderOverrideOperations).
+			if ch.Settings.HeaderOverrideOperations != nil {
+				headerOverrideOps = ch.Settings.HeaderOverrideOperations
+			} else {
+				headerOverrideOps = objects.HeaderEntriesToOverrideOperations(ch.Settings.OverrideHeaders)
+			}
 		}
 	}
 
@@ -509,6 +520,13 @@ func (f *ModelFetcher) FetchModels(ctx context.Context, input FetchModelsInput) 
 	} else {
 		req.Headers.Set("Authorization", "Bearer "+apiKey)
 	}
+
+	if req.Headers == nil {
+		req.Headers = make(http.Header)
+	}
+	// Channel header overrides win over the standard auth headers, matching the
+	// chat/completion path.
+	ApplyModelFetchHeaderOverrides(req.Headers, headerOverrideOps)
 
 	httpClient := f.httpClient
 	if proxyConfig != nil {

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -1139,7 +1139,7 @@ func TestFetchModelsAppliesHeaderOverrideOperationsFromSettings(t *testing.T) {
 	var gotAPIKey, gotAuth string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAPIKey = r.Header.Get("x-api-key")
+		gotAPIKey = r.Header.Get("X-Api-Key")
 		gotAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":"override-model"}]}`))
@@ -1191,7 +1191,7 @@ func TestFetchModelsAppliesLegacyOverrideHeaders(t *testing.T) {
 	var gotAPIKey string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAPIKey = r.Header.Get("x-api-key")
+		gotAPIKey = r.Header.Get("X-Api-Key")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":"legacy-model"}]}`))
 	}))

--- a/internal/server/biz/model_fetcher_test.go
+++ b/internal/server/biz/model_fetcher_test.go
@@ -1134,3 +1134,101 @@ func TestFetchModelsCommandCodeRejectsHTTP(t *testing.T) {
 	}
 	require.Zero(t, calls.Load())
 }
+
+func TestFetchModelsAppliesHeaderOverrideOperationsFromSettings(t *testing.T) {
+	var gotAPIKey, gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"override-model"}]}`))
+	}))
+	defer server.Close()
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:fetch_models_header_override?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithSystemBypass(context.Background(), "test")
+	ch, err := client.Channel.Create().
+		SetName("header-override").
+		SetType(channel.TypeOpenai).
+		SetBaseURL(server.URL).
+		SetCredentials(objects.ChannelCredentials{APIKey: "stored-secret"}).
+		SetSupportedModels([]string{"override-model"}).
+		SetDefaultTestModel("override-model").
+		SetSettings(&objects.ChannelSettings{
+			HeaderOverrideOperations: []objects.OverrideOperation{
+				{Op: objects.OverrideOpSet, Path: "x-api-key", Value: "override-secret"},
+				{Op: objects.OverrideOpDelete, Path: "Authorization"},
+			},
+		}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	fetcher := NewModelFetcher(
+		httpclient.NewHttpClientWithClient(server.Client()),
+		&ChannelService{AbstractService: &AbstractService{db: client}},
+	)
+
+	result, err := fetcher.FetchModels(ctx, FetchModelsInput{
+		ChannelType: channel.TypeOpenai.String(),
+		BaseURL:     server.URL + "/",
+		ChannelID:   &ch.ID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.Len(t, result.Models, 1)
+	require.Equal(t, "override-model", result.Models[0].ID)
+
+	assert.Equal(t, "override-secret", gotAPIKey,
+		"the channel's header override must be applied to the /models probe request")
+	assert.Empty(t, gotAuth,
+		"a delete override must remove the standard Authorization header from the probe")
+}
+
+func TestFetchModelsAppliesLegacyOverrideHeaders(t *testing.T) {
+	var gotAPIKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"legacy-model"}]}`))
+	}))
+	defer server.Close()
+
+	client := enttest.NewEntClient(t, "sqlite3", "file:fetch_models_header_override_legacy?mode=memory&_fk=0")
+	defer client.Close()
+
+	ctx := authz.WithSystemBypass(context.Background(), "test")
+	ch, err := client.Channel.Create().
+		SetName("legacy-header-override").
+		SetType(channel.TypeOpenai).
+		SetBaseURL(server.URL).
+		SetCredentials(objects.ChannelCredentials{APIKey: "stored-secret"}).
+		SetSupportedModels([]string{"legacy-model"}).
+		SetDefaultTestModel("legacy-model").
+		SetSettings(&objects.ChannelSettings{
+			OverrideHeaders: []objects.HeaderEntry{{Key: "x-api-key", Value: "legacy-secret"}},
+		}).
+		Save(ctx)
+	require.NoError(t, err)
+
+	fetcher := NewModelFetcher(
+		httpclient.NewHttpClientWithClient(server.Client()),
+		&ChannelService{AbstractService: &AbstractService{db: client}},
+	)
+
+	result, err := fetcher.FetchModels(ctx, FetchModelsInput{
+		ChannelType: channel.TypeOpenai.String(),
+		BaseURL:     server.URL + "/",
+		ChannelID:   &ch.ID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.Len(t, result.Models, 1)
+	require.Equal(t, "legacy-model", result.Models[0].ID)
+
+	assert.Equal(t, "legacy-secret", gotAPIKey,
+		"the deprecated OverrideHeaders list must still be applied to the probe request")
+}


### PR DESCRIPTION
## What

`FetchModels` (the "获取模型列表 / 同步模型" probe) now applies the channel's **header override** configuration to the outbound `/models` request, so channels that authenticate with a non-standard header (e.g. `x-api-key`, `X-Subscription-Key`) can list their models.

## Why

The chat/completion path applies header overrides (`internal/server/biz/channel_llm.go:145` → `GetHeaderOverrideOperations()` → the orchestrator's `override-request-headers` middleware), but the model-probe path only read `Settings.Proxy` and the credentials, then wrote the standard auth header (`Authorization` / `X-Api-Key` / `X-Goog-Api-Key`). A channel relying on an override header therefore passed a chat test but returned 401/403 on "获取模型列表".

Repro from the issue: an OpenAI-compatible channel whose `/v1/models` requires `x-api-key` rather than `Authorization` gets an empty model list, while chat/completion works.

Fixes #2445

## How

- `internal/server/biz/channel_override.go`: new `ApplyModelFetchHeaderOverrides(headers, ops)` mirroring the chat path's header semantics — `set`, `delete`, `rename`, `copy`, plus the legacy `__AXONHUB_CLEAR__` set-value meaning delete. Operations carrying a `Condition`, and `set` values containing a `{{` template placeholder, are skipped: the probe runs outside the LLM request pipeline, so there is no `RenderContext` to evaluate them against, and sending an unrendered template would corrupt the probe request.
- `internal/server/biz/model_fetcher.go`: `FetchModels` now reads `Settings.HeaderOverrideOperations`, falling back to the deprecated `Settings.OverrideHeaders` via `objects.HeaderEntriesToOverrideOperations` — the same precedence as `(*Channel).GetHeaderOverrideOperations`. The operations are applied **after** the standard auth headers are set, so an override wins (e.g. `delete Authorization` + `set x-api-key`). The single insertion point also covers the Gemini probe, which reuses the same request struct.
- The orchestrator helper is deliberately not reused: `package biz` cannot import `package orchestrator` (import cycle).

## Tests

`internal/server/biz/model_fetcher_test.go`:

- `TestFetchModelsAppliesHeaderOverrideOperationsFromSettings` — a channel whose `/models` endpoint requires `x-api-key`; asserts the override value reaches the probe and that the `delete Authorization` operation removes the standard header. Uses the existing `enttest` + `httptest` pattern.
- `TestFetchModelsAppliesLegacyOverrideHeaders` — the deprecated `OverrideHeaders` list is still applied.

```
go test ./internal/server/biz/ -run 'TestFetchModelsAppliesHeaderOverrideOperationsFromSettings|TestFetchModelsAppliesLegacyOverrideHeaders' -count=1
ok  github.com/looplj/axonhub/internal/server/biz

go test ./internal/server/biz/ -run 'TestFetchModels|TestPrepareModelsEndpoint' -count=1
ok  github.com/looplj/axonhub/internal/server/biz
```

### Mutation check

Removing the new call site `ApplyModelFetchHeaderOverrides(req.Headers, headerOverrideOps)` from `FetchModels`:

```
--- FAIL: TestFetchModelsAppliesHeaderOverrideOperationsFromSettings
        the channel's header override must be applied to the /models probe request
--- FAIL: TestFetchModelsAppliesLegacyOverrideHeaders
FAIL
```

With the call restored, both pass — the tests are load-bearing rather than vacuous.

---
Implemented with AI assistance (OpenCode + muse-spark), then reviewed and verified locally (targeted tests, `gofmt`, mutation check) before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model discovery requests now support configurable header overrides, including setting, deleting, renaming, and copying headers.
  - Standard authentication headers can be replaced or removed when retrieving available models.
  - Existing legacy header override settings continue to work for model discovery.
  - Header override behavior now aligns with chat and completion requests for more consistent channel configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->